### PR TITLE
don't build tls12-download unless it's needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,6 @@ else()
 cmake_minimum_required(VERSION 3.14)
 endif()
 
-project(vcpkg C CXX)
-include(cmake/utilities.cmake)
-
 # ===============
 # === Options ===
 # ===============
@@ -17,36 +14,60 @@ include(CMakeDependentOption)
 option(BUILD_TESTING "Option for enabling testing" ON)
 option(VCPKG_ALLOW_APPLE_CLANG "Option for allowing apple clang, even versions that we don't know will work" OFF)
 option(VCPKG_DEVELOPMENT_WARNINGS "Option for turning on all warnings" ON)
-option(VCPKG_WARNINGS_AS_ERRORS "Set warnings to be errors" ${VCPKG_DEVELOPMENT_WARNINGS})
+option(VCPKG_WARNINGS_AS_ERRORS "Set warnings to be errors" OFF)
+option(VCPKG_BUILD_TLS12_DOWNLOADER "Enable building the tls12-downloader" OFF)
 option(VCPKG_BUILD_FUZZING "Option for enabling vcpkg-fuzz support" OFF)
 option(VCPKG_EMBED_GIT_SHA "Option for to fill in the Git SHA version; off by default to avoid privacy concerns out of official builds" OFF)
+
 
 CMAKE_DEPENDENT_OPTION(VCPKG_BUILD_BENCHMARKING "Option for enabling benchmarking" OFF
     "BUILD_TESTING" OFF)
 
-if(WERROR)
-    message(DEPRECATION "-DWERROR is no longer a supported flag. It doesn't do anything.")
-endif()
 if(DEFINE_DISABLE_METRICS OR VCPKG_DISABLE_METRICS)
     message(DEPRECATION "DEFINE_DISABLE_METRICS / VCPKG_DISABLE_METRICS are now handled by creating a "
         "file vcpkg.disable_metrics next to the binary.")
 endif()
 
+if(VCPKG_BUILD_TLS12_DOWNLOADER AND NOT WIN32)
+    message(FATAL_ERROR "The tls12-downloader binary is only supported on Windows.")
+endif()
+
+project(vcpkg C CXX)
+include(cmake/utilities.cmake)
+
 # =============
 # === Files ===
 # =============
 
-file(GLOB VCPKGLIB_SOURCES CONFIGURE_DEPENDS src/vcpkg/*.cpp)
-file(GLOB VCPKGLIB_BASE_SOURCES CONFIGURE_DEPENDS src/vcpkg/base/*.cpp)
-file(GLOB VCPKGLIB_INCLUDES CONFIGURE_DEPENDS include/vcpkg/*.h include/vcpkg/fwd/*.h)
-file(GLOB VCPKGLIB_BASE_INCLUDES CONFIGURE_DEPENDS include/vcpkg/base/*.h include/vcpkg/base/fwd/*.h)
+file(GLOB VCPKGLIB_SOURCES CONFIGURE_DEPENDS
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/vcpkg/*.cpp"
+)
+file(GLOB VCPKGLIB_BASE_SOURCES CONFIGURE_DEPENDS
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/vcpkg/base/*.cpp"
+)
+file(GLOB VCPKGLIB_INCLUDES CONFIGURE_DEPENDS
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/vcpkg/*.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/vcpkg/fwd/*.h"
+)
+file(GLOB VCPKGLIB_BASE_INCLUDES CONFIGURE_DEPENDS
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/vcpkg/base/*.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/vcpkg/base/fwd/*.h"
+)
 
-set(VCPKG_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/vcpkg.cpp)
+set(VCPKG_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/vcpkg.cpp")
 
-file(GLOB VCPKG_TEST_SOURCES CONFIGURE_DEPENDS src/vcpkg-test/*.cpp)
-file(GLOB VCPKG_TEST_INCLUDES CONFIGURE_DEPENDS include/vcpkg-test/*.h)
+file(GLOB VCPKG_TEST_SOURCES CONFIGURE_DEPENDS
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/vcpkg-test/*.cpp"
+)
+file(GLOB VCPKG_TEST_INCLUDES CONFIGURE_DEPENDS
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/vcpkg-test/*.h"
+)
 
-file(GLOB VCPKG_FUZZ_SOURCES CONFIGURE_DEPENDS src/vcpkg-fuzz/*.cpp)
+file(GLOB VCPKG_FUZZ_SOURCES CONFIGURE_DEPENDS
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/vcpkg-fuzz/*.cpp"
+)
+
+set(TLS12_DOWNLOAD_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/tls12-download.c")
 
 # ========================
 # === System detection ===
@@ -56,28 +77,28 @@ vcpkg_detect_compiler()
 vcpkg_detect_standard_library()
 vcpkg_detect_std_filesystem()
 
-if (VCPKG_EMBED_GIT_SHA)
+if(VCPKG_EMBED_GIT_SHA)
     find_package(Git REQUIRED)
     execute_process(
         COMMAND "${GIT_EXECUTABLE}" status --porcelain=v1
         WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
         OUTPUT_VARIABLE VCPKG_GIT_STATUS
         OUTPUT_STRIP_TRAILING_WHITESPACE
-        )
+    )
 
-    if (VCPKG_GIT_STATUS STREQUAL "")
+    if(VCPKG_GIT_STATUS STREQUAL "")
         execute_process(
             COMMAND "${GIT_EXECUTABLE}" rev-parse HEAD
             WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
             OUTPUT_VARIABLE VCPKG_VERSION
             OUTPUT_STRIP_TRAILING_WHITESPACE
-            )
+        )
     else()
         message(WARNING "Skipping embedding SHA due to local changes.")
     endif()
 endif()
 
-if (NOT DEFINED VCPKG_VERSION OR VCPKG_VERSION STREQUAL "")
+if(NOT DEFINED VCPKG_VERSION OR VCPKG_VERSION STREQUAL "")
     set(VCPKG_VERSION "unknownhash")
 endif()
 
@@ -88,17 +109,17 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 17)
 if(MSVC)
     string(REGEX REPLACE "[-/]W[0-4]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-    if (CMAKE_BUILD_TYPE STREQUAL "Release")
+    if(CMAKE_BUILD_TYPE STREQUAL "Release")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zi /guard:cf")
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /DEBUG /debugtype:cv,fixup /guard:cf")
     endif()
 endif()
 
 if(APPLE)
-    SET(CMAKE_C_ARCHIVE_CREATE   "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
-    SET(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
-    SET(CMAKE_C_ARCHIVE_FINISH   "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
-    SET(CMAKE_CXX_ARCHIVE_FINISH "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
+    set(CMAKE_C_ARCHIVE_CREATE   "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
+    set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
+    set(CMAKE_C_ARCHIVE_FINISH   "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
+    set(CMAKE_CXX_ARCHIVE_FINISH "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
 endif()
 
 # ===============
@@ -111,7 +132,8 @@ add_library(vcpkglib
     ${VCPKGLIB_BASE_SOURCES}
     ${VCPKGLIB_SOURCES}
     ${VCPKGLIB_BASE_INCLUDES}
-    ${VCPKGLIB_INCLUDES})
+    ${VCPKGLIB_INCLUDES}
+)
 target_include_directories(vcpkglib PUBLIC include)
 
 vcpkg_target_add_warning_options(vcpkglib)
@@ -119,7 +141,7 @@ target_compile_definitions(vcpkglib PUBLIC
     VCPKG_USE_STD_FILESYSTEM=$<BOOL:${VCPKG_USE_STD_FILESYSTEM}>
     VCPKG_VERSION=${VCPKG_VERSION}
     VCPKG_BASE_VERSION=${VCPKG_BASE_VERSION}
-    )
+)
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
@@ -150,7 +172,8 @@ if (MINGW)
             UNICODE
             _WIN32_WINNT=0x0601
             WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY=4
-            __fastfail=exit)
+            __fastfail=exit
+    )
     target_link_libraries(vcpkglib PUBLIC winhttp bcrypt version ole32 uuid)
 endif()
 
@@ -167,7 +190,8 @@ if (BUILD_TESTING)
 
     add_executable(vcpkg-test
         ${VCPKG_TEST_SOURCES}
-        ${VCPKG_TEST_INCLUDES})
+        ${VCPKG_TEST_INCLUDES}
+    )
     target_link_libraries(vcpkg-test PRIVATE vcpkglib)
     vcpkg_target_add_warning_options(vcpkg-test)
 
@@ -189,8 +213,7 @@ endif()
 
 # === Target: tls12-download ===
 
-set(TLS12_DOWNLOAD_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/tls12-download.c)
-if(WIN32)
+if(VCPKG_BUILD_TLS12_DOWNLOADER)
     add_executable(tls12-download ${TLS12_DOWNLOAD_SOURCES})
     set_property(TARGET tls12-download PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded")
     set_property(TARGET tls12-download APPEND PROPERTY LINK_OPTIONS "$<IF:$<CONFIG:Debug>,,/ENTRY:entry>")
@@ -204,19 +227,19 @@ find_program(CLANG_FORMAT clang-format)
 if(CLANG_FORMAT)
     # doing all of these formats in one line has a tendency to overflow the command line length
     add_custom_target(format
-        COMMAND ${CLANG_FORMAT} -i -verbose ${CMAKE_CURRENT_SOURCE_DIR}/src/pch.cpp
-        COMMAND ${CLANG_FORMAT} -i -verbose ${VCPKGLIB_BASE_SOURCES}
-        COMMAND ${CLANG_FORMAT} -i -verbose ${VCPKGLIB_SOURCES}
-        COMMAND ${CLANG_FORMAT} -i -verbose ${CMAKE_CURRENT_SOURCE_DIR}/include/pch.h
-        COMMAND ${CLANG_FORMAT} -i -verbose ${VCPKGLIB_BASE_INCLUDES}
-        COMMAND ${CLANG_FORMAT} -i -verbose ${VCPKGLIB_INCLUDES}
+        COMMAND "${CLANG_FORMAT}" -i -verbose ${CMAKE_CURRENT_SOURCE_DIR}/src/pch.cpp
+        COMMAND "${CLANG_FORMAT}" -i -verbose ${VCPKGLIB_BASE_SOURCES}
+        COMMAND "${CLANG_FORMAT}" -i -verbose ${VCPKGLIB_SOURCES}
+        COMMAND "${CLANG_FORMAT}" -i -verbose ${CMAKE_CURRENT_SOURCE_DIR}/include/pch.h
+        COMMAND "${CLANG_FORMAT}" -i -verbose ${VCPKGLIB_BASE_INCLUDES}
+        COMMAND "${CLANG_FORMAT}" -i -verbose ${VCPKGLIB_INCLUDES}
 
-        COMMAND ${CLANG_FORMAT} -i -verbose ${VCPKG_SOURCES}
+        COMMAND "${CLANG_FORMAT}" -i -verbose ${VCPKG_SOURCES}
 
-        COMMAND ${CLANG_FORMAT} -i -verbose ${VCPKG_TEST_SOURCES}
-        COMMAND ${CLANG_FORMAT} -i -verbose ${VCPKG_TEST_INCLUDES}
+        COMMAND "${CLANG_FORMAT}" -i -verbose ${VCPKG_TEST_SOURCES}
+        COMMAND "${CLANG_FORMAT}" -i -verbose ${VCPKG_TEST_INCLUDES}
 
-        COMMAND ${CLANG_FORMAT} -i -verbose ${VCPKG_FUZZ_SOURCES}
-        COMMAND ${CLANG_FORMAT} -i -verbose ${TLS12_DOWNLOAD_SOURCES}
+        COMMAND "${CLANG_FORMAT}" -i -verbose ${VCPKG_FUZZ_SOURCES}
+        COMMAND "${CLANG_FORMAT}" -i -verbose ${TLS12_DOWNLOAD_SOURCES}
         )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,4 @@
-if(WIN32)
-# 3.16 for MSVC_RUNTIME_LIBRARY
-cmake_minimum_required(VERSION 3.16)
-else()
 cmake_minimum_required(VERSION 3.14)
-endif()
 
 # ===============
 # === Options ===
@@ -19,7 +14,6 @@ option(VCPKG_BUILD_TLS12_DOWNLOADER "Enable building the tls12-downloader" OFF)
 option(VCPKG_BUILD_FUZZING "Option for enabling vcpkg-fuzz support" OFF)
 option(VCPKG_EMBED_GIT_SHA "Option for to fill in the Git SHA version; off by default to avoid privacy concerns out of official builds" OFF)
 
-
 CMAKE_DEPENDENT_OPTION(VCPKG_BUILD_BENCHMARKING "Option for enabling benchmarking" OFF
     "BUILD_TESTING" OFF)
 
@@ -28,44 +22,35 @@ if(DEFINE_DISABLE_METRICS OR VCPKG_DISABLE_METRICS)
         "file vcpkg.disable_metrics next to the binary.")
 endif()
 
-if(VCPKG_BUILD_TLS12_DOWNLOADER AND NOT WIN32)
-    message(FATAL_ERROR "The tls12-downloader binary is only supported on Windows.")
-endif()
+set(LANGUAGES "CXX")
+if(VCPKG_BUILD_TLS12_DOWNLOADER)
+    # 3.16 for MSVC_RUNTIME_LIBRARY
+    list(APPEND LANGUAGES "C")
+    cmake_minimum_required(VERSION 3.16)
+else()
 
-project(vcpkg C CXX)
+project(vcpkg
+    DESCRIPTION "vcpkg helps you manage C and C++ libraries on Windows, Linux and MacOS."
+    HOMEPAGE_URL "https://github.com/microsoft/vcpkg"
+    LANGUAGES ${LANGUAGES}
+)
 include(cmake/utilities.cmake)
 
 # =============
 # === Files ===
 # =============
 
-file(GLOB VCPKGLIB_SOURCES CONFIGURE_DEPENDS
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/vcpkg/*.cpp"
-)
-file(GLOB VCPKGLIB_BASE_SOURCES CONFIGURE_DEPENDS
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/vcpkg/base/*.cpp"
-)
-file(GLOB VCPKGLIB_INCLUDES CONFIGURE_DEPENDS
-    "${CMAKE_CURRENT_SOURCE_DIR}/include/vcpkg/*.h"
-    "${CMAKE_CURRENT_SOURCE_DIR}/include/vcpkg/fwd/*.h"
-)
-file(GLOB VCPKGLIB_BASE_INCLUDES CONFIGURE_DEPENDS
-    "${CMAKE_CURRENT_SOURCE_DIR}/include/vcpkg/base/*.h"
-    "${CMAKE_CURRENT_SOURCE_DIR}/include/vcpkg/base/fwd/*.h"
-)
+file(GLOB VCPKGLIB_SOURCES CONFIGURE_DEPENDS "src/vcpkg/*.cpp")
+file(GLOB VCPKGLIB_BASE_SOURCES CONFIGURE_DEPENDS "src/vcpkg/base/*.cpp")
+file(GLOB VCPKGLIB_INCLUDES CONFIGURE_DEPENDS "include/vcpkg/*.h" "include/vcpkg/fwd/*.h")
+file(GLOB VCPKGLIB_BASE_INCLUDES CONFIGURE_DEPENDS "include/vcpkg/base/*.h" "include/vcpkg/base/fwd/*.h")
 
 set(VCPKG_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/vcpkg.cpp")
 
-file(GLOB VCPKG_TEST_SOURCES CONFIGURE_DEPENDS
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/vcpkg-test/*.cpp"
-)
-file(GLOB VCPKG_TEST_INCLUDES CONFIGURE_DEPENDS
-    "${CMAKE_CURRENT_SOURCE_DIR}/include/vcpkg-test/*.h"
-)
+file(GLOB VCPKG_TEST_SOURCES CONFIGURE_DEPENDS "src/vcpkg-test/*.cpp")
+file(GLOB VCPKG_TEST_INCLUDES CONFIGURE_DEPENDS "include/vcpkg-test/*.h")
 
-file(GLOB VCPKG_FUZZ_SOURCES CONFIGURE_DEPENDS
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/vcpkg-fuzz/*.cpp"
-)
+file(GLOB VCPKG_FUZZ_SOURCES CONFIGURE_DEPENDS "src/vcpkg-fuzz/*.cpp")
 
 set(TLS12_DOWNLOAD_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/tls12-download.c")
 
@@ -151,6 +136,8 @@ if(VCPKG_CXXFS_LIBRARY)
     target_link_libraries(vcpkglib PRIVATE ${VCPKG_CXXFS_LIBRARY})
 endif()
 
+vcpkg_target_add_necessary_mingw_definitions(vcpkglib)
+
 if(MSVC)
     get_target_property(_srcs vcpkglib SOURCES)
 
@@ -164,17 +151,6 @@ if(MSVC)
     target_compile_options(vcpkglib PRIVATE /Yupch.h /FIpch.h /Zm200)
 else()
     target_compile_options(vcpkglib PRIVATE -include "${CMAKE_CURRENT_SOURCE_DIR}/include/pch.h")
-endif()
-
-if (MINGW)
-    target_compile_definitions(vcpkglib
-        PUBLIC
-            UNICODE
-            _WIN32_WINNT=0x0601
-            WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY=4
-            __fastfail=exit
-    )
-    target_link_libraries(vcpkglib PUBLIC winhttp bcrypt version ole32 uuid)
 endif()
 
 # === Target: vcpkg ===
@@ -218,6 +194,7 @@ if(VCPKG_BUILD_TLS12_DOWNLOADER)
     set_property(TARGET tls12-download PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded")
     set_property(TARGET tls12-download APPEND PROPERTY LINK_OPTIONS "$<IF:$<CONFIG:Debug>,,/ENTRY:entry>")
     target_link_libraries(tls12-download winhttp)
+    vcpkg_target_add_necessary_mingw_definitions(tls12-download)
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ if(VCPKG_BUILD_TLS12_DOWNLOADER)
     # 3.16 for MSVC_RUNTIME_LIBRARY
     list(APPEND LANGUAGES "C")
     cmake_minimum_required(VERSION 3.16)
-else()
+endif()
 
 project(vcpkg
     DESCRIPTION "vcpkg helps you manage C and C++ libraries on Windows, Linux and MacOS."
@@ -136,8 +136,6 @@ if(VCPKG_CXXFS_LIBRARY)
     target_link_libraries(vcpkglib PRIVATE ${VCPKG_CXXFS_LIBRARY})
 endif()
 
-vcpkg_target_add_necessary_mingw_definitions(vcpkglib)
-
 if(MSVC)
     get_target_property(_srcs vcpkglib SOURCES)
 
@@ -151,6 +149,17 @@ if(MSVC)
     target_compile_options(vcpkglib PRIVATE /Yupch.h /FIpch.h /Zm200)
 else()
     target_compile_options(vcpkglib PRIVATE -include "${CMAKE_CURRENT_SOURCE_DIR}/include/pch.h")
+endif()
+
+if(MINGW)
+    target_compile_definitions(vcpkglib
+        PUBLIC
+            UNICODE
+            _WIN32_WINNT=0x0601
+            WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY=4
+            __fastfail=exit
+    )
+    target_link_libraries(vcpkglib PUBLIC winhttp bcrypt version ole32 uuid)
 endif()
 
 # === Target: vcpkg ===
@@ -194,7 +203,6 @@ if(VCPKG_BUILD_TLS12_DOWNLOADER)
     set_property(TARGET tls12-download PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded")
     set_property(TARGET tls12-download APPEND PROPERTY LINK_OPTIONS "$<IF:$<CONFIG:Debug>,,/ENTRY:entry>")
     target_link_libraries(tls12-download winhttp)
-    vcpkg_target_add_necessary_mingw_definitions(tls12-download)
 endif()
 
 
@@ -218,5 +226,5 @@ if(CLANG_FORMAT)
 
         COMMAND "${CLANG_FORMAT}" -i -verbose ${VCPKG_FUZZ_SOURCES}
         COMMAND "${CLANG_FORMAT}" -i -verbose ${TLS12_DOWNLOAD_SOURCES}
-        )
+    )
 endif()

--- a/azure-pipelines/pipelines.yml
+++ b/azure-pipelines/pipelines.yml
@@ -90,7 +90,7 @@ jobs:
         script: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=x86 -host_arch=x86
           rmdir /s /q build.x86.debug > nul 2> nul
-          cmake.exe -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -DVCPKG_DEVELOPMENT_WARNINGS=ON -DVCPKG_WARNINGS_AS_ERRORS=ON -DVCPKG_BUILD_FUZZING=ON -B build.x86.debug
+          cmake.exe -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -DVCPKG_DEVELOPMENT_WARNINGS=ON -DVCPKG_WARNINGS_AS_ERRORS=ON -DVCPKG_BUILD_FUZZING=ON -DVCPKG_BUILD_TLS12_DOWNLOADER=ON -B build.x86.debug
           ninja.exe -C build.x86.debug
           build.x86.debug\vcpkg-test.exe
         failOnStderr: true

--- a/azure-pipelines/signing.yml
+++ b/azure-pipelines/signing.yml
@@ -27,7 +27,7 @@ jobs:
         failOnStderr: true
         script: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=x86 -host_arch=x86
-          cmake.exe -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DVCPKG_DEVELOPMENT_WARNINGS=ON -DVCPKG_WARNINGS_AS_ERRORS=ON -DVCPKG_BUILD_FUZZING=OFF -DVCPKG_EMBED_GIT_SHA=ON -B "$(Build.StagingDirectory)"
+          cmake.exe -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DVCPKG_DEVELOPMENT_WARNINGS=ON -DVCPKG_WARNINGS_AS_ERRORS=ON -DVCPKG_BUILD_FUZZING=OFF -DVCPKG_BUILD_TLS12_DOWNLOADER=ON -DVCPKG_EMBED_GIT_SHA=ON -B "$(Build.StagingDirectory)"
           ninja.exe -C "$(Build.StagingDirectory)"
     - task: MicroBuildSigningPlugin@2
       inputs:

--- a/cmake/utilities.cmake
+++ b/cmake/utilities.cmake
@@ -248,16 +248,3 @@ function(vcpkg_target_add_warning_options TARGET)
         endif()
     endif()
 endfunction()
-
-function(vcpkg_target_add_necessary_mingw_definitions target)
-    if(MINGW)
-        target_compile_definitions("${target}"
-            PUBLIC
-                UNICODE
-                _WIN32_WINNT=0x0601
-                WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY=4
-                __fastfail=exit
-        )
-        target_link_libraries("${target}" PUBLIC winhttp bcrypt version ole32 uuid)
-    endif()
-endfunction()

--- a/cmake/utilities.cmake
+++ b/cmake/utilities.cmake
@@ -248,3 +248,16 @@ function(vcpkg_target_add_warning_options TARGET)
         endif()
     endif()
 endfunction()
+
+function(vcpkg_target_add_necessary_mingw_definitions target)
+    if(MINGW)
+        target_compile_definitions("${target}"
+            PUBLIC
+                UNICODE
+                _WIN32_WINNT=0x0601
+                WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY=4
+                __fastfail=exit
+        )
+        target_link_libraries("${target}" PUBLIC winhttp bcrypt version ole32 uuid)
+    endif()
+endfunction()


### PR DESCRIPTION
Nobody needs to build it except us, so there's no need to.
Additionally, on mingw, tls12-download fails to build due,
so this also fixes our build on mingw.

Alternative fix to #31 