### PR TITLE
Fix CURL filesystem deadlock with corporate proxy

### DIFF
--- a/src/vcpkg/metrics.cpp
+++ b/src/vcpkg/metrics.cpp
@@ -483,6 +483,8 @@ namespace vcpkg::Metrics
         // TODO: convert to cmd_execute_background or something.
         auto curl = System::Command("curl")
                         .string_arg("https://dc.services.visualstudio.com/v2/track")
+                        .string_arg("--max-time")
+                        .string_arg("3")
                         .string_arg("-H")
                         .string_arg("Content-Type: application/json")
                         .string_arg("-X")


### PR DESCRIPTION
Prevent CURL hanging up without timeout when connection can't be established. Creating a deadlock on the filesystem when executed behind a proxy.

As requested by @JackBoosY, this is PR https://github.com/microsoft/vcpkg/pull/16499, retargeted to vcpkg-tool. Now with longer timeout.