### PR TITLE
Respect secrets in debug output for downloads.

### DIFF
--- a/include/vcpkg/base/downloads.h
+++ b/include/vcpkg/base/downloads.h
@@ -45,11 +45,8 @@ namespace vcpkg::Downloads
     };
 
     // Handles downloading and uploading to a content addressable mirror
-    class DownloadManager
+    struct DownloadManager
     {
-        DownloadManagerConfig m_config;
-
-    public:
         DownloadManager() = default;
         explicit DownloadManager(const DownloadManagerConfig& config) : m_config(config) { }
         explicit DownloadManager(DownloadManagerConfig&& config) : m_config(std::move(config)) { }
@@ -78,5 +75,8 @@ namespace vcpkg::Downloads
         ExpectedS<int> put_file_to_mirror(const Files::Filesystem& fs,
                                           const fs::path& path,
                                           const std::string& sha512) const;
+
+    private:
+        DownloadManagerConfig m_config;
     };
 }

--- a/include/vcpkg/base/downloads.h
+++ b/include/vcpkg/base/downloads.h
@@ -4,6 +4,9 @@
 #include <vcpkg/base/optional.h>
 #include <vcpkg/base/view.h>
 
+#include <string>
+#include <vector>
+
 namespace vcpkg::Downloads
 {
     namespace details
@@ -20,28 +23,16 @@ namespace vcpkg::Downloads
     }
 
     void verify_downloaded_file_hash(const Files::Filesystem& fs,
-                                     const std::string& url,
+                                     const std::string& sanitized_url,
                                      const fs::path& path,
                                      const std::string& sha512);
-
-    // Returns url that was successfully downloaded from
-    std::string download_file(Files::Filesystem& fs,
-                              View<std::string> urls,
-                              View<std::string> headers,
-                              const fs::path& download_path,
-                              const std::string& sha512);
-
-    void download_file(Files::Filesystem& fs,
-                       const std::string& url,
-                       View<std::string> headers,
-                       const fs::path& download_path,
-                       const std::string& sha512);
 
     View<std::string> azure_blob_headers();
 
     std::vector<int> download_files(Files::Filesystem& fs, View<std::pair<std::string, fs::path>> url_pairs);
     ExpectedS<int> put_file(const Files::Filesystem&, StringView url, View<std::string> headers, const fs::path& file);
     std::vector<int> url_heads(View<std::string> urls, View<std::string> headers);
+    std::string replace_secrets(std::string input, View<std::string> secrets);
 
     struct DownloadManagerConfig
     {
@@ -49,6 +40,7 @@ namespace vcpkg::Downloads
         std::vector<std::string> m_read_headers;
         Optional<std::string> m_write_url_template;
         std::vector<std::string> m_write_headers;
+        std::vector<std::string> m_secrets;
         bool m_block_origin = false;
     };
 
@@ -76,6 +68,7 @@ namespace vcpkg::Downloads
                            const fs::path& download_path,
                            const std::string& sha512) const;
 
+        // Returns url that was successfully downloaded from
         std::string download_file(Files::Filesystem& fs,
                                   View<std::string> urls,
                                   View<std::string> headers,

--- a/include/vcpkg/base/downloads.h
+++ b/include/vcpkg/base/downloads.h
@@ -53,14 +53,14 @@ namespace vcpkg::Downloads
     };
 
     // Handles downloading and uploading to a content addressable mirror
-    struct DownloadManager : private DownloadManagerConfig
+    class DownloadManager
     {
+        DownloadManagerConfig m_config;
+
+    public:
         DownloadManager() = default;
-        explicit DownloadManager(Optional<std::string> read_url_template,
-                                 std::vector<std::string> read_headers,
-                                 Optional<std::string> write_url_template,
-                                 std::vector<std::string> write_headers,
-                                 bool block_origin);
+        explicit DownloadManager(const DownloadManagerConfig& config) : m_config(config) { }
+        explicit DownloadManager(DownloadManagerConfig&& config) : m_config(std::move(config)) { }
 
         void download_file(Files::Filesystem& fs,
                            const std::string& url,
@@ -85,9 +85,5 @@ namespace vcpkg::Downloads
         ExpectedS<int> put_file_to_mirror(const Files::Filesystem& fs,
                                           const fs::path& path,
                                           const std::string& sha512) const;
-
-        const DownloadManagerConfig& internal_get_config() const { return *this; }
-
-        bool block_origin() const { return m_block_origin; }
     };
 }

--- a/include/vcpkg/binarycaching.h
+++ b/include/vcpkg/binarycaching.h
@@ -57,7 +57,7 @@ namespace vcpkg
     ExpectedS<std::unique_ptr<IBinaryProvider>> create_binary_provider_from_configs_pure(const std::string& env_string,
                                                                                          View<std::string> args);
 
-    ExpectedS<Downloads::DownloadManager> create_download_manager(const Optional<std::string>& arg);
+    ExpectedS<Downloads::DownloadManagerConfig> parse_download_configuration(const Optional<std::string>& arg);
 
     std::string generate_nuget_packages_config(const Dependencies::ActionPlan& action);
 

--- a/include/vcpkg/vcpkgpaths.h
+++ b/include/vcpkg/vcpkgpaths.h
@@ -36,7 +36,7 @@ namespace vcpkg
 
     namespace Downloads
     {
-        class DownloadManager;
+        struct DownloadManager;
     }
 
     namespace Build

--- a/include/vcpkg/vcpkgpaths.h
+++ b/include/vcpkg/vcpkgpaths.h
@@ -36,7 +36,7 @@ namespace vcpkg
 
     namespace Downloads
     {
-        struct DownloadManager;
+        class DownloadManager;
     }
 
     namespace Build

--- a/src/vcpkg-test/configparser.cpp
+++ b/src/vcpkg-test/configparser.cpp
@@ -403,6 +403,7 @@ TEST_CASE ("AssetConfigParser azurl provider", "[assetconfigparser]")
         CHECK(dm.m_read_url_template == "https://abc/123/<SHA>?foo");
         CHECK(dm.m_read_headers.empty());
         CHECK(dm.m_write_url_template == nullopt);
+        CHECK(dm.m_secrets == std::vector<std::string>{"foo"});
     }
     {
         Downloads::DownloadManagerConfig dm =
@@ -410,6 +411,7 @@ TEST_CASE ("AssetConfigParser azurl provider", "[assetconfigparser]")
         CHECK(dm.m_read_url_template == "https://abc/123/<SHA>?foo");
         CHECK(dm.m_read_headers.empty());
         CHECK(dm.m_write_url_template == nullopt);
+        CHECK(dm.m_secrets == std::vector<std::string>{"?foo"});
     }
     {
         Downloads::DownloadManagerConfig dm = Test::unwrap(parse_download_configuration("x-azurl,https://abc/123"));
@@ -432,6 +434,7 @@ TEST_CASE ("AssetConfigParser azurl provider", "[assetconfigparser]")
         CHECK(dm.m_read_headers.empty());
         CHECK(dm.m_write_url_template == "https://abc/123/<SHA>?foo");
         Test::check_ranges(dm.m_write_headers, Downloads::azure_blob_headers());
+        CHECK(dm.m_secrets == std::vector<std::string>{"foo"});
     }
 }
 

--- a/src/vcpkg-test/configparser.cpp
+++ b/src/vcpkg-test/configparser.cpp
@@ -371,71 +371,75 @@ TEST_CASE ("BinaryConfigParser GCS provider", "[binaryconfigparser]")
 
 TEST_CASE ("AssetConfigParser azurl provider", "[assetconfigparser]")
 {
-    CHECK(create_download_manager({}));
-    CHECK(!create_download_manager("x-azurl"));
-    CHECK(!create_download_manager("x-azurl,"));
-    CHECK(create_download_manager("x-azurl,value"));
-    CHECK(create_download_manager("x-azurl,value,"));
-    CHECK(!create_download_manager("x-azurl,value,,"));
-    CHECK(!create_download_manager("x-azurl,value,,invalid"));
-    CHECK(create_download_manager("x-azurl,value,,read"));
-    CHECK(create_download_manager("x-azurl,value,,readwrite"));
-    CHECK(!create_download_manager("x-azurl,value,,readwrite,"));
-    CHECK(create_download_manager("x-azurl,https://abc/123,?foo"));
-    CHECK(create_download_manager("x-azurl,https://abc/123,foo"));
-    CHECK(create_download_manager("x-azurl,ftp://magic,none"));
-    CHECK(create_download_manager("x-azurl,ftp://magic,none"));
+    CHECK(parse_download_configuration({}));
+    CHECK(!parse_download_configuration("x-azurl"));
+    CHECK(!parse_download_configuration("x-azurl,"));
+    CHECK(parse_download_configuration("x-azurl,value"));
+    CHECK(parse_download_configuration("x-azurl,value,"));
+    CHECK(!parse_download_configuration("x-azurl,value,,"));
+    CHECK(!parse_download_configuration("x-azurl,value,,invalid"));
+    CHECK(parse_download_configuration("x-azurl,value,,read"));
+    CHECK(parse_download_configuration("x-azurl,value,,readwrite"));
+    CHECK(!parse_download_configuration("x-azurl,value,,readwrite,"));
+    CHECK(parse_download_configuration("x-azurl,https://abc/123,?foo"));
+    CHECK(parse_download_configuration("x-azurl,https://abc/123,foo"));
+    CHECK(parse_download_configuration("x-azurl,ftp://magic,none"));
+    CHECK(parse_download_configuration("x-azurl,ftp://magic,none"));
 
     {
-        Downloads::DownloadManager empty;
-        CHECK(empty.internal_get_config().m_write_headers.empty());
-        CHECK(empty.internal_get_config().m_read_headers.empty());
+        Downloads::DownloadManagerConfig empty;
+        CHECK(empty.m_write_headers.empty());
+        CHECK(empty.m_read_headers.empty());
     }
     {
-        Downloads::DownloadManager dm = Test::unwrap(create_download_manager("x-azurl,https://abc/123,foo"));
-        CHECK(dm.internal_get_config().m_read_url_template == "https://abc/123/<SHA>?foo");
-        CHECK(dm.internal_get_config().m_read_headers.empty());
-        CHECK(dm.internal_get_config().m_write_url_template == nullopt);
+        Downloads::DownloadManagerConfig dm = Test::unwrap(parse_download_configuration("x-azurl,https://abc/123,foo"));
+        CHECK(dm.m_read_url_template == "https://abc/123/<SHA>?foo");
+        CHECK(dm.m_read_headers.empty());
+        CHECK(dm.m_write_url_template == nullopt);
     }
     {
-        Downloads::DownloadManager dm = Test::unwrap(create_download_manager("x-azurl,https://abc/123/,foo"));
-        CHECK(dm.internal_get_config().m_read_url_template == "https://abc/123/<SHA>?foo");
-        CHECK(dm.internal_get_config().m_read_headers.empty());
-        CHECK(dm.internal_get_config().m_write_url_template == nullopt);
+        Downloads::DownloadManagerConfig dm =
+            Test::unwrap(parse_download_configuration("x-azurl,https://abc/123/,foo"));
+        CHECK(dm.m_read_url_template == "https://abc/123/<SHA>?foo");
+        CHECK(dm.m_read_headers.empty());
+        CHECK(dm.m_write_url_template == nullopt);
     }
     {
-        Downloads::DownloadManager dm = Test::unwrap(create_download_manager("x-azurl,https://abc/123,?foo"));
-        CHECK(dm.internal_get_config().m_read_url_template == "https://abc/123/<SHA>?foo");
-        CHECK(dm.internal_get_config().m_read_headers.empty());
-        CHECK(dm.internal_get_config().m_write_url_template == nullopt);
+        Downloads::DownloadManagerConfig dm =
+            Test::unwrap(parse_download_configuration("x-azurl,https://abc/123,?foo"));
+        CHECK(dm.m_read_url_template == "https://abc/123/<SHA>?foo");
+        CHECK(dm.m_read_headers.empty());
+        CHECK(dm.m_write_url_template == nullopt);
     }
     {
-        Downloads::DownloadManager dm = Test::unwrap(create_download_manager("x-azurl,https://abc/123"));
-        CHECK(dm.internal_get_config().m_read_url_template == "https://abc/123/<SHA>");
-        CHECK(dm.internal_get_config().m_read_headers.empty());
-        CHECK(dm.internal_get_config().m_write_url_template == nullopt);
+        Downloads::DownloadManagerConfig dm = Test::unwrap(parse_download_configuration("x-azurl,https://abc/123"));
+        CHECK(dm.m_read_url_template == "https://abc/123/<SHA>");
+        CHECK(dm.m_read_headers.empty());
+        CHECK(dm.m_write_url_template == nullopt);
     }
     {
-        Downloads::DownloadManager dm = Test::unwrap(create_download_manager("x-azurl,https://abc/123,,readwrite"));
-        CHECK(dm.internal_get_config().m_read_url_template == "https://abc/123/<SHA>");
-        CHECK(dm.internal_get_config().m_read_headers.empty());
-        CHECK(dm.internal_get_config().m_write_url_template == "https://abc/123/<SHA>");
-        Test::check_ranges(dm.internal_get_config().m_write_headers, Downloads::azure_blob_headers());
+        Downloads::DownloadManagerConfig dm =
+            Test::unwrap(parse_download_configuration("x-azurl,https://abc/123,,readwrite"));
+        CHECK(dm.m_read_url_template == "https://abc/123/<SHA>");
+        CHECK(dm.m_read_headers.empty());
+        CHECK(dm.m_write_url_template == "https://abc/123/<SHA>");
+        Test::check_ranges(dm.m_write_headers, Downloads::azure_blob_headers());
     }
     {
-        Downloads::DownloadManager dm = Test::unwrap(create_download_manager("x-azurl,https://abc/123,foo,readwrite"));
-        CHECK(dm.internal_get_config().m_read_url_template == "https://abc/123/<SHA>?foo");
-        CHECK(dm.internal_get_config().m_read_headers.empty());
-        CHECK(dm.internal_get_config().m_write_url_template == "https://abc/123/<SHA>?foo");
-        Test::check_ranges(dm.internal_get_config().m_write_headers, Downloads::azure_blob_headers());
+        Downloads::DownloadManagerConfig dm =
+            Test::unwrap(parse_download_configuration("x-azurl,https://abc/123,foo,readwrite"));
+        CHECK(dm.m_read_url_template == "https://abc/123/<SHA>?foo");
+        CHECK(dm.m_read_headers.empty());
+        CHECK(dm.m_write_url_template == "https://abc/123/<SHA>?foo");
+        Test::check_ranges(dm.m_write_headers, Downloads::azure_blob_headers());
     }
 }
 
 TEST_CASE ("AssetConfigParser clear provider", "[assetconfigparser]")
 {
-    CHECK(create_download_manager("clear"));
-    CHECK(!create_download_manager("clear,"));
-    CHECK(create_download_manager("x-azurl,value;clear"));
+    CHECK(parse_download_configuration("clear"));
+    CHECK(!parse_download_configuration("clear,"));
+    CHECK(parse_download_configuration("x-azurl,value;clear"));
     auto value_or = [](auto o, auto v) {
         if (o)
             return std::move(*o.get());
@@ -443,20 +447,18 @@ TEST_CASE ("AssetConfigParser clear provider", "[assetconfigparser]")
             return std::move(v);
     };
 
-    Downloads::DownloadManager empty;
+    Downloads::DownloadManagerConfig empty;
 
-    CHECK(value_or(create_download_manager("x-azurl,https://abc/123,foo;clear"), empty)
-              .internal_get_config()
-              .m_read_url_template == nullopt);
-    CHECK(value_or(create_download_manager("clear;x-azurl,https://abc/123/,foo"), empty)
-              .internal_get_config()
-              .m_read_url_template == "https://abc/123/<SHA>?foo");
+    CHECK(value_or(parse_download_configuration("x-azurl,https://abc/123,foo;clear"), empty).m_read_url_template ==
+          nullopt);
+    CHECK(value_or(parse_download_configuration("clear;x-azurl,https://abc/123/,foo"), empty).m_read_url_template ==
+          "https://abc/123/<SHA>?foo");
 }
 
 TEST_CASE ("AssetConfigParser x-block-origin provider", "[assetconfigparser]")
 {
-    CHECK(create_download_manager("x-block-origin"));
-    CHECK(!create_download_manager("x-block-origin,"));
+    CHECK(parse_download_configuration("x-block-origin"));
+    CHECK(!parse_download_configuration("x-block-origin,"));
     auto value_or = [](auto o, auto v) {
         if (o)
             return std::move(*o.get());
@@ -464,9 +466,9 @@ TEST_CASE ("AssetConfigParser x-block-origin provider", "[assetconfigparser]")
             return std::move(v);
     };
 
-    Downloads::DownloadManager empty;
+    Downloads::DownloadManagerConfig empty;
 
-    CHECK(!value_or(create_download_manager({}), empty).block_origin());
-    CHECK(value_or(create_download_manager("x-block-origin"), empty).block_origin());
-    CHECK(!value_or(create_download_manager("x-block-origin;clear"), empty).block_origin());
+    CHECK(!value_or(parse_download_configuration({}), empty).m_block_origin);
+    CHECK(value_or(parse_download_configuration("x-block-origin"), empty).m_block_origin);
+    CHECK(!value_or(parse_download_configuration("x-block-origin;clear"), empty).m_block_origin);
 }

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -195,7 +195,7 @@ namespace vcpkg::Downloads
     }
 
     static Optional<std::string> try_verify_downloaded_file_hash(const Files::Filesystem& fs,
-                                                                 const std::string& url,
+                                                                 const std::string& sanitized_url,
                                                                  const fs::path& path,
                                                                  const std::string& sha512)
     {
@@ -214,7 +214,7 @@ namespace vcpkg::Downloads
 
         if (sha512 != actual_hash)
         {
-            return format_hash_mismatch(url, fs::u8string(path), sha512, actual_hash);
+            return format_hash_mismatch(sanitized_url, fs::u8string(path), sha512, actual_hash);
         }
         return nullopt;
     }
@@ -271,6 +271,17 @@ namespace vcpkg::Downloads
         if (i != urls.size()) url_heads_inner({urls.begin() + i, urls.end()}, headers, &ret);
 
         return ret;
+    }
+
+    std::string replace_secrets(std::string input, View<std::string> secrets)
+    {
+        static constexpr StringLiteral replacement{"*** SECRET ***"};
+        for (const auto& secret : secrets)
+        {
+            Strings::inplace_replace_all(input, secret, replacement);
+        }
+
+        return input;
     }
 
     static void download_files_inner(Files::Filesystem&,
@@ -381,15 +392,6 @@ namespace vcpkg::Downloads
         return code;
     }
 
-    void download_file(Files::Filesystem& fs,
-                       const std::string& url,
-                       View<std::string> headers,
-                       const fs::path& download_path,
-                       const std::string& sha512)
-    {
-        download_file(fs, {&url, 1}, headers, download_path, sha512);
-    }
-
 #if defined(_WIN32)
     namespace
     {
@@ -423,6 +425,7 @@ namespace vcpkg::Downloads
                                      const fs::path& download_path_part_path,
                                      details::SplitURIView split_uri,
                                      const std::string& url,
+                                     const std::vector<std::string>& secrets,
                                      std::string& errors)
         {
             // `download_winhttp` does not support user or port syntax in authorities
@@ -447,26 +450,27 @@ namespace vcpkg::Downloads
 
             WriteFlushFile f(download_path_part_path);
 
-            Debug::print("Downloading ", url, "\n");
+            const auto sanitized_url = replace_secrets(url, secrets);
+            Debug::print("Downloading ", sanitized_url, "\n");
             static auto s = WinHttpSession::make().value_or_exit(VCPKG_LINE_INFO);
             auto conn = WinHttpConnection::make(s.m_hSession.get(), hostname, port);
             if (!conn)
             {
-                Strings::append(errors, url, ": ", conn.error(), '\n');
+                Strings::append(errors, sanitized_url, ": ", conn.error(), '\n');
                 return false;
             }
             auto req = WinHttpRequest::make(
                 conn.get()->m_hConnect.get(), split_uri.path_query_fragment, split_uri.scheme == "https");
             if (!req)
             {
-                Strings::append(errors, url, ": ", req.error(), '\n');
+                Strings::append(errors, sanitized_url, ": ", req.error(), '\n');
                 return false;
             }
             auto forall_data =
                 req.get()->forall_data([&f](Span<char> span) { fwrite(span.data(), 1, span.size(), f.f); });
             if (!forall_data)
             {
-                Strings::append(errors, url, ": ", forall_data.error(), '\n');
+                Strings::append(errors, sanitized_url, ": ", forall_data.error(), '\n');
                 return false;
             }
             return true;
@@ -479,6 +483,7 @@ namespace vcpkg::Downloads
                                   View<std::string> headers,
                                   const fs::path& download_path,
                                   const std::string& sha512,
+                                  const std::vector<std::string>& secrets,
                                   std::string& errors)
     {
         auto download_path_part_path = download_path;
@@ -498,7 +503,7 @@ namespace vcpkg::Downloads
                 // This check causes complex URLs (non-default port, embedded basic auth) to be passed down to curl.exe
                 if (Strings::find_first_of(authority, ":@") == authority.end())
                 {
-                    if (download_winhttp(fs, download_path_part_path, split_uri, url, errors))
+                    if (download_winhttp(fs, download_path_part_path, split_uri, url, secrets, errors))
                     {
                         auto maybe_error = try_verify_downloaded_file_hash(fs, url, download_path_part_path, sha512);
                         if (auto err = maybe_error.get())
@@ -533,13 +538,14 @@ namespace vcpkg::Downloads
             cmd.string_arg("-H").string_arg(header);
         }
         const auto out = System::cmd_execute_and_capture_output(cmd);
+        const auto sanitized_url = replace_secrets(url, secrets);
         if (out.exit_code != 0)
         {
-            Strings::append(errors, url, ": ", out.output, '\n');
+            Strings::append(errors, sanitized_url, ": ", out.output, '\n');
             return false;
         }
 
-        auto maybe_error = try_verify_downloaded_file_hash(fs, url, download_path_part_path, sha512);
+        auto maybe_error = try_verify_downloaded_file_hash(fs, sanitized_url, download_path_part_path, sha512);
         if (auto err = maybe_error.get())
         {
             Strings::append(errors, *err);
@@ -557,11 +563,12 @@ namespace vcpkg::Downloads
                                                            View<std::string> headers,
                                                            const fs::path& download_path,
                                                            const std::string& sha512,
+                                                           const std::vector<std::string>& secrets,
                                                            std::string& errors)
     {
         for (auto&& url : urls)
         {
-            if (try_download_file(fs, url, headers, download_path, sha512, errors)) return url;
+            if (try_download_file(fs, url, headers, download_path, sha512, secrets, errors)) return url;
         }
         return nullopt;
     }
@@ -570,12 +577,13 @@ namespace vcpkg::Downloads
                               View<std::string> urls,
                               View<std::string> headers,
                               const fs::path& download_path,
+                              const std::vector<std::string>& secrets,
                               const std::string& sha512)
     {
         Checks::check_exit(VCPKG_LINE_INFO, urls.size(), "Error: No urls specified to download SHA: %s", sha512);
 
         std::string errors;
-        auto maybe_url = try_download_files(fs, urls, headers, download_path, sha512, errors);
+        auto maybe_url = try_download_files(fs, urls, headers, download_path, sha512, secrets, errors);
         if (auto url = maybe_url.get())
         {
             return *url;
@@ -611,7 +619,8 @@ namespace vcpkg::Downloads
         if (auto read_template = m_config.m_read_url_template.get())
         {
             auto read_url = Strings::replace_all(std::string(*read_template), "<SHA>", sha512);
-            if (Downloads::try_download_file(fs, read_url, m_config.m_read_headers, download_path, sha512, errors))
+            if (Downloads::try_download_file(
+                    fs, read_url, m_config.m_read_headers, download_path, sha512, m_config.m_secrets, errors))
                 return read_url;
         }
 
@@ -623,7 +632,8 @@ namespace vcpkg::Downloads
             }
             else
             {
-                auto maybe_url = try_download_files(fs, urls, headers, download_path, sha512, errors);
+                auto maybe_url =
+                    try_download_files(fs, urls, headers, download_path, sha512, m_config.m_secrets, errors);
                 if (auto url = maybe_url.get())
                 {
                     auto maybe_push = put_file_to_mirror(fs, download_path, sha512);

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -592,19 +592,6 @@ namespace vcpkg::Downloads
         return s_headers;
     }
 
-    DownloadManager::DownloadManager(Optional<std::string> read_url_template,
-                                     std::vector<std::string> read_headers,
-                                     Optional<std::string> write_url_template,
-                                     std::vector<std::string> write_headers,
-                                     bool block_origin)
-        : DownloadManagerConfig{std::move(read_url_template),
-                                std::move(read_headers),
-                                std::move(write_url_template),
-                                std::move(write_headers),
-                                block_origin}
-    {
-    }
-
     void DownloadManager::download_file(Files::Filesystem& fs,
                                         const std::string& url,
                                         View<std::string> headers,
@@ -621,14 +608,14 @@ namespace vcpkg::Downloads
                                                const std::string& sha512) const
     {
         std::string errors;
-        if (auto read_template = m_read_url_template.get())
+        if (auto read_template = m_config.m_read_url_template.get())
         {
             auto read_url = Strings::replace_all(std::string(*read_template), "<SHA>", sha512);
-            if (Downloads::try_download_file(fs, read_url, m_read_headers, download_path, sha512, errors))
+            if (Downloads::try_download_file(fs, read_url, m_config.m_read_headers, download_path, sha512, errors))
                 return read_url;
         }
 
-        if (!m_block_origin)
+        if (!m_config.m_block_origin)
         {
             if (urls.size() == 0)
             {
@@ -656,10 +643,10 @@ namespace vcpkg::Downloads
                                                        const fs::path& path,
                                                        const std::string& sha512) const
     {
-        auto maybe_mirror_url = Strings::replace_all(m_write_url_template.value_or(""), "<SHA>", sha512);
+        auto maybe_mirror_url = Strings::replace_all(m_config.m_write_url_template.value_or(""), "<SHA>", sha512);
         if (!maybe_mirror_url.empty())
         {
-            return Downloads::put_file(fs, maybe_mirror_url, m_write_headers, path);
+            return Downloads::put_file(fs, maybe_mirror_url, m_config.m_write_headers, path);
         }
         return 0;
     }

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -573,27 +573,6 @@ namespace vcpkg::Downloads
         return nullopt;
     }
 
-    std::string download_file(vcpkg::Files::Filesystem& fs,
-                              View<std::string> urls,
-                              View<std::string> headers,
-                              const fs::path& download_path,
-                              const std::vector<std::string>& secrets,
-                              const std::string& sha512)
-    {
-        Checks::check_exit(VCPKG_LINE_INFO, urls.size(), "Error: No urls specified to download SHA: %s", sha512);
-
-        std::string errors;
-        auto maybe_url = try_download_files(fs, urls, headers, download_path, sha512, secrets, errors);
-        if (auto url = maybe_url.get())
-        {
-            return *url;
-        }
-        else
-        {
-            Checks::exit_with_message(VCPKG_LINE_INFO, "Failed to download from mirror set:\n%s", errors);
-        }
-    }
-
     View<std::string> azure_blob_headers()
     {
         static std::string s_headers[2] = {"x-ms-version: 2020-04-08", "x-ms-blob-type: BlockBlob"};

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -333,16 +333,7 @@ namespace
                     continue;
                 }
 
-                auto errors = std::move(maybe_success).error();
-
-                if (!Debug::g_debugging.load(std::memory_order_relaxed))
-                {
-                    for (const auto& secret : m_secrets)
-                    {
-                        Strings::inplace_replace_all(errors, secret, "*** SECRET ***");
-                    }
-                }
-
+                auto errors = Downloads::replace_secrets(std::move(maybe_success).error(), m_secrets);
                 System::print2(System::Color::warning, errors);
             }
 
@@ -1397,8 +1388,6 @@ namespace
         bool block_origin = false;
         std::vector<std::string> url_templates_to_get;
         std::vector<std::string> azblob_templates_to_put;
-
-        // Note: the download manager does not currently respect secrets
         std::vector<std::string> secrets;
 
         void clear()
@@ -1547,8 +1536,12 @@ ExpectedS<Downloads::DownloadManagerConfig> vcpkg::parse_download_configuration(
         put_headers.assign(v.begin(), v.end());
     }
 
-    return Downloads::DownloadManagerConfig{
-        std::move(get_url), std::vector<std::string>{}, std::move(put_url), std::move(put_headers), s.block_origin};
+    return Downloads::DownloadManagerConfig{std::move(get_url),
+                                            std::vector<std::string>{},
+                                            std::move(put_url),
+                                            std::move(put_headers),
+                                            std::move(s.secrets),
+                                            s.block_origin};
 }
 
 ExpectedS<std::unique_ptr<IBinaryProvider>> vcpkg::create_binary_provider_from_configs(View<std::string> args)

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -1504,9 +1504,9 @@ namespace
     };
 }
 
-ExpectedS<Downloads::DownloadManager> vcpkg::create_download_manager(const Optional<std::string>& arg)
+ExpectedS<Downloads::DownloadManagerConfig> vcpkg::parse_download_configuration(const Optional<std::string>& arg)
 {
-    if (!arg || arg.get()->empty()) return Downloads::DownloadManager{};
+    if (!arg || arg.get()->empty()) return Downloads::DownloadManagerConfig{};
 
     Metrics::g_metrics.lock()->track_property("asset-source", "defined");
 
@@ -1547,7 +1547,7 @@ ExpectedS<Downloads::DownloadManager> vcpkg::create_download_manager(const Optio
         put_headers.assign(v.begin(), v.end());
     }
 
-    return Downloads::DownloadManager{
+    return Downloads::DownloadManagerConfig{
         std::move(get_url), std::vector<std::string>{}, std::move(put_url), std::move(put_headers), s.block_origin};
 }
 

--- a/src/vcpkg/commands.xdownload.cpp
+++ b/src/vcpkg/commands.xdownload.cpp
@@ -42,7 +42,8 @@ namespace vcpkg::Commands::X_Download
     void perform_and_exit(const VcpkgCmdArguments& args, Files::Filesystem& fs)
     {
         auto parsed = args.parse_arguments(COMMAND_STRUCTURE);
-        auto download_manager = create_download_manager(args.asset_sources_template).value_or_exit(VCPKG_LINE_INFO);
+        Downloads::DownloadManager download_manager{
+            parse_download_configuration(args.asset_sources_template).value_or_exit(VCPKG_LINE_INFO)};
         fs::path file = fs.absolute(VCPKG_LINE_INFO, fs::u8path(args.command_arguments[0]));
 
         std::string sha = Strings::ascii_to_lowercase(std::string(args.command_arguments[1]));

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -395,8 +395,8 @@ namespace vcpkg
             process_output_directory(filesystem, root, args.buildtrees_root_dir.get(), "buildtrees", VCPKG_LINE_INFO);
         downloads =
             process_output_directory(filesystem, root, args.downloads_root_dir.get(), "downloads", VCPKG_LINE_INFO);
-        m_pimpl->m_download_manager =
-            create_download_manager(args.asset_sources_template).value_or_exit(VCPKG_LINE_INFO);
+        m_pimpl->m_download_manager = Downloads::DownloadManager{
+            parse_download_configuration(args.asset_sources_template).value_or_exit(VCPKG_LINE_INFO)};
         packages =
             process_output_directory(filesystem, root, args.packages_root_dir.get(), "packages", VCPKG_LINE_INFO);
         scripts = process_input_directory(filesystem, root, args.scripts_root_dir.get(), "scripts", VCPKG_LINE_INFO);


### PR DESCRIPTION
We leaked a SAS token, now expired, in CI, because we run downloads with debug turned on, and that printed the token. We shouldn't print the token even during debug, because that would let anyone who controls our command line, which is anyone, to print the token easily.