### PR TITLE
[supports] Add `native` identifier expression and x-check-support command

### DIFF
--- a/include/vcpkg-test/mockcmakevarprovider.h
+++ b/include/vcpkg-test/mockcmakevarprovider.h
@@ -19,11 +19,13 @@ namespace vcpkg::Test
         }
 
         void load_tag_vars(Span<const FullPackageSpec> specs,
-                           const PortFileProvider::PortFileProvider& port_provider) const override
+                           const PortFileProvider::PortFileProvider& port_provider,
+                           Triplet host_triplet) const override
         {
             for (auto&& spec : specs)
                 tag_vars.emplace(spec.package_spec, SMap{});
             (void)(port_provider);
+            (void)(host_triplet);
         }
 
         Optional<const std::unordered_map<std::string, std::string>&> get_generic_triplet_vars(

--- a/include/vcpkg/cmakevars.h
+++ b/include/vcpkg/cmakevars.h
@@ -28,10 +28,12 @@ namespace vcpkg::CMakeVars
         virtual void load_dep_info_vars(Span<const PackageSpec> specs) const = 0;
 
         virtual void load_tag_vars(Span<const FullPackageSpec> specs,
-                                   const PortFileProvider::PortFileProvider& port_provider) const = 0;
+                                   const PortFileProvider::PortFileProvider& port_provider,
+                                   Triplet host_triplet) const = 0;
 
         void load_tag_vars(const vcpkg::Dependencies::ActionPlan& action_plan,
-                           const PortFileProvider::PortFileProvider& port_provider) const;
+                           const PortFileProvider::PortFileProvider& port_provider,
+                           Triplet host_triplet) const;
     };
 
     std::unique_ptr<CMakeVarProvider> make_triplet_cmake_var_provider(const vcpkg::VcpkgPaths& paths);

--- a/include/vcpkg/commands.check-support.h
+++ b/include/vcpkg/commands.check-support.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <vcpkg/commands.interface.h>
+
+namespace vcpkg::Commands::CheckSupport
+{
+    void perform_and_exit(const VcpkgCmdArguments& args,
+                          const VcpkgPaths& paths,
+                          Triplet default_triplet,
+                          Triplet host_triplet);
+
+    struct CheckSupportCommand : TripletCommand
+    {
+        void perform_and_exit(const VcpkgCmdArguments& args,
+                              const VcpkgPaths& paths,
+                              Triplet default_triplet,
+                              Triplet host_triplet) const override;
+    };
+}

--- a/include/vcpkg/commands.setinstalled.h
+++ b/include/vcpkg/commands.setinstalled.h
@@ -14,7 +14,8 @@ namespace vcpkg::Commands::SetInstalled
                              const CMakeVars::CMakeVarProvider& cmake_vars,
                              Dependencies::ActionPlan action_plan,
                              DryRun dry_run,
-                             const Optional<fs::path>& pkgsconfig_path);
+                             const Optional<fs::path>& pkgsconfig_path,
+                             Triplet host_triplet);
     void perform_and_exit(const VcpkgCmdArguments& args,
                           const VcpkgPaths& paths,
                           Triplet default_triplet,

--- a/include/vcpkg/dependencies.h
+++ b/include/vcpkg/dependencies.h
@@ -163,7 +163,7 @@ namespace vcpkg::Dependencies
     /// <param name="status_db">Status of installed packages in the current environment.</param>
     ActionPlan create_feature_install_plan(const PortFileProvider::PortFileProvider& provider,
                                            const CMakeVars::CMakeVarProvider& var_provider,
-                                           const std::vector<FullPackageSpec>& specs,
+                                           View<FullPackageSpec> specs,
                                            const StatusParagraphs& status_db,
                                            const CreateInstallPlanOptions& options = {Triplet{}});
 

--- a/src/vcpkg-test/commands.cpp
+++ b/src/vcpkg-test/commands.cpp
@@ -78,6 +78,7 @@ TEST_CASE ("get_available_commands_type_a works", "[commands]")
         "build-external",
         "export",
         "depend-info",
+        "x-check-support"
         });
 }
 // clang-format on

--- a/src/vcpkg-test/plan.cpp
+++ b/src/vcpkg-test/plan.cpp
@@ -786,9 +786,10 @@ TEST_CASE ("install with default features", "[plan]")
     PortFileProvider::MapPortFileProvider map_port{spec_map.map};
     MockCMakeVarProvider var_provider;
 
-    std::vector<FullPackageSpec> full_package_specs;
-    full_package_specs.push_back(FullPackageSpec{a_spec, {"0"}});
-    full_package_specs.push_back(FullPackageSpec{b_spec, {"core"}});
+    std::vector<FullPackageSpec> full_package_specs{
+        FullPackageSpec{a_spec, {"0"}},
+        FullPackageSpec{b_spec, {"core"}},
+    };
 
     auto install_plan = Dependencies::create_feature_install_plan(
         map_port, var_provider, full_package_specs, StatusParagraphs(std::move(status_db)));

--- a/src/vcpkg-test/plan.cpp
+++ b/src/vcpkg-test/plan.cpp
@@ -99,12 +99,10 @@ TEST_CASE ("multiple install scheme", "[plan]")
     PortFileProvider::MapPortFileProvider map_port(spec_map.map);
     MockCMakeVarProvider var_provider;
 
-    std::vector<FullPackageSpec> full_package_specs{FullPackageSpec{spec_a}, FullPackageSpec{spec_b}, FullPackageSpec{spec_c}};
+    std::vector<FullPackageSpec> full_package_specs{
+        FullPackageSpec{spec_a}, FullPackageSpec{spec_b}, FullPackageSpec{spec_c}};
     auto install_plan = Dependencies::create_feature_install_plan(
-        map_port,
-        var_provider,
-        full_package_specs,
-        StatusParagraphs(std::move(status_paragraphs)));
+        map_port, var_provider, full_package_specs, StatusParagraphs(std::move(status_paragraphs)));
 
     auto iterator_pos = [&](const PackageSpec& spec) {
         auto it = std::find_if(install_plan.install_actions.begin(),
@@ -403,10 +401,8 @@ TEST_CASE ("basic feature test 8", "[plan]")
     MockCMakeVarProvider var_provider;
 
     std::vector<FullPackageSpec> full_package_specs{spec_c_64, spec_a_86, spec_a_64, spec_c_86};
-    auto plan = Dependencies::create_feature_install_plan(map_port,
-                                                          var_provider,
-                                                          full_package_specs,
-                                                          StatusParagraphs(std::move(status_paragraphs)));
+    auto plan = Dependencies::create_feature_install_plan(
+        map_port, var_provider, full_package_specs, StatusParagraphs(std::move(status_paragraphs)));
 
     remove_plan_check(plan.remove_actions.at(0), "a", Test::X64_WINDOWS);
     remove_plan_check(plan.remove_actions.at(1), "a");
@@ -567,10 +563,7 @@ TEST_CASE ("do not install default features of dependency test 1", "[plan]")
     full_package_specs.push_back(spec_a.value_or_exit(VCPKG_LINE_INFO));
     full_package_specs.push_back(spec_b.value_or_exit(VCPKG_LINE_INFO));
     auto install_plan = Dependencies::create_feature_install_plan(
-        map_port,
-        var_provider,
-        full_package_specs,
-        StatusParagraphs(std::move(status_paragraphs)));
+        map_port, var_provider, full_package_specs, StatusParagraphs(std::move(status_paragraphs)));
 
     // Expect "a" to get installed and defaults of "b" through the dependency,
     // as no explicit features of "b" are installed by the user.
@@ -599,10 +592,7 @@ TEST_CASE ("install default features of dependency test 2", "[plan]")
     full_package_specs.push_back(spec_a.value_or_exit(VCPKG_LINE_INFO));
     full_package_specs.push_back(spec_b.value_or_exit(VCPKG_LINE_INFO));
     auto install_plan = Dependencies::create_feature_install_plan(
-        map_port,
-        var_provider,
-        full_package_specs,
-        StatusParagraphs(std::move(status_paragraphs)));
+        map_port, var_provider, full_package_specs, StatusParagraphs(std::move(status_paragraphs)));
 
     // Expect "a" to get installed and defaults of "b" through the dependency
     REQUIRE(install_plan.size() == 2);
@@ -800,11 +790,8 @@ TEST_CASE ("install with default features", "[plan]")
     full_package_specs.push_back(FullPackageSpec{a_spec, {"0"}});
     full_package_specs.push_back(FullPackageSpec{b_spec, {"core"}});
 
-    auto install_plan =
-        Dependencies::create_feature_install_plan(map_port,
-                                                  var_provider,
-                                                  full_package_specs,
-                                                  StatusParagraphs(std::move(status_db)));
+    auto install_plan = Dependencies::create_feature_install_plan(
+        map_port, var_provider, full_package_specs, StatusParagraphs(std::move(status_db)));
 
     // Install "a" and indicate that "b" should not install default features
     REQUIRE(install_plan.size() == 3);

--- a/src/vcpkg-test/plan.cpp
+++ b/src/vcpkg-test/plan.cpp
@@ -72,8 +72,9 @@ TEST_CASE ("basic install scheme", "[plan]")
     PortFileProvider::MapPortFileProvider map_port(spec_map.map);
     MockCMakeVarProvider var_provider;
 
+    auto fullspec_a = FullPackageSpec{spec_a, {}};
     auto install_plan = Dependencies::create_feature_install_plan(
-        map_port, var_provider, {FullPackageSpec{spec_a, {}}}, StatusParagraphs(std::move(status_paragraphs)));
+        map_port, var_provider, {&fullspec_a, 1}, StatusParagraphs(std::move(status_paragraphs)));
 
     REQUIRE(install_plan.size() == 3);
     REQUIRE(install_plan.install_actions.at(0).spec.name() == "c");
@@ -98,10 +99,11 @@ TEST_CASE ("multiple install scheme", "[plan]")
     PortFileProvider::MapPortFileProvider map_port(spec_map.map);
     MockCMakeVarProvider var_provider;
 
+    std::vector<FullPackageSpec> full_package_specs{FullPackageSpec{spec_a}, FullPackageSpec{spec_b}, FullPackageSpec{spec_c}};
     auto install_plan = Dependencies::create_feature_install_plan(
         map_port,
         var_provider,
-        {FullPackageSpec{spec_a}, FullPackageSpec{spec_b}, FullPackageSpec{spec_c}},
+        full_package_specs,
         StatusParagraphs(std::move(status_paragraphs)));
 
     auto iterator_pos = [&](const PackageSpec& spec) {
@@ -144,7 +146,7 @@ TEST_CASE ("existing package scheme", "[plan]")
     MockCMakeVarProvider var_provider;
 
     auto install_plan = Dependencies::create_feature_install_plan(
-        map_port, var_provider, {spec_a}, StatusParagraphs(std::move(status_paragraphs)));
+        map_port, var_provider, {&spec_a, 1}, StatusParagraphs(std::move(status_paragraphs)));
 
     REQUIRE(install_plan.size() == 1);
     const auto p = &install_plan.already_installed.at(0);
@@ -165,7 +167,7 @@ TEST_CASE ("user requested package scheme", "[plan]")
     MockCMakeVarProvider var_provider;
 
     const auto install_plan = Dependencies::create_feature_install_plan(
-        map_port, var_provider, {spec_a}, StatusParagraphs(std::move(status_paragraphs)));
+        map_port, var_provider, {&spec_a, 1}, StatusParagraphs(std::move(status_paragraphs)));
 
     REQUIRE(install_plan.size() == 2);
     const auto p = &install_plan.install_actions.at(0);
@@ -200,8 +202,10 @@ TEST_CASE ("long install scheme", "[plan]")
 
     PortFileProvider::MapPortFileProvider map_port(spec_map.map);
     MockCMakeVarProvider var_provider;
+
+    auto fullspec_a = FullPackageSpec{spec_a};
     auto plan = Dependencies::create_feature_install_plan(
-        map_port, var_provider, {FullPackageSpec{spec_a}}, StatusParagraphs(std::move(status_paragraphs)));
+        map_port, var_provider, {&fullspec_a, 1}, StatusParagraphs(std::move(status_paragraphs)));
 
     auto& install_plan = plan.install_actions;
     REQUIRE(install_plan.size() == 8);
@@ -230,7 +234,7 @@ TEST_CASE ("basic feature test 1", "[plan]")
     MockCMakeVarProvider var_provider;
 
     auto plan = Dependencies::create_feature_install_plan(
-        map_port, var_provider, {spec_a}, StatusParagraphs(std::move(status_paragraphs)));
+        map_port, var_provider, {&spec_a, 1}, StatusParagraphs(std::move(status_paragraphs)));
 
     REQUIRE(plan.size() == 4);
     remove_plan_check(plan.remove_actions.at(0), "a");
@@ -252,7 +256,7 @@ TEST_CASE ("basic feature test 2", "[plan]")
     MockCMakeVarProvider var_provider;
 
     auto plan = Dependencies::create_feature_install_plan(
-        map_port, var_provider, {spec_a}, StatusParagraphs(std::move(status_paragraphs)));
+        map_port, var_provider, {&spec_a, 1}, StatusParagraphs(std::move(status_paragraphs)));
 
     auto& install_plan = plan.install_actions;
     REQUIRE(install_plan.size() == 2);
@@ -274,8 +278,9 @@ TEST_CASE ("basic feature test 3", "[plan]")
     PortFileProvider::MapPortFileProvider map_port{spec_map.map};
     MockCMakeVarProvider var_provider;
 
+    std::vector<FullPackageSpec> full_package_specs{spec_c, spec_a};
     auto plan = Dependencies::create_feature_install_plan(
-        map_port, var_provider, {spec_c, spec_a}, StatusParagraphs(std::move(status_paragraphs)));
+        map_port, var_provider, full_package_specs, StatusParagraphs(std::move(status_paragraphs)));
 
     REQUIRE(plan.size() == 4);
     remove_plan_check(plan.remove_actions.at(0), "a");
@@ -301,7 +306,7 @@ TEST_CASE ("basic feature test 4", "[plan]")
     MockCMakeVarProvider var_provider;
 
     auto install_plan = Dependencies::create_feature_install_plan(
-        map_port, var_provider, {spec_c}, StatusParagraphs(std::move(status_paragraphs)));
+        map_port, var_provider, {&spec_c, 1}, StatusParagraphs(std::move(status_paragraphs)));
 
     REQUIRE(install_plan.size() == 1);
     features_check(install_plan.install_actions.at(0), "c", {"core"});
@@ -321,7 +326,7 @@ TEST_CASE ("basic feature test 5", "[plan]")
     MockCMakeVarProvider var_provider;
 
     auto install_plan = Dependencies::create_feature_install_plan(
-        map_port, var_provider, {spec_a}, StatusParagraphs(std::move(status_paragraphs)));
+        map_port, var_provider, {&spec_a, 1}, StatusParagraphs(std::move(status_paragraphs)));
 
     REQUIRE(install_plan.size() == 2);
     features_check(install_plan.install_actions.at(0), "b", {"core", "b2"});
@@ -340,8 +345,9 @@ TEST_CASE ("basic feature test 6", "[plan]")
     PortFileProvider::MapPortFileProvider map_port{spec_map.map};
     MockCMakeVarProvider var_provider;
 
+    std::vector<FullPackageSpec> full_package_specs{spec_a, spec_b};
     auto plan = Dependencies::create_feature_install_plan(
-        map_port, var_provider, {spec_a, spec_b}, StatusParagraphs(std::move(status_paragraphs)));
+        map_port, var_provider, full_package_specs, StatusParagraphs(std::move(status_paragraphs)));
 
     REQUIRE(plan.size() == 3);
     remove_plan_check(plan.remove_actions.at(0), "b");
@@ -365,7 +371,7 @@ TEST_CASE ("basic feature test 7", "[plan]")
     MockCMakeVarProvider var_provider;
 
     auto plan = Dependencies::create_feature_install_plan(
-        map_port, var_provider, {spec_b}, StatusParagraphs(std::move(status_paragraphs)));
+        map_port, var_provider, {&spec_b, 1}, StatusParagraphs(std::move(status_paragraphs)));
 
     REQUIRE(plan.size() == 5);
     remove_plan_check(plan.remove_actions.at(0), "x");
@@ -396,9 +402,10 @@ TEST_CASE ("basic feature test 8", "[plan]")
     PortFileProvider::MapPortFileProvider map_port{spec_map.map};
     MockCMakeVarProvider var_provider;
 
+    std::vector<FullPackageSpec> full_package_specs{spec_c_64, spec_a_86, spec_a_64, spec_c_86};
     auto plan = Dependencies::create_feature_install_plan(map_port,
                                                           var_provider,
-                                                          {spec_c_64, spec_a_86, spec_a_64, spec_c_86},
+                                                          full_package_specs,
                                                           StatusParagraphs(std::move(status_paragraphs)));
 
     remove_plan_check(plan.remove_actions.at(0), "a", Test::X64_WINDOWS);
@@ -428,7 +435,7 @@ TEST_CASE ("install all features test", "[plan]")
 
     auto install_plan = Dependencies::create_feature_install_plan(map_port,
                                                                   var_provider,
-                                                                  {install_specs.value_or_exit(VCPKG_LINE_INFO)},
+                                                                  {&install_specs.value_or_exit(VCPKG_LINE_INFO), 1},
                                                                   StatusParagraphs(std::move(status_paragraphs)));
 
     REQUIRE(install_plan.size() == 1);
@@ -451,7 +458,7 @@ TEST_CASE ("install default features test 1", "[plan]")
 
     auto install_plan = Dependencies::create_feature_install_plan(map_port,
                                                                   var_provider,
-                                                                  {install_specs.value_or_exit(VCPKG_LINE_INFO)},
+                                                                  {&install_specs.value_or_exit(VCPKG_LINE_INFO), 1},
                                                                   StatusParagraphs(std::move(status_paragraphs)));
 
     // Expect the default feature "1" to be installed, but not "0"
@@ -479,7 +486,7 @@ TEST_CASE ("install default features test 2", "[plan]")
 
     auto install_plan = Dependencies::create_feature_install_plan(map_port,
                                                                   var_provider,
-                                                                  {install_specs.value_or_exit(VCPKG_LINE_INFO)},
+                                                                  {&install_specs.value_or_exit(VCPKG_LINE_INFO), 1},
                                                                   StatusParagraphs(std::move(status_paragraphs)));
 
     // Expect "a" to get removed for rebuild and then installed with default
@@ -505,7 +512,7 @@ TEST_CASE ("install default features test 3", "[plan]")
 
     auto install_plan = Dependencies::create_feature_install_plan(map_port,
                                                                   var_provider,
-                                                                  {install_specs.value_or_exit(VCPKG_LINE_INFO)},
+                                                                  {&install_specs.value_or_exit(VCPKG_LINE_INFO), 1},
                                                                   StatusParagraphs(std::move(status_paragraphs)));
 
     // Expect the default feature not to get installed.
@@ -530,7 +537,7 @@ TEST_CASE ("install default features of dependency test 1", "[plan]")
 
     auto install_plan = Dependencies::create_feature_install_plan(map_port,
                                                                   var_provider,
-                                                                  {install_specs.value_or_exit(VCPKG_LINE_INFO)},
+                                                                  {&install_specs.value_or_exit(VCPKG_LINE_INFO), 1},
                                                                   StatusParagraphs(std::move(status_paragraphs)));
 
     // Expect "a" to get installed and defaults of "b" through the dependency,
@@ -556,10 +563,13 @@ TEST_CASE ("do not install default features of dependency test 1", "[plan]")
     PortFileProvider::MapPortFileProvider map_port{spec_map.map};
     MockCMakeVarProvider var_provider;
 
+    std::vector<FullPackageSpec> full_package_specs;
+    full_package_specs.push_back(spec_a.value_or_exit(VCPKG_LINE_INFO));
+    full_package_specs.push_back(spec_b.value_or_exit(VCPKG_LINE_INFO));
     auto install_plan = Dependencies::create_feature_install_plan(
         map_port,
         var_provider,
-        {spec_a.value_or_exit(VCPKG_LINE_INFO), spec_b.value_or_exit(VCPKG_LINE_INFO)},
+        full_package_specs,
         StatusParagraphs(std::move(status_paragraphs)));
 
     // Expect "a" to get installed and defaults of "b" through the dependency,
@@ -585,10 +595,13 @@ TEST_CASE ("install default features of dependency test 2", "[plan]")
     PortFileProvider::MapPortFileProvider map_port{spec_map.map};
     MockCMakeVarProvider var_provider;
 
+    std::vector<FullPackageSpec> full_package_specs;
+    full_package_specs.push_back(spec_a.value_or_exit(VCPKG_LINE_INFO));
+    full_package_specs.push_back(spec_b.value_or_exit(VCPKG_LINE_INFO));
     auto install_plan = Dependencies::create_feature_install_plan(
         map_port,
         var_provider,
-        {spec_a.value_or_exit(VCPKG_LINE_INFO), spec_b.value_or_exit(VCPKG_LINE_INFO)},
+        full_package_specs,
         StatusParagraphs(std::move(status_paragraphs)));
 
     // Expect "a" to get installed and defaults of "b" through the dependency
@@ -617,7 +630,7 @@ TEST_CASE ("do not install default features of existing dependency", "[plan]")
 
     auto install_plan = Dependencies::create_feature_install_plan(map_port,
                                                                   var_provider,
-                                                                  {install_specs.value_or_exit(VCPKG_LINE_INFO)},
+                                                                  {&install_specs.value_or_exit(VCPKG_LINE_INFO), 1},
                                                                   StatusParagraphs(std::move(status_paragraphs)));
 
     // Expect "a" to get installed, but not require rebuilding "b"
@@ -645,7 +658,7 @@ TEST_CASE ("install default features of existing dependency", "[plan]")
 
     auto install_plan = Dependencies::create_feature_install_plan(map_port,
                                                                   var_provider,
-                                                                  {install_specs.value_or_exit(VCPKG_LINE_INFO)},
+                                                                  {&install_specs.value_or_exit(VCPKG_LINE_INFO), 1},
                                                                   StatusParagraphs(std::move(status_paragraphs)));
 
     // Expect "b" to be rebuilt
@@ -673,7 +686,7 @@ TEST_CASE ("install default features of dependency test 3", "[plan]")
 
     auto install_plan = Dependencies::create_feature_install_plan(map_port,
                                                                   var_provider,
-                                                                  {install_specs.value_or_exit(VCPKG_LINE_INFO)},
+                                                                  {&install_specs.value_or_exit(VCPKG_LINE_INFO), 1},
                                                                   StatusParagraphs(std::move(status_paragraphs)));
 
     // Expect "a" to get installed, not the defaults of "b", as the required
@@ -700,7 +713,7 @@ TEST_CASE ("install plan action dependencies", "[plan]")
 
     auto install_plan = Dependencies::create_feature_install_plan(map_port,
                                                                   var_provider,
-                                                                  {install_specs.value_or_exit(VCPKG_LINE_INFO)},
+                                                                  {&install_specs.value_or_exit(VCPKG_LINE_INFO), 1},
                                                                   StatusParagraphs(std::move(status_paragraphs)));
 
     REQUIRE(install_plan.size() == 3);
@@ -732,7 +745,7 @@ TEST_CASE ("install plan action dependencies 2", "[plan]")
 
     auto install_plan = Dependencies::create_feature_install_plan(map_port,
                                                                   var_provider,
-                                                                  {install_specs.value_or_exit(VCPKG_LINE_INFO)},
+                                                                  {&install_specs.value_or_exit(VCPKG_LINE_INFO), 1},
                                                                   StatusParagraphs(std::move(status_paragraphs)));
 
     REQUIRE(install_plan.size() == 3);
@@ -762,7 +775,7 @@ TEST_CASE ("install plan action dependencies 3", "[plan]")
 
     auto install_plan = Dependencies::create_feature_install_plan(map_port,
                                                                   var_provider,
-                                                                  {install_specs.value_or_exit(VCPKG_LINE_INFO)},
+                                                                  {&install_specs.value_or_exit(VCPKG_LINE_INFO), 1},
                                                                   StatusParagraphs(std::move(status_paragraphs)));
 
     REQUIRE(install_plan.size() == 1);
@@ -783,10 +796,14 @@ TEST_CASE ("install with default features", "[plan]")
     PortFileProvider::MapPortFileProvider map_port{spec_map.map};
     MockCMakeVarProvider var_provider;
 
+    std::vector<FullPackageSpec> full_package_specs;
+    full_package_specs.push_back(FullPackageSpec{a_spec, {"0"}});
+    full_package_specs.push_back(FullPackageSpec{b_spec, {"core"}});
+
     auto install_plan =
         Dependencies::create_feature_install_plan(map_port,
                                                   var_provider,
-                                                  {FullPackageSpec{a_spec, {"0"}}, FullPackageSpec{b_spec, {"core"}}},
+                                                  full_package_specs,
                                                   StatusParagraphs(std::move(status_db)));
 
     // Install "a" and indicate that "b" should not install default features
@@ -904,7 +921,7 @@ TEST_CASE ("transitive features test", "[plan]")
     MockCMakeVarProvider var_provider;
     auto install_plan = Dependencies::create_feature_install_plan(provider,
                                                                   var_provider,
-                                                                  {install_specs.value_or_exit(VCPKG_LINE_INFO)},
+                                                                  {&install_specs.value_or_exit(VCPKG_LINE_INFO), 1},
                                                                   StatusParagraphs(std::move(status_paragraphs)));
 
     REQUIRE(install_plan.size() == 3);
@@ -929,7 +946,7 @@ TEST_CASE ("no transitive features test", "[plan]")
     MockCMakeVarProvider var_provider;
     auto install_plan = Dependencies::create_feature_install_plan(provider,
                                                                   var_provider,
-                                                                  {install_specs.value_or_exit(VCPKG_LINE_INFO)},
+                                                                  {&install_specs.value_or_exit(VCPKG_LINE_INFO), 1},
                                                                   StatusParagraphs(std::move(status_paragraphs)));
 
     REQUIRE(install_plan.size() == 3);
@@ -954,7 +971,7 @@ TEST_CASE ("only transitive features test", "[plan]")
     MockCMakeVarProvider var_provider;
     auto install_plan = Dependencies::create_feature_install_plan(provider,
                                                                   var_provider,
-                                                                  {install_specs.value_or_exit(VCPKG_LINE_INFO)},
+                                                                  {&install_specs.value_or_exit(VCPKG_LINE_INFO), 1},
                                                                   StatusParagraphs(std::move(status_paragraphs)));
 
     REQUIRE(install_plan.size() == 3);
@@ -1077,16 +1094,18 @@ TEST_CASE ("self-referencing scheme", "[plan]")
 
     SECTION ("basic")
     {
+        auto fullspec_a = FullPackageSpec{spec_a, {}};
         auto install_plan = Dependencies::create_feature_install_plan(
-            map_port, var_provider, {FullPackageSpec{spec_a, {}}}, {}, {{}, Test::X64_WINDOWS});
+            map_port, var_provider, {&fullspec_a, 1}, {}, {{}, Test::X64_WINDOWS});
 
         REQUIRE(install_plan.size() == 1);
         REQUIRE(install_plan.install_actions.at(0).spec == spec_a);
     }
     SECTION ("qualified")
     {
+        auto fullspec_b = FullPackageSpec{spec_b, {}};
         auto install_plan = Dependencies::create_feature_install_plan(
-            map_port, var_provider, {FullPackageSpec{spec_b, {}}}, {}, {{}, Test::X64_WINDOWS});
+            map_port, var_provider, {&fullspec_b, 1}, {}, {{}, Test::X64_WINDOWS});
 
         REQUIRE(install_plan.size() == 1);
         REQUIRE(install_plan.install_actions.at(0).spec == spec_b);
@@ -1107,9 +1126,10 @@ TEST_CASE ("basic tool port scheme", "[plan]")
     PortFileProvider::MapPortFileProvider map_port(spec_map.map);
     MockCMakeVarProvider var_provider;
 
+    auto fullspec_a = FullPackageSpec{spec_a, {}};
     auto install_plan = Dependencies::create_feature_install_plan(map_port,
                                                                   var_provider,
-                                                                  {FullPackageSpec{spec_a, {}}},
+                                                                  {&fullspec_a, 1},
                                                                   StatusParagraphs(std::move(status_paragraphs)),
                                                                   {{}, Test::X64_WINDOWS});
 
@@ -1138,8 +1158,9 @@ TEST_CASE ("basic existing tool port scheme", "[plan]")
 
         PortFileProvider::MapPortFileProvider map_port(spec_map.map);
 
+        auto fullspec_a = FullPackageSpec{spec_a, {}};
         auto install_plan = Dependencies::create_feature_install_plan(
-            map_port, var_provider, {FullPackageSpec{spec_a, {}}}, status_db, {{}, Test::X64_WINDOWS});
+            map_port, var_provider, {&fullspec_a, 1}, status_db, {{}, Test::X64_WINDOWS});
 
         REQUIRE(install_plan.size() == 1);
         REQUIRE(install_plan.install_actions.at(0).spec == spec_a);
@@ -1154,8 +1175,9 @@ TEST_CASE ("basic existing tool port scheme", "[plan]")
 
         PortFileProvider::MapPortFileProvider map_port(spec_map.map);
 
+        auto fullspec_a = FullPackageSpec{spec_a, {}};
         auto install_plan = Dependencies::create_feature_install_plan(
-            map_port, var_provider, {FullPackageSpec{spec_a, {}}}, status_db, {{}, Test::X64_WINDOWS});
+            map_port, var_provider, {&fullspec_a, 1}, status_db, {{}, Test::X64_WINDOWS});
 
         REQUIRE(install_plan.size() == 2);
         REQUIRE(install_plan.install_actions.at(0).spec.name() == "a");
@@ -1163,7 +1185,7 @@ TEST_CASE ("basic existing tool port scheme", "[plan]")
         REQUIRE(install_plan.install_actions.at(1).spec == spec_a);
 
         install_plan = Dependencies::create_feature_install_plan(
-            map_port, var_provider, {FullPackageSpec{spec_a, {}}}, status_db, {{}, Test::X86_WINDOWS});
+            map_port, var_provider, {&fullspec_a, 1}, status_db, {{}, Test::X86_WINDOWS});
 
         REQUIRE(install_plan.size() == 1);
         REQUIRE(install_plan.install_actions.at(0).spec == spec_a);
@@ -1179,8 +1201,9 @@ TEST_CASE ("basic existing tool port scheme", "[plan]")
 
         PortFileProvider::MapPortFileProvider map_port(spec_map.map);
 
+        auto fullspec_a = FullPackageSpec{spec_a, {}};
         auto install_plan = Dependencies::create_feature_install_plan(
-            map_port, var_provider, {FullPackageSpec{spec_a, {}}}, status_db, {{}, Test::ARM_UWP});
+            map_port, var_provider, {&fullspec_a, 1}, status_db, {{}, Test::ARM_UWP});
 
         REQUIRE(install_plan.size() == 2);
         REQUIRE(install_plan.install_actions.at(0).spec.name() == "b");
@@ -1199,8 +1222,9 @@ TEST_CASE ("basic existing tool port scheme", "[plan]")
 
         PortFileProvider::MapPortFileProvider map_port(spec_map.map);
 
+        auto fullspec_a = FullPackageSpec{spec_a, {}};
         auto install_plan = Dependencies::create_feature_install_plan(
-            map_port, var_provider, {FullPackageSpec{spec_a, {}}}, status_db, {{}, Test::X64_WINDOWS});
+            map_port, var_provider, {&fullspec_a, 1}, status_db, {{}, Test::X64_WINDOWS});
 
         REQUIRE(install_plan.size() == 1);
         REQUIRE(install_plan.install_actions.at(0).spec == spec_a);

--- a/src/vcpkg-test/platform-expression.cpp
+++ b/src/vcpkg-test/platform-expression.cpp
@@ -20,6 +20,16 @@ TEST_CASE ("platform-expression-identifier", "[platform-expression]")
     CHECK(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "WindowsStore"}}));
     CHECK_FALSE(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "Linux"}}));
     CHECK_FALSE(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "Darwin"}}));
+
+    m_expr = parse_expr("native");
+    CHECK(expr.evaluate({{"Z_VCPKG_IS_NATIVE", "1"}}));
+    CHECK_FALSE(expr.evaluate({{"Z_VCPKG_IS_NATIVE", "0"}}));
+
+    m_expr = parse_expr("staticcrt");
+    CHECK(expr.evaluate({{"VCPKG_CRT_LINKAGE", "static"}, {"VCPKG_LIBRARY_LINKAGE", "static"}}));
+    CHECK(expr.evaluate({{"VCPKG_CRT_LINKAGE", "static"}, {"VCPKG_LIBRARY_LINKAGE", "dynamic"}}));
+    CHECK_FALSE(expr.evaluate({{"VCPKG_CRT_LINKAGE", "dynamic"}, {"VCPKG_LIBRARY_LINKAGE", "static"}}));
+    CHECK_FALSE(expr.evaluate({{"VCPKG_CRT_LINKAGE", "dynamic"}, {"VCPKG_LIBRARY_LINKAGE", "dynamic"}}));
 }
 
 TEST_CASE ("platform-expression-not", "[platform-expression]")

--- a/src/vcpkg-test/platform-expression.cpp
+++ b/src/vcpkg-test/platform-expression.cpp
@@ -34,7 +34,6 @@ TEST_CASE ("platform-expression-identifier", "[platform-expression]")
 
     CHECK(native.evaluate({{"Z_VCPKG_IS_NATIVE", "1"}}));
     CHECK_FALSE(native.evaluate({{"Z_VCPKG_IS_NATIVE", "0"}}));
-    CHECK_FALSE(native.evaluate({}));
 
     CHECK(staticlink.evaluate({{"VCPKG_LIBRARY_LINKAGE", "static"}, {"VCPKG_CRT_LINKAGE", "static"}}));
     CHECK(staticlink.evaluate({{"VCPKG_LIBRARY_LINKAGE", "static"}, {"VCPKG_CRT_LINKAGE", "dynamic"}}));

--- a/src/vcpkg-test/platform-expression.cpp
+++ b/src/vcpkg-test/platform-expression.cpp
@@ -12,24 +12,39 @@ static vcpkg::ExpectedS<Expr> parse_expr(StringView s)
 
 TEST_CASE ("platform-expression-identifier", "[platform-expression]")
 {
-    auto m_expr = parse_expr("windows");
-    REQUIRE(m_expr);
-    auto& expr = *m_expr.get();
+    auto m_windows = parse_expr("windows");
+    REQUIRE(m_windows);
+    auto m_native = parse_expr("native");
+    REQUIRE(m_native);
+    auto m_staticlink = parse_expr("static");
+    REQUIRE(m_staticlink);
+    auto m_staticcrt = parse_expr("staticcrt");
+    REQUIRE(m_staticcrt);
 
-    CHECK(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", ""}}));
-    CHECK(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "WindowsStore"}}));
-    CHECK_FALSE(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "Linux"}}));
-    CHECK_FALSE(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "Darwin"}}));
+    auto& windows = *m_windows.get();
+    auto& native = *m_native.get();
+    auto& staticlink = *m_staticlink.get();
+    auto& staticcrt = *m_staticcrt.get();
 
-    m_expr = parse_expr("native");
-    CHECK(expr.evaluate({{"Z_VCPKG_IS_NATIVE", "1"}}));
-    CHECK_FALSE(expr.evaluate({{"Z_VCPKG_IS_NATIVE", "0"}}));
+    CHECK(windows.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", ""}}));
+    CHECK(windows.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "WindowsStore"}}));
+    CHECK_FALSE(windows.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "Linux"}}));
+    CHECK_FALSE(windows.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "Darwin"}}));
 
-    m_expr = parse_expr("staticcrt");
-    CHECK(expr.evaluate({{"VCPKG_CRT_LINKAGE", "static"}, {"VCPKG_LIBRARY_LINKAGE", "static"}}));
-    CHECK(expr.evaluate({{"VCPKG_CRT_LINKAGE", "static"}, {"VCPKG_LIBRARY_LINKAGE", "dynamic"}}));
-    CHECK_FALSE(expr.evaluate({{"VCPKG_CRT_LINKAGE", "dynamic"}, {"VCPKG_LIBRARY_LINKAGE", "static"}}));
-    CHECK_FALSE(expr.evaluate({{"VCPKG_CRT_LINKAGE", "dynamic"}, {"VCPKG_LIBRARY_LINKAGE", "dynamic"}}));
+
+    CHECK(native.evaluate({{"Z_VCPKG_IS_NATIVE", "1"}}));
+    CHECK_FALSE(native.evaluate({{"Z_VCPKG_IS_NATIVE", "0"}}));
+    CHECK_FALSE(native.evaluate({}));
+
+    CHECK(staticlink.evaluate({{"VCPKG_LIBRARY_LINKAGE", "static"}, {"VCPKG_CRT_LINKAGE", "static"}}));
+    CHECK(staticlink.evaluate({{"VCPKG_LIBRARY_LINKAGE", "static"}, {"VCPKG_CRT_LINKAGE", "dynamic"}}));
+    CHECK_FALSE(staticlink.evaluate({{"VCPKG_LIBRARY_LINKAGE", "dynamic"}, {"VCPKG_CRT_LINKAGE", "static"}}));
+    CHECK_FALSE(staticlink.evaluate({{"VCPKG_LIBRARY_LINKAGE", "dynnamic"}, {"VCPKG_CRT_LINKAGE", "dynamic"}}));
+
+    CHECK(staticcrt.evaluate({{"VCPKG_CRT_LINKAGE", "static"}, {"VCPKG_LIBRARY_LINKAGE", "static"}}));
+    CHECK(staticcrt.evaluate({{"VCPKG_CRT_LINKAGE", "static"}, {"VCPKG_LIBRARY_LINKAGE", "dynamic"}}));
+    CHECK_FALSE(staticcrt.evaluate({{"VCPKG_CRT_LINKAGE", "dynamic"}, {"VCPKG_LIBRARY_LINKAGE", "static"}}));
+    CHECK_FALSE(staticcrt.evaluate({{"VCPKG_CRT_LINKAGE", "dynamic"}, {"VCPKG_LIBRARY_LINKAGE", "dynamic"}}));
 }
 
 TEST_CASE ("platform-expression-not", "[platform-expression]")

--- a/src/vcpkg-test/platform-expression.cpp
+++ b/src/vcpkg-test/platform-expression.cpp
@@ -31,7 +31,6 @@ TEST_CASE ("platform-expression-identifier", "[platform-expression]")
     CHECK_FALSE(windows.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "Linux"}}));
     CHECK_FALSE(windows.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "Darwin"}}));
 
-
     CHECK(native.evaluate({{"Z_VCPKG_IS_NATIVE", "1"}}));
     CHECK_FALSE(native.evaluate({{"Z_VCPKG_IS_NATIVE", "0"}}));
 

--- a/src/vcpkg-test/versionplan.cpp
+++ b/src/vcpkg-test/versionplan.cpp
@@ -76,13 +76,13 @@ TEST_CASE ("qualified dependency", "[dependencies]")
     PortFileProvider::MapPortFileProvider map_port{spec_map.map};
     MockCMakeVarProvider var_provider;
 
-    auto plan = vcpkg::Dependencies::create_feature_install_plan(map_port, var_provider, {spec_a}, {});
+    auto plan = vcpkg::Dependencies::create_feature_install_plan(map_port, var_provider, {&spec_a, 1}, {});
     REQUIRE(plan.install_actions.size() == 2);
     REQUIRE(plan.install_actions.at(0).feature_list == std::vector<std::string>{"core"});
 
     FullPackageSpec linspec_a{{"a", Triplet::from_canonical_name("x64-linux")}, {}};
     var_provider.dep_info_vars[linspec_a.package_spec].emplace("VCPKG_CMAKE_SYSTEM_NAME", "Linux");
-    auto plan2 = vcpkg::Dependencies::create_feature_install_plan(map_port, var_provider, {linspec_a}, {});
+    auto plan2 = vcpkg::Dependencies::create_feature_install_plan(map_port, var_provider, {&linspec_a, 1}, {});
     REQUIRE(plan2.install_actions.size() == 2);
     REQUIRE(plan2.install_actions.at(0).feature_list == std::vector<std::string>{"b1", "core"});
 }

--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -105,7 +105,7 @@ namespace vcpkg::Build
         auto action_plan = Dependencies::create_feature_install_plan(
             provider, var_provider, std::vector<FullPackageSpec>{full_spec}, status_db, {host_triplet});
 
-        var_provider.load_tag_vars(action_plan, provider);
+        var_provider.load_tag_vars(action_plan, provider, host_triplet);
 
         const PackageSpec& spec = full_spec.package_spec;
         const SourceControlFile& scf = *scfl.source_control_file;

--- a/src/vcpkg/cmakevars.cpp
+++ b/src/vcpkg/cmakevars.cpp
@@ -279,7 +279,8 @@ endmacro()
         for (const auto& spec_abi_setting : spec_abi_settings)
         {
             const FullPackageSpec& spec = *spec_abi_setting.first;
-            PlatformExpression::Context ctxt{std::make_move_iterator(var_list_itr->begin()), std::make_move_iterator(var_list_itr->end())};
+            PlatformExpression::Context ctxt{std::make_move_iterator(var_list_itr->begin()),
+                                             std::make_move_iterator(var_list_itr->end())};
             ++var_list_itr;
 
             ctxt.emplace("Z_VCPKG_IS_NATIVE", host_triplet == spec.package_spec.triplet() ? "1" : "0");

--- a/src/vcpkg/cmakevars.cpp
+++ b/src/vcpkg/cmakevars.cpp
@@ -15,7 +15,8 @@ using vcpkg::Optional;
 namespace vcpkg::CMakeVars
 {
     void CMakeVarProvider::load_tag_vars(const vcpkg::Dependencies::ActionPlan& action_plan,
-                                         const PortFileProvider::PortFileProvider& port_provider) const
+                                         const PortFileProvider::PortFileProvider& port_provider,
+                                         Triplet host_triplet) const
     {
         std::vector<FullPackageSpec> install_package_specs;
         for (auto&& action : action_plan.install_actions)
@@ -23,7 +24,7 @@ namespace vcpkg::CMakeVars
             install_package_specs.emplace_back(FullPackageSpec{action.spec, action.feature_list});
         }
 
-        load_tag_vars(install_package_specs, port_provider);
+        load_tag_vars(install_package_specs, port_provider, host_triplet);
     }
 
     namespace
@@ -37,7 +38,8 @@ namespace vcpkg::CMakeVars
             void load_dep_info_vars(View<PackageSpec> specs) const override;
 
             void load_tag_vars(View<FullPackageSpec> specs,
-                               const PortFileProvider::PortFileProvider& port_provider) const override;
+                               const PortFileProvider::PortFileProvider& port_provider,
+                               Triplet host_triplet) const override;
 
             Optional<const std::unordered_map<std::string, std::string>&> get_generic_triplet_vars(
                 Triplet triplet) const override;
@@ -254,7 +256,8 @@ endmacro()
     }
 
     void TripletCMakeVarProvider::load_tag_vars(View<FullPackageSpec> specs,
-                                                const PortFileProvider::PortFileProvider& port_provider) const
+                                                const PortFileProvider::PortFileProvider& port_provider,
+                                                Triplet host_triplet) const
     {
         if (specs.size() == 0) return;
         std::vector<std::pair<const FullPackageSpec*, std::string>> spec_abi_settings;
@@ -276,12 +279,12 @@ endmacro()
         for (const auto& spec_abi_setting : spec_abi_settings)
         {
             const FullPackageSpec& spec = *spec_abi_setting.first;
-
-            tag_vars.emplace(std::piecewise_construct,
-                             std::forward_as_tuple(spec.package_spec),
-                             std::forward_as_tuple(std::make_move_iterator(var_list_itr->begin()),
-                                                   std::make_move_iterator(var_list_itr->end())));
+            PlatformExpression::Context ctxt{std::make_move_iterator(var_list_itr->begin()), std::make_move_iterator(var_list_itr->end())};
             ++var_list_itr;
+
+            ctxt.emplace("Z_VCPKG_IS_NATIVE", host_triplet == spec.package_spec.triplet() ? "1" : "0");
+
+            tag_vars.emplace(spec.package_spec, std::move(ctxt));
         }
     }
 

--- a/src/vcpkg/commands.check-support.cpp
+++ b/src/vcpkg/commands.check-support.cpp
@@ -70,8 +70,7 @@ namespace vcpkg::Commands
                 }
                 else
                 {
-                    System::printf(
-                        "port %s is not supported (supports: \"%s\")\n", full_port_name(p), p.supports_expr);
+                    System::printf("port %s is not supported (supports: \"%s\")\n", full_port_name(p), p.supports_expr);
                 }
 
                 return;
@@ -137,7 +136,8 @@ namespace vcpkg::Commands
             for (const auto& action : action_plan.install_actions)
             {
                 const auto& spec = action.spec;
-                const auto& supports_expression = action.source_control_file_location.value_or_exit(VCPKG_LINE_INFO).source_control_file->core_paragraph->supports_expression;
+                const auto& supports_expression = action.source_control_file_location.value_or_exit(VCPKG_LINE_INFO)
+                                                      .source_control_file->core_paragraph->supports_expression;
 
                 PlatformExpression::Context context = cmake_vars->get_tag_vars(spec).value_or_exit(VCPKG_LINE_INFO);
 
@@ -171,8 +171,7 @@ namespace vcpkg::Commands
                 Json::Object& obj = json_to_print.push_back(Json::Object{});
                 obj.insert("port", to_object(user_port));
                 obj.insert("top-level-support", Json::Value::boolean(user_supported));
-                obj.insert("is-supported",
-                           Json::Value::boolean(user_supported && dependencies_not_supported.empty()));
+                obj.insert("is-supported", Json::Value::boolean(user_supported && dependencies_not_supported.empty()));
                 if (!dependencies_not_supported.empty())
                 {
                     Json::Array& deps = obj.insert("dependencies-not-supported", Json::Array{});

--- a/src/vcpkg/commands.check-support.cpp
+++ b/src/vcpkg/commands.check-support.cpp
@@ -1,0 +1,204 @@
+#include <vcpkg/base/checks.h>
+#include <vcpkg/base/json.h>
+#include <vcpkg/base/strings.h>
+#include <vcpkg/base/system.print.h>
+#include <vcpkg/base/util.h>
+
+#include <vcpkg/cmakevars.h>
+#include <vcpkg/commands.check-support.h>
+#include <vcpkg/dependencies.h>
+#include <vcpkg/input.h>
+#include <vcpkg/packagespec.h>
+#include <vcpkg/platform-expression.h>
+#include <vcpkg/portfileprovider.h>
+#include <vcpkg/vcpkgcmdarguments.h>
+#include <vcpkg/vcpkgpaths.h>
+
+namespace vcpkg::Commands
+{
+    const CommandStructure COMMAND_STRUCTURE = {
+        create_example_string(R"(x-check-support <package>...)"),
+        1,
+        SIZE_MAX,
+        {},
+        nullptr,
+    };
+
+    namespace
+    {
+        struct Port
+        {
+            std::string port_name;
+            std::vector<std::string> features;
+            Triplet triplet;
+            std::string supports_expr;
+        };
+
+        Json::Object to_object(const Port& p)
+        {
+            Json::Object res;
+            res.insert("name", Json::Value::string(p.port_name));
+            res.insert("triplet", Json::Value::string(p.triplet.to_string()));
+
+            Json::Array& features = res.insert("features", Json::Array{});
+            for (const auto& feature : p.features)
+            {
+                features.push_back(Json::Value::string(feature));
+            }
+
+            if (!p.supports_expr.empty())
+            {
+                res.insert("supports", Json::Value::string(p.supports_expr));
+            }
+
+            return res;
+        }
+
+        void print_port_supported(const Port& p, bool is_top_level_supported, View<Port> reasons)
+        {
+            const auto full_port_name = [](const Port& port) {
+                return Strings::format(
+                    "%s[%s]:%s", port.port_name, Strings::join(",", port.features), port.triplet.to_string());
+            };
+
+            if (reasons.size() == 0)
+            {
+                if (is_top_level_supported)
+                {
+                    // supported!
+                    System::printf("port %s is supported\n", full_port_name(p));
+                }
+                else
+                {
+                    System::printf(
+                        "port %s is not supported (supports: \"%s\")\n", full_port_name(p), p.supports_expr);
+                }
+
+                return;
+            }
+
+            if (is_top_level_supported)
+            {
+                System::printf("port %s is not supported due to the following dependencies:\n", full_port_name(p));
+            }
+            else
+            {
+                System::printf(
+                    "port %s is not supported (supports: \"%s\"), and has the following unsupported dependencies:\n",
+                    full_port_name(p),
+                    p.supports_expr);
+            }
+
+            for (const Port& reason : reasons)
+            {
+                System::printf("  - dependency %s is not supported (supports: \"%s\")\n",
+                               full_port_name(reason),
+                               reason.supports_expr);
+            }
+        }
+    }
+
+    void CheckSupport::perform_and_exit(const VcpkgCmdArguments& args,
+                                        const VcpkgPaths& paths,
+                                        Triplet default_triplet,
+                                        Triplet host_triplet)
+    {
+        const ParsedArguments options = args.parse_arguments(COMMAND_STRUCTURE);
+        const bool use_json = args.json.value_or(false);
+        Json::Array json_to_print; // only used when `use_json`
+
+        const std::vector<FullPackageSpec> specs = Util::fmap(args.command_arguments, [&](auto&& arg) {
+            return Input::check_and_get_full_package_spec(
+                std::string(arg), default_triplet, COMMAND_STRUCTURE.example_text);
+        });
+
+        for (auto&& spec : specs)
+        {
+            Input::check_triplet(spec.package_spec.triplet(), paths);
+        }
+
+        PortFileProvider::PathsPortFileProvider provider(paths, args.overlay_ports);
+        auto cmake_vars = CMakeVars::make_triplet_cmake_var_provider(paths);
+
+        // for each spec in the user-requested specs, check all dependencies
+        for (const auto& user_spec : specs)
+        {
+            auto action_plan =
+                Dependencies::create_feature_install_plan(provider, *cmake_vars, {&user_spec, 1}, {}, {host_triplet});
+
+            cmake_vars->load_tag_vars(action_plan, provider, host_triplet);
+
+            Port user_port;
+            user_port.port_name = user_spec.package_spec.name();
+            user_port.triplet = user_spec.package_spec.triplet();
+            bool user_supported = false;
+
+            std::vector<Port> dependencies_not_supported;
+            for (const auto& action : action_plan.install_actions)
+            {
+                const auto& spec = action.spec;
+                const auto& supports_expression = action.source_control_file_location.value_or_exit(VCPKG_LINE_INFO).source_control_file->core_paragraph->supports_expression;
+
+                PlatformExpression::Context context = cmake_vars->get_tag_vars(spec).value_or_exit(VCPKG_LINE_INFO);
+
+                if (spec.name() == user_port.port_name && spec.triplet() == user_port.triplet)
+                {
+                    user_port.features = action.feature_list;
+                    user_port.supports_expr = to_string(supports_expression);
+
+                    if (supports_expression.evaluate(context))
+                    {
+                        user_supported = true;
+                    }
+
+                    continue;
+                }
+
+                if (!supports_expression.evaluate(context))
+                {
+                    Port port;
+                    port.port_name = spec.name();
+                    port.features = action.feature_list;
+                    port.triplet = spec.triplet();
+                    port.supports_expr = to_string(supports_expression);
+
+                    dependencies_not_supported.push_back(port);
+                }
+            }
+
+            if (use_json)
+            {
+                Json::Object& obj = json_to_print.push_back(Json::Object{});
+                obj.insert("port", to_object(user_port));
+                obj.insert("top-level-support", Json::Value::boolean(user_supported));
+                obj.insert("is-supported",
+                           Json::Value::boolean(user_supported && dependencies_not_supported.empty()));
+                if (!dependencies_not_supported.empty())
+                {
+                    Json::Array& deps = obj.insert("dependencies-not-supported", Json::Array{});
+                    for (const Port& p : dependencies_not_supported)
+                    {
+                        deps.push_back(to_object(p));
+                    }
+                }
+            }
+            else
+            {
+                print_port_supported(user_port, user_supported, dependencies_not_supported);
+            }
+        }
+
+        if (use_json)
+        {
+            System::print2(Json::stringify(json_to_print, {}));
+        }
+    }
+
+    void CheckSupport::CheckSupportCommand::perform_and_exit(const VcpkgCmdArguments& args,
+                                                             const VcpkgPaths& paths,
+                                                             Triplet default_triplet,
+                                                             Triplet host_triplet) const
+    {
+        return CheckSupport::perform_and_exit(args, paths, default_triplet, host_triplet);
+    }
+}

--- a/src/vcpkg/commands.ci.cpp
+++ b/src/vcpkg/commands.ci.cpp
@@ -295,7 +295,8 @@ namespace vcpkg::Commands::CI
         const CMakeVars::CMakeVarProvider& var_provider,
         const std::vector<FullPackageSpec>& specs,
         IBinaryProvider& binaryprovider,
-        const Dependencies::CreateInstallPlanOptions& serialize_options)
+        const Dependencies::CreateInstallPlanOptions& serialize_options,
+        Triplet host_triplet)
     {
         auto ret = std::make_unique<UnknownCIPortsResults>();
 
@@ -324,7 +325,7 @@ namespace vcpkg::Commands::CI
             install_specs.emplace_back(install_action.spec, install_action.feature_list);
         }
 
-        var_provider.load_tag_vars(install_specs, provider);
+        var_provider.load_tag_vars(install_specs, provider, host_triplet);
 
         auto timer = Chrono::ElapsedTimer::create_started();
 
@@ -528,7 +529,8 @@ namespace vcpkg::Commands::CI
                                                          var_provider,
                                                          all_default_full_specs,
                                                          binaryprovider,
-                                                         serialize_options);
+                                                         serialize_options,
+                                                         host_triplet);
 
             auto& action_plan = split_specs->plan;
 

--- a/src/vcpkg/commands.cpp
+++ b/src/vcpkg/commands.cpp
@@ -5,6 +5,7 @@
 #include <vcpkg/commands.autocomplete.h>
 #include <vcpkg/commands.buildexternal.h>
 #include <vcpkg/commands.cache.h>
+#include <vcpkg/commands.check-support.h>
 #include <vcpkg/commands.ci.h>
 #include <vcpkg/commands.ciclean.h>
 #include <vcpkg/commands.civerifyversions.h>
@@ -116,6 +117,7 @@ namespace vcpkg::Commands
         static const BuildExternal::BuildExternalCommand build_external{};
         static const Export::ExportCommand export_command{};
         static const DependInfo::DependInfoCommand depend_info{};
+        static const CheckSupport::CheckSupportCommand check_support{};
 
         static std::vector<PackageNameAndFunction<const TripletCommand*>> t = {
             {"install", &install},
@@ -128,6 +130,7 @@ namespace vcpkg::Commands
             {"build-external", &build_external},
             {"export", &export_command},
             {"depend-info", &depend_info},
+            {"x-check-support", &check_support},
         };
         return t;
     }

--- a/src/vcpkg/commands.setinstalled.cpp
+++ b/src/vcpkg/commands.setinstalled.cpp
@@ -41,9 +41,10 @@ namespace vcpkg::Commands::SetInstalled
                              const CMakeVars::CMakeVarProvider& cmake_vars,
                              Dependencies::ActionPlan action_plan,
                              DryRun dry_run,
-                             const Optional<fs::path>& maybe_pkgsconfig)
+                             const Optional<fs::path>& maybe_pkgsconfig,
+                             Triplet host_triplet)
     {
-        cmake_vars.load_tag_vars(action_plan, provider);
+        cmake_vars.load_tag_vars(action_plan, provider, host_triplet);
         Build::compute_all_abis(paths, action_plan, cmake_vars, {});
 
         std::set<std::string> all_abis;
@@ -167,7 +168,8 @@ namespace vcpkg::Commands::SetInstalled
                             *cmake_vars,
                             std::move(action_plan),
                             dry_run ? DryRun::Yes : DryRun::No,
-                            pkgsconfig);
+                            pkgsconfig,
+                            host_triplet);
     }
 
     void SetInstalledCommand::perform_and_exit(const VcpkgCmdArguments& args,

--- a/src/vcpkg/commands.upgrade.cpp
+++ b/src/vcpkg/commands.upgrade.cpp
@@ -184,7 +184,7 @@ namespace vcpkg::Commands::Upgrade
             Checks::exit_fail(VCPKG_LINE_INFO);
         }
 
-        var_provider.load_tag_vars(action_plan, provider);
+        var_provider.load_tag_vars(action_plan, provider, host_triplet);
 
         const Install::InstallSummary summary =
             Install::perform(args,

--- a/src/vcpkg/dependencies.cpp
+++ b/src/vcpkg/dependencies.cpp
@@ -713,7 +713,7 @@ namespace vcpkg::Dependencies
 
     ActionPlan create_feature_install_plan(const PortFileProvider::PortFileProvider& port_provider,
                                            const CMakeVars::CMakeVarProvider& var_provider,
-                                           const std::vector<FullPackageSpec>& specs,
+                                           View<FullPackageSpec> specs,
                                            const StatusParagraphs& status_db,
                                            const CreateInstallPlanOptions& options)
     {

--- a/src/vcpkg/install.cpp
+++ b/src/vcpkg/install.cpp
@@ -935,7 +935,8 @@ namespace vcpkg::Install
                                                         var_provider,
                                                         std::move(install_plan),
                                                         dry_run ? Commands::DryRun::Yes : Commands::DryRun::No,
-                                                        pkgsconfig);
+                                                        pkgsconfig,
+                                                        host_triplet);
         }
 
         PortFileProvider::PathsPortFileProvider provider(paths, args.overlay_ports);
@@ -968,7 +969,7 @@ namespace vcpkg::Install
             }
         }
 
-        var_provider.load_tag_vars(action_plan, provider);
+        var_provider.load_tag_vars(action_plan, provider, host_triplet);
 
         // install plan will be empty if it is already installed - need to change this at status paragraph part
         Checks::check_exit(VCPKG_LINE_INFO, !action_plan.empty(), "Install plan cannot be empty");

--- a/src/vcpkg/platform-expression.cpp
+++ b/src/vcpkg/platform-expression.cpp
@@ -33,6 +33,8 @@ namespace vcpkg::PlatformExpression
 
         static_link,
         static_crt,
+
+        native, // HOST_TRIPLET == TARGET_TRIPLET
     };
 
     static Identifier string2identifier(StringView name)
@@ -52,7 +54,8 @@ namespace vcpkg::PlatformExpression
             {"emscripten", Identifier::emscripten},
             {"ios", Identifier::ios},
             {"static", Identifier::static_link},
-            {"staticcrt", Identifier::static_link},
+            {"staticcrt", Identifier::static_crt},
+            {"native", Identifier::native},
         };
 
         auto id_pair = id_map.find(name);
@@ -401,6 +404,16 @@ namespace vcpkg::PlatformExpression
                         case Identifier::static_link:
                             return true_if_exists_and_equal("VCPKG_LIBRARY_LINKAGE", "static");
                         case Identifier::static_crt: return true_if_exists_and_equal("VCPKG_CRT_LINKAGE", "static");
+                        case Identifier::native:
+                        {
+                            auto is_native = context.find("Z_VCPKG_IS_NATIVE");
+                            if (is_native == context.end())
+                            {
+                                Checks::unreachable(VCPKG_LINE_INFO);
+                            }
+
+                            return is_native->second == "1";
+                        }
                         default: Checks::unreachable(VCPKG_LINE_INFO);
                     }
                 }


### PR DESCRIPTION
`native` means "TARGET_TRIPLET == HOST_TRIPLET

the `x-check-support` command allows one to check if a port supports a platform.