### PR TITLE
Provide better experience to Windows proxy users.

### DIFF
--- a/include/pch.h
+++ b/include/pch.h
@@ -9,6 +9,7 @@
 #include <process.h>
 #include <shellapi.h>
 #include <winhttp.h>
+#include <winreg.h>
 #endif
 
 #include <math.h>

--- a/include/vcpkg/base/system.proxy.h
+++ b/include/vcpkg/base/system.proxy.h
@@ -1,8 +1,6 @@
 #pragma once
-
 #include <optional>
 #include <string>
-
 namespace vcpkg::System
 {
     bool get_windows_proxy_enabled();

--- a/include/vcpkg/base/system.proxy.h
+++ b/include/vcpkg/base/system.proxy.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+namespace vcpkg::System
+{
+    bool get_windows_proxy_enabled();
+    std::optional<std::string> get_windows_proxy_server();
+}

--- a/src/tls12-download.c
+++ b/src/tls12-download.c
@@ -199,7 +199,7 @@ int __stdcall entry()
     }
     else if (GetLastError() == ERROR_ENVVAR_NOT_FOUND)
     {
-        access_type = WINHTTP_ACCESS_TYPE_NO_PROXY;
+        access_type = WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY;
         proxy_setting = WINHTTP_NO_PROXY_NAME;
         proxy_bypass_setting = WINHTTP_NO_PROXY_BYPASS;
     }

--- a/src/tls12-download.c
+++ b/src/tls12-download.c
@@ -1,7 +1,6 @@
 #include <Windows.h>
 #include <process.h>
 #include <winhttp.h>
-
 /* VersionHelper.h (IsWindows8Point1OrGreater, etc..) is deprecated.
  * See https://github.com/glfw/glfw/issues/1294
  * See remark section in https://docs.microsoft.com/en-us/windows/win32/api/versionhelpers/nf-versionhelpers-iswindows8point1orgreater

--- a/src/tls12-download.c
+++ b/src/tls12-download.c
@@ -10,13 +10,12 @@
  * This doesn't increase program size.
  * TODO: Feel free to beautify it.
  */
-typedef int (*RtlGetVersionPtr)(PRTL_OSVERSIONINFOW);
 static int GetRealOSVersion(PRTL_OSVERSIONINFOW ver)
 {
     HMODULE hMod = GetModuleHandleW(L"ntdll.dll");
     if (hMod)
     {
-        RtlGetVersionPtr fxPtr = (RtlGetVersionPtr)GetProcAddress(hMod, "RtlGetVersion");
+        int (*fxPtr)(PRTL_OSVERSIONINFOW) = (int (*)(PRTL_OSVERSIONINFOW))GetProcAddress(hMod, "RtlGetVersion");
         if (fxPtr != NULL)
         {
             ver->dwOSVersionInfoSize = sizeof(RTL_OSVERSIONINFOW);

--- a/src/tls12-download.c
+++ b/src/tls12-download.c
@@ -1,6 +1,7 @@
 #include <Windows.h>
 #include <process.h>
 #include <winhttp.h>
+#include <VersionHelpers.h>
 /*
  * This program must be as small as possible, because it is committed in binary form to the
  * vcpkg github repo to enable downloading the main vcpkg program on Windows 7, where TLS 1.2 is
@@ -199,7 +200,7 @@ int __stdcall entry()
     }
     else if (GetLastError() == ERROR_ENVVAR_NOT_FOUND)
     {
-        access_type = WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY;
+        access_type = IsWindows8Point1OrGreater() ? WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY : WINHTTP_ACCESS_TYPE_DEFAULT_PROXY;
         proxy_setting = WINHTTP_NO_PROXY_NAME;
         proxy_bypass_setting = WINHTTP_NO_PROXY_BYPASS;
     }

--- a/src/tls12-download.c
+++ b/src/tls12-download.c
@@ -3,7 +3,8 @@
 #include <winhttp.h>
 /* VersionHelper.h (IsWindows8Point1OrGreater, etc..) is deprecated.
  * See https://github.com/glfw/glfw/issues/1294
- * See remark section in https://docs.microsoft.com/en-us/windows/win32/api/versionhelpers/nf-versionhelpers-iswindows8point1orgreater
+ * See remark section in
+ * https://docs.microsoft.com/en-us/windows/win32/api/versionhelpers/nf-versionhelpers-iswindows8point1orgreater
  * Applications not manifested for Windows 8.1 or Windows 10 return false, even if the current operating is 8.1 or 10
  * So we need to do this workaround.
  * This doesn't increase program size.
@@ -25,13 +26,14 @@ static int GetRealOSVersion(PRTL_OSVERSIONINFOW ver)
     return -1;
 }
 
-static int IsWindows8Point1OrGreater() {
+static int IsWindows8Point1OrGreater()
+{
     RTL_OSVERSIONINFOW version;
     GetRealOSVersion(&version);
     return version.dwMajorVersion > HIBYTE(_WIN32_WINNT_WINBLUE) ||
-        (version.dwMajorVersion == HIBYTE(_WIN32_WINNT_WINBLUE) && version.dwMinorVersion >= LOBYTE(_WIN32_WINNT_WINBLUE));
+           (version.dwMajorVersion == HIBYTE(_WIN32_WINNT_WINBLUE) &&
+            version.dwMinorVersion >= LOBYTE(_WIN32_WINNT_WINBLUE));
 }
-
 
 /*
  * This program must be as small as possible, because it is committed in binary form to the
@@ -231,7 +233,8 @@ int __stdcall entry()
     }
     else if (GetLastError() == ERROR_ENVVAR_NOT_FOUND)
     {
-        access_type = IsWindows8Point1OrGreater() ? WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY : WINHTTP_ACCESS_TYPE_DEFAULT_PROXY;
+        access_type =
+            IsWindows8Point1OrGreater() ? WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY : WINHTTP_ACCESS_TYPE_DEFAULT_PROXY;
         proxy_setting = WINHTTP_NO_PROXY_NAME;
         proxy_bypass_setting = WINHTTP_NO_PROXY_BYPASS;
     }

--- a/src/tls12-download.c
+++ b/src/tls12-download.c
@@ -1,7 +1,39 @@
 #include <Windows.h>
 #include <process.h>
 #include <winhttp.h>
-#include <VersionHelpers.h>
+
+/* VersionHelper.h (IsWindows8Point1OrGreater, etc..) is deprecated.
+ * See https://github.com/glfw/glfw/issues/1294
+ * See remark section in https://docs.microsoft.com/en-us/windows/win32/api/versionhelpers/nf-versionhelpers-iswindows8point1orgreater
+ * Applications not manifested for Windows 8.1 or Windows 10 return false, even if the current operating is 8.1 or 10
+ * So we need to do this workaround.
+ * This doesn't increase program size.
+ * TODO: Feel free to beautify it.
+ */
+typedef int (*RtlGetVersionPtr)(PRTL_OSVERSIONINFOW);
+static int GetRealOSVersion(PRTL_OSVERSIONINFOW ver)
+{
+    HMODULE hMod = GetModuleHandleW(L"ntdll.dll");
+    if (hMod)
+    {
+        RtlGetVersionPtr fxPtr = (RtlGetVersionPtr)GetProcAddress(hMod, "RtlGetVersion");
+        if (fxPtr != NULL)
+        {
+            ver->dwOSVersionInfoSize = sizeof(RTL_OSVERSIONINFOW);
+            return fxPtr(ver);
+        }
+    }
+    return -1;
+}
+
+static int IsWindows8Point1OrGreater() {
+    RTL_OSVERSIONINFOW version;
+    GetRealOSVersion(&version);
+    return version.dwMajorVersion > HIBYTE(_WIN32_WINNT_WINBLUE) ||
+        (version.dwMajorVersion == HIBYTE(_WIN32_WINNT_WINBLUE) && version.dwMinorVersion >= LOBYTE(_WIN32_WINNT_WINBLUE));
+}
+
+
 /*
  * This program must be as small as possible, because it is committed in binary form to the
  * vcpkg github repo to enable downloading the main vcpkg program on Windows 7, where TLS 1.2 is

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -11,7 +11,8 @@
 #if defined(_WIN32)
 /* VersionHelper.h (IsWindows8Point1OrGreater, etc..) is deprecated.
  * See https://github.com/glfw/glfw/issues/1294
- * See remark section in https://docs.microsoft.com/en-us/windows/win32/api/versionhelpers/nf-versionhelpers-iswindows8point1orgreater
+ * See remark section in
+ * https://docs.microsoft.com/en-us/windows/win32/api/versionhelpers/nf-versionhelpers-iswindows8point1orgreater
  * Applications not manifested for Windows 8.1 or Windows 10 return false, even if the current operating is 8.1 or 10
  * So we need to do this workaround.
  * TODO: Feel free to beautify it.

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -17,13 +17,12 @@
  * So we need to do this workaround.
  * TODO: Feel free to beautify it.
  */
-typedef int (*RtlGetVersionPtr)(PRTL_OSVERSIONINFOW);
 static int GetRealOSVersion(PRTL_OSVERSIONINFOW ver)
 {
     HMODULE hMod = GetModuleHandleW(L"ntdll.dll");
     if (hMod)
     {
-        auto fxPtr = (RtlGetVersionPtr)GetProcAddress(hMod, "RtlGetVersion");
+        auto fxPtr = (int (*)(PRTL_OSVERSIONINFOW))GetProcAddress(hMod, "RtlGetVersion");
         if (fxPtr != nullptr)
         {
             ver->dwOSVersionInfoSize = sizeof(RTL_OSVERSIONINFOW);

--- a/src/vcpkg/base/system.proxy.cpp
+++ b/src/vcpkg/base/system.proxy.cpp
@@ -1,5 +1,4 @@
 #include <vcpkg/base/system.proxy.h>
-
 std::optional<std::string> vcpkg::System::get_windows_proxy_server()
 {
 #if defined(_WIN32)
@@ -25,7 +24,6 @@ std::optional<std::string> vcpkg::System::get_windows_proxy_server()
     return nullptr;
 #endif
 }
-
 bool vcpkg::System::get_windows_proxy_enabled()
 {
 #if defined(_WIN32)

--- a/src/vcpkg/base/system.proxy.cpp
+++ b/src/vcpkg/base/system.proxy.cpp
@@ -1,0 +1,45 @@
+#include <vcpkg/base/system.proxy.h>
+
+std::optional<std::string> vcpkg::System::get_windows_proxy_server()
+{
+#if defined(_WIN32)
+    HKEY proxy_reg;
+    DWORD buf_len = 0;
+
+    auto ret =
+        RegOpenKey(HKEY_CURRENT_USER, R"(Software\Microsoft\Windows\CurrentVersion\Internet Settings)", &proxy_reg);
+    if (ret)
+        return nullptr;
+
+    ret = RegGetValue(proxy_reg, nullptr, "ProxyServer", RRF_RT_REG_SZ, nullptr, nullptr, &buf_len);
+    if (ret)
+        return nullptr;
+
+    std::string srv(buf_len, '\0');
+    ret = RegGetValue(proxy_reg, nullptr, "ProxyServer", RRF_RT_REG_SZ, nullptr, srv.data(), &buf_len);
+    if (ret)
+        return nullptr;
+
+    return srv;
+#else
+    return nullptr;
+#endif
+}
+
+bool vcpkg::System::get_windows_proxy_enabled()
+{
+#if defined(_WIN32)
+    HKEY proxy_reg;
+    DWORD enable = 0;
+    DWORD len = 4;
+
+    auto ret =
+        RegOpenKey(HKEY_CURRENT_USER, R"(Software\Microsoft\Windows\CurrentVersion\Internet Settings)", &proxy_reg);
+
+    ret = RegGetValue(proxy_reg, nullptr, "ProxyEnable", RRF_RT_REG_DWORD, nullptr, &enable, &len);
+
+    return enable;
+#else
+    return false;
+#endif
+}

--- a/src/vcpkg/base/system.proxy.cpp
+++ b/src/vcpkg/base/system.proxy.cpp
@@ -7,17 +7,14 @@ std::optional<std::string> vcpkg::System::get_windows_proxy_server()
 
     auto ret =
         RegOpenKey(HKEY_CURRENT_USER, R"(Software\Microsoft\Windows\CurrentVersion\Internet Settings)", &proxy_reg);
-    if (ret)
-        return nullptr;
+    if (ret) return nullptr;
 
     ret = RegGetValue(proxy_reg, nullptr, "ProxyServer", RRF_RT_REG_SZ, nullptr, nullptr, &buf_len);
-    if (ret)
-        return nullptr;
+    if (ret) return nullptr;
 
     std::string srv(buf_len, '\0');
     ret = RegGetValue(proxy_reg, nullptr, "ProxyServer", RRF_RT_REG_SZ, nullptr, srv.data(), &buf_len);
-    if (ret)
-        return nullptr;
+    if (ret) return nullptr;
 
     return srv;
 #else

--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -407,12 +407,12 @@ namespace vcpkg::Build
                 auto proxy = System::get_windows_proxy_server();
                 if (proxy.has_value())
                 {
-                    // It is better to set HTTPS_PROXY with http:// prefix.
-                    env.emplace("HTTP_PROXY", ("http://" + proxy.value()).c_str());
-                    env.emplace("HTTPS_PROXY", ("http://" + proxy.value()).c_str());
+                    // Most HTTP proxy DOES proxy HTTPS requests.
+                    env.emplace("HTTP_PROXY", proxy.value().c_str());
+                    env.emplace("HTTPS_PROXY", proxy.value().c_str());
 
                     System::print2(
-                        "-- Automatically setting HTTP(S)_PROXY environment variables to http://", proxy.value(), "\n");
+                        "-- Automatically setting HTTP(S)_PROXY environment variables to ", proxy.value(), "\n");
                 }
             }
             return {env};

--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -415,7 +415,6 @@ namespace vcpkg::Build
                         "-- Automatically setting HTTP(S)_PROXY environment variables to http://", proxy.value(), "\n");
                 }
             }
-
             return {env};
         });
 


### PR DESCRIPTION
There are several places I modified:
1. `tls12-download.c`
This file doesn't use Windows proxy settings when `HTTPS_PROXY` env variable not found. The correct manner should be use `access_type = IsWindows8Point1OrGreater() ? WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY : WINHTTP_ACCESS_TYPE_DEFAULT_PROXY;`, not just setting `WINHTTP_ACCESS_TYPE_NO_PROXY` as it is inconvenient to set env variable on Windows.

2. `src/vcpkg/base/downloads.cpp`
VersionHelper.h (IsWindows8Point1OrGreater, etc..) is deprecated. See [this](https://github.com/glfw/glfw/issues/1294) and remark section in [this](https://docs.microsoft.com/en-us/windows/win32/api/versionhelpers/nf-versionhelpers-iswindows8point1orgreater). Applications not manifested for Windows 8.1 or Windows 10 return false, even if the current operating is 8.1 or 10. So we need to do use RtlGetVersion to get correct OS version. Currently the program doesn't seems to have a manifest, and wrongly setting proxies.

3. `pch.h`
Where i will use registry functions

4. `system.proxy.h/.cpp`
Write an helper function to determine whether there's a active Windows proxy setting.

5. `build.cpp`
At `System::Environment& EnvCache::get_action_env` I added the proxy detection and add the HTTP_PROXY and HTTPS_PROXY variables to env list.