### PR TITLE
Enable build scripts to know if we are in manifest mode

### DIFF
--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -684,6 +684,7 @@ namespace vcpkg::Build
             {"_VCPKG_DOWNLOAD_TOOL", to_string(action.build_options.download_tool)},
             {"_VCPKG_EDITABLE", Util::Enum::to_bool(action.build_options.editable) ? "1" : "0"},
             {"_VCPKG_NO_DOWNLOADS", !Util::Enum::to_bool(action.build_options.allow_downloads) ? "1" : "0"},
+            {"VCPKG_MANIFEST_MODE", args.manifest_root_dir ? "1" : "0"},
         };
 
         for (auto cmake_arg : args.cmake_args)


### PR DESCRIPTION
Required for https://github.com/microsoft/vcpkg/pull/16613 to work, otherwise it does nothing.

I did not see any other way to determine if manifests were being used without making this code change. If there is a way for https://github.com/microsoft/vcpkg/pull/16613 to work without this code change, please let me know.