### PR TITLE
Add serialization of configuration and RegistryImplementation

### DIFF
--- a/include/vcpkg/configuration.h
+++ b/include/vcpkg/configuration.h
@@ -21,4 +21,5 @@ namespace vcpkg
     };
 
     std::unique_ptr<Json::IDeserializer<Configuration>> make_configuration_deserializer(const path& config_directory);
+    Json::Object serialize_configuration(const Configuration& config);
 }

--- a/include/vcpkg/registries.h
+++ b/include/vcpkg/registries.h
@@ -67,6 +67,8 @@ namespace vcpkg
 
         virtual Optional<VersionT> get_baseline_version(const VcpkgPaths& paths, StringView port_name) const = 0;
 
+        virtual Json::Object serialize() const;
+
         virtual ~RegistryImplementation() = default;
     };
 
@@ -136,4 +138,6 @@ namespace vcpkg
     ExpectedS<std::map<std::string, VersionT, std::less<>>> get_builtin_baseline(const VcpkgPaths& paths);
 
     bool is_git_commit_sha(StringView sv);
+
+    Json::Object serialize_registry_set(const RegistrySet& config);
 }

--- a/src/vcpkg/configuration.cpp
+++ b/src/vcpkg/configuration.cpp
@@ -61,11 +61,36 @@ namespace
     {
     }
 
+    static Json::Object serialize_configuration_impl(const Configuration& config)
+    {
+        Json::Object obj;
+
+        if(config.registry_set.default_registry())
+        {
+            obj.insert(ConfigurationDeserializer::DEFAULT_REGISTRY, config.registry_set.default_registry()->serialize());
+        }
+
+        auto reg_view = config.registry_set.registries();
+        if(reg_view.size() > 0) {
+            auto& reg_arr = obj.insert(ConfigurationDeserializer::REGISTRIES, Json::Array());
+            for(const auto& reg : reg_view) 
+            {   
+                reg_arr.push_back(reg.implementation().serialize());
+            }
+        }
+        return obj;
+    }
+
 }
 
 std::unique_ptr<Json::IDeserializer<Configuration>> vcpkg::make_configuration_deserializer(const path& config_directory)
 {
     return std::make_unique<ConfigurationDeserializer>(config_directory);
+}
+
+Json::Object vcpkg::serialize_configuration(const Configuration& config)
+{
+    return serialize_configuration_impl(config);
 }
 
 namespace vcpkg

--- a/src/vcpkg/configuration.cpp
+++ b/src/vcpkg/configuration.cpp
@@ -65,16 +65,18 @@ namespace
     {
         Json::Object obj;
 
-        if(config.registry_set.default_registry())
+        if (config.registry_set.default_registry())
         {
-            obj.insert(ConfigurationDeserializer::DEFAULT_REGISTRY, config.registry_set.default_registry()->serialize());
+            obj.insert(ConfigurationDeserializer::DEFAULT_REGISTRY,
+                       config.registry_set.default_registry()->serialize());
         }
 
         auto reg_view = config.registry_set.registries();
-        if(reg_view.size() > 0) {
+        if (reg_view.size() > 0)
+        {
             auto& reg_arr = obj.insert(ConfigurationDeserializer::REGISTRIES, Json::Array());
-            for(const auto& reg : reg_view) 
-            {   
+            for (const auto& reg : reg_view)
+            {
                 reg_arr.push_back(reg.implementation().serialize());
             }
         }

--- a/src/vcpkg/registries.cpp
+++ b/src/vcpkg/registries.cpp
@@ -62,6 +62,8 @@ namespace
 
         Optional<VersionT> get_baseline_version(const VcpkgPaths&, StringView) const override;
 
+        Json::Object serialize() const override;
+
     private:
         friend struct GitRegistryEntry;
 
@@ -216,6 +218,8 @@ namespace
 
         Optional<VersionT> get_baseline_version(const VcpkgPaths& paths, StringView port_name) const override;
 
+        Json::Object serialize() const override;
+
         ~BuiltinRegistry() = default;
 
         std::string m_baseline_identifier;
@@ -236,6 +240,8 @@ namespace
         void get_all_port_names(std::vector<std::string>&, const VcpkgPaths&) const override;
 
         Optional<VersionT> get_baseline_version(const VcpkgPaths&, StringView) const override;
+
+        Json::Object serialize() const override;
 
     private:
         path m_path;
@@ -1172,6 +1178,39 @@ namespace
         }
     }
 }
+
+// serializers
+
+Json::Object RegistryImplementation::serialize() const
+{
+    Json::Object obj;
+    obj.insert(RegistryImplDeserializer::KIND, Json::Value::string(kind()));
+    return obj;
+}
+
+Json::Object BuiltinRegistry::serialize() const {
+    Json::Object obj{RegistryImplementation::serialize()};
+    if(!m_baseline_identifier.empty())
+        obj.insert(RegistryImplDeserializer::BASELINE, Json::Value::string(m_baseline_identifier));
+    return obj;
+}
+
+Json::Object GitRegistry::serialize() const {
+    Json::Object obj{RegistryImplementation::serialize()};
+    if(!m_baseline_identifier.empty())
+        obj.insert(RegistryImplDeserializer::BASELINE, Json::Value::string(m_baseline_identifier));
+    obj.insert(RegistryImplDeserializer::REPO, Json::Value::string(m_repo));
+    return obj;
+}
+
+Json::Object FilesystemRegistry::serialize() const {
+    Json::Object obj{RegistryImplementation::serialize()};
+    if(!m_baseline_identifier.empty())
+        obj.insert(RegistryImplDeserializer::BASELINE, Json::Value::string(m_baseline_identifier));
+    obj.insert(RegistryImplDeserializer::PATH, Json::Value::string(m_path.u8string()));
+    return obj;
+}
+
 
 namespace vcpkg
 {

--- a/src/vcpkg/registries.cpp
+++ b/src/vcpkg/registries.cpp
@@ -1188,29 +1188,31 @@ Json::Object RegistryImplementation::serialize() const
     return obj;
 }
 
-Json::Object BuiltinRegistry::serialize() const {
+Json::Object BuiltinRegistry::serialize() const
+{
     Json::Object obj{RegistryImplementation::serialize()};
-    if(!m_baseline_identifier.empty())
+    if (!m_baseline_identifier.empty())
         obj.insert(RegistryImplDeserializer::BASELINE, Json::Value::string(m_baseline_identifier));
     return obj;
 }
 
-Json::Object GitRegistry::serialize() const {
+Json::Object GitRegistry::serialize() const
+{
     Json::Object obj{RegistryImplementation::serialize()};
-    if(!m_baseline_identifier.empty())
+    if (!m_baseline_identifier.empty())
         obj.insert(RegistryImplDeserializer::BASELINE, Json::Value::string(m_baseline_identifier));
     obj.insert(RegistryImplDeserializer::REPO, Json::Value::string(m_repo));
     return obj;
 }
 
-Json::Object FilesystemRegistry::serialize() const {
+Json::Object FilesystemRegistry::serialize() const
+{
     Json::Object obj{RegistryImplementation::serialize()};
-    if(!m_baseline_identifier.empty())
+    if (!m_baseline_identifier.empty())
         obj.insert(RegistryImplDeserializer::BASELINE, Json::Value::string(m_baseline_identifier));
     obj.insert(RegistryImplDeserializer::PATH, Json::Value::string(m_path.u8string()));
     return obj;
 }
-
 
 namespace vcpkg
 {


### PR DESCRIPTION
The serialization of the vcpkg-configuration.json and RegistryImplementation is missing. 

I don't know if this is in the scope of vcpkglib but I don't see any other way to generate the vcpkg-configuration.json file.

it would be good if someone could check this and guide me your coding guidelines / style a bit.