### PR TITLE
Accept port names in format-manifest in addition to full path.

### DIFF
--- a/include/vcpkg/base/files.h
+++ b/include/vcpkg/base/files.h
@@ -165,7 +165,29 @@ void is_directory(const fs::path& p, std::error_code& ec) = delete;
 
 namespace vcpkg::Files
 {
-    struct Filesystem
+    struct IFilesystemStatusProvider
+    {
+        bool exists(const fs::path& path, std::error_code& ec) const noexcept;
+        bool exists(LineInfo li, const fs::path& path) const noexcept;
+        bool exists(const fs::path& path, ignore_errors_t = ignore_errors) const noexcept;
+        bool is_directory(const fs::path& path, std::error_code& ec) const noexcept;
+        bool is_directory(LineInfo li, const fs::path& path) const noexcept;
+        bool is_directory(const fs::path& path, ignore_errors_t = ignore_errors) const noexcept;
+        bool is_regular_file(const fs::path& path, std::error_code& ec) const noexcept;
+        bool is_regular_file(LineInfo li, const fs::path& path) const noexcept;
+        bool is_regular_file(const fs::path& path, ignore_errors_t = ignore_errors) const noexcept;
+        virtual fs::file_status status(const fs::path& path, std::error_code& ec) const noexcept = 0;
+        fs::file_status status(LineInfo li, const fs::path& p) const noexcept;
+        fs::file_status status(const fs::path& p, ignore_errors_t = ignore_errors) const noexcept;
+        virtual fs::file_status symlink_status(const fs::path& path, std::error_code& ec) const noexcept = 0;
+        fs::file_status symlink_status(LineInfo li, const fs::path& p) const noexcept;
+        fs::file_status symlink_status(const fs::path& p, ignore_errors_t = ignore_errors) const noexcept;
+
+    protected:
+        ~IFilesystemStatusProvider() = default;
+    };
+
+    struct Filesystem : IFilesystemStatusProvider
     {
         std::string read_contents(const fs::path& file_path, LineInfo linfo) const;
         virtual Expected<std::string> read_contents(const fs::path& file_path) const = 0;
@@ -202,11 +224,6 @@ namespace vcpkg::Files
         virtual void remove_all_inside(const fs::path& path, std::error_code& ec, fs::path& failure_point) = 0;
         void remove_all_inside(const fs::path& path, LineInfo li);
         void remove_all_inside(const fs::path& path, ignore_errors_t);
-        bool exists(const fs::path& path, std::error_code& ec) const;
-        bool exists(LineInfo li, const fs::path& path) const;
-        bool exists(const fs::path& path, ignore_errors_t = ignore_errors) const;
-        virtual bool is_directory(const fs::path& path) const = 0;
-        virtual bool is_regular_file(const fs::path& path) const = 0;
         virtual bool is_empty(const fs::path& path) const = 0;
         virtual bool create_directory(const fs::path& path, std::error_code& ec) = 0;
         bool create_directory(const fs::path& path, ignore_errors_t);
@@ -221,12 +238,6 @@ namespace vcpkg::Files
                                std::error_code& ec) = 0;
         void copy_file(const fs::path& oldpath, const fs::path& newpath, fs::copy_options opts, LineInfo li);
         virtual void copy_symlink(const fs::path& oldpath, const fs::path& newpath, std::error_code& ec) = 0;
-        virtual fs::file_status status(const fs::path& path, std::error_code& ec) const = 0;
-        virtual fs::file_status symlink_status(const fs::path& path, std::error_code& ec) const = 0;
-        fs::file_status status(LineInfo li, const fs::path& p) const noexcept;
-        fs::file_status status(const fs::path& p, ignore_errors_t) const noexcept;
-        fs::file_status symlink_status(LineInfo li, const fs::path& p) const noexcept;
-        fs::file_status symlink_status(const fs::path& p, ignore_errors_t) const noexcept;
         virtual fs::path absolute(const fs::path& path, std::error_code& ec) const = 0;
         fs::path absolute(LineInfo li, const fs::path& path) const;
         virtual fs::path canonical(const fs::path& path, std::error_code& ec) const = 0;

--- a/include/vcpkg/commands.format-manifest.h
+++ b/include/vcpkg/commands.format-manifest.h
@@ -1,9 +1,18 @@
 #pragma once
 
+#include <vcpkg/base/expected.h>
+#include <vcpkg/base/files.h>
+#include <vcpkg/base/stringview.h>
+
 #include <vcpkg/commands.interface.h>
 
 namespace vcpkg::Commands::FormatManifest
 {
+    ExpectedS<fs::path> resolve_format_manifest_input(StringView input,
+                                                      const fs::path& original_cwd,
+                                                      const fs::path& ports_base,
+                                                      const Files::IFilesystemStatusProvider& filesystem);
+
     extern const CommandStructure COMMAND_STRUCTURE;
     void perform_and_exit(const VcpkgCmdArguments& args, const VcpkgPaths& paths);
 

--- a/src/vcpkg-test/format-manifest.cpp
+++ b/src/vcpkg-test/format-manifest.cpp
@@ -19,15 +19,17 @@ namespace
 
         ListOfExistingFiles(std::vector<fs::path>&& allowed_paths_) : allowed_paths(std::move(allowed_paths_)) { }
 
-        virtual fs::file_status status(const fs::path& path, std::error_code&) const noexcept override {
-            const bool fileExists = std::any_of(allowed_paths.begin(), allowed_paths.end(), [&](const fs::path& candidate) {
-                return path == candidate;
-            });
+        virtual fs::file_status status(const fs::path& path, std::error_code&) const noexcept override
+        {
+            const bool fileExists = std::any_of(allowed_paths.begin(),
+                                                allowed_paths.end(),
+                                                [&](const fs::path& candidate) { return path == candidate; });
 
             return fs::file_status{fileExists ? fs::file_type::regular : fs::file_type::none, fs::perms::unknown};
         }
 
-        virtual fs::file_status symlink_status(const fs::path& path, std::error_code& ec) const noexcept override {
+        virtual fs::file_status symlink_status(const fs::path& path, std::error_code& ec) const noexcept override
+        {
             return this->status(path, ec);
         }
     };

--- a/src/vcpkg-test/format-manifest.cpp
+++ b/src/vcpkg-test/format-manifest.cpp
@@ -1,0 +1,131 @@
+#include <catch2/catch.hpp>
+
+#include <vcpkg/base/files.h>
+#include <vcpkg/base/stringview.h>
+
+#include <vcpkg/commands.format-manifest.h>
+
+#include <algorithm>
+#include <system_error>
+
+using namespace vcpkg;
+using namespace vcpkg::Commands::FormatManifest;
+
+namespace
+{
+    struct ListOfExistingFiles : Files::IFilesystemStatusProvider
+    {
+        std::vector<fs::path> allowed_paths;
+
+        ListOfExistingFiles(std::vector<fs::path>&& allowed_paths_) : allowed_paths(std::move(allowed_paths_)) { }
+
+        virtual fs::file_status status(const fs::path& path, std::error_code&) const noexcept override {
+            const bool fileExists = std::any_of(allowed_paths.begin(), allowed_paths.end(), [&](const fs::path& candidate) {
+                return path == candidate;
+            });
+
+            return fs::file_status{fileExists ? fs::file_type::regular : fs::file_type::none, fs::perms::unknown};
+        }
+
+        virtual fs::file_status symlink_status(const fs::path& path, std::error_code& ec) const noexcept override {
+            return this->status(path, ec);
+        }
+    };
+
+#if defined(_WIN32)
+    StringView existing_absolute{"C:\\hello"};
+    StringView missing_absolute{"C:\\hello\\world"};
+#define SEPARATOR "\\"
+#else // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
+    StringView existing_absolute{"/hello"};
+    StringView missing_absolute{"/hello/world"};
+#define SEPARATOR "/"
+#endif // ^^^ !defined(_WIN32)
+
+    const auto existing_absolute_path = fs::u8path(existing_absolute);
+
+    const auto original_cwd = existing_absolute_path / fs::u8path("cwd");
+    const auto ports = existing_absolute_path / fs::u8path("ports");
+
+    ListOfExistingFiles filesystem{std::vector<fs::path>{
+        existing_absolute_path,
+        // relative test cases
+        original_cwd,
+        original_cwd / fs::u8path("example"),
+        original_cwd / fs::u8path("example" SEPARATOR "CONTROL"),
+        original_cwd / fs::u8path("example" SEPARATOR "vcpkg.json"),
+        original_cwd / fs::u8path("example" SEPARATOR "anything.json"),
+        // port name test cases
+        ports,
+        ports / fs::u8path("control-port"),
+        ports / fs::u8path("control-port" SEPARATOR "CONTROL"),
+        ports / fs::u8path("manifest-port"),
+        ports / fs::u8path("manifest-port" SEPARATOR "vcpkg.json"),
+        ports / fs::u8path("ambiguous-port"),
+        ports / fs::u8path("ambiguous-port" SEPARATOR "CONTROL"),
+        ports / fs::u8path("ambiguous-port" SEPARATOR "vcpkg.json"),
+        // conflict between port name and filesystem name test cases
+        original_cwd / fs::u8path("overlap-port"),
+        ports / fs::u8path("overlap-port"),
+        ports / fs::u8path("overlap-port" SEPARATOR "CONTROL"),
+    }};
+}
+
+TEST_CASE ("resolves_existing_absolute_path", "[commands][format-manifest]")
+{
+    const auto result = resolve_format_manifest_input(existing_absolute, original_cwd, ports, filesystem);
+    REQUIRE(result.has_value());
+    REQUIRE(result.value_or_exit(VCPKG_LINE_INFO) == existing_absolute_path);
+}
+
+TEST_CASE ("does_not_resolve_missing_absolute_path", "[commands][format-manifest]")
+{
+    const auto result = resolve_format_manifest_input(missing_absolute, original_cwd, ports, filesystem);
+    REQUIRE(!result.has_value());
+    REQUIRE(result.error().find(" not found.") != std::string::npos);
+}
+
+TEST_CASE ("resolves_relative_paths", "[commands][format-manifest]")
+{
+    vcpkg::StringView relative_paths[] = {
+        vcpkg::StringView{"example"},
+        vcpkg::StringView{"example" SEPARATOR "CONTROL"},
+        vcpkg::StringView{"example" SEPARATOR "vcpkg.json"},
+        vcpkg::StringView{"example" SEPARATOR "anything.json"},
+    };
+
+    for (vcpkg::StringView& relative : relative_paths)
+    {
+        const auto result = resolve_format_manifest_input(relative, original_cwd, ports, filesystem);
+        REQUIRE(result.has_value());
+        REQUIRE(result.value_or_exit(VCPKG_LINE_INFO) == original_cwd / fs::u8path(relative));
+    }
+}
+
+TEST_CASE ("resolves_control_port", "[commands][format-manifest]")
+{
+    const auto result = resolve_format_manifest_input("control-port", original_cwd, ports, filesystem);
+    REQUIRE(result.has_value());
+    REQUIRE(result.value_or_exit(VCPKG_LINE_INFO) == ports / fs::u8path("control-port" SEPARATOR "CONTROL"));
+}
+
+TEST_CASE ("resolves_manifest_port", "[commands][format-manifest]")
+{
+    const auto result = resolve_format_manifest_input("manifest-port", original_cwd, ports, filesystem);
+    REQUIRE(result.has_value());
+    REQUIRE(result.value_or_exit(VCPKG_LINE_INFO) == ports / fs::u8path("manifest-port" SEPARATOR "vcpkg.json"));
+}
+
+TEST_CASE ("does_not_resolve_ambiguous_port", "[commands][format-manifest]")
+{
+    const auto result = resolve_format_manifest_input("ambiguous-port", original_cwd, ports, filesystem);
+    REQUIRE(!result.has_value());
+    REQUIRE(result.error().find("Both a manifest file and a CONTROL file exist") != std::string::npos);
+}
+
+TEST_CASE ("chooses_filesystem_path_over_port_name", "[commands][format-manifest]")
+{
+    const auto result = resolve_format_manifest_input("overlap-port", original_cwd, ports, filesystem);
+    REQUIRE(result.has_value());
+    REQUIRE(result.value_or_exit(VCPKG_LINE_INFO) == original_cwd / fs::u8path("overlap-port"));
+}

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -336,7 +336,7 @@ namespace vcpkg::Files
 
             return fs::file_status(ft, permissions);
 
-#else  // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
+#else // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
             auto result = follow_symlinks ? fs::stdfs::status(p, ec) : fs::stdfs::symlink_status(p, ec);
             // libstdc++ doesn't correctly not-set ec on nonexistent paths
             if (ec.value() == ENOENT || ec.value() == ENOTDIR)
@@ -410,7 +410,7 @@ namespace vcpkg::Files
             }
             ec.clear();
             return;
-#else  // ^^^ defined(_WIN32) && !VCPKG_USE_STD_FILESYSTEM // !defined(_WIN32) || VCPKG_USE_STD_FILESYSTEM vvv
+#else // ^^^ defined(_WIN32) && !VCPKG_USE_STD_FILESYSTEM // !defined(_WIN32) || VCPKG_USE_STD_FILESYSTEM vvv
             return fs::stdfs::copy_symlink(oldpath, newpath, ec);
 #endif // ^^^ !defined(_WIN32) || VCPKG_USE_STD_FILESYSTEM
         }
@@ -433,7 +433,7 @@ namespace vcpkg::Files
             {
                 ec.assign(GetLastError(), std::system_category());
             }
-#else  // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
+#else // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
             struct stat s;
             if (lstat(path.c_str(), &s))
             {
@@ -929,7 +929,7 @@ namespace vcpkg::Files
                 auto written_bytes = sendfile(o_fd, i_fd, &bytes, info.st_size);
 #elif defined(__APPLE__)
                 auto written_bytes = fcopyfile(i_fd, o_fd, 0, COPYFILE_ALL);
-#else  // ^^^ defined(__APPLE__) // !(defined(__APPLE__) || defined(__linux__)) vvv
+#else // ^^^ defined(__APPLE__) // !(defined(__APPLE__) || defined(__linux__)) vvv
                 ssize_t written_bytes = 0;
                 {
                     constexpr std::size_t buffer_length = 4096;
@@ -1026,7 +1026,7 @@ namespace vcpkg::Files
                         {
                             ec.assign(GetLastError(), std::system_category());
                         }
-#else  // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
+#else // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
                         if (rmdir(current_path.c_str()))
                         {
                             ec.assign(errno, std::system_category());
@@ -1055,7 +1055,7 @@ namespace vcpkg::Files
                             ec.assign(GetLastError(), std::system_category());
                         }
                     }
-#else  // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
+#else // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
                     else
                     {
                         if (unlink(current_path.c_str()))
@@ -1203,7 +1203,7 @@ namespace vcpkg::Files
             FILE* f = nullptr;
 #if defined(_WIN32)
             auto err = _wfopen_s(&f, file_path.native().c_str(), L"wb");
-#else  // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
+#else // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
             f = fopen(file_path.native().c_str(), "wb");
             int err = f != nullptr ? 0 : 1;
 #endif // ^^^ !defined(_WIN32)
@@ -1249,7 +1249,7 @@ namespace vcpkg::Files
 #if defined(_WIN32)
             // absolute was called system_complete in experimental filesystem
             return fs::stdfs::system_complete(path, ec);
-#else  // ^^^ defined(_WIN32) / !defined(_WIN32) vvv
+#else // ^^^ defined(_WIN32) / !defined(_WIN32) vvv
             if (path.is_absolute())
             {
                 return path;
@@ -1420,7 +1420,7 @@ namespace vcpkg::Files
         {
 #if defined(_WIN32)
             static constexpr wchar_t const* EXTS[] = {L".cmd", L".exe", L".bat"};
-#else  // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
+#else // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
             static constexpr char const* EXTS[] = {""};
 #endif // ^^^!defined(_WIN32)
             auto paths = Strings::split_paths(System::get_environment_variable("PATH").value_or_exit(VCPKG_LINE_INFO));
@@ -1482,7 +1482,7 @@ namespace vcpkg::Files
         {
             return lhs / rhs;
         }
-#else  // ^^^ unix // windows vvv
+#else // ^^^ unix // windows vvv
         auto rhs_root_directory = rhs.root_directory();
         auto rhs_root_name = rhs.root_name();
 

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -336,7 +336,7 @@ namespace vcpkg::Files
 
             return fs::file_status(ft, permissions);
 
-#else // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
+#else  // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
             auto result = follow_symlinks ? fs::stdfs::status(p, ec) : fs::stdfs::symlink_status(p, ec);
             // libstdc++ doesn't correctly not-set ec on nonexistent paths
             if (ec.value() == ENOENT || ec.value() == ENOTDIR)
@@ -410,7 +410,7 @@ namespace vcpkg::Files
             }
             ec.clear();
             return;
-#else // ^^^ defined(_WIN32) && !VCPKG_USE_STD_FILESYSTEM // !defined(_WIN32) || VCPKG_USE_STD_FILESYSTEM vvv
+#else  // ^^^ defined(_WIN32) && !VCPKG_USE_STD_FILESYSTEM // !defined(_WIN32) || VCPKG_USE_STD_FILESYSTEM vvv
             return fs::stdfs::copy_symlink(oldpath, newpath, ec);
 #endif // ^^^ !defined(_WIN32) || VCPKG_USE_STD_FILESYSTEM
         }
@@ -433,7 +433,7 @@ namespace vcpkg::Files
             {
                 ec.assign(GetLastError(), std::system_category());
             }
-#else // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
+#else  // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
             struct stat s;
             if (lstat(path.c_str(), &s))
             {
@@ -453,6 +453,79 @@ namespace vcpkg::Files
             }
 #endif // ^^^ !defined(_WIN32)
         }
+    }
+
+    bool IFilesystemStatusProvider::exists(const fs::path& path, std::error_code& ec) const noexcept
+    {
+        return fs::exists(this->status(path, ec));
+    }
+    bool IFilesystemStatusProvider::exists(LineInfo li, const fs::path& path) const noexcept
+    {
+        return fs::exists(this->status(li, path));
+    }
+    bool IFilesystemStatusProvider::exists(const fs::path& path, ignore_errors_t) const noexcept
+    {
+        return fs::exists(this->status(path, ignore_errors));
+    }
+    bool IFilesystemStatusProvider::is_directory(const fs::path& path, std::error_code& ec) const noexcept
+    {
+        return fs::is_directory(this->status(path, ec));
+    }
+    bool IFilesystemStatusProvider::is_directory(LineInfo li, const fs::path& path) const noexcept
+    {
+        return fs::is_directory(this->status(li, path));
+    }
+    bool IFilesystemStatusProvider::is_directory(const fs::path& path, ignore_errors_t) const noexcept
+    {
+        return fs::is_directory(this->status(path, ignore_errors));
+    }
+    bool IFilesystemStatusProvider::is_regular_file(const fs::path& path, std::error_code& ec) const noexcept
+    {
+        return fs::is_regular_file(this->status(path, ec));
+    }
+    bool IFilesystemStatusProvider::is_regular_file(LineInfo li, const fs::path& path) const noexcept
+    {
+        return fs::is_regular_file(this->status(li, path));
+    }
+    bool IFilesystemStatusProvider::is_regular_file(const fs::path& path, ignore_errors_t) const noexcept
+    {
+        return fs::is_regular_file(this->status(path, ignore_errors));
+    }
+
+    fs::file_status IFilesystemStatusProvider::status(LineInfo li, const fs::path& p) const noexcept
+    {
+        std::error_code ec;
+        auto result = this->status(p, ec);
+        if (ec)
+        {
+            vcpkg::Checks::exit_with_message(li, "error getting status of path %s: %s", p.string(), ec.message());
+        }
+
+        return result;
+    }
+
+    fs::file_status IFilesystemStatusProvider::status(const fs::path& p, ignore_errors_t) const noexcept
+    {
+        std::error_code ec;
+        return this->status(p, ec);
+    }
+
+    fs::file_status IFilesystemStatusProvider::symlink_status(LineInfo li, const fs::path& p) const noexcept
+    {
+        std::error_code ec;
+        auto result = this->symlink_status(p, ec);
+        if (ec)
+        {
+            vcpkg::Checks::exit_with_message(li, "error getting status of path %s: %s", p.string(), ec.message());
+        }
+
+        return result;
+    }
+
+    fs::file_status IFilesystemStatusProvider::symlink_status(const fs::path& p, ignore_errors_t) const noexcept
+    {
+        std::error_code ec;
+        return this->symlink_status(p, ec);
     }
 
     std::vector<std::string> Filesystem::read_lines(const fs::path& path, LineInfo linfo) const
@@ -526,26 +599,6 @@ namespace vcpkg::Files
         return this->remove(path, ec);
     }
 
-    bool Filesystem::exists(const fs::path& path, std::error_code& ec) const
-    {
-        return fs::exists(this->symlink_status(path, ec));
-    }
-
-    bool Filesystem::exists(LineInfo li, const fs::path& path) const
-    {
-        std::error_code ec;
-        auto result = this->exists(path, ec);
-        if (ec)
-            Checks::exit_with_message(li, "error checking existence of file %s: %s", fs::u8string(path), ec.message());
-        return result;
-    }
-
-    bool Filesystem::exists(const fs::path& path, ignore_errors_t) const
-    {
-        std::error_code ec;
-        return this->exists(path, ec);
-    }
-
     bool Filesystem::create_directory(const fs::path& path, ignore_errors_t)
     {
         std::error_code ec;
@@ -591,42 +644,6 @@ namespace vcpkg::Files
             vcpkg::Checks::exit_with_message(
                 li, "error copying file from %s to %s: %s", fs::u8string(oldpath), fs::u8string(newpath), ec.message());
         }
-    }
-
-    fs::file_status Filesystem::status(vcpkg::LineInfo li, const fs::path& p) const noexcept
-    {
-        std::error_code ec;
-        auto result = this->status(p, ec);
-        if (ec)
-        {
-            vcpkg::Checks::exit_with_message(li, "error getting status of path %s: %s", p.string(), ec.message());
-        }
-
-        return result;
-    }
-
-    fs::file_status Filesystem::status(const fs::path& p, ignore_errors_t) const noexcept
-    {
-        std::error_code ec;
-        return this->status(p, ec);
-    }
-
-    fs::file_status Filesystem::symlink_status(vcpkg::LineInfo li, const fs::path& p) const noexcept
-    {
-        std::error_code ec;
-        auto result = this->symlink_status(p, ec);
-        if (ec)
-        {
-            vcpkg::Checks::exit_with_message(li, "error getting status of path %s: %s", p.string(), ec.message());
-        }
-
-        return result;
-    }
-
-    fs::file_status Filesystem::symlink_status(const fs::path& p, ignore_errors_t) const noexcept
-    {
-        std::error_code ec;
-        return this->symlink_status(p, ec);
     }
 
     void Filesystem::write_lines(const fs::path& path, const std::vector<std::string>& lines, LineInfo linfo)
@@ -912,7 +929,7 @@ namespace vcpkg::Files
                 auto written_bytes = sendfile(o_fd, i_fd, &bytes, info.st_size);
 #elif defined(__APPLE__)
                 auto written_bytes = fcopyfile(i_fd, o_fd, 0, COPYFILE_ALL);
-#else // ^^^ defined(__APPLE__) // !(defined(__APPLE__) || defined(__linux__)) vvv
+#else  // ^^^ defined(__APPLE__) // !(defined(__APPLE__) || defined(__linux__)) vvv
                 ssize_t written_bytes = 0;
                 {
                     constexpr std::size_t buffer_length = 4096;
@@ -1009,7 +1026,7 @@ namespace vcpkg::Files
                         {
                             ec.assign(GetLastError(), std::system_category());
                         }
-#else // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
+#else  // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
                         if (rmdir(current_path.c_str()))
                         {
                             ec.assign(errno, std::system_category());
@@ -1038,7 +1055,7 @@ namespace vcpkg::Files
                             ec.assign(GetLastError(), std::system_category());
                         }
                     }
-#else // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
+#else  // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
                     else
                     {
                         if (unlink(current_path.c_str()))
@@ -1146,8 +1163,6 @@ namespace vcpkg::Files
             failure_point = first->path();
         }
 
-        virtual bool is_directory(const fs::path& path) const override { return fs::stdfs::is_directory(path); }
-        virtual bool is_regular_file(const fs::path& path) const override { return fs::stdfs::is_regular_file(path); }
         virtual bool is_empty(const fs::path& path) const override { return fs::stdfs::is_empty(path); }
         virtual bool create_directory(const fs::path& path, std::error_code& ec) override
         {
@@ -1173,11 +1188,11 @@ namespace vcpkg::Files
             return Files::copy_symlink_implementation(oldpath, newpath, ec);
         }
 
-        virtual fs::file_status status(const fs::path& path, std::error_code& ec) const override
+        virtual fs::file_status status(const fs::path& path, std::error_code& ec) const noexcept override
         {
             return Files::status(path, ec);
         }
-        virtual fs::file_status symlink_status(const fs::path& path, std::error_code& ec) const override
+        virtual fs::file_status symlink_status(const fs::path& path, std::error_code& ec) const noexcept override
         {
             return Files::symlink_status(path, ec);
         }
@@ -1188,7 +1203,7 @@ namespace vcpkg::Files
             FILE* f = nullptr;
 #if defined(_WIN32)
             auto err = _wfopen_s(&f, file_path.native().c_str(), L"wb");
-#else // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
+#else  // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
             f = fopen(file_path.native().c_str(), "wb");
             int err = f != nullptr ? 0 : 1;
 #endif // ^^^ !defined(_WIN32)
@@ -1234,7 +1249,7 @@ namespace vcpkg::Files
 #if defined(_WIN32)
             // absolute was called system_complete in experimental filesystem
             return fs::stdfs::system_complete(path, ec);
-#else // ^^^ defined(_WIN32) / !defined(_WIN32) vvv
+#else  // ^^^ defined(_WIN32) / !defined(_WIN32) vvv
             if (path.is_absolute())
             {
                 return path;
@@ -1405,7 +1420,7 @@ namespace vcpkg::Files
         {
 #if defined(_WIN32)
             static constexpr wchar_t const* EXTS[] = {L".cmd", L".exe", L".bat"};
-#else // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
+#else  // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
             static constexpr char const* EXTS[] = {""};
 #endif // ^^^!defined(_WIN32)
             auto paths = Strings::split_paths(System::get_environment_variable("PATH").value_or_exit(VCPKG_LINE_INFO));
@@ -1467,7 +1482,7 @@ namespace vcpkg::Files
         {
             return lhs / rhs;
         }
-#else // ^^^ unix // windows vvv
+#else  // ^^^ unix // windows vvv
         auto rhs_root_directory = rhs.root_directory();
         auto rhs_root_name = rhs.root_name();
 

--- a/src/vcpkg/commands.format-manifest.cpp
+++ b/src/vcpkg/commands.format-manifest.cpp
@@ -10,6 +10,8 @@
 #include <vcpkg/vcpkgcmdarguments.h>
 #include <vcpkg/vcpkgpaths.h>
 
+#include <algorithm>
+
 namespace
 {
     using namespace vcpkg;
@@ -22,7 +24,7 @@ namespace
         std::string original_source;
     };
 
-    Optional<ToWrite> read_manifest(Files::Filesystem& fs, fs::path&& manifest_path)
+    Optional<ToWrite> read_manifest(Files::Filesystem& fs, const fs::path& manifest_path)
     {
         auto path_string = fs::u8string(manifest_path);
         Debug::print("Reading ", path_string, "\n");
@@ -60,7 +62,7 @@ namespace
         };
     }
 
-    Optional<ToWrite> read_control_file(Files::Filesystem& fs, fs::path&& control_path)
+    Optional<ToWrite> read_control_file(Files::Filesystem& fs, const fs::path& control_path)
     {
         std::error_code ec;
         auto control_path_string = fs::u8string(control_path);
@@ -172,20 +174,103 @@ Please open an issue at https://github.com/microsoft/vcpkg, with the following o
             }
         }
     }
+
+    static const auto CONTROL_name = fs::u8path("CONTROL");
+    static const auto vcpkg_json_name = fs::u8path("vcpkg.json");
+
+    Optional<ToWrite> read_input_file(Files::Filesystem& fs, const fs::path& resolved_path)
+    {
+        if (resolved_path.filename() == CONTROL_name)
+        {
+            return read_control_file(fs, resolved_path);
+        }
+
+        return read_manifest(fs, resolved_path);
+    }
+
+    void add_write(std::vector<std::string>& errors,
+                   std::vector<ToWrite>& to_write,
+                   Optional<ToWrite>&& this_manifest,
+                   const fs::path& resolved_path)
+    {
+        if (this_manifest.get())
+        {
+            to_write.push_back(std::move(this_manifest).value_or_exit(VCPKG_LINE_INFO));
+        }
+        else
+        {
+            errors.push_back(Strings::concat("Failed to parse ", fs::u8string(resolved_path)));
+        }
+    }
+
+    std::string format_both_manifest_and_control_error(StringView port_name)
+    {
+        return Strings::concat("Both a manifest file and a CONTROL file exist in port ", port_name, ".");
+    }
 }
 
 namespace vcpkg::Commands::FormatManifest
 {
+    ExpectedS<fs::path> resolve_format_manifest_input(StringView input,
+                                                      const fs::path& original_cwd,
+                                                      const fs::path& ports_base,
+                                                      const Files::IFilesystemStatusProvider& filesystem)
+    {
+        auto p = fs::u8path(input);
+        if (p.is_absolute())
+        {
+            if (filesystem.exists(p, ignore_errors))
+            {
+                return std::move(p);
+            }
+
+            return {Strings::concat(input, " not found.")};
+        }
+
+        {
+            auto as_absolute = Files::combine(original_cwd, p);
+            if (filesystem.exists(as_absolute, ignore_errors))
+            {
+                return std::move(as_absolute);
+            }
+        } // destroy as_absolute
+
+        if (std::none_of(input.begin(), input.end(), fs::is_slash))
+        {
+            // nonexistent single element relative path, try to interpret as port name
+            const auto port_path = Files::combine(ports_base, p);
+            auto control_path = Files::combine(port_path, CONTROL_name);
+            auto vcpkg_json_path = Files::combine(port_path, vcpkg_json_name);
+            const bool control_exists = filesystem.exists(control_path, ignore_errors);
+            const bool vcpkg_json_exists = filesystem.exists(vcpkg_json_path, ignore_errors);
+            if (control_exists)
+            {
+                if (vcpkg_json_exists)
+                {
+                    return {format_both_manifest_and_control_error(input)};
+                }
+
+                return {std::move(control_path)};
+            }
+            else if (vcpkg_json_exists)
+            {
+                return {std::move(vcpkg_json_path)};
+            }
+        }
+
+        return {Strings::concat(input, " could not be interpreted as a port name, CONTROL path, or manifest path.")};
+    }
+
     static constexpr StringLiteral OPTION_ALL = "all";
     static constexpr StringLiteral OPTION_CONVERT_CONTROL = "convert-control";
 
     const CommandSwitch FORMAT_SWITCHES[] = {
         {OPTION_ALL, "Format all ports' manifest files."},
-        {OPTION_CONVERT_CONTROL, "Convert CONTROL files to manifest files."},
+        {OPTION_CONVERT_CONTROL, "Convert CONTROL files to manifest files; requires --all."},
     };
 
     const CommandStructure COMMAND_STRUCTURE = {
-        create_example_string(R"###(format-manifest --all)###"),
+        create_example_string(R"###(format-manifest name-of-port path/to/vcpkg.json path/to/CONTROL)###"),
         0,
         SIZE_MAX,
         {FORMAT_SWITCHES, {}, {}},
@@ -197,73 +282,62 @@ namespace vcpkg::Commands::FormatManifest
         auto parsed_args = args.parse_arguments(COMMAND_STRUCTURE);
 
         auto& fs = paths.get_filesystem();
-        bool has_error = false;
 
         const bool format_all = Util::Sets::contains(parsed_args.switches, OPTION_ALL);
         const bool convert_control = Util::Sets::contains(parsed_args.switches, OPTION_CONVERT_CONTROL);
 
         if (!format_all && convert_control)
         {
-            System::print2(System::Color::warning, R"(format-manifest was passed '--convert-control' without '--all'.
-    This doesn't do anything:
-    we will automatically convert all control files passed explicitly.)");
+            System::print2(System::Color::warning, R"(Warning: '--convert-control' has no effect without '--all'.
+    Explicit paths to CONTROL files, or names of ports using CONTROL files
+    are always converted.)");
         }
 
         if (!format_all && args.command_arguments.empty())
         {
-            Checks::exit_with_message(
-                VCPKG_LINE_INFO,
-                "No files to format; please pass either --all, or the explicit files to format or convert.");
+            Checks::exit_with_message(VCPKG_LINE_INFO, R"(Error: No targets to format. Please pass --all,
+    or a list of port names, CONTROL files, and/or manifests to format or convert.)");
         }
 
+        std::vector<std::string> errors;
         std::vector<ToWrite> to_write;
-
-        const auto add_file = [&to_write, &has_error](Optional<ToWrite>&& opt) {
-            if (auto t = opt.get())
-                to_write.push_back(std::move(*t));
-            else
-                has_error = true;
-        };
-
         for (const auto& arg : args.command_arguments)
         {
-            auto path = fs::u8path(arg);
-            if (path.is_relative())
+            auto maybe_resolved =
+                resolve_format_manifest_input(arg, paths.original_cwd, paths.builtin_ports_directory(), fs);
+            if (!maybe_resolved)
             {
-                path = paths.original_cwd / path;
+                errors.push_back(std::move(maybe_resolved).error());
+                continue;
             }
 
-            if (path.filename() == fs::u8path("CONTROL"))
-            {
-                add_file(read_control_file(fs, std::move(path)));
-            }
-            else
-            {
-                add_file(read_manifest(fs, std::move(path)));
-            }
+            const auto& resolved = maybe_resolved.value_or_exit(VCPKG_LINE_INFO);
+            add_write(errors, to_write, read_input_file(fs, resolved), resolved);
         }
 
         if (format_all)
         {
             for (const auto& dir : fs::directory_iterator(paths.builtin_ports_directory()))
             {
-                auto control_path = dir.path() / fs::u8path("CONTROL");
-                auto manifest_path = dir.path() / fs::u8path("vcpkg.json");
-                auto manifest_exists = fs.exists(manifest_path);
-                auto control_exists = fs.exists(control_path);
-
-                Checks::check_exit(VCPKG_LINE_INFO,
-                                   !manifest_exists || !control_exists,
-                                   "Both a manifest file and a CONTROL file exist in port directory: %s",
-                                   fs::u8string(dir.path()));
-
-                if (manifest_exists)
+                const auto& port_path = dir.path();
+                auto control_path = port_path / CONTROL_name;
+                auto manifest_path = port_path / vcpkg_json_name;
+                auto manifest_exists = fs.exists(manifest_path, ignore_errors);
+                auto control_exists = fs.exists(control_path, ignore_errors);
+                if (control_exists)
                 {
-                    add_file(read_manifest(fs, std::move(manifest_path)));
+                    if (manifest_exists)
+                    {
+                        errors.push_back(format_both_manifest_and_control_error(fs::u8string(port_path.filename())));
+                    }
+                    else if (convert_control)
+                    {
+                        add_write(errors, to_write, read_control_file(fs, control_path), control_path);
+                    }
                 }
-                if (convert_control && control_exists)
+                else if (manifest_exists)
                 {
-                    add_file(read_control_file(fs, std::move(control_path)));
+                    add_write(errors, to_write, read_manifest(fs, manifest_path), manifest_path);
                 }
             }
         }
@@ -273,15 +347,18 @@ namespace vcpkg::Commands::FormatManifest
             write_file(fs, el);
         }
 
-        if (has_error)
+        if (errors.empty())
         {
-            Checks::exit_fail(VCPKG_LINE_INFO);
-        }
-        else
-        {
-            System::print2("Succeeded in formatting the manifest files.\n");
+            System::print2("Succeeded in formatting all manifests.\n");
             Checks::exit_success(VCPKG_LINE_INFO);
         }
+
+        for (const std::string& error : errors)
+        {
+            System::print2(System::Color::error, error, "\n");
+        }
+
+        Checks::exit_fail(VCPKG_LINE_INFO);
     }
 
     void FormatManifestCommand::perform_and_exit(const VcpkgCmdArguments& args, const VcpkgPaths& paths) const


### PR DESCRIPTION
Resurrects https://github.com/microsoft/vcpkg/pull/15809/ with a change to ITestFileExists from there as requested by Nicole.

Replaces https://github.com/microsoft/vcpkg-tool/pull/56 by implementing much the same functionality, except this version has tests and defenses against port directories that misbehave by having both CONTROL and vcpkg.json and similar.