### PR TITLE
Choose MinGW triplets when building vcpkg with MinGW

### DIFF
--- a/src/vcpkg/triplet.cpp
+++ b/src/vcpkg/triplet.cpp
@@ -75,7 +75,17 @@ namespace vcpkg
 
     static Triplet system_triplet()
     {
-#if defined(_WIN32)
+#if defined(__MINGW32__)
+        auto host_proc = System::get_host_processor();
+        switch (host_proc)
+        {
+            case System::CPUArchitecture::X86: return Triplet::from_canonical_name("x86-mingw-dynamic");
+            case System::CPUArchitecture::X64: return Triplet::from_canonical_name("x64-mingw-dynamic");
+            case System::CPUArchitecture::ARM: return Triplet::from_canonical_name("arm-mingw-dynamic");
+            case System::CPUArchitecture::ARM64: return Triplet::from_canonical_name("arm64-mingw-dynamic");
+            default: return Triplet::from_canonical_name("x86-mingw-dynamic");
+        }
+#elif defined(_WIN32)
         auto host_proc = System::get_host_processor();
         switch (host_proc)
         {
@@ -115,7 +125,7 @@ namespace vcpkg
         {
             return Triplet::from_canonical_name(std::string(*args.triplet));
         }
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(__MINGW32__)
         return Triplet::from_canonical_name("x86-windows");
 #else
         return system_triplet();


### PR DESCRIPTION
This commit enables build and use of vcpkg on Windows systems which only have a MSYS2 MinGW environment.

This PR is complemented by #31 and a pending change to bootstrapping (https://github.com/dg0yt/vcpkg/commit/31c31d9b418bdbe3f0f07dad1505a43c5d94cb1d, pointless without #31).

Tested only with x64-mingw-dynamic and zlib.