### PR TITLE
ignore .DS_store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /cmake-build-*
 /.vs
 /CMakeSettings.json
+.DS_Store


### PR DESCRIPTION
There are files create by the apple finder in every folder that you have opened with the finder