### PR TITLE
Fixed issue with output from CMake 3.21.0

### DIFF
--- a/src/vcpkg/cmakevars.cpp
+++ b/src/vcpkg/cmakevars.cpp
@@ -183,7 +183,8 @@ endmacro()
         const auto ec_data = cmd_execute_and_capture_output(cmd_launch_cmake);
         Checks::check_exit(VCPKG_LINE_INFO, ec_data.exit_code == 0, ec_data.output);
 
-        const std::vector<std::string> lines = Strings::split(ec_data.output, '\n');
+        std::vector<std::string> lines = Strings::split(ec_data.output, '\n');
+        Strings::trim_all_and_remove_whitespace_strings(&lines);
 
         const auto end = lines.cend();
 

--- a/src/vcpkg/cmakevars.cpp
+++ b/src/vcpkg/cmakevars.cpp
@@ -180,20 +180,27 @@ endmacro()
         static constexpr CStringView BLOCK_END_GUID = "e1e74b5c-18cb-4474-a6bd-5c1c8bc81f3f";
 
         const auto cmd_launch_cmake = vcpkg::make_cmake_cmd(paths, script_path, {});
-        const auto ec_data = cmd_execute_and_capture_output(cmd_launch_cmake);
-        Checks::check_exit(VCPKG_LINE_INFO, ec_data.exit_code == 0, ec_data.output);
 
-        std::vector<std::string> lines = Strings::split(ec_data.output, '\n');
-        Strings::trim_all_and_remove_whitespace_strings(&lines);
+        std::vector<std::string> lines;
+        auto const exit_code = cmd_execute_and_stream_lines(
+            cmd_launch_cmake, [&](StringView sv) { lines.emplace_back(sv.begin(), sv.end()); });
+
+        Checks::check_exit(VCPKG_LINE_INFO, exit_code == 0, exit_code == 0 ? "" : Strings::join("\n", lines));
 
         const auto end = lines.cend();
 
         auto port_start = std::find(lines.cbegin(), end, PORT_START_GUID);
         auto port_end = std::find(port_start, end, PORT_END_GUID);
+        Checks::check_exit(VCPKG_LINE_INFO,
+                           port_start != end && port_end != end,
+                           "Failed to parse CMake console output to locate port start/end markers");
 
         for (auto var_itr = vars.begin(); port_start != end && var_itr != vars.end(); ++var_itr)
         {
             auto block_start = std::find(port_start, port_end, BLOCK_START_GUID);
+            Checks::check_exit(VCPKG_LINE_INFO,
+                               block_start != port_end,
+                               "Failed to parse CMake console output to locate block start marker");
             auto block_end = std::find(++block_start, port_end, BLOCK_END_GUID);
 
             while (block_start != port_end)


### PR DESCRIPTION
When calling CMake to obtain triplet information a regression change from CMake 3.20.5 to 3.21.0-rc1
causes the tool to exit due to an exception.

This is due to the response containing a mixture of '\n' and  '\r\n' line endings.

After splitting the output on line feeds ('\n') each line is then trimmed of whitespace to remove
any carriage returns ('\r') or trailing whitespace. This could be fixed in CMake but this
change makes it robust.

This commit in CMake caused the fault: https://github.com/Kitware/CMake/commit/0a0a0f8a744e2bfa35cdbc90db6e4e23adadd59b
It is unlikely to change as they have added a new helper file for writing the terminal output.