### PR TITLE
switch to Casey convention for declarations

### DIFF
--- a/include/vcpkg/base/chrono.h
+++ b/include/vcpkg/base/chrono.h
@@ -8,11 +8,8 @@
 
 namespace vcpkg::Chrono
 {
-    class ElapsedTime
+    struct ElapsedTime
     {
-        using duration = std::chrono::high_resolution_clock::time_point::duration;
-
-    public:
         constexpr ElapsedTime() noexcept : m_duration() { }
         constexpr ElapsedTime(duration d) noexcept : m_duration(d) { }
 
@@ -26,12 +23,12 @@ namespace vcpkg::Chrono
         void to_string(std::string& into) const;
 
     private:
+        using duration = std::chrono::high_resolution_clock::time_point::duration;
         std::chrono::high_resolution_clock::time_point::duration m_duration;
     };
 
-    class ElapsedTimer
+    struct ElapsedTimer
     {
-    public:
         static ElapsedTimer create_started();
 
         constexpr ElapsedTimer() noexcept : m_start_tick() { }
@@ -50,9 +47,8 @@ namespace vcpkg::Chrono
         std::chrono::high_resolution_clock::time_point m_start_tick;
     };
 
-    class CTime
+    struct CTime
     {
-    public:
         static Optional<CTime> get_current_date_time();
         static Optional<CTime> parse(CStringView str);
 

--- a/include/vcpkg/base/chrono.h
+++ b/include/vcpkg/base/chrono.h
@@ -13,6 +13,7 @@ namespace vcpkg::Chrono
     private:
         using duration = std::chrono::high_resolution_clock::time_point::duration;
         duration m_duration;
+
     public:
         constexpr ElapsedTime() noexcept : m_duration() { }
         constexpr ElapsedTime(duration d) noexcept : m_duration(d) { }

--- a/include/vcpkg/base/chrono.h
+++ b/include/vcpkg/base/chrono.h
@@ -10,11 +10,8 @@ namespace vcpkg::Chrono
 {
     struct ElapsedTime
     {
-    private:
         using duration = std::chrono::high_resolution_clock::time_point::duration;
-        duration m_duration;
 
-    public:
         constexpr ElapsedTime() noexcept : m_duration() { }
         constexpr ElapsedTime(duration d) noexcept : m_duration(d) { }
 
@@ -26,6 +23,9 @@ namespace vcpkg::Chrono
 
         std::string to_string() const;
         void to_string(std::string& into) const;
+
+    private:
+        duration m_duration;
     };
 
     struct ElapsedTimer

--- a/include/vcpkg/base/chrono.h
+++ b/include/vcpkg/base/chrono.h
@@ -10,6 +10,10 @@ namespace vcpkg::Chrono
 {
     struct ElapsedTime
     {
+    private:
+        using duration = std::chrono::high_resolution_clock::time_point::duration;
+        duration m_duration;
+    public:
         constexpr ElapsedTime() noexcept : m_duration() { }
         constexpr ElapsedTime(duration d) noexcept : m_duration(d) { }
 
@@ -21,10 +25,6 @@ namespace vcpkg::Chrono
 
         std::string to_string() const;
         void to_string(std::string& into) const;
-
-    private:
-        using duration = std::chrono::high_resolution_clock::time_point::duration;
-        std::chrono::high_resolution_clock::time_point::duration m_duration;
     };
 
     struct ElapsedTimer

--- a/include/vcpkg/base/expected.h
+++ b/include/vcpkg/base/expected.h
@@ -103,9 +103,8 @@ namespace vcpkg
     };
 
     template<class T, class S>
-    class ExpectedT
+    struct ExpectedT
     {
-    public:
         constexpr ExpectedT() = default;
 
         // Constructors are intentionally implicit

--- a/include/vcpkg/base/lazy.h
+++ b/include/vcpkg/base/lazy.h
@@ -2,10 +2,9 @@
 
 namespace vcpkg
 {
-    template<typename T>
-    class Lazy
+    template<class T>
+    struct Lazy
     {
-    public:
         Lazy() : value(T()), initialized(false) { }
 
         template<class F>

--- a/include/vcpkg/base/sortedvector.h
+++ b/include/vcpkg/base/sortedvector.h
@@ -7,9 +7,8 @@
 namespace vcpkg
 {
     template<class T>
-    class SortedVector
+    struct SortedVector
     {
-    public:
         using size_type = typename std::vector<T>::size_type;
         using iterator = typename std::vector<T>::const_iterator;
 

--- a/include/vcpkg/base/system.print.h
+++ b/include/vcpkg/base/system.print.h
@@ -42,14 +42,8 @@ namespace vcpkg::System
         ::vcpkg::System::details::print(Strings::concat_or_view(args...));
     }
 
-    class BufferedPrint
+    struct BufferedPrint
     {
-        ::std::string stdout_buffer;
-        static constexpr ::std::size_t buffer_size_target = 2048;
-        static constexpr ::std::size_t expected_maximum_print = 256;
-        static constexpr ::std::size_t alloc_size = buffer_size_target + expected_maximum_print;
-
-    public:
         BufferedPrint() { stdout_buffer.reserve(alloc_size); }
         BufferedPrint(const BufferedPrint&) = delete;
         BufferedPrint& operator=(const BufferedPrint&) = delete;
@@ -63,5 +57,11 @@ namespace vcpkg::System
             }
         }
         ~BufferedPrint() { ::vcpkg::System::details::print(stdout_buffer); }
+    private:
+        ::std::string stdout_buffer;
+        static constexpr ::std::size_t buffer_size_target = 2048;
+        static constexpr ::std::size_t expected_maximum_print = 256;
+        static constexpr ::std::size_t alloc_size = buffer_size_target + expected_maximum_print;
+
     };
 }

--- a/include/vcpkg/base/system.print.h
+++ b/include/vcpkg/base/system.print.h
@@ -57,11 +57,11 @@ namespace vcpkg::System
             }
         }
         ~BufferedPrint() { ::vcpkg::System::details::print(stdout_buffer); }
+
     private:
         ::std::string stdout_buffer;
         static constexpr ::std::size_t buffer_size_target = 2048;
         static constexpr ::std::size_t expected_maximum_print = 256;
         static constexpr ::std::size_t alloc_size = buffer_size_target + expected_maximum_print;
-
     };
 }

--- a/include/vcpkg/commands.h
+++ b/include/vcpkg/commands.h
@@ -15,7 +15,7 @@ namespace vcpkg::Commands
     Span<const PackageNameAndFunction<const PathsCommand*>> get_available_paths_commands();
     Span<const PackageNameAndFunction<const TripletCommand*>> get_available_triplet_commands();
 
-    template<typename T>
+    template<class T>
     T find(StringView command_name, Span<const PackageNameAndFunction<T>> available_commands)
     {
         for (const PackageNameAndFunction<T>& cmd : available_commands)

--- a/src/vcpkg/commands.ci.cpp
+++ b/src/vcpkg/commands.ci.cpp
@@ -31,11 +31,8 @@ namespace
     const fs::path dot_log = fs::u8path(".log");
     const fs::path readme_dot_log = fs::u8path("readme.log");
 
-    class CiBuildLogsRecorder final : public IBuildLogsRecorder
+    struct CiBuildLogsRecorder final : IBuildLogsRecorder
     {
-        fs::path base_path;
-
-    public:
         CiBuildLogsRecorder(const fs::path& base_path_) : base_path(base_path_) { }
 
         virtual void record_build_result(const VcpkgPaths& paths,
@@ -71,6 +68,8 @@ namespace
                 }
             }
         }
+    private:
+        fs::path base_path;
     };
 }
 

--- a/src/vcpkg/commands.ci.cpp
+++ b/src/vcpkg/commands.ci.cpp
@@ -68,6 +68,7 @@ namespace
                 }
             }
         }
+
     private:
         fs::path base_path;
     };

--- a/src/vcpkg/platform-expression.cpp
+++ b/src/vcpkg/platform-expression.cpp
@@ -100,9 +100,8 @@ namespace vcpkg::PlatformExpression
             }
         };
 
-        class ExpressionParser : public Parse::ParserBase
+        struct ExpressionParser : Parse::ParserBase
         {
-        public:
             ExpressionParser(StringView str, MultipleBinaryOperators multiple_binary_operators)
                 : Parse::ParserBase(str, "CONTROL"), multiple_binary_operators(multiple_binary_operators)
             {


### PR DESCRIPTION
* use `struct` for declaring class types
* use `class` for declaring template parameters
* use `typename` for disambiguating in templates