### PR TITLE
vcpkg install: requesting non existing features should be an error

### DIFF
--- a/include/vcpkg/base/strings.h
+++ b/include/vcpkg/base/strings.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vcpkg/base/cstringview.h>
+#include <vcpkg/base/lineinfo.h>
 #include <vcpkg/base/optional.h>
 #include <vcpkg/base/pragmas.h>
 #include <vcpkg/base/stringliteral.h>
@@ -52,6 +53,13 @@ namespace vcpkg::Strings::details
     inline void append_internal(std::string& into, const char* v) { into.append(v); }
     inline void append_internal(std::string& into, const std::string& s) { into.append(s); }
     inline void append_internal(std::string& into, StringView s) { into.append(s.begin(), s.end()); }
+    inline void append_internal(std::string& into, LineInfo ln)
+    {
+        into.append(ln.file_name);
+        into.push_back(':');
+        into += std::to_string(ln.line_number);
+        into.push_back(':');
+    }
 
     template<class T, class = decltype(std::declval<const T&>().to_string(std::declval<std::string&>()))>
     void append_internal(std::string& into, const T& t)

--- a/src/vcpkg-test/dependencies.cpp
+++ b/src/vcpkg-test/dependencies.cpp
@@ -1708,6 +1708,22 @@ TEST_CASE ("version install self features", "[versionplan]")
     check_name_and_version(install_plan.install_actions[0], "a", {"1", 0}, {"x", "y"});
 }
 
+TEST_CASE ("version install nonexisting features", "[versionplan]")
+{
+    MockBaselineProvider bp;
+    bp.v["a"] = {"1", 0};
+
+    MockVersionedPortfileProvider vp;
+    auto& a_scf = vp.emplace("a", {"1", 0}).source_control_file;
+    a_scf->feature_paragraphs.push_back(make_fpgh("x"));
+
+    MockCMakeVarProvider var_provider;
+
+    auto install_plan = create_versioned_install_plan(vp, bp, var_provider, {{"a", {"y"}}}, {}, toplevel_spec());
+
+    REQUIRE_FALSE(install_plan.has_value());
+}
+
 static auto create_versioned_install_plan(MockVersionedPortfileProvider& vp,
                                           MockBaselineProvider& bp,
                                           std::vector<Dependency> deps)

--- a/src/vcpkg-test/dependencies.cpp
+++ b/src/vcpkg-test/dependencies.cpp
@@ -1777,7 +1777,7 @@ TEST_CASE ("version remove features during upgrade", "[versionplan]")
     auto install_plan =
         unwrap(create_versioned_install_plan(vp,
                                              bp,
-{
+                                             {
                                                  Dependency{"a", {}, {}, {Constraint::Type::Minimum, "1"}},
                                                  Dependency{"a", {}, {}, {Constraint::Type::Minimum, "1", 1}},
                                                  Dependency{"b", {}, {}, {Constraint::Type::Minimum, "1", 1}},

--- a/src/vcpkg/dependencies.cpp
+++ b/src/vcpkg/dependencies.cpp
@@ -1909,6 +1909,21 @@ namespace vcpkg::Dependencies
                         }
                     }
 
+                    for (auto& requested_feature : node.features)
+                    {
+                        if (requested_feature == "core")
+                        {
+                            continue;
+                        }
+                        if (!p_vnode->scfl->source_control_file->find_feature(requested_feature))
+                        {
+                            return Strings::format("Error: The port %s@%s does not have the feature \"%s\"",
+                                                   spec,
+                                                   new_ver,
+                                                   requested_feature);
+                        }
+                    }
+
                     // -> Add stack frame
                     auto maybe_vars = m_var_provider.get_dep_info_vars(spec);
 

--- a/src/vcpkg/dependencies.cpp
+++ b/src/vcpkg/dependencies.cpp
@@ -1870,8 +1870,7 @@ namespace vcpkg::Dependencies
             auto push = [&emitted, this, &stack](const PackageSpec& spec,
                                                  const Versions::Version& new_ver,
                                                  const PackageSpec& origin,
-                                                 View<std::string> features) -> Optional<std::string>
-            {
+                                                 View<std::string> features) -> Optional<std::string> {
                 auto&& node = m_graph[spec];
                 auto overlay = m_o_provider.get_control_file(spec.name());
                 auto over_it = m_overrides.find(spec.name());


### PR DESCRIPTION
Currently I can create the following vcpkg.json file and vcpkg runs without any errors or warnings:
```
{
    ...
    "dependencies": [
        {
            "name": "qtbase",
            "features": ["libdouble-conversion"]
        },
    ]
}
```