### PR TITLE
[vcpkg] Introduce experimental workaround X_VCPKG_NUGET_ID_PREFIX

### DIFF
--- a/include/vcpkg/binarycaching.private.h
+++ b/include/vcpkg/binarycaching.private.h
@@ -13,24 +13,29 @@ namespace vcpkg
 
     struct NugetReference
     {
-        explicit NugetReference(const Dependencies::InstallPlanAction& action)
-            : NugetReference(action.spec,
-                             action.source_control_file_location.value_or_exit(VCPKG_LINE_INFO)
-                                 .source_control_file->core_paragraph->version,
-                             action.abi_info.value_or_exit(VCPKG_LINE_INFO).package_abi)
-        {
-        }
-
-        NugetReference(const PackageSpec& spec, const std::string& raw_version, const std::string& abi_tag)
-            : id(spec.dir()), version(reformat_version(raw_version, abi_tag))
-        {
-        }
+        NugetReference(std::string id, std::string version) : id(std::move(id)), version(std::move(version)) { }
 
         std::string id;
         std::string version;
 
         std::string nupkg_filename() const { return Strings::concat(id, '.', version, ".nupkg"); }
     };
+
+    inline NugetReference make_nugetref(const PackageSpec& spec,
+                                        const std::string& raw_version,
+                                        const std::string& abi_tag,
+                                        const std::string& prefix)
+    {
+        return {Strings::concat(prefix, spec.dir()), reformat_version(raw_version, abi_tag)};
+    }
+    inline NugetReference make_nugetref(const Dependencies::InstallPlanAction& action, const std::string& prefix)
+    {
+        return make_nugetref(action.spec,
+                             action.source_control_file_location.value_or_exit(VCPKG_LINE_INFO)
+                                 .source_control_file->core_paragraph->version,
+                             action.abi_info.value_or_exit(VCPKG_LINE_INFO).package_abi,
+                             prefix);
+    }
 
     namespace details
     {

--- a/src/vcpkg-test/binarycaching.cpp
+++ b/src/vcpkg-test/binarycaching.cpp
@@ -100,7 +100,11 @@ Build-Depends: bzip
     compiler_info.version = "compilerversion";
     ipa.abi_info.get()->compiler_info = compiler_info;
 
-    NugetReference ref(ipa);
+    NugetReference ref2 = make_nugetref(ipa, "prefix_");
+
+    REQUIRE(ref2.nupkg_filename() == "prefix_zlib2_x64-windows.1.5.0-vcpkgpackageabi.nupkg");
+
+    NugetReference ref = make_nugetref(ipa, "");
 
     REQUIRE(ref.nupkg_filename() == "zlib2_x64-windows.1.5.0-vcpkgpackageabi.nupkg");
 


### PR DESCRIPTION
This PR introduces an experimental workaround for the problem described in https://github.com/microsoft/vcpkg/issues/16579 by enabling a prefix to be added to all binary cached NuGet package ids. This enables multiple projects using the same NuGet feed to "see" a completely independent universe of cached packages and prevents all collisions.

To activate the workaround, simply set the environment variable `X_VCPKG_NUGET_ID_PREFIX` to a non-empty string. Package IDs will then be constructed as `<prefix>_<port>_<triplet>` instead of the default `<port>_<triplet>`.

@PazerOP I'd greatly appreciate it if you could try out this PR and confirm that it solves your issue. You will need to build the tool from source, which can be done by cloning this repo and using standard cmake.