### PR TITLE
tls12-download: Use WinHttp Automatic Proxy instead of HTTPS_PROXY

### DIFF
--- a/src/tls12-download.c
+++ b/src/tls12-download.c
@@ -199,7 +199,7 @@ int __stdcall entry()
     }
     else if (GetLastError() == ERROR_ENVVAR_NOT_FOUND)
     {
-        access_type = WINHTTP_ACCESS_TYPE_NO_PROXY;
+        access_type = WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY;
         proxy_setting = WINHTTP_NO_PROXY_NAME;
         proxy_bypass_setting = WINHTTP_NO_PROXY_BYPASS;
     }

--- a/src/tls12-download.c
+++ b/src/tls12-download.c
@@ -1,6 +1,7 @@
 #include <Windows.h>
 #include <process.h>
 #include <winhttp.h>
+#include <VersionHelpers.h>
 /*
  * This program must be as small as possible, because it is committed in binary form to the
  * vcpkg github repo to enable downloading the main vcpkg program on Windows 7, where TLS 1.2 is
@@ -199,7 +200,7 @@ int __stdcall entry()
     }
     else if (GetLastError() == ERROR_ENVVAR_NOT_FOUND)
     {
-        access_type = WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY;
+        access_type = IsWindows8Point1OrGreater() ? WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY : WINHTTP_ACCESS_TYPE_DEFAULT_PROXY;
         proxy_setting = WINHTTP_NO_PROXY_NAME;
         proxy_bypass_setting = WINHTTP_NO_PROXY_BYPASS;
     }


### PR DESCRIPTION
On Windows 10 it is not a good way to let user set environment variable "HTTPS_PROXY" manually. 
Simply using WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY (or WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY when WinVer < 8.1) instead of WINHTTP_ACCESS_TYPE_NO_PROXY will let WinHttp use proxies automatically set by v2ray, shadowsocks, etc..
This manner is same as `src/vcpkg/base/downloads.cpp`.