### PR TITLE
Allow shallow git registries

### DIFF
--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -845,8 +845,11 @@ If you wish to silence this error and use classic mode, you can:
         std::error_code ec;
         Files::ExclusiveFileLock guard(Files::ExclusiveFileLock::Wait::Yes, fs, lock_file, ec);
 
-        System::Command fetch_git_ref =
-            git_cmd_builder(*this, dot_git_dir, work_tree).string_arg("fetch").string_arg("--").string_arg(repo);
+        System::Command fetch_git_ref = git_cmd_builder(*this, dot_git_dir, work_tree)
+                                            .string_arg("fetch")
+                                            .string_arg("--update-shallow")
+                                            .string_arg("--")
+                                            .string_arg(repo);
         if (treeish.size() != 0)
         {
             fetch_git_ref.string_arg(treeish);


### PR DESCRIPTION
`git fetch` normally refuses to deal with shallow repositories.
For vcpkg, this makes it impossible to use shallow clones of remote
registries such as `VCPKG_INSTALLATION_ROOT` on Azure Pipelines.
An extra parameter makes `git fetch` accept shallow repositories.