### PR TITLE
Add --clean-non-downloads-after-build switch to be used by CI to reduce our disk consumption there.

### DIFF
--- a/azure-pipelines/end-to-end-tests-dir/binarycaching.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/binarycaching.ps1
@@ -57,10 +57,11 @@ Throw-IfFailed
 Require-FileNotExists "$installRoot/$Triplet/include/rapidjson/rapidjson.h"
 Require-FileNotExists "$buildtreesRoot/rapidjson/src"
 Require-FileExists "$TestingRoot/packages.config"
+$fetchNuGetArgs = $commonArgs + @('fetch', 'nuget')
 if ($IsLinux -or $IsMacOS) {
-    mono $(./vcpkg fetch nuget) restore $TestingRoot/packages.config -OutputDirectory "$NuGetRoot2" -Source "$NuGetRoot"
+    mono $(./vcpkg @fetchNuGetArgs) restore $TestingRoot/packages.config -OutputDirectory "$NuGetRoot2" -Source "$NuGetRoot"
 } else {
-    & $(./vcpkg fetch nuget) restore $TestingRoot/packages.config -OutputDirectory "$NuGetRoot2" -Source "$NuGetRoot"
+    & $(./vcpkg @fetchNuGetArgs) restore $TestingRoot/packages.config -OutputDirectory "$NuGetRoot2" -Source "$NuGetRoot"
 }
 Throw-IfFailed
 Remove-Item -Recurse -Force $NuGetRoot -ErrorAction SilentlyContinue

--- a/azure-pipelines/end-to-end-tests-dir/clean-after-build.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/clean-after-build.ps1
@@ -1,0 +1,29 @@
+. $PSScriptRoot/../end-to-end-tests-prelude.ps1
+
+$CurrentTest = "Clean After Build"
+
+$ZlibInstalledHeader = Join-Path $installRoot "$Triplet/include/zlib.h"
+$ZlibDownloadTarball = Join-Path $downloadsRoot 'zlib1211.tar.gz'
+$ZlibPackageRoot = Join-Path $packagesRoot "zlib_$Triplet"
+$ZlibSrc = Join-Path $buildtreesRoot "zlib/src"
+
+Refresh-TestRoot
+Run-Vcpkg -TestArgs ($commonArgs + @("install", "zlib", "--no-binarycaching"))
+Require-FileExists $ZlibInstalledHeader
+Require-FileExists $ZlibDownloadTarball
+Require-FileExists $ZlibPackageRoot
+Require-FileExists $ZlibSrc
+
+Refresh-TestRoot
+Run-Vcpkg -TestArgs ($commonArgs + @("install", "zlib", "--clean-non-downloads-after-build", "--no-binarycaching"))
+Require-FileExists $ZlibInstalledHeader
+Require-FileExists $ZlibDownloadTarball
+Require-FileNotExists $ZlibPackageRoot
+Require-FileNotExists $ZlibSrc
+
+Refresh-TestRoot
+Run-Vcpkg -TestArgs ($commonArgs + @("install", "zlib", "--clean-after-build", "--no-binarycaching"))
+Require-FileExists $ZlibInstalledHeader
+Require-FileNotExists $ZlibDownloadTarball
+Require-FileNotExists $ZlibPackageRoot
+Require-FileNotExists $ZlibSrc

--- a/azure-pipelines/end-to-end-tests-dir/clean-after-build.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/clean-after-build.ps1
@@ -7,22 +7,59 @@ $ZlibDownloadTarball = Join-Path $downloadsRoot 'zlib1211.tar.gz'
 $ZlibPackageRoot = Join-Path $packagesRoot "zlib_$Triplet"
 $ZlibSrc = Join-Path $buildtreesRoot "zlib/src"
 
+$installZlibArgs = @("install", "zlib", "--no-binarycaching")
+
 Refresh-TestRoot
-Run-Vcpkg -TestArgs ($commonArgs + @("install", "zlib", "--no-binarycaching"))
+Run-Vcpkg -TestArgs ($commonArgs + $installZlibArgs)
 Require-FileExists $ZlibInstalledHeader
 Require-FileExists $ZlibDownloadTarball
 Require-FileExists $ZlibPackageRoot
 Require-FileExists $ZlibSrc
 
 Refresh-TestRoot
-Run-Vcpkg -TestArgs ($commonArgs + @("install", "zlib", "--clean-non-downloads-after-build", "--no-binarycaching"))
+Run-Vcpkg -TestArgs ($commonArgs + $installZlibArgs + @("--clean-packages-after-build"))
+Require-FileExists $ZlibInstalledHeader
+Require-FileExists $ZlibDownloadTarball
+Require-FileNotExists $ZlibPackageRoot
+Require-FileExists $ZlibSrc
+
+Refresh-TestRoot
+Run-Vcpkg -TestArgs ($commonArgs + $installZlibArgs + @("--clean-buildtrees-after-build"))
+Require-FileExists $ZlibInstalledHeader
+Require-FileExists $ZlibDownloadTarball
+Require-FileExists $ZlibPackageRoot
+Require-FileNotExists $ZlibSrc
+
+Refresh-TestRoot
+Run-Vcpkg -TestArgs ($commonArgs + $installZlibArgs + @("--clean-packages-after-build", "--clean-buildtrees-after-build"))
 Require-FileExists $ZlibInstalledHeader
 Require-FileExists $ZlibDownloadTarball
 Require-FileNotExists $ZlibPackageRoot
 Require-FileNotExists $ZlibSrc
 
 Refresh-TestRoot
-Run-Vcpkg -TestArgs ($commonArgs + @("install", "zlib", "--clean-after-build", "--no-binarycaching"))
+Run-Vcpkg -TestArgs ($commonArgs + $installZlibArgs + @("--clean-buildtrees-after-build"))
+Require-FileExists $ZlibInstalledHeader
+Require-FileExists $ZlibDownloadTarball
+Require-FileExists $ZlibPackageRoot
+Require-FileNotExists $ZlibSrc
+
+Refresh-TestRoot
+Run-Vcpkg -TestArgs ($commonArgs + $installZlibArgs + @("--clean-downloads-after-build", "--clean-packages-after-build", "--clean-buildtrees-after-build"))
+Require-FileExists $ZlibInstalledHeader
+Require-FileNotExists $ZlibDownloadTarball
+Require-FileNotExists $ZlibPackageRoot
+Require-FileNotExists $ZlibSrc
+
+Refresh-TestRoot
+Run-Vcpkg -TestArgs ($commonArgs + $installZlibArgs + @("--clean-after-build"))
+Require-FileExists $ZlibInstalledHeader
+Require-FileNotExists $ZlibDownloadTarball
+Require-FileNotExists $ZlibPackageRoot
+Require-FileNotExists $ZlibSrc
+
+Refresh-TestRoot
+Run-Vcpkg -TestArgs ($commonArgs + $installZlibArgs + @("--clean-after-build", "--clean-downloads-after-build", "--clean-packages-after-build", "--clean-buildtrees-after-build"))
 Require-FileExists $ZlibInstalledHeader
 Require-FileNotExists $ZlibDownloadTarball
 Require-FileNotExists $ZlibPackageRoot

--- a/azure-pipelines/end-to-end-tests-prelude.ps1
+++ b/azure-pipelines/end-to-end-tests-prelude.ps1
@@ -2,6 +2,7 @@ $TestingRoot = Join-Path $WorkingRoot 'testing'
 $buildtreesRoot = Join-Path $TestingRoot 'buildtrees'
 $installRoot = Join-Path $TestingRoot 'installed'
 $packagesRoot = Join-Path $TestingRoot 'packages'
+$downloadsRoot = Join-Path $TestingRoot 'downloads'
 $NuGetRoot = Join-Path $TestingRoot 'nuget'
 $NuGetRoot2 = Join-Path $TestingRoot 'nuget2'
 $ArchiveRoot = Join-Path $TestingRoot 'archives'
@@ -12,6 +13,7 @@ $commonArgs = @(
     "--x-buildtrees-root=$buildtreesRoot",
     "--x-install-root=$installRoot",
     "--x-packages-root=$packagesRoot",
+    "--downloads-root=$downloadsRoot",
     "--overlay-ports=$PSScriptRoot/e2e_ports/overlays",
     "--overlay-triplets=$PSScriptRoot/e2e_ports/triplets"
 )

--- a/include/vcpkg/base/util.h
+++ b/include/vcpkg/base/util.h
@@ -207,30 +207,6 @@ namespace vcpkg::Util
         return fmap(input_map, [](auto&& p) { return p.first; });
     }
 
-    struct MoveOnlyBase
-    {
-        MoveOnlyBase() = default;
-        MoveOnlyBase(const MoveOnlyBase&) = delete;
-        MoveOnlyBase(MoveOnlyBase&&) = default;
-
-        MoveOnlyBase& operator=(const MoveOnlyBase&) = delete;
-        MoveOnlyBase& operator=(MoveOnlyBase&&) = default;
-
-        ~MoveOnlyBase() = default;
-    };
-
-    struct ResourceBase
-    {
-        ResourceBase() = default;
-        ResourceBase(const ResourceBase&) = delete;
-        ResourceBase(ResourceBase&&) = delete;
-
-        ResourceBase& operator=(const ResourceBase&) = delete;
-        ResourceBase& operator=(ResourceBase&&) = delete;
-
-        ~ResourceBase() = default;
-    };
-
     namespace Enum
     {
         template<class E>

--- a/include/vcpkg/build.h
+++ b/include/vcpkg/build.h
@@ -214,11 +214,14 @@ namespace vcpkg::Build
     /// <summary>
     /// Settings from the triplet file which impact the build environment and post-build checks
     /// </summary>
-    struct PreBuildInfo : Util::ResourceBase
+    struct PreBuildInfo
     {
         PreBuildInfo(const VcpkgPaths& paths,
                      Triplet triplet,
                      const std::unordered_map<std::string, std::string>& cmakevars);
+
+        PreBuildInfo(const PreBuildInfo&) = delete;
+        PreBuildInfo& operator=(const PreBuildInfo&) = delete;
 
         Triplet triplet;
         bool load_vcvars_env = false;

--- a/include/vcpkg/dependencies.h
+++ b/include/vcpkg/dependencies.h
@@ -45,11 +45,15 @@ namespace vcpkg::Dependencies
         EXCLUDED
     };
 
-    struct InstallPlanAction : Util::MoveOnlyBase
+    struct InstallPlanAction
     {
         static bool compare_by_name(const InstallPlanAction* left, const InstallPlanAction* right);
 
         InstallPlanAction() noexcept;
+        InstallPlanAction(const InstallPlanAction&) = delete;
+        InstallPlanAction(InstallPlanAction&&) = default;
+        InstallPlanAction& operator=(const InstallPlanAction&) = delete;
+        InstallPlanAction& operator=(InstallPlanAction&&) = default;
 
         InstallPlanAction(InstalledPackageView&& spghs, const RequestType& request_type);
 
@@ -89,11 +93,16 @@ namespace vcpkg::Dependencies
         REMOVE
     };
 
-    struct RemovePlanAction : Util::MoveOnlyBase
+    struct RemovePlanAction
     {
         static bool compare_by_name(const RemovePlanAction* left, const RemovePlanAction* right);
 
         RemovePlanAction() noexcept;
+        RemovePlanAction(const RemovePlanAction&) = delete;
+        RemovePlanAction(RemovePlanAction&&) = default;
+        RemovePlanAction& operator=(const RemovePlanAction&) = delete;
+        RemovePlanAction& operator=(RemovePlanAction&&) = default;
+
         RemovePlanAction(const PackageSpec& spec, const RemovePlanType& plan_type, const RequestType& request_type);
 
         PackageSpec spec;
@@ -118,11 +127,16 @@ namespace vcpkg::Dependencies
         ALREADY_BUILT
     };
 
-    struct ExportPlanAction : Util::MoveOnlyBase
+    struct ExportPlanAction
     {
         static bool compare_by_name(const ExportPlanAction* left, const ExportPlanAction* right);
 
         ExportPlanAction() noexcept;
+        ExportPlanAction(const ExportPlanAction&) = delete;
+        ExportPlanAction(ExportPlanAction&&) = default;
+        ExportPlanAction& operator=(const ExportPlanAction&) = delete;
+        ExportPlanAction& operator=(ExportPlanAction&&) = default;
+
         ExportPlanAction(const PackageSpec& spec,
                          InstalledPackageView&& installed_package,
                          const RequestType& request_type);

--- a/include/vcpkg/metrics.h
+++ b/include/vcpkg/metrics.h
@@ -8,8 +8,12 @@
 
 namespace vcpkg::Metrics
 {
-    struct Metrics : Util::ResourceBase
+    struct Metrics
     {
+        Metrics() = default;
+        Metrics(const Metrics&) = delete;
+        Metrics& operator=(const Metrics&) = delete;
+
         void set_send_metrics(bool should_send_metrics);
         void set_print_metrics(bool should_print_metrics);
         void set_disabled(bool disabled);

--- a/include/vcpkg/portfileprovider.h
+++ b/include/vcpkg/portfileprovider.h
@@ -18,9 +18,11 @@ namespace vcpkg::PortFileProvider
         virtual std::vector<const SourceControlFileLocation*> load_all_control_files() const = 0;
     };
 
-    struct MapPortFileProvider : Util::ResourceBase, PortFileProvider
+    struct MapPortFileProvider : PortFileProvider
     {
         explicit MapPortFileProvider(const std::unordered_map<std::string, SourceControlFileLocation>& map);
+        MapPortFileProvider(const MapPortFileProvider&) = delete;
+        MapPortFileProvider& operator=(const MapPortFileProvider&) = delete;
         ExpectedS<const SourceControlFileLocation&> get_control_file(const std::string& src_name) const override;
         std::vector<const SourceControlFileLocation*> load_all_control_files() const override;
 
@@ -51,9 +53,11 @@ namespace vcpkg::PortFileProvider
         virtual void load_all_control_files(std::map<std::string, const SourceControlFileLocation*>& out) const = 0;
     };
 
-    struct PathsPortFileProvider : Util::ResourceBase, PortFileProvider
+    struct PathsPortFileProvider : PortFileProvider
     {
         explicit PathsPortFileProvider(const vcpkg::VcpkgPaths& paths, const std::vector<std::string>& overlay_ports);
+        PathsPortFileProvider(const PathsPortFileProvider&) = delete;
+        PathsPortFileProvider& operator=(const PathsPortFileProvider&) = delete;
         ExpectedS<const SourceControlFileLocation&> get_control_file(const std::string& src_name) const override;
         std::vector<const SourceControlFileLocation*> load_all_control_files() const override;
 

--- a/include/vcpkg/vcpkgpaths.h
+++ b/include/vcpkg/vcpkgpaths.h
@@ -60,7 +60,7 @@ namespace vcpkg
     struct PackageSpec;
     struct Triplet;
 
-    struct VcpkgPaths : Util::MoveOnlyBase
+    struct VcpkgPaths
     {
         struct TripletFile
         {
@@ -71,6 +71,10 @@ namespace vcpkg
         };
 
         VcpkgPaths(Files::Filesystem& filesystem, const VcpkgCmdArguments& args);
+        VcpkgPaths(const VcpkgPaths&) = delete;
+        VcpkgPaths(VcpkgPaths&&) = default;
+        VcpkgPaths& operator=(const VcpkgPaths&) = delete;
+        VcpkgPaths& operator=(VcpkgPaths&&) = default;
         ~VcpkgPaths();
 
         fs::path package_dir(const PackageSpec& spec) const;

--- a/src/vcpkg-test/dependencies.cpp
+++ b/src/vcpkg-test/dependencies.cpp
@@ -165,15 +165,21 @@ static const PackageSpec& toplevel_spec()
     return ret;
 }
 
-struct MockOverlayProvider : PortFileProvider::IOverlayProvider, Util::ResourceBase
+struct MockOverlayProvider : PortFileProvider::IOverlayProvider
 {
+    MockOverlayProvider() = default;
+    MockOverlayProvider(const MockOverlayProvider&) = delete;
+    MockOverlayProvider& operator=(const MockOverlayProvider&) = delete;
+
     virtual Optional<const SourceControlFileLocation&> get_control_file(StringView name) const override
     {
         auto it = mappings.find(name);
-        if (it != mappings.end())
-            return it->second;
-        else
+        if (it == mappings.end())
+        {
             return nullopt;
+        }
+
+        return it->second;
     }
 
     SourceControlFileLocation& emplace(const std::string& name,

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -988,7 +988,7 @@ namespace vcpkg::Files
 
             struct remove
             {
-                struct ErrorInfo : Util::ResourceBase
+                struct ErrorInfo
                 {
                     std::error_code ec;
                     fs::path failure_point;

--- a/src/vcpkg/cmakevars.cpp
+++ b/src/vcpkg/cmakevars.cpp
@@ -29,9 +29,11 @@ namespace vcpkg::CMakeVars
 
     namespace
     {
-        struct TripletCMakeVarProvider : Util::ResourceBase, CMakeVarProvider
+        struct TripletCMakeVarProvider : CMakeVarProvider
         {
             explicit TripletCMakeVarProvider(const vcpkg::VcpkgPaths& paths) : paths(paths) { }
+            TripletCMakeVarProvider(const TripletCMakeVarProvider&) = delete;
+            TripletCMakeVarProvider& operator=(const TripletCMakeVarProvider&) = delete;
 
             void load_generic_triplet_vars(Triplet triplet) const override;
 

--- a/src/vcpkg/dependencies.cpp
+++ b/src/vcpkg/dependencies.cpp
@@ -49,7 +49,7 @@ namespace vcpkg::Dependencies
         /// <summary>
         /// Representation of a package and its features in a ClusterGraph.
         /// </summary>
-        struct Cluster : Util::MoveOnlyBase
+        struct Cluster
         {
             Cluster(const InstalledPackageView& ipv, ExpectedS<const SourceControlFileLocation&>&& scfl)
                 : m_spec(ipv.spec()), m_scfl(std::move(scfl)), m_installed(ipv)
@@ -57,6 +57,11 @@ namespace vcpkg::Dependencies
             }
 
             Cluster(const PackageSpec& spec, const SourceControlFileLocation& scfl) : m_spec(spec), m_scfl(scfl) { }
+
+            Cluster(const Cluster&) = delete;
+            Cluster(Cluster&&) = default;
+            Cluster& operator=(const Cluster&) = delete;
+            Cluster& operator=(Cluster&&) = default;
 
             bool has_feature_installed(const std::string& feature) const
             {
@@ -260,12 +265,15 @@ namespace vcpkg::Dependencies
     /// <summary>
     /// Directional graph representing a collection of packages with their features connected by their dependencies.
     /// </summary>
-    struct ClusterGraph : Util::ResourceBase
+    struct ClusterGraph
     {
         explicit ClusterGraph(const PortFileProvider::PortFileProvider& port_provider, Triplet host_triplet)
             : m_port_provider(port_provider), m_host_triplet(host_triplet)
         {
         }
+
+        ClusterGraph(const ClusterGraph&) = delete;
+        ClusterGraph& operator=(const ClusterGraph&) = delete;
 
         /// <summary>
         ///     Find the cluster associated with spec or if not found, create it from the PortFileProvider.
@@ -1259,7 +1267,7 @@ namespace vcpkg::Dependencies
                 bool is_less_than(const Versions::Version& new_ver) const;
             };
 
-            struct PackageNode : Util::MoveOnlyBase
+            struct PackageNode
             {
                 std::map<Versions::Version, VersionSchemeInfo*, VersionTMapLess> vermap;
                 std::map<std::string, VersionSchemeInfo> exacts;
@@ -1271,6 +1279,12 @@ namespace vcpkg::Dependencies
 
                 VersionSchemeInfo* get_node(const Versions::Version& ver);
                 VersionSchemeInfo& emplace_node(Versions::Scheme scheme, const Versions::Version& ver);
+
+                PackageNode() = default;
+                PackageNode(const PackageNode&) = delete;
+                PackageNode(PackageNode&&) = default;
+                PackageNode& operator=(const PackageNode&) = delete;
+                PackageNode& operator=(PackageNode&&) = default;
 
                 template<class F>
                 void foreach_vsi(F f)

--- a/src/vcpkg/install.cpp
+++ b/src/vcpkg/install.cpp
@@ -529,13 +529,15 @@ namespace vcpkg::Install
     static constexpr StringLiteral OPTION_XUNIT = "x-xunit";
     static constexpr StringLiteral OPTION_USE_ARIA2 = "x-use-aria2";
     static constexpr StringLiteral OPTION_CLEAN_AFTER_BUILD = "clean-after-build";
-    static constexpr StringLiteral OPTION_CLEAN_NON_DOWNLOADS_AFTER_BUILD = "clean-non-downloads-after-build";
+    static constexpr StringLiteral OPTION_CLEAN_BUILDTREES_AFTER_BUILD = "clean-buildtrees-after-build";
+    static constexpr StringLiteral OPTION_CLEAN_PACKAGES_AFTER_BUILD = "clean-packages-after-build";
+    static constexpr StringLiteral OPTION_CLEAN_DOWNLOADS_AFTER_BUILD = "clean-downloads-after-build";
     static constexpr StringLiteral OPTION_WRITE_PACKAGES_CONFIG = "x-write-nuget-packages-config";
     static constexpr StringLiteral OPTION_MANIFEST_NO_DEFAULT_FEATURES = "x-no-default-features";
     static constexpr StringLiteral OPTION_MANIFEST_FEATURE = "x-feature";
     static constexpr StringLiteral OPTION_PROHIBIT_BACKCOMPAT_FEATURES = "x-prohibit-backcompat-features";
 
-    static constexpr std::array<CommandSwitch, 12> INSTALL_SWITCHES = {{
+    static constexpr std::array<CommandSwitch, 14> INSTALL_SWITCHES = {{
         {OPTION_DRY_RUN, "Do not actually build or install"},
         {OPTION_USE_HEAD_VERSION, "Install the libraries on the command line using the latest upstream sources"},
         {OPTION_NO_DOWNLOADS, "Do not download new sources"},
@@ -547,11 +549,13 @@ namespace vcpkg::Install
 
         {OPTION_USE_ARIA2, "Use aria2 to perform download tasks"},
         {OPTION_CLEAN_AFTER_BUILD, "Clean buildtrees, packages and downloads after building each package"},
-        {OPTION_CLEAN_NON_DOWNLOADS_AFTER_BUILD, "Clean buildtrees and packages after building each package"},
+        {OPTION_CLEAN_BUILDTREES_AFTER_BUILD, "Clean buildtrees after building each package"},
+        {OPTION_CLEAN_PACKAGES_AFTER_BUILD, "Clean packages after building each package"},
+        {OPTION_CLEAN_DOWNLOADS_AFTER_BUILD, "Clean downloads after building each package"},
         {OPTION_PROHIBIT_BACKCOMPAT_FEATURES,
          "(experimental) Fail install if a package attempts to use a deprecated feature"},
     }};
-    static constexpr std::array<CommandSwitch, 12> MANIFEST_INSTALL_SWITCHES = {{
+    static constexpr std::array<CommandSwitch, 14> MANIFEST_INSTALL_SWITCHES = {{
         {OPTION_DRY_RUN, "Do not actually build or install"},
         {OPTION_USE_HEAD_VERSION, "Install the libraries on the command line using the latest upstream sources"},
         {OPTION_NO_DOWNLOADS, "Do not download new sources"},
@@ -562,7 +566,9 @@ namespace vcpkg::Install
         {OPTION_EDITABLE, "Disable source re-extraction and binary caching for libraries on the command line"},
         {OPTION_USE_ARIA2, "Use aria2 to perform download tasks"},
         {OPTION_CLEAN_AFTER_BUILD, "Clean buildtrees, packages and downloads after building each package"},
-        {OPTION_CLEAN_NON_DOWNLOADS_AFTER_BUILD, "Clean buildtrees and packages after building each package"},
+        {OPTION_CLEAN_BUILDTREES_AFTER_BUILD, "Clean buildtrees after building each package"},
+        {OPTION_CLEAN_PACKAGES_AFTER_BUILD, "Clean packages after building each package"},
+        {OPTION_CLEAN_DOWNLOADS_AFTER_BUILD, "Clean downloads after building each package"},
         {OPTION_MANIFEST_NO_DEFAULT_FEATURES, "Don't install the default features from the manifest."},
     }};
 
@@ -788,8 +794,12 @@ namespace vcpkg::Install
         const bool is_editable = Util::Sets::contains(options.switches, (OPTION_EDITABLE)) || !args.cmake_args.empty();
         const bool use_aria2 = Util::Sets::contains(options.switches, (OPTION_USE_ARIA2));
         const bool clean_after_build = Util::Sets::contains(options.switches, (OPTION_CLEAN_AFTER_BUILD));
-        const bool clean_non_downloads_after_build =
-            Util::Sets::contains(options.switches, (OPTION_CLEAN_NON_DOWNLOADS_AFTER_BUILD));
+        const bool clean_buildtrees_after_build =
+            Util::Sets::contains(options.switches, (OPTION_CLEAN_BUILDTREES_AFTER_BUILD));
+        const bool clean_packages_after_build =
+            Util::Sets::contains(options.switches, (OPTION_CLEAN_PACKAGES_AFTER_BUILD));
+        const bool clean_downloads_after_build =
+            Util::Sets::contains(options.switches, (OPTION_CLEAN_DOWNLOADS_AFTER_BUILD));
         const KeepGoing keep_going =
             to_keep_going(Util::Sets::contains(options.switches, OPTION_KEEP_GOING) || only_downloads);
         const bool prohibit_backcompat_features =
@@ -805,9 +815,9 @@ namespace vcpkg::Install
             Util::Enum::to_enum<Build::UseHeadVersion>(use_head_version),
             Util::Enum::to_enum<Build::AllowDownloads>(!no_downloads),
             Util::Enum::to_enum<Build::OnlyDownloads>(only_downloads),
-            Util::Enum::to_enum<Build::CleanBuildtrees>(clean_after_build || clean_non_downloads_after_build),
-            Util::Enum::to_enum<Build::CleanPackages>(clean_after_build || clean_non_downloads_after_build),
-            Util::Enum::to_enum<Build::CleanDownloads>(clean_after_build),
+            Util::Enum::to_enum<Build::CleanBuildtrees>(clean_after_build || clean_buildtrees_after_build),
+            Util::Enum::to_enum<Build::CleanPackages>(clean_after_build || clean_packages_after_build),
+            Util::Enum::to_enum<Build::CleanDownloads>(clean_after_build || clean_downloads_after_build),
             download_tool,
             Build::PurgeDecompressFailure::NO,
             Util::Enum::to_enum<Build::Editable>(is_editable),

--- a/src/vcpkg/install.cpp
+++ b/src/vcpkg/install.cpp
@@ -1007,7 +1007,7 @@ namespace vcpkg::Install
         Checks::check_exit(VCPKG_LINE_INFO, !action_plan.empty(), "Install plan cannot be empty");
 
 #if defined(_WIN32)
-        const auto maybe_common_triplet = common_projection(
+        const auto maybe_common_triplet = Util::common_projection(
             action_plan.install_actions, [](const InstallPlanAction& to_install) { return to_install.spec.triplet(); });
         if (maybe_common_triplet)
         {

--- a/src/vcpkg/install.cpp
+++ b/src/vcpkg/install.cpp
@@ -529,12 +529,13 @@ namespace vcpkg::Install
     static constexpr StringLiteral OPTION_XUNIT = "x-xunit";
     static constexpr StringLiteral OPTION_USE_ARIA2 = "x-use-aria2";
     static constexpr StringLiteral OPTION_CLEAN_AFTER_BUILD = "clean-after-build";
+    static constexpr StringLiteral OPTION_CLEAN_NON_DOWNLOADS_AFTER_BUILD = "clean-non-downloads-after-build";
     static constexpr StringLiteral OPTION_WRITE_PACKAGES_CONFIG = "x-write-nuget-packages-config";
     static constexpr StringLiteral OPTION_MANIFEST_NO_DEFAULT_FEATURES = "x-no-default-features";
     static constexpr StringLiteral OPTION_MANIFEST_FEATURE = "x-feature";
     static constexpr StringLiteral OPTION_PROHIBIT_BACKCOMPAT_FEATURES = "x-prohibit-backcompat-features";
 
-    static constexpr std::array<CommandSwitch, 11> INSTALL_SWITCHES = {{
+    static constexpr std::array<CommandSwitch, 12> INSTALL_SWITCHES = {{
         {OPTION_DRY_RUN, "Do not actually build or install"},
         {OPTION_USE_HEAD_VERSION, "Install the libraries on the command line using the latest upstream sources"},
         {OPTION_NO_DOWNLOADS, "Do not download new sources"},
@@ -546,10 +547,11 @@ namespace vcpkg::Install
 
         {OPTION_USE_ARIA2, "Use aria2 to perform download tasks"},
         {OPTION_CLEAN_AFTER_BUILD, "Clean buildtrees, packages and downloads after building each package"},
+        {OPTION_CLEAN_NON_DOWNLOADS_AFTER_BUILD, "Clean buildtrees and packages after building each package"},
         {OPTION_PROHIBIT_BACKCOMPAT_FEATURES,
          "(experimental) Fail install if a package attempts to use a deprecated feature"},
     }};
-    static constexpr std::array<CommandSwitch, 11> MANIFEST_INSTALL_SWITCHES = {{
+    static constexpr std::array<CommandSwitch, 12> MANIFEST_INSTALL_SWITCHES = {{
         {OPTION_DRY_RUN, "Do not actually build or install"},
         {OPTION_USE_HEAD_VERSION, "Install the libraries on the command line using the latest upstream sources"},
         {OPTION_NO_DOWNLOADS, "Do not download new sources"},
@@ -560,6 +562,7 @@ namespace vcpkg::Install
         {OPTION_EDITABLE, "Disable source re-extraction and binary caching for libraries on the command line"},
         {OPTION_USE_ARIA2, "Use aria2 to perform download tasks"},
         {OPTION_CLEAN_AFTER_BUILD, "Clean buildtrees, packages and downloads after building each package"},
+        {OPTION_CLEAN_NON_DOWNLOADS_AFTER_BUILD, "Clean buildtrees and packages after building each package"},
         {OPTION_MANIFEST_NO_DEFAULT_FEATURES, "Don't install the default features from the manifest."},
     }};
 
@@ -785,6 +788,8 @@ namespace vcpkg::Install
         const bool is_editable = Util::Sets::contains(options.switches, (OPTION_EDITABLE)) || !args.cmake_args.empty();
         const bool use_aria2 = Util::Sets::contains(options.switches, (OPTION_USE_ARIA2));
         const bool clean_after_build = Util::Sets::contains(options.switches, (OPTION_CLEAN_AFTER_BUILD));
+        const bool clean_non_downloads_after_build =
+            Util::Sets::contains(options.switches, (OPTION_CLEAN_NON_DOWNLOADS_AFTER_BUILD));
         const KeepGoing keep_going =
             to_keep_going(Util::Sets::contains(options.switches, OPTION_KEEP_GOING) || only_downloads);
         const bool prohibit_backcompat_features =
@@ -800,8 +805,8 @@ namespace vcpkg::Install
             Util::Enum::to_enum<Build::UseHeadVersion>(use_head_version),
             Util::Enum::to_enum<Build::AllowDownloads>(!no_downloads),
             Util::Enum::to_enum<Build::OnlyDownloads>(only_downloads),
-            Util::Enum::to_enum<Build::CleanBuildtrees>(clean_after_build),
-            Util::Enum::to_enum<Build::CleanPackages>(clean_after_build),
+            Util::Enum::to_enum<Build::CleanBuildtrees>(clean_after_build || clean_non_downloads_after_build),
+            Util::Enum::to_enum<Build::CleanPackages>(clean_after_build || clean_non_downloads_after_build),
             Util::Enum::to_enum<Build::CleanDownloads>(clean_after_build),
             download_tool,
             Build::PurgeDecompressFailure::NO,

--- a/src/vcpkg/portfileprovider.cpp
+++ b/src/vcpkg/portfileprovider.cpp
@@ -93,9 +93,11 @@ namespace vcpkg::PortFileProvider
 
     namespace
     {
-        struct BaselineProviderImpl : IBaselineProvider, Util::ResourceBase
+        struct BaselineProviderImpl : IBaselineProvider
         {
             BaselineProviderImpl(const VcpkgPaths& paths_) : paths(paths_) { }
+            BaselineProviderImpl(const BaselineProviderImpl&) = delete;
+            BaselineProviderImpl& operator=(const BaselineProviderImpl&) = delete;
 
             virtual Optional<VersionT> get_baseline_version(StringView port_name) const override
             {
@@ -117,9 +119,11 @@ namespace vcpkg::PortFileProvider
             mutable std::map<std::string, Optional<VersionT>, std::less<>> m_baseline_cache;
         };
 
-        struct VersionedPortfileProviderImpl : IVersionedPortfileProvider, Util::ResourceBase
+        struct VersionedPortfileProviderImpl : IVersionedPortfileProvider
         {
             VersionedPortfileProviderImpl(const VcpkgPaths& paths_) : paths(paths_) { }
+            VersionedPortfileProviderImpl(const VersionedPortfileProviderImpl&) = delete;
+            VersionedPortfileProviderImpl& operator=(const VersionedPortfileProviderImpl&) = delete;
 
             const ExpectedS<std::unique_ptr<RegistryEntry>>& entry(StringView name) const
             {
@@ -237,7 +241,7 @@ namespace vcpkg::PortFileProvider
             mutable std::map<std::string, ExpectedS<std::unique_ptr<RegistryEntry>>, std::less<>> m_entry_cache;
         };
 
-        struct OverlayProviderImpl : IOverlayProvider, Util::ResourceBase
+        struct OverlayProviderImpl : IOverlayProvider
         {
             OverlayProviderImpl(const VcpkgPaths& paths, View<std::string> overlay_ports)
                 : m_fs(paths.get_filesystem())
@@ -256,6 +260,9 @@ namespace vcpkg::PortFileProvider
                                        s_overlay);
                 }
             }
+
+            OverlayProviderImpl(const OverlayProviderImpl&) = delete;
+            OverlayProviderImpl& operator=(const OverlayProviderImpl&) = delete;
 
             Optional<SourceControlFileLocation> load_port(StringView port_name) const
             {


### PR DESCRIPTION
We're exceeding the 400GB temporary disk size in our CI right now and about half that is buildtrees we don't need:

![image](https://user-images.githubusercontent.com/1544943/115625347-c9e36980-a2b0-11eb-9664-5fc0395a02ab.png)
