### PR TITLE
Add CUDA 11.1 and 11.2 to KEEP_ENV_VARS defaults

### DIFF
--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -313,6 +313,8 @@ namespace vcpkg
             L"CUDA_PATH_V10_1",
             L"CUDA_PATH_V10_2",
             L"CUDA_PATH_V11_0",
+            L"CUDA_PATH_V11_1",
+            L"CUDA_PATH_V11_2",
             L"CUDA_TOOLKIT_ROOT_DIR",
             // Environmental variable generated automatically by CUDA after installation
             L"NVCUDASAMPLES_ROOT",


### PR DESCRIPTION
vcpkg right now can't build CUDA ports with version 11.1 and 11.2, since the associated environment variables aren't being forwarded.