### PR TITLE
[x-add-versions] Perform atomic replacement of versioning files

### DIFF
--- a/src/tls12-download.c
+++ b/src/tls12-download.c
@@ -148,7 +148,7 @@ static void __declspec(noreturn) abort_api_failure(const HANDLE std_out, const w
 
 #ifndef NDEBUG
 int main()
-#else  // ^^^ debug // !debug vvv
+#else // ^^^ debug // !debug vvv
 int __stdcall entry()
 #endif // ^^^ !debug
 {

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -336,7 +336,7 @@ namespace vcpkg::Files
 
             return fs::file_status(ft, permissions);
 
-#else  // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
+#else // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
             auto result = follow_symlinks ? fs::stdfs::status(p, ec) : fs::stdfs::symlink_status(p, ec);
             // libstdc++ doesn't correctly not-set ec on nonexistent paths
             if (ec.value() == ENOENT || ec.value() == ENOTDIR)
@@ -410,7 +410,7 @@ namespace vcpkg::Files
             }
             ec.clear();
             return;
-#else  // ^^^ defined(_WIN32) && !VCPKG_USE_STD_FILESYSTEM // !defined(_WIN32) || VCPKG_USE_STD_FILESYSTEM vvv
+#else // ^^^ defined(_WIN32) && !VCPKG_USE_STD_FILESYSTEM // !defined(_WIN32) || VCPKG_USE_STD_FILESYSTEM vvv
             return fs::stdfs::copy_symlink(oldpath, newpath, ec);
 #endif // ^^^ !defined(_WIN32) || VCPKG_USE_STD_FILESYSTEM
         }
@@ -433,7 +433,7 @@ namespace vcpkg::Files
             {
                 ec.assign(GetLastError(), std::system_category());
             }
-#else  // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
+#else // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
             struct stat s;
             if (lstat(path.c_str(), &s))
             {
@@ -900,7 +900,7 @@ namespace vcpkg::Files
                 auto written_bytes = sendfile(o_fd, i_fd, &bytes, info.st_size);
 #elif defined(__APPLE__)
                 auto written_bytes = fcopyfile(i_fd, o_fd, 0, COPYFILE_ALL);
-#else  // ^^^ defined(__APPLE__) // !(defined(__APPLE__) || defined(__linux__)) vvv
+#else // ^^^ defined(__APPLE__) // !(defined(__APPLE__) || defined(__linux__)) vvv
                 ssize_t written_bytes = 0;
                 {
                     constexpr std::size_t buffer_length = 4096;
@@ -997,7 +997,7 @@ namespace vcpkg::Files
                         {
                             ec.assign(GetLastError(), std::system_category());
                         }
-#else  // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
+#else // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
                         if (rmdir(current_path.c_str()))
                         {
                             ec.assign(errno, std::system_category());
@@ -1026,7 +1026,7 @@ namespace vcpkg::Files
                             ec.assign(GetLastError(), std::system_category());
                         }
                     }
-#else  // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
+#else // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
                     else
                     {
                         if (unlink(current_path.c_str()))
@@ -1176,7 +1176,7 @@ namespace vcpkg::Files
             FILE* f = nullptr;
 #if defined(_WIN32)
             auto err = _wfopen_s(&f, file_path.native().c_str(), L"wb");
-#else  // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
+#else // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
             f = fopen(file_path.native().c_str(), "wb");
             int err = f != nullptr ? 0 : 1;
 #endif // ^^^ !defined(_WIN32)
@@ -1222,7 +1222,7 @@ namespace vcpkg::Files
 #if defined(_WIN32)
             // absolute was called system_complete in experimental filesystem
             return fs::stdfs::system_complete(path, ec);
-#else  // ^^^ defined(_WIN32) / !defined(_WIN32) vvv
+#else // ^^^ defined(_WIN32) / !defined(_WIN32) vvv
             if (path.is_absolute())
             {
                 return path;
@@ -1393,7 +1393,7 @@ namespace vcpkg::Files
         {
 #if defined(_WIN32)
             static constexpr wchar_t const* EXTS[] = {L".cmd", L".exe", L".bat"};
-#else  // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
+#else // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
             static constexpr char const* EXTS[] = {""};
 #endif // ^^^!defined(_WIN32)
             auto paths = Strings::split_paths(System::get_environment_variable("PATH").value_or_exit(VCPKG_LINE_INFO));
@@ -1455,7 +1455,7 @@ namespace vcpkg::Files
         {
             return lhs / rhs;
         }
-#else  // ^^^ unix // windows vvv
+#else // ^^^ unix // windows vvv
         auto rhs_root_directory = rhs.root_directory();
         auto rhs_root_name = rhs.root_name();
 

--- a/src/vcpkg/base/system.cpp
+++ b/src/vcpkg/base/system.cpp
@@ -114,7 +114,7 @@ namespace vcpkg
         Checks::check_exit(VCPKG_LINE_INFO, sz2 + 1 == sz);
         ret.pop_back();
         return Strings::to_utf8(ret.c_str());
-#else  // ^^^ defined(_WIN32) / !defined(_WIN32) vvv
+#else // ^^^ defined(_WIN32) / !defined(_WIN32) vvv
         auto v = getenv(varname.c_str());
         if (!v) return nullopt;
         return std::string(v);
@@ -137,7 +137,7 @@ namespace vcpkg
         }
 
         Checks::check_exit(VCPKG_LINE_INFO, exit_code != 0);
-#else  // ^^^ defined(_WIN32) / !defined(_WIN32) vvv
+#else // ^^^ defined(_WIN32) / !defined(_WIN32) vvv
         if (auto v = value.get())
         {
             Checks::check_exit(VCPKG_LINE_INFO, setenv(varname.c_str(), v->c_str(), 1) == 0);
@@ -263,7 +263,7 @@ namespace vcpkg
         ret.pop_back(); // remove extra trailing null byte
         return Strings::to_utf8(ret);
     }
-#else  // ^^^ defined(_WIN32) / !defined(_WIN32) vvv
+#else // ^^^ defined(_WIN32) / !defined(_WIN32) vvv
     Optional<std::string> System::get_registry_string(void*, StringView, StringView) { return nullopt; }
 #endif // defined(_WIN32)
 

--- a/src/vcpkg/commands.add-version.cpp
+++ b/src/vcpkg/commands.add-version.cpp
@@ -89,61 +89,26 @@ namespace
                                     const std::map<std::string, VersionT, std::less<>>& baseline_map,
                                     const fs::path& output_path)
     {
-        auto backup_path = fs::u8path(Strings::concat(fs::u8string(output_path), ".backup"));
-        if (fs.exists(output_path))
-        {
-            fs.rename(output_path, backup_path, VCPKG_LINE_INFO);
-            fs.remove(output_path, VCPKG_LINE_INFO);
-        }
-
+        auto new_path = output_path;
+        new_path += fs::u8path(".tmp");
         std::error_code ec;
+        fs.create_directories(output_path.parent_path(), VCPKG_LINE_INFO);
         fs.write_contents(
-            output_path, Json::stringify(serialize_baseline(baseline_map), Json::JsonStyle::with_spaces(2)), ec);
-        if (ec)
-        {
-            System::printf(
-                System::Color::error, "Error: Couldn't write baseline file to %s.", fs::u8string(output_path));
-            if (fs.exists(backup_path))
-            {
-                fs.rename(backup_path, output_path, VCPKG_LINE_INFO);
-            }
-            Checks::exit_fail(VCPKG_LINE_INFO);
-        }
-        if (fs.exists(backup_path))
-        {
-            fs.remove(backup_path, VCPKG_LINE_INFO);
-        }
+            new_path, Json::stringify(serialize_baseline(baseline_map), Json::JsonStyle::with_spaces(2)), VCPKG_LINE_INFO);
+        fs.rename(new_path, output_path, VCPKG_LINE_INFO);
     }
 
     static void write_versions_file(Files::Filesystem& fs,
                                     const std::vector<VersionGitTree>& versions,
                                     const fs::path& output_path)
     {
-        auto backup_path = fs::u8path(Strings::concat(fs::u8string(output_path), ".backup"));
-        if (fs.exists(output_path))
-        {
-            fs.rename(output_path, backup_path, VCPKG_LINE_INFO);
-            fs.remove(output_path, VCPKG_LINE_INFO);
-        }
-
+        auto new_path = output_path;
+        new_path += fs::u8path(".tmp");
         std::error_code ec;
         fs.create_directories(output_path.parent_path(), VCPKG_LINE_INFO);
         fs.write_contents(
-            output_path, Json::stringify(serialize_versions(versions), Json::JsonStyle::with_spaces(2)), ec);
-        if (ec)
-        {
-            System::printf(
-                System::Color::error, "Error: Couldn't write versions file to %s.", fs::u8string(output_path));
-            if (fs.exists(backup_path))
-            {
-                fs.rename(backup_path, output_path, VCPKG_LINE_INFO);
-            }
-            Checks::exit_fail(VCPKG_LINE_INFO);
-        }
-        if (fs.exists(backup_path))
-        {
-            fs.remove(backup_path, VCPKG_LINE_INFO);
-        }
+            new_path, Json::stringify(serialize_versions(versions), Json::JsonStyle::with_spaces(2)), VCPKG_LINE_INFO);
+        fs.rename(new_path, output_path, VCPKG_LINE_INFO);
     }
 
     static void update_baseline_version(const VcpkgPaths& paths,

--- a/src/vcpkg/commands.add-version.cpp
+++ b/src/vcpkg/commands.add-version.cpp
@@ -93,8 +93,9 @@ namespace
         new_path += fs::u8path(".tmp");
         std::error_code ec;
         fs.create_directories(output_path.parent_path(), VCPKG_LINE_INFO);
-        fs.write_contents(
-            new_path, Json::stringify(serialize_baseline(baseline_map), Json::JsonStyle::with_spaces(2)), VCPKG_LINE_INFO);
+        fs.write_contents(new_path,
+                          Json::stringify(serialize_baseline(baseline_map), Json::JsonStyle::with_spaces(2)),
+                          VCPKG_LINE_INFO);
         fs.rename(new_path, output_path, VCPKG_LINE_INFO);
     }
 

--- a/src/vcpkg/commands.integrate.cpp
+++ b/src/vcpkg/commands.integrate.cpp
@@ -519,7 +519,7 @@ With a project open, go to Tools->NuGet Package Manager->Package Manager Console
         table.format("vcpkg integrate remove", "Remove user-wide integration");
         table.format("vcpkg integrate project", "Generate a referencing nuget package for individual VS project use");
         table.format("vcpkg integrate powershell", "Enable PowerShell tab-completion");
-#else  // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
+#else // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
         table.format("vcpkg integrate install", "Make installed packages available user-wide");
         table.format("vcpkg integrate remove", "Remove user-wide integration");
         table.format("vcpkg integrate bash", "Enable bash tab-completion");

--- a/src/vcpkg/metrics.cpp
+++ b/src/vcpkg/metrics.cpp
@@ -432,7 +432,7 @@ namespace vcpkg::Metrics
         if (request) WinHttpCloseHandle(request);
         if (connect) WinHttpCloseHandle(connect);
         if (session) WinHttpCloseHandle(session);
-#else  // ^^^ _WIN32 // !_WIN32 vvv
+#else // ^^^ _WIN32 // !_WIN32 vvv
         (void)payload;
 #endif // ^^^ !_WIN32
     }


### PR DESCRIPTION
Otherwise, we hit issues like:
```
$ ./vcpkg x-add-version azure-kinect-sensor-sdk --overwrite-version
error removing file: /home/codespace/workspace/vcpkg/versions/a-/azure-kinect-sensor-sdk.json: No such file or directory
```
where afterwards the backup file exists and the original file has been removed. This is also just generally more "correct" and guards against process termination during the file write.