### PR TITLE
[osx] add support for rosetta

### DIFF
--- a/src/vcpkg/base/system.cpp
+++ b/src/vcpkg/base/system.cpp
@@ -64,7 +64,8 @@ namespace vcpkg
 #if defined(__x86_64__) || defined(_M_X64)
 #if defined(__APPLE__)
         // check for rosetta 2 emulation
-        // see docs: https://developer.apple.com/documentation/apple_silicon/about_the_rosetta_translation_environment#3616845
+        // see docs:
+        // https://developer.apple.com/documentation/apple_silicon/about_the_rosetta_translation_environment#3616845
         int is_translated = 0;
         size_t size = sizeof is_translated;
         if (sysctlbyname("sysctl.proc_translated", &is_translated, &size, nullptr, 0) == -1)

--- a/src/vcpkg/base/system.cpp
+++ b/src/vcpkg/base/system.cpp
@@ -6,14 +6,11 @@
 
 #include <ctime>
 
-using namespace vcpkg::System;
-
 #if defined(__APPLE__)
-extern "C"
-{
-    int sysctlbyname(const char*, void*, size_t*, void*, size_t);
-}
+#include <sys/sysctl.h>
 #endif
+
+using namespace vcpkg::System;
 
 namespace vcpkg
 {

--- a/src/vcpkg/base/system.cpp
+++ b/src/vcpkg/base/system.cpp
@@ -8,6 +8,13 @@
 
 using namespace vcpkg::System;
 
+#if defined(__APPLE__)
+extern "C"
+{
+    int sysctlbyname(const char*, void*, size_t*, void*, size_t);
+}
+#endif
+
 namespace vcpkg
 {
     long System::get_process_id()
@@ -55,6 +62,20 @@ namespace vcpkg
         return to_cpu_architecture(procarch).value_or_exit(VCPKG_LINE_INFO);
 #else // ^^^ defined(_WIN32) / !defined(_WIN32) vvv
 #if defined(__x86_64__) || defined(_M_X64)
+#if defined(__APPLE__)
+        // check for rosetta 2 emulation
+        // see docs: https://developer.apple.com/documentation/apple_silicon/about_the_rosetta_translation_environment#3616845
+        int is_translated = 0;
+        size_t size = sizeof is_translated;
+        if (sysctlbyname("sysctl.proc_translated", &is_translated, &size, nullptr, 0) == -1)
+        {
+            return CPUArchitecture::X64;
+        }
+        if (is_translated == 1)
+        {
+            return CPUArchitecture::ARM64;
+        }
+#endif // ^^^ macos
         return CPUArchitecture::X64;
 #elif defined(__x86__) || defined(_M_X86) || defined(__i386__)
         return CPUArchitecture::X86;

--- a/src/vcpkg/triplet.cpp
+++ b/src/vcpkg/triplet.cpp
@@ -75,8 +75,8 @@ namespace vcpkg
 
     static Triplet system_triplet()
     {
-#if defined(_WIN32)
         auto host_proc = System::get_host_processor();
+#if defined(_WIN32)
         switch (host_proc)
         {
             case System::CPUArchitecture::X86: return Triplet::from_canonical_name("x86-windows");
@@ -86,7 +86,12 @@ namespace vcpkg
             default: return Triplet::from_canonical_name("x86-windows");
         }
 #elif defined(__APPLE__)
-        return Triplet::from_canonical_name("x64-osx");
+        switch (host_proc)
+        {
+            case System::CPUArchitecture::X64: return Triplet::from_canonical_name("x64-osx");
+            case System::CPUArchitecture::ARM64: return Triplet::from_canonical_name("arm64-osx");
+            default: return Triplet::from_canonical_name("x64-osx");
+        }
 #elif defined(__FreeBSD__)
         return Triplet::from_canonical_name("x64-freebsd");
 #elif defined(__OpenBSD__)

--- a/src/vcpkg/triplet.cpp
+++ b/src/vcpkg/triplet.cpp
@@ -97,18 +97,14 @@ namespace vcpkg
 #elif defined(__OpenBSD__)
         return Triplet::from_canonical_name("x64-openbsd");
 #elif defined(__GLIBC__)
-#if defined(__aarch64__)
-        return Triplet::from_canonical_name("arm64-linux");
-#elif defined(__arm__)
-        return Triplet::from_canonical_name("arm-linux");
-#elif defined(__s390x__)
-        return Triplet::from_canonical_name("s390x-linux");
-#elif (defined(__ppc64__) || defined(__PPC64__) || defined(__ppc64le__) || defined(__PPC64LE__)) &&                    \
-    defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
-        return Triplet::from_canonical_name("ppc64le-linux");
-#else
-        return Triplet::from_canonical_name("x64-linux");
-#endif
+        switch (host_proc)
+        {
+            case System::CPUArchitecture::ARM64: return Triplet::from_canonical_name("arm64-linux");
+            case System::CPUArchitecture::ARM: return Triplet::from_canonical_name("arm-linux");
+            case System::CPUArchitecture::S390X: return Triplet::from_canonical_name("s390x-linux");
+            case System::CPUArchitecture::PPC64LE: return Triplet::from_canonical_name("ppc64le-linux");
+            case System::CPUArchitecture::X64: return Triplet::from_canonical_name("x64-linux");
+        }
 #else
         return Triplet::from_canonical_name("x64-linux-musl");
 #endif

--- a/src/vcpkg/triplet.cpp
+++ b/src/vcpkg/triplet.cpp
@@ -99,11 +99,12 @@ namespace vcpkg
 #elif defined(__GLIBC__)
         switch (host_proc)
         {
-            case System::CPUArchitecture::ARM64: return Triplet::from_canonical_name("arm64-linux");
+            case System::CPUArchitecture::X64: return Triplet::from_canonical_name("x64-linux");
             case System::CPUArchitecture::ARM: return Triplet::from_canonical_name("arm-linux");
+            case System::CPUArchitecture::ARM64: return Triplet::from_canonical_name("arm64-linux");
             case System::CPUArchitecture::S390X: return Triplet::from_canonical_name("s390x-linux");
             case System::CPUArchitecture::PPC64LE: return Triplet::from_canonical_name("ppc64le-linux");
-            case System::CPUArchitecture::X64: return Triplet::from_canonical_name("x64-linux");
+            default: return Triplet::from_canonical_name("x64-linux");
         }
 #else
         return Triplet::from_canonical_name("x64-linux-musl");

--- a/src/vcpkg/triplet.cpp
+++ b/src/vcpkg/triplet.cpp
@@ -75,40 +75,22 @@ namespace vcpkg
 
     static Triplet system_triplet()
     {
-        auto host_proc = System::get_host_processor();
 #if defined(_WIN32)
-        switch (host_proc)
-        {
-            case System::CPUArchitecture::X86: return Triplet::from_canonical_name("x86-windows");
-            case System::CPUArchitecture::X64: return Triplet::from_canonical_name("x64-windows");
-            case System::CPUArchitecture::ARM: return Triplet::from_canonical_name("arm-windows");
-            case System::CPUArchitecture::ARM64: return Triplet::from_canonical_name("arm64-windows");
-            default: return Triplet::from_canonical_name("x86-windows");
-        }
+        StringLiteral operating_system = "windows";
 #elif defined(__APPLE__)
-        switch (host_proc)
-        {
-            case System::CPUArchitecture::X64: return Triplet::from_canonical_name("x64-osx");
-            case System::CPUArchitecture::ARM64: return Triplet::from_canonical_name("arm64-osx");
-            default: return Triplet::from_canonical_name("x64-osx");
-        }
+        StringLiteral operating_system = "osx";
 #elif defined(__FreeBSD__)
-        return Triplet::from_canonical_name("x64-freebsd");
+        StringLiteral operating_system = "freebsd";
 #elif defined(__OpenBSD__)
-        return Triplet::from_canonical_name("x64-openbsd");
+        StringLiteral operating_system = "openbsd";
 #elif defined(__GLIBC__)
-        switch (host_proc)
-        {
-            case System::CPUArchitecture::X64: return Triplet::from_canonical_name("x64-linux");
-            case System::CPUArchitecture::ARM: return Triplet::from_canonical_name("arm-linux");
-            case System::CPUArchitecture::ARM64: return Triplet::from_canonical_name("arm64-linux");
-            case System::CPUArchitecture::S390X: return Triplet::from_canonical_name("s390x-linux");
-            case System::CPUArchitecture::PPC64LE: return Triplet::from_canonical_name("ppc64le-linux");
-            default: return Triplet::from_canonical_name("x64-linux");
-        }
+        StringLiteral operating_system = "linux";
 #else
-        return Triplet::from_canonical_name("x64-linux-musl");
+        StringLiteral operating_system = "linux-musl";
 #endif
+        auto host_proc = System::get_host_processor();
+        auto canonical_name = Strings::format("%s-%s", to_zstring_view(host_proc), operating_system);
+        return Triplet::from_canonical_name(std::move(canonical_name));
     }
 
     Triplet default_triplet(const VcpkgCmdArguments& args)


### PR DESCRIPTION
When running an x64 vcpkg binary on arm64, we should still have host processor be arm64

I'm not sure this is the way we should do this, but if we do decide to go this way this is how we should do it.

Fixes microsoft/vcpkg#16504