### PR TITLE
Disable git autocrlf when archiving tree

### DIFF
--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -776,6 +776,7 @@ If you wish to silence this error and use classic mode, you can:
         auto tar_cmd_builder = git_cmd_builder(*this, dot_git_dir, dot_git_dir)
                                    .string_arg("archive")
                                    .string_arg(git_tree)
+                                   .string_arg("--worktree-attributes")
                                    .string_arg("-o")
                                    .path_arg(destination_tar);
         const auto tar_output = System::cmd_execute_and_capture_output(tar_cmd_builder);

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -774,10 +774,10 @@ If you wish to silence this error and use classic mode, you can:
         }
 
         auto tar_cmd_builder = git_cmd_builder(*this, dot_git_dir, dot_git_dir)
-                                   .string_arg("archive")
-                                   .string_arg(git_tree)
                                    .string_arg("-c")
                                    .string_arg("core.autocrlf=false")
+                                   .string_arg("archive")
+                                   .string_arg(git_tree)
                                    .string_arg("-o")
                                    .path_arg(destination_tar);
         const auto tar_output = System::cmd_execute_and_capture_output(tar_cmd_builder);

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -776,7 +776,7 @@ If you wish to silence this error and use classic mode, you can:
         auto tar_cmd_builder = git_cmd_builder(*this, dot_git_dir, dot_git_dir)
                                    .string_arg("archive")
                                    .string_arg(git_tree)
-                                   .string_arg("--worktree-attributes")
+                                   .string_arg("-c").string_arg("core.autocrlf=false")
                                    .string_arg("-o")
                                    .path_arg(destination_tar);
         const auto tar_output = System::cmd_execute_and_capture_output(tar_cmd_builder);

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -776,7 +776,8 @@ If you wish to silence this error and use classic mode, you can:
         auto tar_cmd_builder = git_cmd_builder(*this, dot_git_dir, dot_git_dir)
                                    .string_arg("archive")
                                    .string_arg(git_tree)
-                                   .string_arg("-c").string_arg("core.autocrlf=false")
+                                   .string_arg("-c")
+                                   .string_arg("core.autocrlf=false")
                                    .string_arg("-o")
                                    .path_arg(destination_tar);
         const auto tar_output = System::cmd_execute_and_capture_output(tar_cmd_builder);


### PR DESCRIPTION
Ensures that file endings are consistent between the ports and the versioned port under `versioning`.

Fixes https://github.com/microsoft/vcpkg/issues/16615#issuecomment-804928402 (verified locally). Before this fix, a patch with LF endings could end up with CRLF endings on Windows causing corrupt patch issues.