### PR TITLE
tls12-download: Use WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY

### DIFF
--- a/src/tls12-download.c
+++ b/src/tls12-download.c
@@ -199,7 +199,7 @@ int __stdcall entry()
     }
     else if (GetLastError() == ERROR_ENVVAR_NOT_FOUND)
     {
-        access_type = WINHTTP_ACCESS_TYPE_NO_PROXY;
+        access_type = WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY;
         proxy_setting = WINHTTP_NO_PROXY_NAME;
         proxy_bypass_setting = WINHTTP_NO_PROXY_BYPASS;
     }


### PR DESCRIPTION
On Windows 10 it is not a good way to let user set environment variable "HTTPS_PROXY" manually. Simply using `WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY` instead of `WINHTTP_ACCESS_TYPE_NO_PROXY` will let WinHttp use proxies automatically set by v2ray, shadowsocks, etc..
![image](https://user-images.githubusercontent.com/29846655/113849755-5fb8c800-97cc-11eb-93c3-c1bcdd94d528.png)
