### PR TITLE
vcpkg search: Users should use git pull to get the latest results

### DIFF
--- a/src/vcpkg/commands.search.cpp
+++ b/src/vcpkg/commands.search.cpp
@@ -181,6 +181,7 @@ namespace vcpkg::Commands::Search
         if (!enable_json)
         {
             System::print2(
+                "The search result is maybe outdated. Execute `git pull` to get the latest results.\n"
                 "\nIf your library is not listed, please open an issue at and/or consider making a pull request:\n"
                 "    https://github.com/Microsoft/vcpkg/issues\n");
         }

--- a/src/vcpkg/commands.search.cpp
+++ b/src/vcpkg/commands.search.cpp
@@ -181,7 +181,7 @@ namespace vcpkg::Commands::Search
         if (!enable_json)
         {
             System::print2(
-                "The search result is maybe outdated. Execute `git pull` to get the latest results.\n"
+                "The search result may be outdated. Run `git pull` to get the latest results.\n"
                 "\nIf your library is not listed, please open an issue at and/or consider making a pull request:\n"
                 "    https://github.com/Microsoft/vcpkg/issues\n");
         }


### PR DESCRIPTION
See:
- microsoft/vcpkg#18648
- microsoft/vcpkg#18576 
- microsoft/vcpkg#18280
- microsoft/vcpkg#18165
- ...

The users don't know that the list is probably outdated and must be updated with `git pull`. So explain that.