### PR TITLE
[registries] Fix git registry path

### DIFF
--- a/src/vcpkg/registries.cpp
+++ b/src/vcpkg/registries.cpp
@@ -19,6 +19,7 @@ namespace
 
     using Baseline = std::map<std::string, VersionT, std::less<>>;
 
+    static const fs::path registry_default_ports_dir_name = fs::u8path("ports");
     static const fs::path registry_versions_dir_name = fs::u8path("versions");
 
     // this class is an implementation detail of `BuiltinRegistryEntry`;
@@ -656,7 +657,12 @@ namespace
         }
 
         const auto& git_tree = git_trees[it - port_versions.begin()];
-        return paths.git_checkout_object_from_remote_registry(git_tree);
+        const auto& maybe_path = paths.git_checkout_object_from_remote_registry(git_tree);
+        if (auto root = maybe_path.get())
+        {
+            return *root / registry_default_ports_dir_name / port_name;
+        }
+        return maybe_path;
     }
     // } GitRegistryEntry::RegistryEntry
 


### PR DESCRIPTION
**Summary**

Right now, when using a git registry, the path searched for a port `CONTROL` or `vcpkg.json` file is, for instance, `$HOME/.cache/vcpkg/registries/git-trees/SHA/`. I think the path searched should at least include the port name, that is, at least be `$HOME/.cache/vcpkg/registries/git-trees/SHA/PORT_NAME/`. Otherwise, each registry could only have a single port. That being said, it could be a good idea to have the same default layout than the [official vcpkg repository](https://github.com/microsoft/vcpkg), that is, search in the directory `$HOME/.cache/vcpkg/registries/git-trees/SHA/ports/PORT_NAME/`. This is what I implement here. 

I understand from the [specifications](https://github.com/microsoft/vcpkg/blob/master/docs/specifications/registries.md) that the `ports` part of the path will be configurable in `vcpkg-configuration.json` at some point via the `path:` attribute. What I implement here is a default behavior that will allow to start using git registries immediately.

**Reproduction**

Related repositories:
https://github.com/klalumiere/toyprojectvcpkg
https://github.com/klalumiere/vcpkg-overlays

```
export VCPKG_FEATURE_FLAGS=manifests,registries,versions
export VCPKG_ROOT=PATH_OF_VCPKG
git clone https://github.com/klalumiere/toyprojectvcpkg
cd toyprojectvcpkg
mkdir debug
cd debug
cmake -G Ninja ..
```

without my fix, this fails with a message 

```
[DEBUG] cmd_execute_and_stream_data() returned 0 after     2871 us
Error: while loading 49fdf3529f1a0bd69c6ef113929bd534e6b89d55:
Failed to find either a CONTROL file or vcpkg.json file.
Error: Failed to load port personaldependency from /home/klalumiere/.cache/vcpkg/registries/git-trees/49fdf3529f1a0bd69c6ef113929bd534e6b89d55
Note: Updating vcpkg by rerunning bootstrap-vcpkg may resolve this failure.
[DEBUG] /home/klalumiere/Projects/vcpkg/buildtrees/_vcpkg/src/vcpkg-tool-2021-02-24-d67989bce1043b98092ac45996a8230a059a2d7e/src/vcpkg/portfileprovider.cpp(188)
```

Listing the directory `/home/klalumiere/.cache/vcpkg/registries/git-trees/49fdf3529f1a0bd69c6ef113929bd534e6b89d55` confirmes that it contains both `personaldependency/vcpkg.json` and `ports/personaldependency/vcpkg.json`.

With my fix, the example above works fine.