### PR TITLE
[vcpkg] format-manifest --all now also formats changed CONTROL files

### DIFF
--- a/include/vcpkg/vcpkgpaths.h
+++ b/include/vcpkg/vcpkgpaths.h
@@ -128,6 +128,7 @@ namespace vcpkg
         ExpectedS<std::string> git_show(const std::string& treeish, const fs::path& dot_git_dir) const;
 
         ExpectedS<std::map<std::string, std::string, std::less<>>> git_get_local_port_treeish_map() const;
+        ExpectedS<std::vector<fs::path>> git_changed_port_files() const;
 
         // Git manipulation for remote registries
         // runs `git fetch {uri} {treeish}`, and returns the hash of FETCH_HEAD.

--- a/src/vcpkg/commands.format-manifest.cpp
+++ b/src/vcpkg/commands.format-manifest.cpp
@@ -266,6 +266,22 @@ namespace vcpkg::Commands::FormatManifest
                     add_file(read_control_file(fs, std::move(control_path)));
                 }
             }
+
+            auto changed = paths.git_changed_port_files();
+            Checks::check_exit(VCPKG_LINE_INFO, static_cast<bool>(changed), changed.error());
+            for (auto& path : std::move(changed).value_or_exit(VCPKG_LINE_INFO))
+            {
+                if (!fs.exists(path)) continue;
+
+                if (path.filename() == "CONTROL")
+                {
+                    add_file(read_control_file(fs, std::move(path)));
+                }
+                else if (path.filename() == "vcpkg.json")
+                {
+                    add_file(read_manifest(fs, std::move(path)));
+                }
+            }
         }
 
         for (auto const& el : to_write)


### PR DESCRIPTION
Than we can simple suggest that the user should run `vcpkg format-manifest --all` before committing the changes. 

Maybe extend this PR to also check the files given by `git diff --name-only master...` (shows all files that has been changed on current branch), so that if someone have not changed the format to the vcpkg.json format, you can simply answer `vcpkg format-manifest --all`