### PR TITLE
[visualstudio] Fix v120 toolset detection issue.

### DIFF
--- a/src/vcpkg/visualstudio.cpp
+++ b/src/vcpkg/visualstudio.cpp
@@ -126,45 +126,38 @@ namespace vcpkg::VisualStudio
             }
         }
 
-        // VS2019 instance from environment variable
-        auto maybe_vs160_comntools = System::get_environment_variable("vs160comntools");
-        if (const auto path_as_string = maybe_vs160_comntools.get())
-        {
-            // We want lexically_normal(), but it is not available
-            // Correct root path might be 2 or 3 levels up, depending on if the path has trailing backslash.
-            auto common7_tools = fs::u8path(*path_as_string);
-            if (common7_tools.filename().empty())
-                instances.emplace_back(common7_tools.parent_path().parent_path().parent_path(),
-                                       "16.0",
-                                       VisualStudioInstance::ReleaseType::LEGACY);
-            else
-                instances.emplace_back(
-                    common7_tools.parent_path().parent_path(), "16.0", VisualStudioInstance::ReleaseType::LEGACY);
-        }
-
-        const auto append_if_has_cl_vs140 = [&](fs::path&& path_root) {
+        const auto append_if_has_cl = [&](fs::path&& path_root, CStringView version) {
             const auto cl_exe = path_root / "VC" / "bin" / "cl.exe";
             const auto vcvarsall_bat = path_root / "VC" / "vcvarsall.bat";
 
             if (fs.exists(cl_exe) && fs.exists(vcvarsall_bat))
-                instances.emplace_back(std::move(path_root), "14.0", VisualStudioInstance::ReleaseType::LEGACY);
+                instances.emplace_back(std::move(path_root), version.c_str(), VisualStudioInstance::ReleaseType::LEGACY);
         };
 
-        // VS2015 instance from environment variable
-        auto maybe_vs140_comntools = System::get_environment_variable("vs140comntools");
-        if (const auto path_as_string = maybe_vs140_comntools.get())
-        {
-            // We want lexically_normal(), but it is not available
-            // Correct root path might be 2 or 3 levels up, depending on if the path has trailing backslash.
-            auto common7_tools = fs::u8path(*path_as_string);
-            if (common7_tools.filename().empty())
-                append_if_has_cl_vs140(common7_tools.parent_path().parent_path().parent_path());
-            else
-                append_if_has_cl_vs140(common7_tools.parent_path().parent_path());
-        }
+        const auto append_if_comntools_has_cl = [&](ZStringView env_var, CStringView version) {
+            auto maybe_comntools = System::get_environment_variable(env_var);
+            if (const auto path_as_string = maybe_comntools.get())
+            {
+                // We want lexically_normal(), but it is not available
+                // Correct root path might be 2 or 3 levels up, depending on if the path has trailing backslash.
+                auto common7_tools = fs::u8path(*path_as_string);
+                if (common7_tools.filename().empty())
+                    append_if_has_cl(common7_tools.parent_path().parent_path().parent_path(), version);
+                else
+                    append_if_has_cl(common7_tools.parent_path().parent_path(), version);
+            }
+        };
 
-        // VS2015 instance from Program Files
-        append_if_has_cl_vs140(program_files_32_bit / "Microsoft Visual Studio 14.0");
+        const auto maybe_append_legacy_vs = [&](ZStringView env_var, const fs::path& dir, CStringView version) {
+            // VS instance from environment variable
+            append_if_comntools_has_cl(env_var, version);
+            // VS instance from Program Files
+            append_if_has_cl(program_files_32_bit / dir, version);
+        };
+
+        append_if_comntools_has_cl("vs160comntools", "16.0");
+        maybe_append_legacy_vs("vs140comntools", "Microsoft Visual Studio 14.0", "14.0");
+        maybe_append_legacy_vs("vs120comntools", "Microsoft Visual Studio 12.0", "12.0");
 
         return instances;
     }

--- a/src/vcpkg/visualstudio.cpp
+++ b/src/vcpkg/visualstudio.cpp
@@ -131,7 +131,8 @@ namespace vcpkg::VisualStudio
             const auto vcvarsall_bat = path_root / "VC" / "vcvarsall.bat";
 
             if (fs.exists(cl_exe) && fs.exists(vcvarsall_bat))
-                instances.emplace_back(std::move(path_root), version.c_str(), VisualStudioInstance::ReleaseType::LEGACY);
+                instances.emplace_back(
+                    std::move(path_root), version.c_str(), VisualStudioInstance::ReleaseType::LEGACY);
         };
 
         const auto append_if_comntools_has_cl = [&](ZStringView env_var, CStringView version) {

--- a/src/vcpkg/visualstudio.cpp
+++ b/src/vcpkg/visualstudio.cpp
@@ -126,19 +126,16 @@ namespace vcpkg::VisualStudio
             }
         }
 
-
         const auto maybe_append_path = [&](fs::path&& path_root, CStringView version, bool check_cl = true) {
             if (check_cl)
             {
                 const auto cl_exe = path_root / "VC" / "bin" / "cl.exe";
                 const auto vcvarsall_bat = path_root / "VC" / "vcvarsall.bat";
 
-                if (!(fs.exists(cl_exe) && fs.exists(vcvarsall_bat)))
-                    return;
+                if (!(fs.exists(cl_exe) && fs.exists(vcvarsall_bat))) return;
             }
 
-            instances.emplace_back(
-                std::move(path_root), version.c_str(), VisualStudioInstance::ReleaseType::LEGACY);
+            instances.emplace_back(std::move(path_root), version.c_str(), VisualStudioInstance::ReleaseType::LEGACY);
         };
 
         const auto maybe_append_comntools = [&](ZStringView env_var, CStringView version, bool check_cl = true) {


### PR DESCRIPTION
Previously, the v120 toolset was only detected by finding Visual Studio 2013 with `vswhere.exe`. Unfortunately, `vswhere.exe` is only available if Visual Studio 2017 (or higher) is installed. So, if you are using a configuration that has only ever had Visual Studio 2015 and Visual Studio 2013 installed, then the community triplet `x86-windows-v120` would fail with the error `Could not find Visual Studio instance with v120 toolset`. This can be easily [observed](https://ci.appveyor.com/project/Hoikas/appveyorvcpkg2013/builds/37646642) by attempting to use vcpkg on the "Visual Studio 2015" AppVeyor image. Now that bootstrapping no longer requires Visual Studio >= 2015 available, this also affects machines that only have Visual Studio 2013 installed... eg the "Visual Studio 2013" AppVeyor image.

This pull request add version independent detection of Visual Studio 2013 to [fix](https://ci.appveyor.com/project/Hoikas/appveyorvcpkg2013/builds/37647047) this issue. Because the detection code contained a lot of duplication before I started, this includes a round of de-duplication. I'm unfamiliar with the (what seemed to be) five different variants of string types in use in vcpkg, so please let me know if I goofed with making extra copies or something silly like that :smile:.