### PR TITLE
Add new telemetry points for versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 
 /.idea
 /cmake-build-*
+/.vs
+/CMakeSettings.json

--- a/src/vcpkg/dependencies.cpp
+++ b/src/vcpkg/dependencies.cpp
@@ -5,6 +5,7 @@
 
 #include <vcpkg/cmakevars.h>
 #include <vcpkg/dependencies.h>
+#include <vcpkg/metrics.h>
 #include <vcpkg/packagespec.h>
 #include <vcpkg/paragraphs.h>
 #include <vcpkg/portfileprovider.h>

--- a/src/vcpkg/install.cpp
+++ b/src/vcpkg/install.cpp
@@ -915,23 +915,15 @@ namespace vcpkg::Install
             auto oprovider = PortFileProvider::make_overlay_provider(paths, extended_overlay_ports);
 
             PackageSpec toplevel{manifest_scf.core_paragraph->name, default_triplet};
-            auto maybe_install_plan =
-                Dependencies::create_versioned_install_plan(*verprovider,
-                                                            *baseprovider,
-                                                            *oprovider,
-                                                            var_provider,
-                                                            dependencies,
-                                                            manifest_scf.core_paragraph->overrides,
-                                                            toplevel,
-                                                            host_triplet);
-
-            auto pip = maybe_install_plan.get();
-            if (!pip)
-            {
-                Metrics::g_metrics.lock()->track_property("error-versioning-plan", "defined");
-                maybe_install_plan.value_or_exit(VCPKG_LINE_INFO);
-            }
-            auto& install_plan = *pip;
+            auto install_plan = Dependencies::create_versioned_install_plan(*verprovider,
+                                                                            *baseprovider,
+                                                                            *oprovider,
+                                                                            var_provider,
+                                                                            dependencies,
+                                                                            manifest_scf.core_paragraph->overrides,
+                                                                            toplevel,
+                                                                            host_triplet)
+                                    .value_or_exit(VCPKG_LINE_INFO);
 
             for (InstallPlanAction& action : install_plan.install_actions)
             {

--- a/src/vcpkg/portfileprovider.cpp
+++ b/src/vcpkg/portfileprovider.cpp
@@ -2,6 +2,7 @@
 #include <vcpkg/base/system.debug.h>
 
 #include <vcpkg/configuration.h>
+#include <vcpkg/metrics.h>
 #include <vcpkg/paragraphs.h>
 #include <vcpkg/portfileprovider.h>
 #include <vcpkg/registries.h>
@@ -193,6 +194,7 @@ namespace vcpkg::PortFileProvider
                     }
                     else
                     {
+                        Metrics::g_metrics.lock()->track_property("versioning-error-version", "defined");
                         return maybe_path.error();
                     }
                 }

--- a/src/vcpkg/sourceparagraph.cpp
+++ b/src/vcpkg/sourceparagraph.cpp
@@ -6,6 +6,7 @@
 #include <vcpkg/base/system.print.h>
 #include <vcpkg/base/util.h>
 
+#include <vcpkg/metrics.h>
 #include <vcpkg/packagespec.h>
 #include <vcpkg/platform-expression.h>
 #include <vcpkg/sourceparagraph.h>
@@ -1033,6 +1034,7 @@ namespace vcpkg
                 {
                     if (dep.constraint.type != Versions::Constraint::Type::None)
                     {
+                        Metrics::g_metrics.lock()->track_property("error-versioning-disabled", "defined");
                         return Strings::concat(
                             fs::u8string(origin),
                             " was rejected because it uses constraints and the `",
@@ -1053,6 +1055,7 @@ namespace vcpkg
 
             if (core_paragraph->overrides.size() != 0)
             {
+                Metrics::g_metrics.lock()->track_property("error-versioning-disabled", "defined");
                 return Strings::concat(fs::u8string(origin),
                                        " was rejected because it uses overrides and the `",
                                        VcpkgCmdArguments::VERSIONS_FEATURE,
@@ -1062,6 +1065,7 @@ namespace vcpkg
 
             if (core_paragraph->builtin_baseline.has_value())
             {
+                Metrics::g_metrics.lock()->track_property("error-versioning-disabled", "defined");
                 return Strings::concat(
                     fs::u8string(origin),
                     " was rejected because it uses builtin-baseline and the `",
@@ -1080,6 +1084,7 @@ namespace vcpkg
                                     return dependency.constraint.type != Versions::Constraint::Type::None;
                                 }))
                 {
+                    Metrics::g_metrics.lock()->track_property("error-versioning-no-baseline", "defined");
                     return Strings::concat(
                         fs::u8string(origin),
                         " was rejected because it uses \"version>=\" without setting a \"builtin-baseline\".\n",
@@ -1088,6 +1093,7 @@ namespace vcpkg
 
                 if (!core_paragraph->overrides.empty())
                 {
+                    Metrics::g_metrics.lock()->track_property("error-versioning-no-baseline", "defined");
                     return Strings::concat(
                         fs::u8string(origin),
                         " was rejected because it uses \"overrides\" without setting a \"builtin-baseline\".\n",


### PR DESCRIPTION
Adds telemetry for the following properties:

Name | Description
-- | --
`versioning-error-disabled` | User has declared  `builtin-baseline`, `version>=` or   `overrides` without enabling the versions feature flag
`versioning-error-no-baseline` | User has declared `version>=` or `overrides` but not a baseline
`versioning-error-baseline` | (**WIP**) User has declared an invalid baseline 
`versioning-error-version` | User has declared a constraint on a non-existing version
`manifest_version_constraint` | User has declared `version>=`

