### PR TITLE
[vcpkg] Add experimental $X_VCPKG_ASSET_SOURCES for source caching

### DIFF
--- a/include/vcpkg/base/downloads.h
+++ b/include/vcpkg/base/downloads.h
@@ -16,7 +16,7 @@ namespace vcpkg::Downloads
         };
 
         // e.g. {"https","//example.org", "/index.html"}
-        Optional<SplitURIView> split_uri_view(StringView uri);
+        ExpectedS<SplitURIView> split_uri_view(StringView uri);
     }
 
     void verify_downloaded_file_hash(const Files::Filesystem& fs,

--- a/include/vcpkg/base/downloads.h
+++ b/include/vcpkg/base/downloads.h
@@ -38,4 +38,30 @@ namespace vcpkg::Downloads
     std::vector<int> download_files(Files::Filesystem& fs, View<std::pair<std::string, fs::path>> url_pairs);
     int put_file(const Files::Filesystem&, StringView url, const fs::path& file);
     std::vector<int> url_heads(View<std::string> urls);
+
+    // Handles downloading and uploading to a content addressable mirror
+    struct DownloadManager
+    {
+        DownloadManager() = default;
+        explicit DownloadManager(Optional<std::string> read_url_template, Optional<std::string> write_url_template);
+
+        void download_file(Files::Filesystem& fs,
+                           const std::string& url,
+                           const fs::path& download_path,
+                           const std::string& sha512) const;
+
+        std::string download_file(Files::Filesystem& fs,
+                                  View<std::string> urls,
+                                  const fs::path& download_path,
+                                  const std::string& sha512) const;
+
+        int put_file_to_mirror(const Files::Filesystem& fs, const fs::path& path, const std::string& sha512) const;
+
+        const Optional<std::string>& internal_get_read_url_template() const { return m_read_url_template; }
+        const Optional<std::string>& internal_get_write_url_template() const { return m_write_url_template; }
+
+    private:
+        Optional<std::string> m_read_url_template;
+        Optional<std::string> m_write_url_template;
+    };
 }

--- a/include/vcpkg/base/files.h
+++ b/include/vcpkg/base/files.h
@@ -214,6 +214,10 @@ namespace vcpkg::Files
         virtual bool create_directories(const fs::path& path, std::error_code& ec) = 0;
         bool create_directories(const fs::path& path, ignore_errors_t);
         bool create_directories(const fs::path& path, LineInfo);
+        virtual void create_symlink(const fs::path& to, const fs::path& from, std::error_code& ec) = 0;
+        virtual void create_hard_link(const fs::path& to, const fs::path& from, std::error_code& ec) = 0;
+        void create_best_link(const fs::path& to, const fs::path& from, std::error_code& ec);
+        void create_best_link(const fs::path& to, const fs::path& from, LineInfo);
         virtual void copy(const fs::path& oldpath, const fs::path& newpath, fs::copy_options opts) = 0;
         virtual bool copy_file(const fs::path& oldpath,
                                const fs::path& newpath,

--- a/include/vcpkg/base/lockguarded.h
+++ b/include/vcpkg/base/lockguarded.h
@@ -29,7 +29,7 @@ namespace vcpkg::Util
         LockGuardPtr(LockGuarded<T>& sync) : m_lock(sync.m_mutex), m_ptr(sync.m_t) { }
 
     private:
-        std::unique_lock<std::mutex> m_lock;
+        std::lock_guard<std::mutex> m_lock;
         T& m_ptr;
     };
 }

--- a/include/vcpkg/binarycaching.h
+++ b/include/vcpkg/binarycaching.h
@@ -3,6 +3,7 @@
 #include <vcpkg/fwd/dependencies.h>
 #include <vcpkg/fwd/vcpkgpaths.h>
 
+#include <vcpkg/base/downloads.h>
 #include <vcpkg/base/expected.h>
 #include <vcpkg/base/files.h>
 
@@ -55,6 +56,8 @@ namespace vcpkg
     ExpectedS<std::unique_ptr<IBinaryProvider>> create_binary_provider_from_configs(View<std::string> args);
     ExpectedS<std::unique_ptr<IBinaryProvider>> create_binary_provider_from_configs_pure(const std::string& env_string,
                                                                                          View<std::string> args);
+
+    ExpectedS<Downloads::DownloadManager> create_download_manager(const Optional<std::string>& arg);
 
     std::string generate_nuget_packages_config(const Dependencies::ActionPlan& action);
 

--- a/include/vcpkg/binarycaching.private.h
+++ b/include/vcpkg/binarycaching.private.h
@@ -3,7 +3,6 @@
 #include <vcpkg/fwd/packagespec.h>
 #include <vcpkg/fwd/vcpkgpaths.h>
 
-#include <vcpkg/base/parse.h>
 #include <vcpkg/base/strings.h>
 
 #include <vcpkg/dependencies.h>

--- a/include/vcpkg/binarycaching.private.h
+++ b/include/vcpkg/binarycaching.private.h
@@ -3,6 +3,7 @@
 #include <vcpkg/fwd/packagespec.h>
 #include <vcpkg/fwd/vcpkgpaths.h>
 
+#include <vcpkg/base/parse.h>
 #include <vcpkg/base/strings.h>
 
 #include <vcpkg/dependencies.h>

--- a/include/vcpkg/commands.xdownload.h
+++ b/include/vcpkg/commands.xdownload.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <vcpkg/commands.interface.h>
+
+namespace vcpkg::Commands::X_Download
+{
+    void perform_and_exit(const VcpkgCmdArguments& args, const VcpkgPaths& paths);
+
+    struct XDownloadCommand : PathsCommand
+    {
+        virtual void perform_and_exit(const VcpkgCmdArguments& args, const VcpkgPaths& paths) const override;
+    };
+}

--- a/include/vcpkg/vcpkgcmdarguments.h
+++ b/include/vcpkg/vcpkgcmdarguments.h
@@ -180,6 +180,9 @@ namespace vcpkg
         constexpr static StringLiteral JSON_SWITCH = "x-json";
         Optional<bool> json = nullopt;
 
+        constexpr static StringLiteral READWRITE_MIRROR_URL_TEMPLATE_ENV = "X_VCPKG_ASSET_SOURCES";
+        Optional<std::string> readwrite_mirror_url_template;
+
         // feature flags
         constexpr static StringLiteral FEATURE_FLAGS_ENV = "VCPKG_FEATURE_FLAGS";
         constexpr static StringLiteral FEATURE_FLAGS_ARG = "feature-flags";
@@ -198,7 +201,7 @@ namespace vcpkg
         constexpr static StringLiteral VERSIONS_FEATURE = "versions";
         Optional<bool> versions_feature = nullopt;
 
-        constexpr static StringLiteral RECURSIVE_DATA_ENV = "VCPKG_X_RECURSIVE_DATA";
+        constexpr static StringLiteral RECURSIVE_DATA_ENV = "X_VCPKG_RECURSIVE_DATA";
 
         bool binary_caching_enabled() const { return binary_caching.value_or(true); }
         bool compiler_tracking_enabled() const { return compiler_tracking.value_or(true); }

--- a/include/vcpkg/vcpkgcmdarguments.h
+++ b/include/vcpkg/vcpkgcmdarguments.h
@@ -180,8 +180,8 @@ namespace vcpkg
         constexpr static StringLiteral JSON_SWITCH = "x-json";
         Optional<bool> json = nullopt;
 
-        constexpr static StringLiteral READWRITE_MIRROR_URL_TEMPLATE_ENV = "X_VCPKG_ASSET_SOURCES";
-        Optional<std::string> readwrite_mirror_url_template;
+        constexpr static StringLiteral ASSET_SOURCES_ENV = "X_VCPKG_ASSET_SOURCES";
+        Optional<std::string> asset_sources_template;
 
         // feature flags
         constexpr static StringLiteral FEATURE_FLAGS_ENV = "VCPKG_FEATURE_FLAGS";

--- a/include/vcpkg/vcpkgpaths.h
+++ b/include/vcpkg/vcpkgpaths.h
@@ -34,6 +34,11 @@ namespace vcpkg
         std::vector<ToolsetArchOption> supported_architectures;
     };
 
+    namespace Downloads
+    {
+        struct DownloadManager;
+    }
+
     namespace Build
     {
         struct PreBuildInfo;
@@ -129,6 +134,8 @@ namespace vcpkg
                                               StringView git_tree,
                                               const fs::path& dot_git_dir) const;
         ExpectedS<std::string> git_show(const std::string& treeish, const fs::path& dot_git_dir) const;
+
+        const Downloads::DownloadManager& get_download_manager() const;
 
         ExpectedS<std::map<std::string, std::string, std::less<>>> git_get_local_port_treeish_map() const;
 

--- a/src/vcpkg-test/commands.cpp
+++ b/src/vcpkg-test/commands.cpp
@@ -57,6 +57,7 @@ TEST_CASE ("get_available_paths_commands works", "[commands]")
         "fetch",
         "format-manifest",
         "x-ci-clean",
+        "x-download",
         "x-history",
         "x-package-info",
         "x-vsinstances",

--- a/src/vcpkg-test/configparser.cpp
+++ b/src/vcpkg-test/configparser.cpp
@@ -366,3 +366,38 @@ TEST_CASE ("BinaryConfigParser GCS provider", "[binaryconfigparser]")
         REQUIRE(parsed.has_value());
     }
 }
+
+TEST_CASE ("AssetConfigParser azurl provider", "[assetconfigparser]")
+{
+    CHECK(create_download_manager({}));
+    CHECK(!create_download_manager("x-azurl"));
+    CHECK(!create_download_manager("x-azurl,"));
+    CHECK(create_download_manager("x-azurl,value"));
+    CHECK(create_download_manager("x-azurl,value,"));
+    CHECK(!create_download_manager("x-azurl,value,,"));
+    CHECK(!create_download_manager("x-azurl,value,,invalid"));
+    CHECK(create_download_manager("x-azurl,value,,read"));
+    CHECK(create_download_manager("x-azurl,value,,readwrite"));
+    CHECK(!create_download_manager("x-azurl,value,,readwrite,"));
+    CHECK(create_download_manager("x-azurl,https://abc/123,?foo"));
+    CHECK(create_download_manager("x-azurl,https://abc/123,foo"));
+    CHECK(create_download_manager("x-azurl,ftp://magic,none"));
+    CHECK(create_download_manager("x-azurl,ftp://magic,none"));
+    auto value_or = [](auto o, auto v) {
+        if (o)
+            return std::move(*o.get());
+        else
+            return std::move(v);
+    };
+
+    Downloads::DownloadManager empty;
+
+    CHECK(value_or(create_download_manager("x-azurl,https://abc/123,foo"), empty).internal_get_read_url_template() ==
+          "https://abc/123/<SHA>?foo");
+    CHECK(value_or(create_download_manager("x-azurl,https://abc/123/,foo"), empty).internal_get_read_url_template() ==
+          "https://abc/123/<SHA>?foo");
+    CHECK(value_or(create_download_manager("x-azurl,https://abc/123,?foo"), empty).internal_get_read_url_template() ==
+          "https://abc/123/<SHA>?foo");
+    CHECK(value_or(create_download_manager("x-azurl,https://abc/123"), empty).internal_get_read_url_template() ==
+          "https://abc/123/<SHA>");
+}

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -182,10 +182,10 @@ namespace vcpkg::Downloads
     };
 #endif
 
-    Optional<details::SplitURIView> details::split_uri_view(StringView uri)
+    ExpectedS<details::SplitURIView> details::split_uri_view(StringView uri)
     {
         auto sep = std::find(uri.begin(), uri.end(), ':');
-        if (sep == uri.end()) return nullopt;
+        if (sep == uri.end()) return Strings::concat("Error: unable to parse uri: '", uri, "'");
 
         StringView scheme(uri.begin(), sep);
         if (Strings::starts_with({sep + 1, uri.end()}, "//"))

--- a/src/vcpkg/commands.cpp
+++ b/src/vcpkg/commands.cpp
@@ -29,6 +29,7 @@
 #include <vcpkg/commands.upgrade.h>
 #include <vcpkg/commands.upload-metrics.h>
 #include <vcpkg/commands.version.h>
+#include <vcpkg/commands.xdownload.h>
 #include <vcpkg/commands.xvsinstances.h>
 #include <vcpkg/export.h>
 #include <vcpkg/help.h>
@@ -75,6 +76,7 @@ namespace vcpkg::Commands
         static const CIClean::CICleanCommand ciclean{};
         static const PortHistory::PortHistoryCommand porthistory{};
         static const X_VSInstances::VSInstancesCommand vsinstances{};
+        static const X_Download::XDownloadCommand xdownload{};
         static const FormatManifest::FormatManifestCommand format_manifest{};
         static const CIVerifyVersions::CIVerifyVersionsCommand ci_verify_versions{};
         static const AddVersion::AddVersionCommand add_version{};
@@ -98,6 +100,7 @@ namespace vcpkg::Commands
             {"x-package-info", &info},
             {"x-history", &porthistory},
             {"x-vsinstances", &vsinstances},
+            {"x-download", &xdownload},
             {"format-manifest", &format_manifest},
             {"x-ci-verify-versions", &ci_verify_versions},
             {"x-add-version", &add_version},

--- a/src/vcpkg/commands.xdownload.cpp
+++ b/src/vcpkg/commands.xdownload.cpp
@@ -1,0 +1,91 @@
+#include <vcpkg/base/downloads.h>
+#include <vcpkg/base/hash.h>
+#include <vcpkg/base/parse.h>
+#include <vcpkg/base/system.debug.h>
+#include <vcpkg/base/system.print.h>
+
+#include <vcpkg/commands.xdownload.h>
+#include <vcpkg/vcpkgcmdarguments.h>
+#include <vcpkg/vcpkgpaths.h>
+
+namespace vcpkg::Commands::X_Download
+{
+    static constexpr StringLiteral OPTION_STORE = "store";
+    static constexpr StringLiteral OPTION_URL = "url";
+    static constexpr StringLiteral OPTION_HEADER = "header";
+
+    static constexpr CommandSwitch FETCH_SWITCHES[] = {
+        {OPTION_STORE, "Indicates the file should be stored instead of fetched"},
+    };
+    static constexpr CommandMultiSetting FETCH_MULTISETTINGS[] = {
+        {OPTION_URL, "URL to download and store if missing from cache"},
+        {OPTION_HEADER, "(Not Implemented) Additional header to use when fetching from URLs"},
+    };
+
+    const CommandStructure COMMAND_STRUCTURE = {
+        Strings::format("The argument must be at least a file path and a SHA512\n%s",
+                        create_example_string("x-download <filepath> <sha512> [--url=https://...]...")),
+        2,
+        2,
+        {{FETCH_SWITCHES}, {}, FETCH_MULTISETTINGS},
+        nullptr,
+    };
+
+    static bool is_lower_hex(StringView sha)
+    {
+        return std::all_of(
+            sha.begin(), sha.end(), [](char ch) { return (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f'); });
+    }
+    static bool is_lower_sha512(StringView sha) { return sha.size() == 128 && is_lower_hex(sha); }
+
+    void perform_and_exit(const VcpkgCmdArguments& args, const VcpkgPaths& paths)
+    {
+        auto parsed = args.parse_arguments(COMMAND_STRUCTURE);
+        fs::path file = Files::combine(paths.original_cwd, fs::u8path(args.command_arguments[0]));
+        file.make_preferred();
+
+        std::string sha = Strings::ascii_to_lowercase(std::string(args.command_arguments[1]));
+        if (!is_lower_sha512(sha))
+        {
+            Checks::exit_with_message(
+                VCPKG_LINE_INFO, "Error: SHA512's must be 128 hex characters: '%s'", args.command_arguments[1]);
+        }
+
+        auto& fs = paths.get_filesystem();
+
+        // Is this a store command?
+        if (Util::Sets::contains(parsed.switches, OPTION_STORE))
+        {
+            auto s = fs.status(VCPKG_LINE_INFO, file);
+            if (s.type() != fs::file_type::regular)
+            {
+                Checks::exit_with_message(
+                    VCPKG_LINE_INFO, "Error: path was not a regular file: %s", fs::u8string(file));
+            }
+            auto hash =
+                Strings::ascii_to_lowercase(Hash::get_file_hash(VCPKG_LINE_INFO, fs, file, Hash::Algorithm::Sha512));
+            if (hash != sha) Checks::exit_with_message(VCPKG_LINE_INFO, "Error: file to store does not match hash");
+            paths.get_download_manager().put_file_to_mirror(fs, file, sha);
+            Checks::exit_success(VCPKG_LINE_INFO);
+        }
+        else
+        {
+            // Try to fetch from urls
+            auto it_urls = parsed.multisettings.find(OPTION_URL);
+            if (it_urls == parsed.multisettings.end())
+            {
+                paths.get_download_manager().download_file(fs, View<std::string>{}, file, sha);
+            }
+            else
+            {
+                paths.get_download_manager().download_file(fs, it_urls->second, file, sha);
+            }
+            Checks::exit_success(VCPKG_LINE_INFO);
+        }
+    }
+
+    void XDownloadCommand::perform_and_exit(const VcpkgCmdArguments& args, const VcpkgPaths& paths) const
+    {
+        X_Download::perform_and_exit(args, paths);
+    }
+}

--- a/src/vcpkg/install.cpp
+++ b/src/vcpkg/install.cpp
@@ -490,7 +490,14 @@ namespace vcpkg::Install
 
         Build::compute_all_abis(paths, action_plan, var_provider, status_db);
 
-        auto to_prefetch = Util::fmap(action_plan.install_actions, [](const auto& x) { return &x; });
+        std::vector<const InstallPlanAction*> to_prefetch;
+        for (auto&& action : action_plan.install_actions)
+        {
+            if (action.has_package_abi())
+            {
+                to_prefetch.push_back(&action);
+            }
+        }
         binaryprovider.prefetch(paths, to_prefetch);
 
         for (auto&& action : action_plan.install_actions)

--- a/src/vcpkg/tools.cpp
+++ b/src/vcpkg/tools.cpp
@@ -204,7 +204,7 @@ namespace vcpkg
         {
             System::print2("Downloading ", tool_name, "...\n");
             System::print2("  ", tool_data.url, " -> ", fs::u8string(tool_data.download_path), "\n");
-            Downloads::download_file(fs, tool_data.url, tool_data.download_path, tool_data.sha512);
+            paths.get_download_manager().download_file(fs, tool_data.url, tool_data.download_path, tool_data.sha512);
         }
         else
         {

--- a/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/src/vcpkg/vcpkgcmdarguments.cpp
@@ -655,6 +655,12 @@ namespace vcpkg
             dst = std::make_unique<std::string>(std::move(*val));
         }
     }
+    static void from_env(ZStringView var, Optional<std::string>& dst)
+    {
+        if (dst) return;
+
+        dst = System::get_environment_variable(var);
+    }
 
     void VcpkgCmdArguments::imbue_from_environment()
     {
@@ -672,6 +678,7 @@ namespace vcpkg
         from_env(VCPKG_ROOT_DIR_ENV, vcpkg_root_dir);
         from_env(DOWNLOADS_ROOT_DIR_ENV, downloads_root_dir);
         from_env(DEFAULT_VISUAL_STUDIO_PATH_ENV, default_visual_studio_path);
+        from_env(READWRITE_MIRROR_URL_TEMPLATE_ENV, readwrite_mirror_url_template);
 
         {
             const auto vcpkg_disable_lock = System::get_environment_variable(IGNORE_LOCK_FAILURES_ENV);
@@ -728,6 +735,11 @@ namespace vcpkg
                 args.downloads_root_dir = std::make_unique<std::string>(entry->string().to_string());
             }
 
+            if (auto entry = obj.get(READWRITE_MIRROR_URL_TEMPLATE_ENV))
+            {
+                args.readwrite_mirror_url_template = entry->string().to_string();
+            }
+
             if (obj.get(DISABLE_METRICS_ENV))
             {
                 args.disable_metrics = true;
@@ -743,6 +755,12 @@ namespace vcpkg
             if (args.downloads_root_dir)
             {
                 obj.insert(DOWNLOADS_ROOT_DIR_ENV, Json::Value::string(*args.downloads_root_dir.get()));
+            }
+
+            if (args.readwrite_mirror_url_template)
+            {
+                obj.insert(READWRITE_MIRROR_URL_TEMPLATE_ENV,
+                           Json::Value::string(*args.readwrite_mirror_url_template.get()));
             }
 
             if (args.disable_metrics)
@@ -956,6 +974,8 @@ namespace vcpkg
     constexpr StringLiteral VcpkgCmdArguments::IGNORE_LOCK_FAILURES_ENV;
 
     constexpr StringLiteral VcpkgCmdArguments::JSON_SWITCH;
+
+    constexpr StringLiteral VcpkgCmdArguments::READWRITE_MIRROR_URL_TEMPLATE_ENV;
 
     constexpr StringLiteral VcpkgCmdArguments::FEATURE_FLAGS_ENV;
     constexpr StringLiteral VcpkgCmdArguments::FEATURE_FLAGS_ARG;

--- a/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/src/vcpkg/vcpkgcmdarguments.cpp
@@ -678,7 +678,7 @@ namespace vcpkg
         from_env(VCPKG_ROOT_DIR_ENV, vcpkg_root_dir);
         from_env(DOWNLOADS_ROOT_DIR_ENV, downloads_root_dir);
         from_env(DEFAULT_VISUAL_STUDIO_PATH_ENV, default_visual_studio_path);
-        from_env(READWRITE_MIRROR_URL_TEMPLATE_ENV, readwrite_mirror_url_template);
+        from_env(ASSET_SOURCES_ENV, asset_sources_template);
 
         {
             const auto vcpkg_disable_lock = System::get_environment_variable(IGNORE_LOCK_FAILURES_ENV);
@@ -735,9 +735,9 @@ namespace vcpkg
                 args.downloads_root_dir = std::make_unique<std::string>(entry->string().to_string());
             }
 
-            if (auto entry = obj.get(READWRITE_MIRROR_URL_TEMPLATE_ENV))
+            if (auto entry = obj.get(ASSET_SOURCES_ENV))
             {
-                args.readwrite_mirror_url_template = entry->string().to_string();
+                args.asset_sources_template = entry->string().to_string();
             }
 
             if (obj.get(DISABLE_METRICS_ENV))
@@ -757,10 +757,10 @@ namespace vcpkg
                 obj.insert(DOWNLOADS_ROOT_DIR_ENV, Json::Value::string(*args.downloads_root_dir.get()));
             }
 
-            if (args.readwrite_mirror_url_template)
+            if (args.asset_sources_template)
             {
-                obj.insert(READWRITE_MIRROR_URL_TEMPLATE_ENV,
-                           Json::Value::string(*args.readwrite_mirror_url_template.get()));
+                obj.insert(ASSET_SOURCES_ENV,
+                           Json::Value::string(*args.asset_sources_template.get()));
             }
 
             if (args.disable_metrics)
@@ -975,7 +975,7 @@ namespace vcpkg
 
     constexpr StringLiteral VcpkgCmdArguments::JSON_SWITCH;
 
-    constexpr StringLiteral VcpkgCmdArguments::READWRITE_MIRROR_URL_TEMPLATE_ENV;
+    constexpr StringLiteral VcpkgCmdArguments::ASSET_SOURCES_ENV;
 
     constexpr StringLiteral VcpkgCmdArguments::FEATURE_FLAGS_ENV;
     constexpr StringLiteral VcpkgCmdArguments::FEATURE_FLAGS_ARG;

--- a/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/src/vcpkg/vcpkgcmdarguments.cpp
@@ -759,8 +759,7 @@ namespace vcpkg
 
             if (args.asset_sources_template)
             {
-                obj.insert(ASSET_SOURCES_ENV,
-                           Json::Value::string(*args.asset_sources_template.get()));
+                obj.insert(ASSET_SOURCES_ENV, Json::Value::string(*args.asset_sources_template.get()));
             }
 
             if (args.disable_metrics)

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -370,7 +370,7 @@ If you wish to silence this error and use classic mode, you can:
         downloads =
             process_output_directory(filesystem, root, args.downloads_root_dir.get(), "downloads", VCPKG_LINE_INFO);
         m_pimpl->m_download_manager =
-            create_download_manager(args.readwrite_mirror_url_template).value_or_exit(VCPKG_LINE_INFO);
+            create_download_manager(args.asset_sources_template).value_or_exit(VCPKG_LINE_INFO);
         packages =
             process_output_directory(filesystem, root, args.packages_root_dir.get(), "packages", VCPKG_LINE_INFO);
         scripts = process_input_directory(filesystem, root, args.scripts_root_dir.get(), "scripts", VCPKG_LINE_INFO);

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -1,3 +1,4 @@
+#include <vcpkg/base/downloads.h>
 #include <vcpkg/base/expected.h>
 #include <vcpkg/base/files.h>
 #include <vcpkg/base/hash.h>
@@ -6,6 +7,7 @@
 #include <vcpkg/base/system.process.h>
 #include <vcpkg/base/util.h>
 
+#include <vcpkg/binarycaching.h>
 #include <vcpkg/binaryparagraph.h>
 #include <vcpkg/build.h>
 #include <vcpkg/commands.h>
@@ -219,6 +221,8 @@ namespace vcpkg
             fs::path m_manifest_path;
             Configuration m_config;
 
+            Downloads::DownloadManager m_download_manager;
+
             FeatureFlagSettings m_ff_settings;
 
             fs::path registries_work_tree_dir;
@@ -365,6 +369,8 @@ If you wish to silence this error and use classic mode, you can:
             process_output_directory(filesystem, root, args.buildtrees_root_dir.get(), "buildtrees", VCPKG_LINE_INFO);
         downloads =
             process_output_directory(filesystem, root, args.downloads_root_dir.get(), "downloads", VCPKG_LINE_INFO);
+        m_pimpl->m_download_manager =
+            create_download_manager(args.readwrite_mirror_url_template).value_or_exit(VCPKG_LINE_INFO);
         packages =
             process_output_directory(filesystem, root, args.packages_root_dir.get(), "packages", VCPKG_LINE_INFO);
         scripts = process_input_directory(filesystem, root, args.scripts_root_dir.get(), "scripts", VCPKG_LINE_INFO);
@@ -996,6 +1002,7 @@ If you wish to silence this error and use classic mode, you can:
     }
 
     const Configuration& VcpkgPaths::get_configuration() const { return m_pimpl->m_config; }
+    const Downloads::DownloadManager& VcpkgPaths::get_download_manager() const { return m_pimpl->m_download_manager; }
 
     const Toolset& VcpkgPaths::get_toolset(const Build::PreBuildInfo& prebuildinfo) const
     {


### PR DESCRIPTION
Tool changes for https://github.com/microsoft/vcpkg/pull/13639.

See https://github.com/ras0219/vcpkg/blob/dev/roschuma/azblob-src/docs/users/config-environment.md#x_vcpkg_asset_sources for behavior docs.

The `X_VCPKG_ASSET_SOURCES` is designed to be similar to `X_VCPKG_BINARY_SOURCES` with the intent that they can share backends in the future.