### PR TITLE
Use only named packages from extra registries

### DIFF
--- a/src/vcpkg/paragraphs.cpp
+++ b/src/vcpkg/paragraphs.cpp
@@ -426,7 +426,8 @@ namespace vcpkg::Paragraphs
 
         for (const auto& registry : registries.registries())
         {
-            registry.implementation().get_all_port_names(ports, paths);
+            const auto packages = registry.packages();
+            ports.insert(end(ports), begin(packages), end(packages));
         }
         if (auto registry = registries.default_registry())
         {


### PR DESCRIPTION
This change resolves errors from RegistryEntry::get_path_to_version() when the default registry doesn't have a port for a name which is part of some extra registry but not listed in that registry's "packages" configuration field.
This is consistent with RegistrySet::registry_for_port() which only considers the the named packages from the extra registries.

Use case:
~~~
{
  "default-registry": {
    "kind": "filesystem",
    "path": "/my/tiny/repository"
  },
  "registries": [
    {
      "kind": "git",
      "repository": "https://github.com/microsoft/vcpkg",
      "packages": [ "vcpkg-cmake", "vcpkg-cmake-config" ]
    }
  ]
}
~~~