### PR TITLE
[vcpkg] Fix the inconsistency issue in tools required version

### DIFF
--- a/src/vcpkg/tools.cpp
+++ b/src/vcpkg/tools.cpp
@@ -40,7 +40,7 @@ namespace vcpkg
         const int d2 = atoi(match[2].str().c_str());
         const int d3 = [&] {
             if (match[4].str().empty()) return 0;
-            return atoi(match[5].str().c_str());
+            return atoi(match[4].str().c_str());
         }();
         const std::array<int, 3> result = {d1, d2, d3};
         return result;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/17791

It may be a mistakes in previous code, the third part of version is getting from wrong element, that cause the inconsistency issue in tools required version with actual downloaded version.

Previously:
```
A suitable version of cmake was not found (required v3.20.0). Downloading portable cmake v3.20.0...
Downloading cmake...
  https://github.com/Kitware/CMake/releases/download/v3.20.2/cmake-3.20.2-Linux-x86_64.tar.gz -> /home/kpa/Projekte/vcpkg/vcpkg/downloads/cmake-3.20.2-linux-x86_64.tar.gz
```

Currently:
```
A suitable version of cmake was not found (required v3.20.2). Downloading portable cmake v3.20.2...
Downloading cmake...
  https://github.com/Kitware/CMake/releases/download/v3.20.2/cmake-3.20.2-Linux-x86_64.tar.gz -> /home/kpa/Projekte/vcpkg/vcpkg/downloads/cmake-3.20.2-linux-x86_64.tar.gz
```