### PR TITLE
[x-download] Implement `--header` argument

### DIFF
--- a/include/vcpkg-test/util.h
+++ b/include/vcpkg-test/util.h
@@ -107,6 +107,20 @@ namespace vcpkg::Test
         return std::move(*opt.get());
     }
 
+    template<class R1, class R2>
+    void check_ranges(const R1& r1, const R2& r2)
+    {
+        CHECK(r1.size() == r2.size());
+        auto it1 = r1.begin();
+        auto e1 = r1.end();
+        auto it2 = r2.begin();
+        auto e2 = r2.end();
+        while (it1 != e1 && it2 != e2)
+        {
+            CHECK(*it1++ == *it2++);
+        }
+    }
+
     struct AllowSymlinks
     {
         enum Tag : bool

--- a/include/vcpkg-test/util.h
+++ b/include/vcpkg-test/util.h
@@ -115,9 +115,9 @@ namespace vcpkg::Test
         auto e1 = r1.end();
         auto it2 = r2.begin();
         auto e2 = r2.end();
-        while (it1 != e1 && it2 != e2)
+        for (; it1 != e1 && it2 != e2; ++it1, ++it2)
         {
-            CHECK(*it1++ == *it2++);
+            CHECK(*it1 == *it2);
         }
     }
 

--- a/include/vcpkg/base/downloads.h
+++ b/include/vcpkg/base/downloads.h
@@ -40,7 +40,7 @@ namespace vcpkg::Downloads
     View<std::string> azure_blob_headers();
 
     std::vector<int> download_files(Files::Filesystem& fs, View<std::pair<std::string, fs::path>> url_pairs);
-    int put_file(const Files::Filesystem&, StringView url, View<std::string> headers, const fs::path& file);
+    ExpectedS<int> put_file(const Files::Filesystem&, StringView url, View<std::string> headers, const fs::path& file);
     std::vector<int> url_heads(View<std::string> urls, View<std::string> headers);
 
     struct DownloadManagerConfig
@@ -82,7 +82,9 @@ namespace vcpkg::Downloads
                                   const fs::path& download_path,
                                   const std::string& sha512) const;
 
-        int put_file_to_mirror(const Files::Filesystem& fs, const fs::path& path, const std::string& sha512) const;
+        ExpectedS<int> put_file_to_mirror(const Files::Filesystem& fs,
+                                          const fs::path& path,
+                                          const std::string& sha512) const;
 
         const DownloadManagerConfig& internal_get_config() const { return *this; }
 

--- a/include/vcpkg/base/downloads.h
+++ b/include/vcpkg/base/downloads.h
@@ -27,46 +27,65 @@ namespace vcpkg::Downloads
     // Returns url that was successfully downloaded from
     std::string download_file(Files::Filesystem& fs,
                               View<std::string> urls,
+                              View<std::string> headers,
                               const fs::path& download_path,
                               const std::string& sha512);
 
     void download_file(Files::Filesystem& fs,
                        const std::string& url,
+                       View<std::string> headers,
                        const fs::path& download_path,
                        const std::string& sha512);
 
+    View<std::string> azure_blob_headers();
+
     std::vector<int> download_files(Files::Filesystem& fs, View<std::pair<std::string, fs::path>> url_pairs);
-    int put_file(const Files::Filesystem&, StringView url, const fs::path& file);
-    std::vector<int> url_heads(View<std::string> urls);
+    int put_file(const Files::Filesystem&, StringView url, View<std::string> headers, const fs::path& file);
+    std::vector<int> url_heads(View<std::string> urls, View<std::string> headers);
+
+    struct DownloadManagerConfig
+    {
+        Optional<std::string> m_read_url_template;
+        std::vector<std::string> m_read_headers;
+        Optional<std::string> m_write_url_template;
+        std::vector<std::string> m_write_headers;
+        bool m_block_origin = false;
+    };
 
     // Handles downloading and uploading to a content addressable mirror
-    struct DownloadManager
+    struct DownloadManager : private DownloadManagerConfig
     {
         DownloadManager() = default;
         explicit DownloadManager(Optional<std::string> read_url_template,
+                                 std::vector<std::string> read_headers,
                                  Optional<std::string> write_url_template,
+                                 std::vector<std::string> write_headers,
                                  bool block_origin);
 
         void download_file(Files::Filesystem& fs,
                            const std::string& url,
                            const fs::path& download_path,
+                           const std::string& sha512) const
+        {
+            this->download_file(fs, url, {}, download_path, sha512);
+        }
+
+        void download_file(Files::Filesystem& fs,
+                           const std::string& url,
+                           View<std::string> headers,
+                           const fs::path& download_path,
                            const std::string& sha512) const;
 
         std::string download_file(Files::Filesystem& fs,
                                   View<std::string> urls,
+                                  View<std::string> headers,
                                   const fs::path& download_path,
                                   const std::string& sha512) const;
 
         int put_file_to_mirror(const Files::Filesystem& fs, const fs::path& path, const std::string& sha512) const;
 
-        const Optional<std::string>& internal_get_read_url_template() const { return m_read_url_template; }
-        const Optional<std::string>& internal_get_write_url_template() const { return m_write_url_template; }
+        const DownloadManagerConfig& internal_get_config() const { return *this; }
 
         bool block_origin() const { return m_block_origin; }
-
-    private:
-        bool m_block_origin = false;
-        Optional<std::string> m_read_url_template;
-        Optional<std::string> m_write_url_template;
     };
 }

--- a/src/vcpkg/base/checks.cpp
+++ b/src/vcpkg/base/checks.cpp
@@ -71,6 +71,10 @@ namespace vcpkg
     {
         if (!expression)
         {
+            System::print2(System::Color::error,
+                           "Error: vcpkg has crashed; no additional details are available.\nThe source line is ",
+                           Strings::format("%s(%d)\n", line_info.file_name, line_info.line_number),
+                           '\n');
             exit_fail(line_info);
         }
     }

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -231,7 +231,7 @@ namespace vcpkg::Downloads
         }
     }
 
-    static void url_heads_inner(View<std::string> urls, std::vector<int>* out)
+    static void url_heads_inner(View<std::string> urls, View<std::string> headers, std::vector<int>* out)
     {
         static constexpr StringLiteral guid_marker = "8a1db05f-a65d-419b-aa72-037fb4d0672e";
 
@@ -241,6 +241,10 @@ namespace vcpkg::Downloads
             .string_arg("--location")
             .string_arg("-w")
             .string_arg(Strings::concat(guid_marker, " %{http_code}\\n"));
+        for (auto&& header : headers)
+        {
+            cmd.string_arg("-H").string_arg(header);
+        }
         for (auto&& url : urls)
         {
             cmd.string_arg(url);
@@ -253,7 +257,7 @@ namespace vcpkg::Downloads
         });
         Checks::check_exit(VCPKG_LINE_INFO, res == 0, "curl failed to execute with exit code: %d", res);
     }
-    std::vector<int> url_heads(View<std::string> urls)
+    std::vector<int> url_heads(View<std::string> urls, View<std::string> headers)
     {
         static constexpr size_t batch_size = 100;
 
@@ -262,9 +266,9 @@ namespace vcpkg::Downloads
         size_t i = 0;
         for (; i + batch_size <= urls.size(); i += batch_size)
         {
-            url_heads_inner({urls.data() + i, batch_size}, &ret);
+            url_heads_inner({urls.data() + i, batch_size}, headers, &ret);
         }
-        if (i != urls.size()) url_heads_inner({urls.begin() + i, urls.end()}, &ret);
+        if (i != urls.size()) url_heads_inner({urls.begin() + i, urls.end()}, headers, &ret);
 
         return ret;
     }
@@ -309,12 +313,13 @@ namespace vcpkg::Downloads
         return ret;
     }
 
-    int put_file(const Files::Filesystem&, StringView url, const fs::path& file)
+    int put_file(const Files::Filesystem&, StringView url, View<std::string> headers, const fs::path& file)
     {
         static constexpr StringLiteral guid_marker = "9a1db05f-a65d-419b-aa72-037fb4d0672e";
 
         if (Strings::starts_with(url, "ftp://"))
         {
+            // HTTP headers are ignored for FTP clients
             System::Command cmd;
             cmd.string_arg("curl");
             cmd.string_arg(url);
@@ -329,11 +334,13 @@ namespace vcpkg::Downloads
         }
         System::Command cmd;
         cmd.string_arg("curl").string_arg("-X").string_arg("PUT");
+        for (auto&& header : headers)
+        {
+            cmd.string_arg("-H").string_arg(header);
+        }
         cmd.string_arg("-w").string_arg(Strings::concat("\\n", guid_marker, "%{http_code}"));
         cmd.string_arg(url);
         cmd.string_arg("-T").path_arg(file);
-        cmd.string_arg("-H").string_arg("x-ms-version: 2020-04-08");
-        cmd.string_arg("-H").string_arg("x-ms-blob-type: BlockBlob");
         int code = 0;
         auto res = System::cmd_execute_and_stream_lines(cmd, [&code](StringView line) {
             if (Strings::starts_with(line, guid_marker))
@@ -350,10 +357,11 @@ namespace vcpkg::Downloads
 
     void download_file(Files::Filesystem& fs,
                        const std::string& url,
+                       View<std::string> headers,
                        const fs::path& download_path,
                        const std::string& sha512)
     {
-        download_file(fs, {&url, 1}, download_path, sha512);
+        download_file(fs, {&url, 1}, headers, download_path, sha512);
     }
 
 #if defined(_WIN32)
@@ -440,13 +448,13 @@ namespace vcpkg::Downloads
     }
 #endif
 
-    std::string download_file(vcpkg::Files::Filesystem& fs,
-                              View<std::string> urls,
-                              const fs::path& download_path,
-                              const std::string& sha512)
+    static bool try_download_file(vcpkg::Files::Filesystem& fs,
+                                  const std::string& url,
+                                  View<std::string> headers,
+                                  const fs::path& download_path,
+                                  const std::string& sha512,
+                                  std::string& errors)
     {
-        Checks::check_exit(VCPKG_LINE_INFO, urls.size() > 0);
-
         auto download_path_part_path = download_path;
 #if defined(_WIN32)
         download_path_part_path += fs::u8path(Strings::concat(".", _getpid(), ".part"));
@@ -454,10 +462,9 @@ namespace vcpkg::Downloads
         download_path_part_path += fs::u8path(Strings::concat(".", getpid(), ".part"));
 #endif
 
-        std::string errors;
-        for (const std::string& url : urls)
-        {
 #if defined(_WIN32)
+        if (headers.size() == 0)
+        {
             auto split_uri = details::split_uri_view(url).value_or_exit(VCPKG_LINE_INFO);
             auto authority = split_uri.authority.value_or_exit(VCPKG_LINE_INFO).substr(2);
             if (split_uri.scheme == "https" || split_uri.scheme == "http")
@@ -471,89 +478,147 @@ namespace vcpkg::Downloads
                         if (auto err = maybe_error.get())
                         {
                             Strings::append(errors, *err);
+                            return false;
                         }
                         else
                         {
                             fs.rename(download_path_part_path, download_path, VCPKG_LINE_INFO);
-                            return url;
+                            return true;
                         }
                     }
-                    continue;
+                    else
+                    {
+                        return false;
+                    }
                 }
             }
-#endif
-            System::Command cmd;
-            cmd.string_arg("curl")
-                .string_arg("--fail")
-                .string_arg("-L")
-                .string_arg(url)
-                .string_arg("--create-dirs")
-                .string_arg("--output")
-                .path_arg(download_path_part_path);
-            const auto out = System::cmd_execute_and_capture_output(cmd);
-            if (out.exit_code != 0)
-            {
-                Strings::append(errors, url, ": ", out.output, '\n');
-                continue;
-            }
-
-            auto maybe_error = try_verify_downloaded_file_hash(fs, url, download_path_part_path, sha512);
-            if (auto err = maybe_error.get())
-            {
-                Strings::append(errors, *err);
-            }
-            else
-            {
-                fs.rename(download_path_part_path, download_path, VCPKG_LINE_INFO);
-                return url;
-            }
         }
-        Checks::exit_with_message(VCPKG_LINE_INFO, Strings::concat("Failed to download from mirror set:\n", errors));
+#endif
+        System::Command cmd;
+        cmd.string_arg("curl")
+            .string_arg("--fail")
+            .string_arg("-L")
+            .string_arg(url)
+            .string_arg("--create-dirs")
+            .string_arg("--output")
+            .path_arg(download_path_part_path);
+        for (auto&& header : headers)
+        {
+            cmd.string_arg("-H").string_arg(header);
+        }
+        const auto out = System::cmd_execute_and_capture_output(cmd);
+        if (out.exit_code != 0)
+        {
+            Strings::append(errors, url, ": ", out.output, '\n');
+            return false;
+        }
+
+        auto maybe_error = try_verify_downloaded_file_hash(fs, url, download_path_part_path, sha512);
+        if (auto err = maybe_error.get())
+        {
+            Strings::append(errors, *err);
+            return false;
+        }
+        else
+        {
+            fs.rename(download_path_part_path, download_path, VCPKG_LINE_INFO);
+            return true;
+        }
+    }
+
+    static Optional<const std::string&> try_download_files(vcpkg::Files::Filesystem& fs,
+                                                           View<std::string> urls,
+                                                           View<std::string> headers,
+                                                           const fs::path& download_path,
+                                                           const std::string& sha512,
+                                                           std::string& errors)
+    {
+        for (auto&& url : urls)
+        {
+            if (try_download_file(fs, url, headers, download_path, sha512, errors)) return url;
+        }
+        return nullopt;
+    }
+
+    std::string download_file(vcpkg::Files::Filesystem& fs,
+                              View<std::string> urls,
+                              View<std::string> headers,
+                              const fs::path& download_path,
+                              const std::string& sha512)
+    {
+        Checks::check_exit(VCPKG_LINE_INFO, urls.size(), "Error: No urls specified to download SHA: %s", sha512);
+
+        std::string errors;
+        auto maybe_url = try_download_files(fs, urls, headers, download_path, sha512, errors);
+        if (auto url = maybe_url.get())
+        {
+            return *url;
+        }
+        else
+        {
+            Checks::exit_with_message(VCPKG_LINE_INFO, "Failed to download from mirror set:\n%s", errors);
+        }
+    }
+
+    View<std::string> azure_blob_headers()
+    {
+        static std::string s_headers[2] = {"x-ms-version: 2020-04-08", "x-ms-blob-type: BlockBlob"};
+        return s_headers;
     }
 
     DownloadManager::DownloadManager(Optional<std::string> read_url_template,
+                                     std::vector<std::string> read_headers,
                                      Optional<std::string> write_url_template,
+                                     std::vector<std::string> write_headers,
                                      bool block_origin)
-        : m_block_origin(block_origin)
-        , m_read_url_template(std::move(read_url_template))
-        , m_write_url_template(std::move(write_url_template))
+        : DownloadManagerConfig{std::move(read_url_template),
+                                std::move(read_headers),
+                                std::move(write_url_template),
+                                std::move(write_headers),
+                                block_origin}
     {
     }
 
     void DownloadManager::download_file(Files::Filesystem& fs,
                                         const std::string& url,
+                                        View<std::string> headers,
                                         const fs::path& download_path,
                                         const std::string& sha512) const
     {
-        this->download_file(fs, View<std::string>(&url, 1), download_path, sha512);
+        this->download_file(fs, View<std::string>(&url, 1), headers, download_path, sha512);
     }
 
     std::string DownloadManager::download_file(Files::Filesystem& fs,
                                                View<std::string> urls,
+                                               View<std::string> headers,
                                                const fs::path& download_path,
                                                const std::string& sha512) const
     {
-        auto maybe_mirror_url = Strings::replace_all(m_read_url_template.value_or(""), "<SHA>", sha512);
-
-        std::vector<std::string> all_urls;
-        if (!maybe_mirror_url.empty()) all_urls.push_back(maybe_mirror_url);
+        std::string errors;
+        if (auto read_template = m_read_url_template.get())
+        {
+            auto read_url = Strings::replace_all(std::string(*read_template), "<SHA>", sha512);
+            if (Downloads::try_download_file(fs, read_url, m_read_headers, download_path, sha512, errors))
+                return read_url;
+        }
 
         if (!m_block_origin)
         {
-            Util::Vectors::append(&all_urls, urls);
+            if (urls.size() == 0)
+            {
+                Strings::append(errors, "Error: No urls specified to download SHA: %s", sha512);
+            }
+            else
+            {
+                auto maybe_url = try_download_files(fs, urls, headers, download_path, sha512, errors);
+                if (auto url = maybe_url.get())
+                {
+                    put_file_to_mirror(fs, download_path, sha512);
+                    return *url;
+                }
+            }
         }
-
-        if (all_urls.empty())
-        {
-            Checks::exit_with_message(VCPKG_LINE_INFO, "Error: No urls specified to download SHA: %s", sha512);
-        }
-
-        auto fetched_url = Downloads::download_file(fs, all_urls, download_path, sha512);
-        if (fetched_url != maybe_mirror_url)
-        {
-            put_file_to_mirror(fs, download_path, sha512);
-        }
-        return fetched_url;
+        Checks::exit_with_message(VCPKG_LINE_INFO, "Error: Failed to download from mirror set:\n%s", errors);
     }
 
     int DownloadManager::put_file_to_mirror(const Files::Filesystem& fs,
@@ -564,7 +629,7 @@ namespace vcpkg::Downloads
         auto maybe_mirror_url = Strings::replace_all(m_write_url_template.value_or(""), "<SHA>", sha512);
         if (!maybe_mirror_url.empty())
         {
-            code = Downloads::put_file(fs, maybe_mirror_url, path);
+            code = Downloads::put_file(fs, maybe_mirror_url, m_write_headers, path);
             Debug::print("Putting to cache: ", maybe_mirror_url, ": ", code, "\n");
         }
         return code;

--- a/src/vcpkg/commands.xdownload.cpp
+++ b/src/vcpkg/commands.xdownload.cpp
@@ -19,7 +19,7 @@ namespace vcpkg::Commands::X_Download
     };
     static constexpr CommandMultiSetting FETCH_MULTISETTINGS[] = {
         {OPTION_URL, "URL to download and store if missing from cache"},
-        {OPTION_HEADER, "(Not Implemented) Additional header to use when fetching from URLs"},
+        {OPTION_HEADER, "Additional header to use when fetching from URLs"},
     };
 
     const CommandStructure COMMAND_STRUCTURE = {
@@ -71,14 +71,21 @@ namespace vcpkg::Commands::X_Download
         else
         {
             // Try to fetch from urls
+            auto it_headers = parsed.multisettings.find(OPTION_HEADER);
+            View<std::string> headers;
+            if (it_headers != parsed.multisettings.end())
+            {
+                headers = it_headers->second;
+            }
+
             auto it_urls = parsed.multisettings.find(OPTION_URL);
             if (it_urls == parsed.multisettings.end())
             {
-                paths.get_download_manager().download_file(fs, View<std::string>{}, file, sha);
+                paths.get_download_manager().download_file(fs, View<std::string>{}, headers, file, sha);
             }
             else
             {
-                paths.get_download_manager().download_file(fs, it_urls->second, file, sha);
+                paths.get_download_manager().download_file(fs, it_urls->second, headers, file, sha);
             }
             Checks::exit_success(VCPKG_LINE_INFO);
         }

--- a/src/vcpkg/commands.xdownload.cpp
+++ b/src/vcpkg/commands.xdownload.cpp
@@ -65,7 +65,7 @@ namespace vcpkg::Commands::X_Download
             auto hash =
                 Strings::ascii_to_lowercase(Hash::get_file_hash(VCPKG_LINE_INFO, fs, file, Hash::Algorithm::Sha512));
             if (hash != sha) Checks::exit_with_message(VCPKG_LINE_INFO, "Error: file to store does not match hash");
-            paths.get_download_manager().put_file_to_mirror(fs, file, sha);
+            paths.get_download_manager().put_file_to_mirror(fs, file, sha).value_or_exit(VCPKG_LINE_INFO);
             Checks::exit_success(VCPKG_LINE_INFO);
         }
         else


### PR DESCRIPTION
- If any headers are specified, we use `curl.exe` on Windows. If we need this feature to support earlier than win10 without requiring the user to provide curl, we can look at finding a copy of curl to download on demand or to look at adding header support to the WinHTTP download.
- Future PRs will expose options for binarycaching and assetcaching to provide headers for use when connecting to the mirror (e.g. `Authorization: bearer <token>`).

Without debug output:
```
$ export X_VCPKG_ASSET_SOURCES=x-azurl,https://127.0.0.1,,readwrite
$ vcpkg x-download \
    "--header=Authorization: bearer ABC123" \
    --url=https://github.com/microsoft/vcpkg-tool/releases/download/2021-05-05- 
    9f849c4c43e50d1b16186ae76681c27b0c1be9d9/tls12-download.exe \
    tls12-download.exe \
    691ff5333b2e96ccd1ad72d4414b93c2ee909bd58bdbd9816dd451560ec19ce717ae49971a992a288d891462388f9ae39f28a15d70d8bf7804fa218135d47269
Warning: failed to store back to mirror:
Error: curl failed to put file to https://127.0.0.1/691ff5333b2e96ccd1ad72d4414b93c2ee909bd58bdbd9816dd451560ec19ce717ae49971a992a288d891462388f9ae39f28a15d70d8bf7804fa218135d47269 with exit code '1792' and http code '0'
** Note: vcpkg's return code is still success (0)**
```
With debug output:
```
$ export X_VCPKG_ASSET_SOURCES=x-azurl,https://127.0.0.1,,readwrite
$ vcpkg x-download \
    "--header=Authorization: bearer ABC123" \
    --url=https://github.com/microsoft/vcpkg-tool/releases/download/2021-05-05- 
    9f849c4c43e50d1b16186ae76681c27b0c1be9d9/tls12-download.exe \
    tls12-download.exe \
    691ff5333b2e96ccd1ad72d4414b93c2ee909bd58bdbd9816dd451560ec19ce717ae49971a992a288d891462388f9ae39f28a15d70d8bf7804fa218135d47269
...
[DEBUG] popen(curl --fail -L https://127.0.0.1/691ff5333b2e96ccd1ad72d4414b93c2ee909bd58bdbd9816dd451560ec19ce717ae49971a992a288d891462388f9ae39f28a15d70d8bf7804fa218135d47269 --create-dirs --output /workspaces/vcpkg-tool/tls12-download.exe.49705.part 2>&1)
[DEBUG] cmd_execute_and_stream_data() returned 1792 after     5767 us
[DEBUG] popen(curl --fail -L https://github.com/microsoft/vcpkg-tool/releases/download/2021-05-05-9f849c4c43e50d1b16186ae76681c27b0c1be9d9/tls12-download.exe --create-dirs --output /workspaces/vcpkg-tool/tls12-download.exe.49705.part -H "Authorization: bearer ABC123" 2>&1)
[DEBUG] cmd_execute_and_stream_data() returned 0 after  1610996 us
[DEBUG] popen(curl -X PUT -H "x-ms-version: 2020-04-08" -H "x-ms-blob-type: BlockBlob" -w "\\n9a1db05f-a65d-419b-aa72-037fb4d0672e%{http_code}" https://127.0.0.1/691ff5333b2e96ccd1ad72d4414b93c2ee909bd58bdbd9816dd451560ec19ce717ae49971a992a288d891462388f9ae39f28a15d70d8bf7804fa218135d47269 -T /workspaces/vcpkg-tool/tls12-download.exe 2>&1)
[DEBUG] cmd_execute_and_stream_data() returned 1792 after     6242 us
Warning: failed to store back to mirror:
Error: curl failed to put file to https://127.0.0.1/691ff5333b2e96ccd1ad72d4414b93c2ee909bd58bdbd9816dd451560ec19ce717ae49971a992a288d891462388f9ae39f28a15d70d8bf7804fa218135d47269 with exit code '1792' and http code '0'
[DEBUG] /workspaces/vcpkg-tool/src/vcpkg/commands.xdownload.cpp(90)
[DEBUG] Exiting after 1624398 us (1624254 us)
```