### PR TITLE
Initial attempt at showing usage information in manifest mode

### DIFF
--- a/src/vcpkg/commands.setinstalled.cpp
+++ b/src/vcpkg/commands.setinstalled.cpp
@@ -119,6 +119,23 @@ namespace vcpkg::Commands::SetInstalled
 
         System::print2("\nTotal elapsed time: ", summary.total_elapsed_time, "\n\n");
 
+        // TODO: this only shows the usage information when the packages are installed the first time
+        //       the behavior of vcpkg install is to always show the usage information, even if nothing is installed
+        // TODO: add some -x-manifest-show-usage-blah flag to enable this behavior
+        for (auto&& result : summary.results)
+        {
+            if (!result.action) continue;
+            //if (result.action->request_type != RequestType::USER_REQUESTED) continue;
+            auto bpgh = result.get_binary_paragraph();
+            if (!bpgh) continue;
+            auto usage = Install::get_cmake_usage(*bpgh, paths);
+
+            if (!usage.message.empty())
+            {
+                System::print2(usage.message);
+            }
+        }
+
         Checks::exit_success(VCPKG_LINE_INFO);
     }
 


### PR DESCRIPTION
I switched to using manifest mode with vcpkg, but I'm missing the functionality of showing usage information after running vcpkg. I tried to add this back in, but I couldn't manage to get the usage information for the packages already installed. It doesn't seem to be possible to get the `BinaryParagraph` when that package isn't installed, could you help me with this?

Also is this the right place to ask for feedback or should I move to the vcpkg issue tracker?