### PR TITLE
When registry.baseline == 'HEAD', automatically use latest commit SHA.

### DIFF
--- a/src/vcpkg/registries.cpp
+++ b/src/vcpkg/registries.cpp
@@ -561,10 +561,13 @@ namespace
                 std::string latest_commit_sha = e.value();
 
                 // For easy use, please just considering HEAD as 'use latest'.
-                if(Strings::equals(m_baseline_identifier, "HEAD")) {
+                if (Strings::equals(m_baseline_identifier, "HEAD"))
+                {
                     m_baseline_identifier = latest_commit_sha;
                     System::print2("Using HEAD commit SHA ", latest_commit_sha, " for git registry ", m_repo, ".\n");
-                } else {
+                }
+                else
+                {
                     Checks::exit_maybe_upgrade(
                         VCPKG_LINE_INFO,
                         "Error: the git registry entry for \"%s\" must have a \"baseline\" field that is a valid git "


### PR DESCRIPTION
The latest registry requires developers provide Git Registry's baseline, which is not convenient. (https://github.com/microsoft/vcpkg/issues/17726) For decreasing the complexity, just set HEAD commit SHA when registry.baseline == 'HEAD'.

For example:
```json
{
    "registries": [
        {
            "kind": "git",
            "repository": "https://github.com/cnSchwarzer/vcpkg-registry.git",
            "packages": [ "bup", "k1ee" ],
            "baseline": "HEAD"
        }
    ]
}
```