### PR TITLE
Don't build tls12-download with MINGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,7 +190,7 @@ endif()
 # === Target: tls12-download ===
 
 set(TLS12_DOWNLOAD_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/tls12-download.c)
-if(WIN32)
+if(WIN32 AND NOT MINGW)
     add_executable(tls12-download ${TLS12_DOWNLOAD_SOURCES})
     set_property(TARGET tls12-download PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded")
     set_property(TARGET tls12-download APPEND PROPERTY LINK_OPTIONS "$<IF:$<CONFIG:Debug>,,/ENTRY:entry>")


### PR DESCRIPTION
In MSYS2 MinGW environments on Windows, the build of `tls12-download` fails due to missing symbols. This change disables this component, similar to the situation on non-Windows systems. And this particular configuration of tls12-download is not needed because a binary from a MSVC build is already part of the vcpkg-repository.