### PR TITLE
init-registry: registries can only be created at the root of a git repository

### DIFF
--- a/src/vcpkg/commands.init-registry.cpp
+++ b/src/vcpkg/commands.init-registry.cpp
@@ -18,8 +18,17 @@ namespace vcpkg::Commands::InitRegistry
     {
         auto parsed_args = args.parse_arguments(COMMAND_STRUCTURE);
 
-        auto path = vcpkg::u8path(args.command_arguments.front());
-        path = combine(fs.current_path(VCPKG_LINE_INFO), path);
+        const auto path_argument = vcpkg::u8path(args.command_arguments.front());
+        const auto path = combine(fs.current_path(VCPKG_LINE_INFO), path_argument);
+        if (!fs.exists(path / vcpkg::u8path(".git")))
+        {
+            vcpkg::printf(Color::error,
+                          "Could not create registry at %s because this is not a git repository root.\n"
+                          "Use `git init %s` to create a git repository in this folder.\n",
+                          u8string(path),
+                          u8string(path_argument));
+            Checks::exit_fail(VCPKG_LINE_INFO);
+        }
         const auto ports = path / vcpkg::u8path("ports");
         const auto baseline = path / vcpkg::u8path("versions") / vcpkg::u8path("baseline.json");
         if (!fs.exists(ports))


### PR DESCRIPTION
As a response to [this](https://github.com/microsoft/vcpkg-tool/pull/93#discussion_r658918215)