### PR TITLE
[binaryparagraph] Fix VS 2015 compile error.

### DIFF
--- a/src/vcpkg/binaryparagraph.cpp
+++ b/src/vcpkg/binaryparagraph.cpp
@@ -138,7 +138,7 @@ namespace vcpkg
 
     void BinaryParagraph::canonicalize()
     {
-        constexpr auto all_empty = [](const std::vector<std::string>& range) {
+        const auto all_empty = [](const std::vector<std::string>& range) {
             return std::all_of(range.begin(), range.end(), [](const std::string& el) { return el.empty(); });
         };
 


### PR DESCRIPTION
This fixes compilation on Visual Studio 2015. `constexpr` lambdas were added in Visual Studio 2017 update 15.3. Further, `std::all_of` did not become `constexpr` until C++20.