### PR TITLE
Support custom registries in commands

### DIFF
--- a/include/vcpkg/base/files.h
+++ b/include/vcpkg/base/files.h
@@ -235,6 +235,8 @@ namespace vcpkg::Files
         fs::file_status status(const fs::path& p, ignore_errors_t) const noexcept;
         fs::file_status symlink_status(LineInfo li, const fs::path& p) const noexcept;
         fs::file_status symlink_status(const fs::path& p, ignore_errors_t) const noexcept;
+        virtual fs::path relative(const fs::path& path, const fs::path& base, std::error_code& ec) const = 0;
+        fs::path relative(LineInfo li, const fs::path& path, const fs::path& base) const;
         virtual fs::path absolute(const fs::path& path, std::error_code& ec) const = 0;
         fs::path absolute(LineInfo li, const fs::path& path) const;
         virtual fs::path canonical(const fs::path& path, std::error_code& ec) const = 0;

--- a/include/vcpkg/registries.h
+++ b/include/vcpkg/registries.h
@@ -132,7 +132,13 @@ namespace vcpkg
 
     ExpectedS<std::vector<std::pair<SchemedVersion, std::string>>> get_builtin_versions(const VcpkgPaths& paths,
                                                                                         StringView port_name);
+    ExpectedS<std::vector<std::pair<SchemedVersion, std::string>>> get_versions(const Files::Filesystem& fs,
+                                                                                const fs::path& versions_dir,
+                                                                                StringView port_name);
 
+    ExpectedS<std::map<std::string, VersionT, std::less<>>> get_baseline(const VcpkgPaths& paths,
+                                                                         const fs::path& dot_git_dir,
+                                                                         const fs::path& versions_dir);
     ExpectedS<std::map<std::string, VersionT, std::less<>>> get_builtin_baseline(const VcpkgPaths& paths);
 
     bool is_git_commit_sha(StringView sv);

--- a/include/vcpkg/vcpkgcmdarguments.h
+++ b/include/vcpkg/vcpkgcmdarguments.h
@@ -138,6 +138,13 @@ namespace vcpkg
         constexpr static StringLiteral BUILTIN_REGISTRY_VERSIONS_DIR_ARG = "x-builtin-registry-versions-dir";
         std::unique_ptr<std::string> builtin_registry_versions_dir;
 
+        constexpr static StringLiteral REGISTRY_VERSIONS_DIR_ARG = "x-registry-versions-dir";
+        std::unique_ptr<std::string> registry_versions_dir;
+        constexpr static StringLiteral REGISTRY_PORTS_DIR_ARG = "x-registry-ports-dir";
+        std::unique_ptr<std::string> registry_ports_dir;
+        constexpr static StringLiteral REGISTRY_ROOT_DIR_ARG = "x-registry-root";
+        std::unique_ptr<std::string> registry_root_dir;
+
         constexpr static StringLiteral DEFAULT_VISUAL_STUDIO_PATH_ENV = "VCPKG_VISUAL_STUDIO_PATH";
         std::unique_ptr<std::string> default_visual_studio_path;
 

--- a/include/vcpkg/vcpkgpaths.h
+++ b/include/vcpkg/vcpkgpaths.h
@@ -141,7 +141,12 @@ namespace vcpkg
         // Git manipulation in the vcpkg directory
         ExpectedS<std::string> get_current_git_sha() const;
         std::string get_current_git_sha_message() const;
-        ExpectedS<fs::path> git_checkout_baseline(StringView commit_sha) const;
+        ExpectedS<std::string> get_current_git_sha(const fs::path& dot_git_dir) const;
+        std::string get_current_git_sha_message(const fs::path& dot_git_dir) const;
+        ExpectedS<fs::path> git_checkout_builtin_baseline(StringView commit_sha) const;
+        ExpectedS<fs::path> git_checkout_baseline(const fs::path& dot_git_dir,
+                                                  const fs::path& versions_dir,
+                                                  StringView commit_sha) const;
         ExpectedS<fs::path> git_checkout_port(StringView port_name,
                                               StringView git_tree,
                                               const fs::path& dot_git_dir) const;
@@ -149,6 +154,8 @@ namespace vcpkg
 
         const Downloads::DownloadManager& get_download_manager() const;
 
+        ExpectedS<std::map<std::string, std::string, std::less<>>> git_get_port_treeish_map(
+            const fs::path& ports_dir) const;
         ExpectedS<std::map<std::string, std::string, std::less<>>> git_get_local_port_treeish_map() const;
 
         // Git manipulation for remote registries

--- a/include/vcpkg/vcpkgpaths.h
+++ b/include/vcpkg/vcpkgpaths.h
@@ -108,6 +108,11 @@ namespace vcpkg
         fs::path builtin_ports;
         fs::path builtin_registry_versions;
 
+        // When we are in a custom registry, these values are different from builtin_ports, otherwise they are the same
+        fs::path current_registry_dot_git_dir;
+        fs::path current_registry_ports;
+        fs::path current_registry_versions;
+
         fs::path tools;
         fs::path buildsystems;
         fs::path buildsystems_msbuild_targets;

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -718,6 +718,19 @@ namespace vcpkg::Files
         this->remove_all_inside(path, ec, failure_point);
     }
 
+    fs::path Filesystem::relative(LineInfo li, const fs::path& path, const fs::path& base) const
+    {
+        std::error_code ec;
+        const auto result = this->relative(path, base, ec);
+        if (ec)
+        {
+            Checks::exit_with_message(
+                li, "Error getting relative path of %s to base %s: %s", path.string(), base.string(), ec.message());
+        }
+
+        return result;
+    }
+
     fs::path Filesystem::absolute(LineInfo li, const fs::path& path) const
     {
         std::error_code ec;
@@ -1261,6 +1274,11 @@ namespace vcpkg::Files
                 }
                 write_contents(file_path, data, ec);
             }
+        }
+
+        virtual fs::path relative(const fs::path& path, const fs::path& base, std::error_code& ec) const override
+        {
+            return fs::stdfs::relative(path, base, ec);
         }
 
         virtual fs::path absolute(const fs::path& path, std::error_code& ec) const override

--- a/src/vcpkg/commands.format-manifest.cpp
+++ b/src/vcpkg/commands.format-manifest.cpp
@@ -245,7 +245,7 @@ namespace vcpkg::Commands::FormatManifest
 
         if (format_all)
         {
-            for (const auto& dir : fs::directory_iterator(paths.builtin_ports_directory()))
+            for (const auto& dir : fs::directory_iterator(paths.current_registry_ports))
             {
                 auto control_path = dir.path() / fs::u8path("CONTROL");
                 auto manifest_path = dir.path() / fs::u8path("vcpkg.json");

--- a/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/src/vcpkg/vcpkgcmdarguments.cpp
@@ -285,6 +285,9 @@ namespace vcpkg
                     {SCRIPTS_ROOT_DIR_ARG, &VcpkgCmdArguments::scripts_root_dir},
                     {BUILTIN_PORTS_ROOT_DIR_ARG, &VcpkgCmdArguments::builtin_ports_root_dir},
                     {BUILTIN_REGISTRY_VERSIONS_DIR_ARG, &VcpkgCmdArguments::builtin_registry_versions_dir},
+                    {REGISTRY_PORTS_DIR_ARG, &VcpkgCmdArguments::registry_ports_dir},
+                    {REGISTRY_VERSIONS_DIR_ARG, &VcpkgCmdArguments::registry_versions_dir},
+                    {REGISTRY_ROOT_DIR_ARG, &VcpkgCmdArguments::registry_root_dir},
                 };
 
             constexpr static std::pair<StringView, std::vector<std::string> VcpkgCmdArguments::*>

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -445,6 +445,75 @@ namespace vcpkg
         }
         m_pimpl->triplets_dirs.emplace_back(triplets);
         m_pimpl->triplets_dirs.emplace_back(community_triplets);
+
+        // detect custom registry
+        if (args.registry_ports_dir || args.registry_versions_dir || args.registry_root_dir)
+        {
+            const auto canonical = [&](const auto& arg) {
+                return filesystem.canonical(VCPKG_LINE_INFO, fs::u8path(*arg));
+            };
+            auto registry_root = args.registry_root_dir ? canonical(args.registry_ports_dir) : original_cwd;
+            const auto find_dir = [&](const fs::path& filename) {
+                fs::path path;
+                if (args.registry_root_dir)
+                {
+                    path = registry_root / filename;
+                }
+                else
+                {
+                    path = filesystem.find_file_recursively_up(original_cwd, filename);
+                }
+                Checks::check_exit(VCPKG_LINE_INFO,
+                                   !path.empty() && filesystem.exists(path),
+                                   "Error: Could not detect " + fs::u8string(filename) +
+                                       " dir for custom registry at " + fs::u8string(registry_root));
+                return path;
+            };
+            current_registry_ports = args.registry_ports_dir ? canonical(args.registry_ports_dir) : find_dir("ports");
+            current_registry_versions =
+                args.registry_versions_dir ? canonical(args.registry_versions_dir) : find_dir("versions");
+            auto git_dir_root = filesystem.find_file_recursively_up(registry_root, ".git");
+            Checks::check_exit(VCPKG_LINE_INFO,
+                               !git_dir_root.empty(),
+                               "Error: Could not detect .git dir for custom registry at " +
+                                   fs::u8string(registry_root));
+            current_registry_dot_git_dir = git_dir_root / ".git";
+        }
+        else
+        {
+            auto registry_root = filesystem.find_file_recursively_up(original_cwd, "ports");
+            if (!registry_root.empty())
+            {
+                current_registry_ports = registry_root / fs::u8path("ports");
+                current_registry_versions = registry_root / fs::u8path("versions");
+                if (filesystem.exists(current_registry_versions))
+                {
+                    auto git_dir = filesystem.find_file_recursively_up(registry_root, ".git");
+                    Checks::check_exit(VCPKG_LINE_INFO,
+                                       !git_dir.empty(),
+                                       "Error: Could not detect .git dir for custom registry at " +
+                                           fs::u8string(registry_root));
+                    current_registry_dot_git_dir = git_dir / fs::u8path(".git");
+                }
+                else
+                {
+                    Debug::print("Found ports dir ",
+                                 fs::u8string(current_registry_ports),
+                                 " but versions dir ",
+                                 fs::u8string(current_registry_versions),
+                                 " does not exists\n");
+                }
+            }
+            if (current_registry_dot_git_dir.empty())
+            {
+                current_registry_ports = this->builtin_ports;
+                current_registry_versions = this->builtin_registry_versions;
+                current_registry_dot_git_dir = this->root / fs::u8path(".git");
+            }
+            Debug::print("Using current_registry_ports: ", fs::u8string(current_registry_ports), '\n');
+            Debug::print("Using current_registry_versions: ", fs::u8string(current_registry_versions), '\n');
+            Debug::print("Using current_registry_dot_git_dir: ", fs::u8string(current_registry_dot_git_dir), '\n');
+        }
     }
 
     fs::path VcpkgPaths::package_dir(const PackageSpec& spec) const { return this->packages / fs::u8path(spec.dir()); }


### PR DESCRIPTION
I have started with `format-manifest` and `x-add-version`. I would add support for more commands, but before that it would be cool if you can say if the current design is okay or if I should change it.
 