### PR TITLE
Output error code when getting VS ENV failed

### DIFF
--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -591,7 +591,7 @@ namespace vcpkg
         actual_cmd_line.raw_arg(Strings::concat(" & echo ", magic_string, " & set"));
 
         auto rc_output = cmd_execute_and_capture_output(actual_cmd_line, env);
-        Checks::check_exit(VCPKG_LINE_INFO, rc_output.exit_code == 0);
+        Checks::check_exit(VCPKG_LINE_INFO, rc_output.exit_code == 0, "Run vcvarsall.bat to get Visual Studio env failed with exit code %d", rc_output.exit_code);
         Debug::print("command line: ", actual_cmd_line.command_line(), "\n");
         Debug::print(rc_output.output, "\n");
 

--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -591,7 +591,10 @@ namespace vcpkg
         actual_cmd_line.raw_arg(Strings::concat(" & echo ", magic_string, " & set"));
 
         auto rc_output = cmd_execute_and_capture_output(actual_cmd_line, env);
-        Checks::check_exit(VCPKG_LINE_INFO, rc_output.exit_code == 0, "Run vcvarsall.bat to get Visual Studio env failed with exit code %d", rc_output.exit_code);
+        Checks::check_exit(VCPKG_LINE_INFO,
+                           rc_output.exit_code == 0,
+                           "Run vcvarsall.bat to get Visual Studio env failed with exit code %d",
+                           rc_output.exit_code);
         Debug::print("command line: ", actual_cmd_line.command_line(), "\n");
         Debug::print(rc_output.output, "\n");
 


### PR DESCRIPTION
When using `vcvarsall.bat` to obtain the Visual Studio environment variable fails, output the error message to notice user.

Fixes https://github.com/microsoft/vcpkg/issues/17319
