### PR TITLE
Fix x-download when downloads isn't in a vcpkg root

### DIFF
--- a/include/vcpkg/commands.xdownload.h
+++ b/include/vcpkg/commands.xdownload.h
@@ -4,10 +4,10 @@
 
 namespace vcpkg::Commands::X_Download
 {
-    void perform_and_exit(const VcpkgCmdArguments& args, const VcpkgPaths& paths);
+    void perform_and_exit(const VcpkgCmdArguments& args, Files::Filesystem& fs);
 
-    struct XDownloadCommand : PathsCommand
+    struct XDownloadCommand : BasicCommand
     {
-        virtual void perform_and_exit(const VcpkgCmdArguments& args, const VcpkgPaths& paths) const override;
+        virtual void perform_and_exit(const VcpkgCmdArguments& args, Files::Filesystem& fs) const override;
     };
 }

--- a/src/vcpkg-test/commands.cpp
+++ b/src/vcpkg-test/commands.cpp
@@ -32,6 +32,7 @@ TEST_CASE ("get_available_basic_commands works", "[commands]")
     check_all_commands(Commands::get_available_basic_commands(), {
         "contact",
         "version",
+        "x-download",
         "x-init-registry",
 #if defined(_WIN32)
         "x-upload-metrics",
@@ -58,7 +59,6 @@ TEST_CASE ("get_available_paths_commands works", "[commands]")
         "fetch",
         "format-manifest",
         "x-ci-clean",
-        "x-download",
         "x-history",
         "x-package-info",
         "x-vsinstances",

--- a/src/vcpkg/commands.cpp
+++ b/src/vcpkg/commands.cpp
@@ -45,6 +45,7 @@ namespace vcpkg::Commands
         static const Version::VersionCommand version{};
         static const Contact::ContactCommand contact{};
         static const InitRegistry::InitRegistryCommand init_registry{};
+        static const X_Download::XDownloadCommand xdownload{};
 #if defined(_WIN32)
         static const UploadMetrics::UploadMetricsCommand upload_metrics{};
 #endif // defined(_WIN32)
@@ -53,6 +54,7 @@ namespace vcpkg::Commands
             {"version", &version},
             {"contact", &contact},
             {"x-init-registry", &init_registry},
+            {"x-download", &xdownload},
 
 #if defined(_WIN32)
             {"x-upload-metrics", &upload_metrics},
@@ -80,7 +82,6 @@ namespace vcpkg::Commands
         static const CIClean::CICleanCommand ciclean{};
         static const PortHistory::PortHistoryCommand porthistory{};
         static const X_VSInstances::VSInstancesCommand vsinstances{};
-        static const X_Download::XDownloadCommand xdownload{};
         static const FormatManifest::FormatManifestCommand format_manifest{};
         static const CIVerifyVersions::CIVerifyVersionsCommand ci_verify_versions{};
         static const AddVersion::AddVersionCommand add_version{};
@@ -104,7 +105,6 @@ namespace vcpkg::Commands
             {"x-package-info", &info},
             {"x-history", &porthistory},
             {"x-vsinstances", &vsinstances},
-            {"x-download", &xdownload},
             {"format-manifest", &format_manifest},
             {"x-ci-verify-versions", &ci_verify_versions},
             {"x-add-version", &add_version},

--- a/src/vcpkg/commands.xdownload.cpp
+++ b/src/vcpkg/commands.xdownload.cpp
@@ -3,10 +3,11 @@
 #include <vcpkg/base/parse.h>
 #include <vcpkg/base/system.debug.h>
 #include <vcpkg/base/system.print.h>
+#include <vcpkg/base/util.h>
 
+#include <vcpkg/binarycaching.h>
 #include <vcpkg/commands.xdownload.h>
 #include <vcpkg/vcpkgcmdarguments.h>
-#include <vcpkg/vcpkgpaths.h>
 
 namespace vcpkg::Commands::X_Download
 {
@@ -38,11 +39,11 @@ namespace vcpkg::Commands::X_Download
     }
     static bool is_lower_sha512(StringView sha) { return sha.size() == 128 && is_lower_hex(sha); }
 
-    void perform_and_exit(const VcpkgCmdArguments& args, const VcpkgPaths& paths)
+    void perform_and_exit(const VcpkgCmdArguments& args, Files::Filesystem& fs)
     {
         auto parsed = args.parse_arguments(COMMAND_STRUCTURE);
-        fs::path file = Files::combine(paths.original_cwd, fs::u8path(args.command_arguments[0]));
-        file.make_preferred();
+        auto download_manager = create_download_manager(args.asset_sources_template).value_or_exit(VCPKG_LINE_INFO);
+        fs::path file = fs.absolute(VCPKG_LINE_INFO, fs::u8path(args.command_arguments[0]));
 
         std::string sha = Strings::ascii_to_lowercase(std::string(args.command_arguments[1]));
         if (!is_lower_sha512(sha))
@@ -50,8 +51,6 @@ namespace vcpkg::Commands::X_Download
             Checks::exit_with_message(
                 VCPKG_LINE_INFO, "Error: SHA512's must be 128 hex characters: '%s'", args.command_arguments[1]);
         }
-
-        auto& fs = paths.get_filesystem();
 
         // Is this a store command?
         if (Util::Sets::contains(parsed.switches, OPTION_STORE))
@@ -65,7 +64,7 @@ namespace vcpkg::Commands::X_Download
             auto hash =
                 Strings::ascii_to_lowercase(Hash::get_file_hash(VCPKG_LINE_INFO, fs, file, Hash::Algorithm::Sha512));
             if (hash != sha) Checks::exit_with_message(VCPKG_LINE_INFO, "Error: file to store does not match hash");
-            paths.get_download_manager().put_file_to_mirror(fs, file, sha).value_or_exit(VCPKG_LINE_INFO);
+            download_manager.put_file_to_mirror(fs, file, sha).value_or_exit(VCPKG_LINE_INFO);
             Checks::exit_success(VCPKG_LINE_INFO);
         }
         else
@@ -81,18 +80,18 @@ namespace vcpkg::Commands::X_Download
             auto it_urls = parsed.multisettings.find(OPTION_URL);
             if (it_urls == parsed.multisettings.end())
             {
-                paths.get_download_manager().download_file(fs, View<std::string>{}, headers, file, sha);
+                download_manager.download_file(fs, View<std::string>{}, headers, file, sha);
             }
             else
             {
-                paths.get_download_manager().download_file(fs, it_urls->second, headers, file, sha);
+                download_manager.download_file(fs, it_urls->second, headers, file, sha);
             }
             Checks::exit_success(VCPKG_LINE_INFO);
         }
     }
 
-    void XDownloadCommand::perform_and_exit(const VcpkgCmdArguments& args, const VcpkgPaths& paths) const
+    void XDownloadCommand::perform_and_exit(const VcpkgCmdArguments& args, Files::Filesystem& fs) const
     {
-        X_Download::perform_and_exit(args, paths);
+        X_Download::perform_and_exit(args, fs);
     }
 }

--- a/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/src/vcpkg/vcpkgcmdarguments.cpp
@@ -731,6 +731,11 @@ namespace vcpkg
             auto rec_doc = Json::parse(*vcpkg_recursive_data).value_or_exit(VCPKG_LINE_INFO).first;
             const auto& obj = rec_doc.object();
 
+            if (auto entry = obj.get(VCPKG_ROOT_DIR_ENV))
+            {
+                args.vcpkg_root_dir = std::make_unique<std::string>(entry->string().to_string());
+            }
+
             if (auto entry = obj.get(DOWNLOADS_ROOT_DIR_ENV))
             {
                 args.downloads_root_dir = std::make_unique<std::string>(entry->string().to_string());
@@ -753,6 +758,11 @@ namespace vcpkg
         else
         {
             Json::Object obj;
+            if (args.vcpkg_root_dir)
+            {
+                obj.insert(VCPKG_ROOT_DIR_ENV, Json::Value::string(*args.vcpkg_root_dir.get()));
+            }
+
             if (args.downloads_root_dir)
             {
                 obj.insert(DOWNLOADS_ROOT_DIR_ENV, Json::Value::string(*args.downloads_root_dir.get()));


### PR DESCRIPTION
* Pass --vcpkg-root through recursive bits
* Change x-download into a basic command, meaning we don't need to make a vcpkgpaths for it (and its associated need of vcpkg roots etc.)

I'm pretty sure we should make `fetch` into a basic command too but that's more surgery