### PR TITLE
Eliminate iostreams

### DIFF
--- a/cmake/utilities.cmake
+++ b/cmake/utilities.cmake
@@ -212,7 +212,7 @@ function(vcpkg_target_add_warning_options TARGET)
                     -Wno-range-loop-analysis
                     )
             else()
-                target_compile_options(${TARGET} PRIVATE -analyze)
+                target_compile_options(${TARGET} PRIVATE -analyze -analyze:stacksize 39000)
             endif()
         else()
             target_compile_options(${TARGET} PRIVATE -W3)

--- a/include/pch.h
+++ b/include/pch.h
@@ -23,11 +23,7 @@
 #include <cassert>
 #include <cctype>
 #include <chrono>
-#include <codecvt>
-#include <fstream>
 #include <functional>
-#include <iomanip>
-#include <iostream>
 #include <iterator>
 #include <limits>
 #include <map>

--- a/include/vcpkg/base/cofffilereader.h
+++ b/include/vcpkg/base/cofffilereader.h
@@ -17,9 +17,7 @@ namespace vcpkg::CoffFileReader
         std::vector<MachineType> machine_types;
     };
 
-#if defined(_WIN32)
     DllInfo read_dll(const ReadFilePointer& fs);
 
     LibInfo read_lib(const ReadFilePointer& fs);
-#endif
 }

--- a/include/vcpkg/base/cofffilereader.h
+++ b/include/vcpkg/base/cofffilereader.h
@@ -18,8 +18,8 @@ namespace vcpkg::CoffFileReader
     };
 
 #if defined(_WIN32)
-    DllInfo read_dll(const path& dll);
+    DllInfo read_dll(const ReadFilePointer& fs);
 
-    LibInfo read_lib(const path& lib);
+    LibInfo read_lib(const ReadFilePointer& fs);
 #endif
 }

--- a/include/vcpkg/base/files.h
+++ b/include/vcpkg/base/files.h
@@ -189,6 +189,7 @@ namespace vcpkg
 #if defined(_WIN32)
             return ::_fseeki64(m_fs, static_cast<long long>(offset), origin);
 #else // ^^^ _WIN32 / !_WIN32 vvv
+            Checks::check_exit(VCPKG_LINE_INFO, offset < LLONG_MAX);
             return ::fseek(m_fs, offset, origin);
 #endif // ^^^ !_WIN32
         }
@@ -202,7 +203,7 @@ namespace vcpkg
         }
         int seek(unsigned long long offset, int origin) const noexcept
         {
-            Checks::check_exit(VCPKG_LINE_INFO, offset < LONG_MAX);
+            Checks::check_exit(VCPKG_LINE_INFO, offset < LLONG_MAX);
             return this->seek(static_cast<long long>(offset), origin);
         }
         int eof() const noexcept { return ::feof(m_fs); }

--- a/include/vcpkg/base/files.h
+++ b/include/vcpkg/base/files.h
@@ -332,11 +332,11 @@ namespace vcpkg
 
         virtual std::vector<path> find_from_PATH(const std::string& name) const = 0;
 
-        virtual ReadFilePointer read_file(const path& file_path, std::error_code& ec) const = 0;
-        ReadFilePointer read_file(LineInfo li, const path& file_path) const;
+        virtual ReadFilePointer open_for_read(const path& file_path, std::error_code& ec) const = 0;
+        ReadFilePointer open_for_read(LineInfo li, const path& file_path) const;
 
-        virtual WriteFilePointer write_file(const path& file_path, std::error_code& ec) = 0;
-        WriteFilePointer write_file(LineInfo li, const path& file_path);
+        virtual WriteFilePointer open_for_write(const path& file_path, std::error_code& ec) = 0;
+        WriteFilePointer open_for_write(LineInfo li, const path& file_path);
     };
 
     Filesystem& get_real_filesystem();

--- a/include/vcpkg/base/files.h
+++ b/include/vcpkg/base/files.h
@@ -241,16 +241,6 @@ namespace vcpkg
         int put(int c) const noexcept { return ::fputc(c, m_fs); }
     };
 
-    class LinesCollector
-    {
-        std::vector<std::string> results;
-        std::string previous_partial;
-
-    public:
-        void append(const char* data, size_t data_size);
-        std::vector<std::string> extract();
-    };
-
     struct Filesystem
     {
         std::string read_contents(const path& file_path, LineInfo li) const;

--- a/include/vcpkg/base/files.h
+++ b/include/vcpkg/base/files.h
@@ -4,6 +4,7 @@
 #include <vcpkg/base/ignore_errors.h>
 #include <vcpkg/base/pragmas.h>
 
+#include <stdio.h>
 #include <string.h>
 
 #if !defined(VCPKG_USE_STD_FILESYSTEM)
@@ -163,12 +164,97 @@ void is_directory(const stdfs::path& p, std::error_code& ec) = delete;
 
 namespace vcpkg
 {
+    struct FilePointer
+    {
+    protected:
+        FILE* m_fs;
+
+    public:
+        FilePointer() noexcept : m_fs(nullptr) { }
+
+        FilePointer(const FilePointer&) = delete;
+        FilePointer(FilePointer&& other) noexcept : m_fs(other.m_fs) { other.m_fs = nullptr; }
+
+        FilePointer& operator=(const FilePointer&) = delete;
+        explicit operator bool() const noexcept { return m_fs != nullptr; }
+
+        int seek(int offset, int origin) const noexcept { return ::fseek(m_fs, offset, origin); }
+        int seek(unsigned int offset, int origin) const noexcept
+        {
+            return this->seek(static_cast<long long>(offset), origin);
+        }
+        int seek(long offset, int origin) const noexcept { return ::fseek(m_fs, offset, origin); }
+        int seek(unsigned long offset, int origin) const noexcept
+        {
+#if defined(_WIN32)
+            return ::_fseeki64(m_fs, static_cast<long long>(offset), origin);
+#else // ^^^ _WIN32 / !_WIN32 vvv
+            return ::fseek(m_fs, offset, origin);
+#endif // ^^^ !_WIN32
+        }
+        int seek(long long offset, int origin) const noexcept
+        {
+#if defined(_WIN32)
+            return ::_fseeki64(m_fs, offset, origin);
+#else // ^^^ _WIN32 / !_WIN32 vvv
+            return ::fseek(m_fs, offset, origin);
+#endif // ^^^ !_WIN32
+        }
+        int seek(unsigned long long offset, int origin) const noexcept
+        {
+            Checks::check_exit(VCPKG_LINE_INFO, offset < LONG_MAX);
+            return this->seek(static_cast<long long>(offset), origin);
+        }
+        int eof() const noexcept { return ::feof(m_fs); }
+        int error() const noexcept { return ::ferror(m_fs); }
+
+        ~FilePointer()
+        {
+            if (m_fs)
+            {
+                Checks::check_exit(VCPKG_LINE_INFO, ::fclose(m_fs) == 0);
+            }
+        }
+    };
+
+    struct ReadFilePointer : FilePointer
+    {
+        ReadFilePointer() = default;
+        explicit ReadFilePointer(const path& file_path, std::error_code& ec) noexcept;
+
+        size_t read(void* buffer, size_t element_size, size_t element_count) const noexcept
+        {
+            return ::fread(buffer, element_size, element_count, m_fs);
+        }
+    };
+
+    struct WriteFilePointer : FilePointer
+    {
+        WriteFilePointer() = default;
+        explicit WriteFilePointer(const path& file_path, std::error_code& ec) noexcept;
+
+        size_t write(const void* buffer, size_t element_size, size_t element_count) const noexcept
+        {
+            return ::fwrite(buffer, element_size, element_count, m_fs);
+        }
+
+        int put(int c) const noexcept { return ::fputc(c, m_fs); }
+    };
+
+    class LinesCollector
+    {
+        std::vector<std::string> results;
+        std::string previous_partial;
+
+    public:
+        void append(const char* data, size_t data_size);
+        std::vector<std::string> extract();
+    };
+
     struct Filesystem
     {
         std::string read_contents(const path& file_path, LineInfo li) const;
         virtual Expected<std::string> read_contents(const path& file_path) const = 0;
-        /// <summary>Read text lines from a file</summary>
-        /// <remarks>Lines will have up to one trailing carriage-return character stripped (CRLF)</remarks>
         virtual Expected<std::vector<std::string>> read_lines(const path& file_path) const = 0;
         std::vector<std::string> read_lines(const path& file_path, LineInfo li) const;
         virtual path find_file_recursively_up(const path& starting_dir, const path& filename) const = 0;
@@ -255,6 +341,12 @@ namespace vcpkg
         virtual void unlock_file_lock(SystemHandle handle, std::error_code&) = 0;
 
         virtual std::vector<path> find_from_PATH(const std::string& name) const = 0;
+
+        virtual ReadFilePointer read_file(const path& file_path, std::error_code& ec) const = 0;
+        ReadFilePointer read_file(LineInfo li, const path& file_path) const;
+
+        virtual WriteFilePointer write_file(const path& file_path, std::error_code& ec) = 0;
+        WriteFilePointer write_file(LineInfo li, const path& file_path);
     };
 
     Filesystem& get_real_filesystem();

--- a/include/vcpkg/base/strings.h
+++ b/include/vcpkg/base/strings.h
@@ -326,10 +326,10 @@ namespace vcpkg::Strings
                     cb(StringView{previous_partial_line});
                     previous_partial_line.clear();
                 }
-                else if (!last_was_cr || *newline != '\n')
+                else if (!last_was_cr || *newline != '\n' || newline != start)
                 {
                     // implement \r\n, \r, \n newlines by logically generating all newlines,
-                    // and skippimg emission of a \n newline iff immediately followed by \r
+                    // and skipping emission of an empty \n newline iff immediately following \r
                     cb(StringView{start, newline});
                 }
 

--- a/src/vcpkg-test/files.cpp
+++ b/src/vcpkg-test/files.cpp
@@ -283,6 +283,29 @@ TEST_CASE ("lexically_normal", "[files]")
 #endif
 }
 
+TEST_CASE ("LinesCollector", "[files]")
+{
+    using vcpkg::LinesCollector;
+    LinesCollector lc;
+    CHECK(lc.extract().empty());
+    lc.append("a\nb\r\nc\rd\r\r\r\r\r\n\n\n\ne", 18);
+    CHECK(lc.extract() == std::vector<std::string>{"a", "b", "c", "d", "e"});
+    CHECK(lc.extract().empty());
+    lc.append("hello ", 6);
+    lc.append("there ", 6);
+    lc.append("world", 5);
+    CHECK(lc.extract() == std::vector<std::string>{"hello there world"});
+    lc.append("\r\nhello \r\n", 10);
+    lc.append("\r\nworld", 7);
+    CHECK(lc.extract() == std::vector<std::string>{"hello ", "world"});
+    lc.append("\r\n\r\n\r\n", 6);
+    CHECK(lc.extract().empty());
+    lc.append("a", 1);
+    lc.append("b\nc", 3);
+    lc.append("d", 1);
+    CHECK(lc.extract() == std::vector<std::string>{"ab", "cd"});
+}
+
 #if defined(_WIN32)
 TEST_CASE ("win32_fix_path_case", "[files]")
 {

--- a/src/vcpkg-test/files.cpp
+++ b/src/vcpkg-test/files.cpp
@@ -285,25 +285,28 @@ TEST_CASE ("lexically_normal", "[files]")
 
 TEST_CASE ("LinesCollector", "[files]")
 {
-    using vcpkg::LinesCollector;
+    using vcpkg::Strings::LinesCollector;
     LinesCollector lc;
-    CHECK(lc.extract().empty());
-    lc.append("a\nb\r\nc\rd\r\r\r\r\r\n\n\n\ne", 18);
-    CHECK(lc.extract() == std::vector<std::string>{"a", "b", "c", "d", "e"});
-    CHECK(lc.extract().empty());
-    lc.append("hello ", 6);
-    lc.append("there ", 6);
-    lc.append("world", 5);
+    CHECK(lc.extract() == std::vector<std::string>{""});
+    lc.append({"a\nb\r\nc\rd\r\r\n\ne\n\rx", 16});
+    CHECK(lc.extract() == std::vector<std::string>{"a", "b", "c", "d", "", "", "e", "", "x"});
+    CHECK(lc.extract() == std::vector<std::string>{""});
+    lc.append({"hello ", 6});
+    lc.append({"there ", 6});
+    lc.append({"world", 5});
     CHECK(lc.extract() == std::vector<std::string>{"hello there world"});
-    lc.append("\r\nhello \r\n", 10);
-    lc.append("\r\nworld", 7);
-    CHECK(lc.extract() == std::vector<std::string>{"hello ", "world"});
-    lc.append("\r\n\r\n\r\n", 6);
-    CHECK(lc.extract().empty());
-    lc.append("a", 1);
-    lc.append("b\nc", 3);
-    lc.append("d", 1);
+    lc.append({"\r\nhello \r\n", 10});
+    lc.append({"\r\nworld", 7});
+    CHECK(lc.extract() == std::vector<std::string>{"", "hello ", "", "world"});
+    lc.append({"\r\n\r\n\r\n", 6});
+    CHECK(lc.extract() == std::vector<std::string>{"", "", "", ""});
+    lc.append({"a", 1});
+    lc.append({"b\nc", 3});
+    lc.append({"d", 1});
     CHECK(lc.extract() == std::vector<std::string>{"ab", "cd"});
+    lc.append({"a\r", 2});
+    lc.append({"\nb", 2});
+    CHECK(lc.extract() == std::vector<std::string>{"a", "b"});
 }
 
 #if defined(_WIN32)

--- a/src/vcpkg-test/files.cpp
+++ b/src/vcpkg-test/files.cpp
@@ -307,6 +307,12 @@ TEST_CASE ("LinesCollector", "[files]")
     lc.on_data({"a\r", 2});
     lc.on_data({"\nb", 2});
     CHECK(lc.extract() == std::vector<std::string>{"a", "b"});
+    lc.on_data({"a\r", 2});
+    CHECK(lc.extract() == std::vector<std::string>{"a", ""});
+    lc.on_data({"\n", 1});
+    CHECK(lc.extract() == std::vector<std::string>{"", ""});
+    lc.on_data({"\rabc\n", 5});
+    CHECK(lc.extract() == std::vector<std::string>{"", "abc", ""});
 }
 
 #if defined(_WIN32)

--- a/src/vcpkg-test/files.cpp
+++ b/src/vcpkg-test/files.cpp
@@ -288,24 +288,24 @@ TEST_CASE ("LinesCollector", "[files]")
     using vcpkg::Strings::LinesCollector;
     LinesCollector lc;
     CHECK(lc.extract() == std::vector<std::string>{""});
-    lc.append({"a\nb\r\nc\rd\r\r\n\ne\n\rx", 16});
+    lc.on_data({"a\nb\r\nc\rd\r\r\n\ne\n\rx", 16});
     CHECK(lc.extract() == std::vector<std::string>{"a", "b", "c", "d", "", "", "e", "", "x"});
     CHECK(lc.extract() == std::vector<std::string>{""});
-    lc.append({"hello ", 6});
-    lc.append({"there ", 6});
-    lc.append({"world", 5});
+    lc.on_data({"hello ", 6});
+    lc.on_data({"there ", 6});
+    lc.on_data({"world", 5});
     CHECK(lc.extract() == std::vector<std::string>{"hello there world"});
-    lc.append({"\r\nhello \r\n", 10});
-    lc.append({"\r\nworld", 7});
+    lc.on_data({"\r\nhello \r\n", 10});
+    lc.on_data({"\r\nworld", 7});
     CHECK(lc.extract() == std::vector<std::string>{"", "hello ", "", "world"});
-    lc.append({"\r\n\r\n\r\n", 6});
+    lc.on_data({"\r\n\r\n\r\n", 6});
     CHECK(lc.extract() == std::vector<std::string>{"", "", "", ""});
-    lc.append({"a", 1});
-    lc.append({"b\nc", 3});
-    lc.append({"d", 1});
+    lc.on_data({"a", 1});
+    lc.on_data({"b\nc", 3});
+    lc.on_data({"d", 1});
     CHECK(lc.extract() == std::vector<std::string>{"ab", "cd"});
-    lc.append({"a\r", 2});
-    lc.append({"\nb", 2});
+    lc.on_data({"a\r", 2});
+    lc.on_data({"\nb", 2});
     CHECK(lc.extract() == std::vector<std::string>{"a", "b"});
 }
 

--- a/src/vcpkg.cpp
+++ b/src/vcpkg.cpp
@@ -22,7 +22,6 @@
 #include <vcpkg/vcpkgpaths.h>
 
 #include <cassert>
-#include <fstream>
 #include <memory>
 #include <random>
 

--- a/src/vcpkg/base/cofffilereader.cpp
+++ b/src/vcpkg/base/cofffilereader.cpp
@@ -1,34 +1,49 @@
 #include <vcpkg/base/checks.h>
 #include <vcpkg/base/cofffilereader.h>
+#include <vcpkg/base/optional.h>
 #include <vcpkg/base/stringliteral.h>
+
+#include <stdio.h>
 
 using namespace std;
 
 namespace vcpkg::CoffFileReader
 {
-#if defined(_WIN32)
-    template<class T>
-    static T reinterpret_bytes(const char* data)
+    static uint16_t read_uint16_le(const char* data) noexcept
     {
-        return (*reinterpret_cast<const T*>(&data[0]));
+        return static_cast<unsigned char>(data[0]) | static_cast<unsigned char>(data[1]) << 8;
+    }
+    static uint32_t read_uint32_le(const char* data) noexcept
+    {
+        return static_cast<unsigned char>(data[0]) | static_cast<unsigned char>(data[1]) << 8 |
+               static_cast<unsigned char>(data[2]) << 16 | static_cast<unsigned char>(data[3]) << 24;
     }
 
     template<class T>
-    static T read_value_from_stream(fstream& fs)
+    static Optional<T> read_value_from_stream(const ReadFilePointer& fs)
     {
         T data;
-        fs.read(reinterpret_cast<char*>(&data), sizeof data);
-        return data;
+        if (fs.read(&data, sizeof(T), 1) == 1)
+        {
+            return data;
+        }
+
+        return nullopt;
     }
 
     template<class T>
-    static T peek_value_from_stream(fstream& fs)
+    static Optional<T> peek_value_from_stream(const ReadFilePointer& fs)
     {
-        const std::streampos original_pos = fs.tellg();
         T data;
-        fs.read(reinterpret_cast<char*>(&data), sizeof data);
-        fs.seekg(original_pos);
-        return data;
+        if (fs.read(&data, sizeof(T), 1) == 1)
+        {
+            if (fs.seek(-static_cast<long>(sizeof(T)), SEEK_CUR) == 0)
+            {
+                return data;
+            }
+        }
+
+        return nullopt;
     }
 
     static void verify_equal_strings(const LineInfo& line_info,
@@ -41,24 +56,24 @@ namespace vcpkg::CoffFileReader
                            "Incorrect string (%s) found. Expected: (%s) but found (%s)",
                            label,
                            expected,
-                           actual);
+                           actual); // FIXME HEX
     }
 
-    static void read_and_verify_pe_signature(fstream& fs)
+    static void read_and_verify_pe_signature(const ReadFilePointer& fs)
     {
-        static constexpr size_t OFFSET_TO_PE_SIGNATURE_OFFSET = 0x3c;
+        static constexpr long OFFSET_TO_PE_SIGNATURE_OFFSET = 0x3c;
 
         static constexpr StringLiteral PE_SIGNATURE = "PE\0\0";
         static constexpr size_t PE_SIGNATURE_SIZE = 4;
 
-        fs.seekg(OFFSET_TO_PE_SIGNATURE_OFFSET, ios_base::beg);
+        Checks::check_exit(VCPKG_LINE_INFO, fs.seek(OFFSET_TO_PE_SIGNATURE_OFFSET, SEEK_SET) == 0);
         const auto offset_to_pe_signature = read_value_from_stream<int32_t>(fs);
+        Checks::check_exit(VCPKG_LINE_INFO,
+                           fs.seek(offset_to_pe_signature.value_or_exit(VCPKG_LINE_INFO), SEEK_SET) == 0);
 
-        fs.seekg(offset_to_pe_signature);
         char signature[PE_SIGNATURE_SIZE];
-        fs.read(signature, PE_SIGNATURE_SIZE);
+        Checks::check_exit(VCPKG_LINE_INFO, fs.read(signature, sizeof(char), PE_SIGNATURE_SIZE) == PE_SIGNATURE_SIZE);
         verify_equal_strings(VCPKG_LINE_INFO, PE_SIGNATURE, {signature, PE_SIGNATURE_SIZE}, "PE_SIGNATURE");
-        fs.seekg(offset_to_pe_signature + PE_SIGNATURE_SIZE, ios_base::beg);
     }
 
     static fpos_t align_to_size(const uint64_t unaligned, const uint64_t alignment_size)
@@ -74,21 +89,17 @@ namespace vcpkg::CoffFileReader
     {
         static constexpr size_t HEADER_SIZE = 20;
 
-        static CoffFileHeader read(fstream& fs)
+        static CoffFileHeader read(const ReadFilePointer& fs)
         {
             CoffFileHeader ret;
             ret.data.resize(HEADER_SIZE);
-            fs.read(&ret.data[0], HEADER_SIZE);
+            Checks::check_exit(VCPKG_LINE_INFO, fs.read(&ret.data[0], HEADER_SIZE, 1) == 1);
             return ret;
         }
 
         MachineType machine_type() const
         {
-            static constexpr size_t MACHINE_TYPE_OFFSET = 0;
-            static constexpr size_t MACHINE_TYPE_SIZE = 2;
-
-            std::string machine_field_as_string = data.substr(MACHINE_TYPE_OFFSET, MACHINE_TYPE_SIZE);
-            const auto machine = reinterpret_bytes<uint16_t>(machine_field_as_string.c_str());
+            const auto machine = read_uint16_le(data.c_str());
             return to_machine_type(machine);
         }
 
@@ -100,7 +111,7 @@ namespace vcpkg::CoffFileReader
     {
         static constexpr size_t HEADER_SIZE = 60;
 
-        static ArchiveMemberHeader read(fstream& fs)
+        static ArchiveMemberHeader read(const ReadFilePointer& fs)
         {
             static constexpr size_t HEADER_END_OFFSET = 58;
             static constexpr StringLiteral HEADER_END = "`\n";
@@ -108,8 +119,7 @@ namespace vcpkg::CoffFileReader
 
             ArchiveMemberHeader ret;
             ret.data.resize(HEADER_SIZE);
-            fs.read(&ret.data[0], HEADER_SIZE);
-
+            Checks::check_exit(VCPKG_LINE_INFO, fs.read(&ret.data[0], HEADER_SIZE, 1) == 1);
             if (ret.data[0] != '\0') // Due to freeglut. github issue #223
             {
                 const std::string header_end = ret.data.substr(HEADER_END_OFFSET, HEADER_END_SIZE);
@@ -145,21 +155,22 @@ namespace vcpkg::CoffFileReader
 
     struct OffsetsArray
     {
-        static OffsetsArray read(fstream& fs, const uint32_t offset_count)
+        static OffsetsArray read(const ReadFilePointer& fs, const uint32_t offset_count)
         {
             static constexpr uint32_t OFFSET_WIDTH = 4;
+            Checks::check_exit(VCPKG_LINE_INFO, offset_count <= UINT32_MAX / OFFSET_WIDTH);
 
             std::string raw_offsets;
             const uint32_t raw_offset_size = offset_count * OFFSET_WIDTH;
             raw_offsets.resize(raw_offset_size);
-            fs.read(&raw_offsets[0], raw_offset_size);
+            Checks::check_exit(VCPKG_LINE_INFO, fs.read(&raw_offsets[0], OFFSET_WIDTH, offset_count) == offset_count);
 
             OffsetsArray ret;
             for (uint32_t i = 0; i < offset_count; ++i)
             {
                 const std::string value_as_string = raw_offsets.substr(OFFSET_WIDTH * static_cast<size_t>(i),
                                                                        OFFSET_WIDTH * (static_cast<size_t>(i) + 1));
-                const auto value = reinterpret_bytes<uint32_t>(value_as_string.c_str());
+                const auto value = read_uint32_le(value_as_string.c_str());
 
                 // Ignore offsets that point to offset 0. See vcpkg github #223 #288 #292
                 if (value != 0)
@@ -180,7 +191,7 @@ namespace vcpkg::CoffFileReader
     {
         static constexpr size_t HEADER_SIZE = 20;
 
-        static ImportHeader read(fstream& fs)
+        static ImportHeader read(const ReadFilePointer& fs)
         {
             static constexpr size_t SIG1_OFFSET = 0;
             static constexpr auto SIG1 = static_cast<uint16_t>(MachineType::UNKNOWN);
@@ -192,14 +203,14 @@ namespace vcpkg::CoffFileReader
 
             ImportHeader ret;
             ret.data.resize(HEADER_SIZE);
-            fs.read(&ret.data[0], HEADER_SIZE);
+            Checks::check_exit(VCPKG_LINE_INFO, fs.read(&ret.data[0], HEADER_SIZE, 1) == 1);
 
             const std::string sig1_as_string = ret.data.substr(SIG1_OFFSET, SIG1_SIZE);
-            const auto sig1 = reinterpret_bytes<uint16_t>(sig1_as_string.c_str());
+            const auto sig1 = read_uint16_le(sig1_as_string.c_str());
             Checks::check_exit(VCPKG_LINE_INFO, sig1 == SIG1, "Sig1 was incorrect. Expected %s but got %s", SIG1, sig1);
 
             const std::string sig2_as_string = ret.data.substr(SIG2_OFFSET, SIG2_SIZE);
-            const auto sig2 = reinterpret_bytes<uint16_t>(sig2_as_string.c_str());
+            const auto sig2 = read_uint16_le(sig2_as_string.c_str());
             Checks::check_exit(VCPKG_LINE_INFO, sig2 == SIG2, "Sig2 was incorrect. Expected %s but got %s", SIG2, sig2);
 
             return ret;
@@ -211,7 +222,7 @@ namespace vcpkg::CoffFileReader
             static constexpr size_t MACHINE_TYPE_SIZE = 2;
 
             std::string machine_field_as_string = data.substr(MACHINE_TYPE_OFFSET, MACHINE_TYPE_SIZE);
-            const auto machine = reinterpret_bytes<uint16_t>(machine_field_as_string.c_str());
+            const auto machine = read_uint16_le(machine_field_as_string.c_str());
             return to_machine_type(machine);
         }
 
@@ -219,23 +230,20 @@ namespace vcpkg::CoffFileReader
         std::string data;
     };
 
-    static void read_and_verify_archive_file_signature(fstream& fs)
+    static void read_and_verify_archive_file_signature(const ReadFilePointer& fs)
     {
         static constexpr StringLiteral FILE_START = "!<arch>\n";
         static constexpr size_t FILE_START_SIZE = 8;
 
-        fs.seekg(std::fstream::beg);
+        Checks::check_exit(VCPKG_LINE_INFO, fs.seek(0, SEEK_SET) == 0);
 
         char file_start[FILE_START_SIZE];
-        fs.read(file_start, FILE_START_SIZE);
+        Checks::check_exit(VCPKG_LINE_INFO, fs.read(&file_start, FILE_START_SIZE, 1) == 1);
         verify_equal_strings(VCPKG_LINE_INFO, FILE_START, {file_start, FILE_START_SIZE}, "LIB FILE_START");
     }
 
-    DllInfo read_dll(const path& dll)
+    DllInfo read_dll(const ReadFilePointer& fs)
     {
-        std::fstream fs(dll, std::ios::in | std::ios::binary | std::ios::ate);
-        Checks::check_exit(VCPKG_LINE_INFO, fs.is_open(), "Could not open file %s for reading", generic_u8string(dll));
-
         read_and_verify_pe_signature(fs);
         CoffFileHeader header = CoffFileHeader::read(fs);
         const MachineType machine = header.machine_type();
@@ -246,9 +254,15 @@ namespace vcpkg::CoffFileReader
     {
         void set_to_offset(const fpos_t position) { this->m_absolute_position = position; }
 
-        void set_to_current_pos(fstream& fs) { this->m_absolute_position = fs.tellg(); }
+        void set_to_current_pos(const ReadFilePointer& fs)
+        {
+            Checks::check_exit(VCPKG_LINE_INFO, fs.getpos(&m_absolute_position) == 0);
+        }
 
-        void seek_to_marker(fstream& fs) const { fs.seekg(this->m_absolute_position, ios_base::beg); }
+        void seek_to_marker(const ReadFilePointer& fs) const
+        {
+            Checks::check_exit(VCPKG_LINE_INFO, fs.setpos(&m_absolute_position) == 0);
+        }
 
         void advance_by(const uint64_t offset) { this->m_absolute_position += offset; }
 
@@ -256,11 +270,8 @@ namespace vcpkg::CoffFileReader
         fpos_t m_absolute_position = 0;
     };
 
-    LibInfo read_lib(const path& lib)
+    LibInfo read_lib(const ReadFilePointer& fs)
     {
-        std::fstream fs(lib, std::ios::in | std::ios::binary | std::ios::ate);
-        Checks::check_exit(VCPKG_LINE_INFO, fs.is_open(), "Could not open file %s for reading", generic_u8string(lib));
-
         read_and_verify_archive_file_signature(fs);
 
         Marker marker;
@@ -280,11 +291,12 @@ namespace vcpkg::CoffFileReader
                            "Could not find proper second linker member");
         // The first 4 bytes contains the number of archive members
         const auto archive_member_count = read_value_from_stream<uint32_t>(fs);
-        const OffsetsArray offsets = OffsetsArray::read(fs, archive_member_count);
+        const OffsetsArray offsets = OffsetsArray::read(fs, archive_member_count.value_or_exit(VCPKG_LINE_INFO));
         marker.advance_by(ArchiveMemberHeader::HEADER_SIZE + second_linker_member_header.member_size());
         marker.seek_to_marker(fs);
 
-        const bool has_longname_member_header = peek_value_from_stream<uint16_t>(fs) == 0x2F2F;
+        const bool has_longname_member_header =
+            peek_value_from_stream<uint16_t>(fs).value_or_exit(VCPKG_LINE_INFO) == 0x2F2F;
         if (has_longname_member_header)
         {
             const ArchiveMemberHeader longnames_member_header = ArchiveMemberHeader::read(fs);
@@ -298,7 +310,7 @@ namespace vcpkg::CoffFileReader
         {
             marker.set_to_offset(offset + ArchiveMemberHeader::HEADER_SIZE); // Skip the header, no need to read it.
             marker.seek_to_marker(fs);
-            const auto first_two_bytes = peek_value_from_stream<uint16_t>(fs);
+            const auto first_two_bytes = peek_value_from_stream<uint16_t>(fs).value_or_exit(VCPKG_LINE_INFO);
             const bool is_import_header = to_machine_type(first_two_bytes) == MachineType::UNKNOWN;
             const MachineType machine =
                 is_import_header ? ImportHeader::read(fs).machine_type() : CoffFileHeader::read(fs).machine_type();
@@ -307,5 +319,4 @@ namespace vcpkg::CoffFileReader
 
         return {std::vector<MachineType>(machine_types.cbegin(), machine_types.cend())};
     }
-#endif
 }

--- a/src/vcpkg/base/cofffilereader.cpp
+++ b/src/vcpkg/base/cofffilereader.cpp
@@ -8,213 +8,131 @@
 
 using namespace std;
 
+// See https://docs.microsoft.com/en-us/windows/win32/debug/pe-format
+
 namespace vcpkg::CoffFileReader
 {
-    static uint16_t read_uint16_le(const char* data) noexcept
-    {
-        return static_cast<unsigned char>(data[0]) | static_cast<unsigned char>(data[1]) << 8;
-    }
-
-    template<class T>
-    static Optional<T> peek_value_from_stream(const ReadFilePointer& fs)
-    {
-        T data;
-        if (fs.read(&data, sizeof(T), 1) == 1)
-        {
-            if (fs.seek(-static_cast<long>(sizeof(T)), SEEK_CUR) == 0)
-            {
-                return data;
-            }
-        }
-
-        return nullopt;
-    }
-
-    static void verify_equal_strings(const LineInfo& line_info,
-                                     StringView expected,
-                                     StringView actual,
-                                     const char* label)
-    {
-        Checks::check_exit(line_info,
-                           expected == actual,
-                           "Incorrect string (%s) found. Expected: (%s) but found (%s)",
-                           label,
-                           expected,
-                           actual); // FIXME HEX
-    }
-
     static void read_and_verify_pe_signature(const ReadFilePointer& fs)
     {
         static constexpr long OFFSET_TO_PE_SIGNATURE_OFFSET = 0x3c;
 
         static constexpr StringLiteral PE_SIGNATURE = "PE\0\0";
-        static constexpr size_t PE_SIGNATURE_SIZE = 4;
 
         Checks::check_exit(VCPKG_LINE_INFO, fs.seek(OFFSET_TO_PE_SIGNATURE_OFFSET, SEEK_SET) == 0);
-        int32_t offset_to_pe_signature;
-        Checks::check_exit(VCPKG_LINE_INFO, fs.read(&offset_to_pe_signature, sizeof(int32_t), 1) == 1);
+        uint32_t offset_to_pe_signature;
+        Checks::check_exit(VCPKG_LINE_INFO, fs.read(&offset_to_pe_signature, sizeof(uint32_t), 1) == 1);
         Checks::check_exit(VCPKG_LINE_INFO, fs.seek(offset_to_pe_signature, SEEK_SET) == 0);
 
-        char signature[PE_SIGNATURE_SIZE];
-        Checks::check_exit(VCPKG_LINE_INFO, fs.read(signature, sizeof(char), PE_SIGNATURE_SIZE) == PE_SIGNATURE_SIZE);
-        verify_equal_strings(VCPKG_LINE_INFO, PE_SIGNATURE, {signature, PE_SIGNATURE_SIZE}, "PE_SIGNATURE");
-    }
-
-    static uint64_t align_to_size(const uint64_t unaligned, const uint64_t alignment_size)
-    {
-        uint64_t aligned = unaligned - 1;
-        aligned /= alignment_size;
-        aligned += 1;
-        aligned *= alignment_size;
-        return aligned;
+        char signature[PE_SIGNATURE.size()];
+        Checks::check_exit(VCPKG_LINE_INFO,
+                           fs.read(signature, sizeof(char), PE_SIGNATURE.size()) == PE_SIGNATURE.size());
+        Checks::check_exit(
+            VCPKG_LINE_INFO, PE_SIGNATURE == StringView{signature, PE_SIGNATURE.size()}, "Incorrect PE signature.");
     }
 
     struct CoffFileHeader
     {
-        static constexpr size_t HEADER_SIZE = 20;
-
-        static CoffFileHeader read(const ReadFilePointer& fs)
-        {
-            CoffFileHeader ret;
-            ret.data.resize(HEADER_SIZE);
-            Checks::check_exit(VCPKG_LINE_INFO, fs.read(&ret.data[0], HEADER_SIZE, 1) == 1);
-            return ret;
-        }
-
-        MachineType machine_type() const
-        {
-            const auto machine = read_uint16_le(data.c_str());
-            return to_machine_type(machine);
-        }
-
-    private:
-        std::string data;
+        uint16_t machine;
+        uint16_t number_of_sections;
+        uint32_t date_time_stamp;
+        uint32_t pointer_to_symbol_table;
+        uint32_t number_of_symbols;
+        uint16_t size_of_optional_header;
+        uint16_t characteristics;
     };
 
-    struct ArchiveMemberHeader
-    {
-        static constexpr size_t HEADER_SIZE = 60;
-
-        static ArchiveMemberHeader read(const ReadFilePointer& fs)
-        {
-            static constexpr size_t HEADER_END_OFFSET = 58;
-            static constexpr StringLiteral HEADER_END = "`\n";
-            static constexpr size_t HEADER_END_SIZE = 2;
-
-            ArchiveMemberHeader ret;
-            ret.data.resize(HEADER_SIZE);
-            Checks::check_exit(VCPKG_LINE_INFO, fs.read(&ret.data[0], HEADER_SIZE, 1) == 1);
-            if (ret.data[0] != '\0') // Due to freeglut. github issue #223
-            {
-                const std::string header_end = ret.data.substr(HEADER_END_OFFSET, HEADER_END_SIZE);
-                verify_equal_strings(VCPKG_LINE_INFO, HEADER_END, header_end, "LIB HEADER_END");
-            }
-
-            return ret;
-        }
-
-        std::string name() const
-        {
-            static constexpr size_t HEADER_NAME_OFFSET = 0;
-            static constexpr size_t HEADER_NAME_SIZE = 16;
-            return data.substr(HEADER_NAME_OFFSET, HEADER_NAME_SIZE);
-        }
-
-        uint64_t member_size() const
-        {
-            static constexpr size_t ALIGNMENT_SIZE = 2;
-
-            static constexpr size_t HEADER_SIZE_OFFSET = 48;
-            static constexpr size_t HEADER_SIZE_FIELD_SIZE = 10;
-            const std::string as_string = data.substr(HEADER_SIZE_OFFSET, HEADER_SIZE_FIELD_SIZE);
-            // This is in ASCII decimal representation
-            const uint64_t value = std::strtoull(as_string.c_str(), nullptr, 10);
-            return align_to_size(value, ALIGNMENT_SIZE);
-        }
-
-        std::string data;
-    };
-
-    struct ImportHeader
-    {
-        static constexpr size_t HEADER_SIZE = 20;
-
-        static ImportHeader read(const ReadFilePointer& fs)
-        {
-            static constexpr size_t SIG1_OFFSET = 0;
-            static constexpr auto SIG1 = static_cast<uint16_t>(MachineType::UNKNOWN);
-            static constexpr size_t SIG1_SIZE = 2;
-
-            static constexpr size_t SIG2_OFFSET = 2;
-            static constexpr uint16_t SIG2 = 0xFFFF;
-            static constexpr size_t SIG2_SIZE = 2;
-
-            ImportHeader ret;
-            ret.data.resize(HEADER_SIZE);
-            Checks::check_exit(VCPKG_LINE_INFO, fs.read(&ret.data[0], HEADER_SIZE, 1) == 1);
-
-            const std::string sig1_as_string = ret.data.substr(SIG1_OFFSET, SIG1_SIZE);
-            const auto sig1 = read_uint16_le(sig1_as_string.c_str());
-            Checks::check_exit(VCPKG_LINE_INFO, sig1 == SIG1, "Sig1 was incorrect. Expected %s but got %s", SIG1, sig1);
-
-            const std::string sig2_as_string = ret.data.substr(SIG2_OFFSET, SIG2_SIZE);
-            const auto sig2 = read_uint16_le(sig2_as_string.c_str());
-            Checks::check_exit(VCPKG_LINE_INFO, sig2 == SIG2, "Sig2 was incorrect. Expected %s but got %s", SIG2, sig2);
-
-            return ret;
-        }
-
-        MachineType machine_type() const
-        {
-            static constexpr size_t MACHINE_TYPE_OFFSET = 6;
-            static constexpr size_t MACHINE_TYPE_SIZE = 2;
-
-            std::string machine_field_as_string = data.substr(MACHINE_TYPE_OFFSET, MACHINE_TYPE_SIZE);
-            const auto machine = read_uint16_le(machine_field_as_string.c_str());
-            return to_machine_type(machine);
-        }
-
-    private:
-        std::string data;
-    };
-
-    static void read_and_verify_archive_file_signature(const ReadFilePointer& fs)
-    {
-        static constexpr StringLiteral FILE_START = "!<arch>\n";
-        static constexpr size_t FILE_START_SIZE = 8;
-
-        Checks::check_exit(VCPKG_LINE_INFO, fs.seek(0, SEEK_SET) == 0);
-
-        char file_start[FILE_START_SIZE];
-        Checks::check_exit(VCPKG_LINE_INFO, fs.read(&file_start, FILE_START_SIZE, 1) == 1);
-        verify_equal_strings(VCPKG_LINE_INFO, FILE_START, {file_start, FILE_START_SIZE}, "LIB FILE_START");
-    }
+    static_assert(sizeof(CoffFileHeader) == 20, "The CoffFileHeader struct must match its on-disk representation");
 
     DllInfo read_dll(const ReadFilePointer& fs)
     {
         read_and_verify_pe_signature(fs);
-        CoffFileHeader header = CoffFileHeader::read(fs);
-        const MachineType machine = header.machine_type();
-        return {machine};
+        CoffFileHeader header;
+        Checks::check_exit(VCPKG_LINE_INFO, fs.read(&header, sizeof(header), 1) == 1);
+        return {to_machine_type(header.machine)};
     }
 
-    LibInfo read_lib(const ReadFilePointer& fs)
+    struct ArchiveMemberHeader
     {
-        read_and_verify_archive_file_signature(fs);
+        char name[16];
+        char date[12];
+        char user_id[6];
+        char group_id[6];
+        char mode[8];
+        char size[10];
+        char end_of_header[2];
 
-        // First Linker Member
-        const ArchiveMemberHeader first_linker_member_header = ArchiveMemberHeader::read(fs);
+        void check_end_of_header() const
+        {
+            // The name[0] == '\0' check is for freeglut, see GitHub issue #223
+            Checks::check_exit(
+                VCPKG_LINE_INFO, name[0] == '\0' ||(end_of_header[0] == '`' && end_of_header[1] == '\n'), "Incorrect lib header end");
+        }
+
+        uint64_t decoded_size() const
+        {
+            char size_plus_null[11];
+            memcpy(size_plus_null, size, 10);
+            size_plus_null[10] = '\0';
+            uint64_t value = strtoull(size_plus_null, nullptr, 10);
+            if (value & 1u)
+            {
+                ++value; // align to short
+            }
+
+            return value;
+        }
+    };
+
+    static_assert(sizeof(ArchiveMemberHeader) == 60,
+                  "The ArchiveMemberHeader struct must match its on-disk representation");
+
+    static MachineType read_import_machine_type_after_sig1(const ReadFilePointer& fs)
+    {
+        struct ImportHeaderPrefixAfterSig1
+        {
+            uint16_t sig2;
+            uint16_t version;
+            uint16_t machine;
+        } tmp;
+
+        Checks::check_exit(VCPKG_LINE_INFO, fs.read(&tmp, sizeof(tmp), 1) == 1);
+        Checks::check_exit(VCPKG_LINE_INFO, tmp.sig2 == 0xFFFF, "Import member SIG2 was incorrect");
+        return to_machine_type(tmp.machine);
+    }
+
+    static void read_and_verify_archive_file_signature(const ReadFilePointer& fs)
+    {
+        static constexpr StringLiteral FILE_START = "!<arch>\n";
+        Checks::check_exit(VCPKG_LINE_INFO, fs.seek(0, SEEK_SET) == 0);
+
+        char file_start[FILE_START.size()];
+        Checks::check_exit(VCPKG_LINE_INFO, fs.read(&file_start, FILE_START.size(), 1) == 1);
         Checks::check_exit(VCPKG_LINE_INFO,
-                           first_linker_member_header.name().substr(0, 2) == "/ ",
+                           FILE_START == StringView{file_start, FILE_START.size()},
+                           "Incorrect archive file signature");
+    }
+
+    static void read_and_skip_first_linker_member(const vcpkg::ReadFilePointer& fs)
+    {
+        ArchiveMemberHeader first_linker_member_header;
+        Checks::check_exit(VCPKG_LINE_INFO,
+                           fs.read(&first_linker_member_header, sizeof(first_linker_member_header), 1) == 1);
+        Checks::check_exit(VCPKG_LINE_INFO,
+                           memcmp(first_linker_member_header.name, "/ ", 2) == 0,
                            "Could not find proper first linker member");
-        Checks::check_exit(VCPKG_LINE_INFO, fs.seek(first_linker_member_header.member_size(), SEEK_CUR) == 0);
+        Checks::check_exit(VCPKG_LINE_INFO, fs.seek(first_linker_member_header.decoded_size(), SEEK_CUR) == 0);
+    }
 
-        const ArchiveMemberHeader second_linker_member_header = ArchiveMemberHeader::read(fs);
+    static std::vector<uint32_t> read_second_linker_member_offsets(const vcpkg::ReadFilePointer& fs)
+    {
+        ArchiveMemberHeader second_linker_member_header;
         Checks::check_exit(VCPKG_LINE_INFO,
-                           second_linker_member_header.name().substr(0, 2) == "/ ",
+                           fs.read(&second_linker_member_header, sizeof(second_linker_member_header), 1) == 1);
+        Checks::check_exit(VCPKG_LINE_INFO,
+                           memcmp(second_linker_member_header.name, "/ ", 2) == 0,
                            "Could not find proper second linker member");
 
-        const auto second_size = second_linker_member_header.member_size();
+        const auto second_size = second_linker_member_header.decoded_size();
         // The first 4 bytes contains the number of archive members
         uint32_t archive_member_count;
         Checks::check_exit(VCPKG_LINE_INFO,
@@ -235,31 +153,40 @@ namespace vcpkg::CoffFileReader
         std::sort(offsets.begin(), offsets.end());
         uint64_t leftover = second_size - sizeof(uint32_t) - (archive_member_count * sizeof(uint32_t));
         Checks::check_exit(VCPKG_LINE_INFO, fs.seek(leftover, SEEK_CUR) == 0);
+        return offsets;
+    }
 
-        // const bool has_longname_member_header = peek_value_from_stream<uint16_t>(fs).value_or_exit(VCPKG_LINE_INFO)
-        // == 0x2F2F; if (has_longname_member_header)
-        //{
-        //    const ArchiveMemberHeader longnames_member_header = ArchiveMemberHeader::read(fs);
-        //    marker.advance_by(ArchiveMemberHeader::HEADER_SIZE + longnames_member_header.member_size());
-        //    marker.seek_to_marker(fs);
-        //}
-
-        std::vector<MachineType> machine_types{offsets.size()};
+    static std::vector<MachineType> read_machine_types_from_archive_members(const vcpkg::ReadFilePointer& fs,
+                                                                            const std::vector<uint32_t>& member_offsets)
+    {
+        std::vector<MachineType> machine_types{member_offsets.size()};
         // Next we have the obj and pseudo-object files
-        for (size_t idx = 0; idx < archive_member_count; ++idx)
+        for (size_t idx = 0; idx < member_offsets.size(); ++idx)
         {
-            const auto offset = offsets[idx];
+            const auto offset = member_offsets[idx];
             // Skip the header, no need to read it
-            Checks::check_exit(VCPKG_LINE_INFO, fs.seek(offset + ArchiveMemberHeader::HEADER_SIZE, SEEK_SET) == 0);
-            const auto first_two_bytes = peek_value_from_stream<uint16_t>(fs).value_or_exit(VCPKG_LINE_INFO);
-            const bool is_import_header = to_machine_type(first_two_bytes) == MachineType::UNKNOWN;
-            const MachineType machine =
-                is_import_header ? ImportHeader::read(fs).machine_type() : CoffFileHeader::read(fs).machine_type();
-            machine_types[idx] = machine;
+            Checks::check_exit(VCPKG_LINE_INFO, fs.seek(offset + sizeof(ArchiveMemberHeader), SEEK_SET) == 0);
+            uint16_t machine_type_raw;
+            Checks::check_exit(VCPKG_LINE_INFO, fs.read(&machine_type_raw, sizeof(machine_type_raw), 1) == 1);
+            auto result_machine_type = to_machine_type(machine_type_raw);
+            if (result_machine_type == MachineType::UNKNOWN)
+            {
+                result_machine_type = read_import_machine_type_after_sig1(fs);
+            }
+
+            machine_types[idx] = result_machine_type;
         }
 
         std::sort(machine_types.begin(), machine_types.end());
         machine_types.erase(std::unique(machine_types.begin(), machine_types.end()), machine_types.end());
-        return {std::move(machine_types)};
+        return machine_types;
+    }
+
+    LibInfo read_lib(const ReadFilePointer& fs)
+    {
+        read_and_verify_archive_file_signature(fs);
+        read_and_skip_first_linker_member(fs);
+        const auto offsets = read_second_linker_member_offsets(fs);
+        return {read_machine_types_from_archive_members(fs, offsets)};
     }
 }

--- a/src/vcpkg/base/cofffilereader.cpp
+++ b/src/vcpkg/base/cofffilereader.cpp
@@ -64,8 +64,9 @@ namespace vcpkg::CoffFileReader
         void check_end_of_header() const
         {
             // The name[0] == '\0' check is for freeglut, see GitHub issue #223
-            Checks::check_exit(
-                VCPKG_LINE_INFO, name[0] == '\0' ||(end_of_header[0] == '`' && end_of_header[1] == '\n'), "Incorrect lib header end");
+            Checks::check_exit(VCPKG_LINE_INFO,
+                               name[0] == '\0' || (end_of_header[0] == '`' && end_of_header[1] == '\n'),
+                               "Incorrect lib header end");
         }
 
         uint64_t decoded_size() const

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -896,7 +896,7 @@ namespace vcpkg
                 const auto this_read = file.read(buffer, 1, buffer_size);
                 if (this_read != 0)
                 {
-                    output.append({buffer, this_read});
+                    output.on_data({buffer, this_read});
                 }
                 else if (file.error())
                 {

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -283,7 +283,7 @@ namespace vcpkg
 #if defined(_WIN32)
         ec.assign(::_wfopen_s(&m_fs, file_path.c_str(), L"rb"), std::generic_category());
 #else // ^^^ _WIN32 / !_WIN32 vvv
-        m_fs = ::fopen(path.c_str(), "rb");
+        m_fs = ::fopen(file_path.c_str(), "rb");
         if (m_fs)
         {
             ec.clear();
@@ -300,7 +300,7 @@ namespace vcpkg
 #if defined(_WIN32)
         ec.assign(::_wfopen_s(&m_fs, file_path.c_str(), L"wb"), std::generic_category());
 #else // ^^^ _WIN32 / !_WIN32 vvv
-        m_fs = ::fopen(path.c_str(), "wb");
+        m_fs = ::fopen(file_path.c_str(), "wb");
         if (m_fs)
         {
             ec.clear();

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -278,6 +278,94 @@ namespace vcpkg
         return std::move(normalized);
     }
 
+    ReadFilePointer::ReadFilePointer(const path& file_path, std::error_code& ec) noexcept
+    {
+#if defined(_WIN32)
+        ec.assign(::_wfopen_s(&m_fs, file_path.c_str(), L"rb"), std::generic_category());
+#else // ^^^ _WIN32 / !_WIN32 vvv
+        m_fs = ::fopen(path.c_str(), "rb");
+        if (m_fs)
+        {
+            ec.clear();
+        }
+        else
+        {
+            ec.assign(errno, std::generic_category());
+        }
+#endif // ^^^ !_WIN32
+    }
+
+    WriteFilePointer::WriteFilePointer(const path& file_path, std::error_code& ec) noexcept
+    {
+#if defined(_WIN32)
+        ec.assign(::_wfopen_s(&m_fs, file_path.c_str(), L"wb"), std::generic_category());
+#else // ^^^ _WIN32 / !_WIN32 vvv
+        m_fs = ::fopen(path.c_str(), "wb");
+        if (m_fs)
+        {
+            ec.clear();
+        }
+        else
+        {
+            ec.assign(errno, std::generic_category());
+        }
+#endif // ^^^ !_WIN32
+    }
+
+    void LinesCollector::append(const char* data, size_t data_size)
+    {
+        struct IsNewline
+        {
+            bool operator()(const char c) const noexcept { return c == '\n' || c == '\r'; }
+        };
+
+        static constexpr IsNewline is_newline;
+
+        {
+            const auto after_newline = std::find_if_not(data, data + data_size, is_newline);
+            data_size -= after_newline - data;
+            data = after_newline;
+        }
+
+        while (data_size != 0)
+        {
+            const auto end = data + data_size;
+            const auto newline = std::find_if(data, end, is_newline);
+            if (newline == end)
+            {
+                previous_partial.append(data, newline - data);
+                return;
+            }
+            else if (previous_partial.empty())
+            {
+                results.emplace_back(data, newline - data);
+            }
+            else
+            {
+                previous_partial.append(data, newline - data);
+                results.push_back(std::move(previous_partial));
+                previous_partial.clear();
+            }
+
+            const auto after_newline = std::find_if_not(newline, end, is_newline);
+            data_size -= after_newline - data;
+            data = after_newline;
+        }
+    }
+
+    std::vector<std::string> LinesCollector::extract()
+    {
+        if (!previous_partial.empty())
+        {
+            results.push_back(std::move(previous_partial));
+            previous_partial.clear();
+        }
+
+        auto ret = std::move(results);
+        results.clear();
+        return ret;
+    }
+
     static const std::regex FILESYSTEM_INVALID_CHARACTERS_REGEX = std::regex(R"([\/:*?"<>|])");
 
     namespace
@@ -789,52 +877,91 @@ namespace vcpkg
         }
     }
 
+    ReadFilePointer Filesystem::read_file(LineInfo li, const path& file_path) const
+    {
+        std::error_code ec;
+        auto ret = this->read_file(file_path, ec);
+        if (ec)
+        {
+            Checks::exit_with_message(li, "Could not open file %s for reading (%s)", u8string(file_path), ec.message());
+        }
+
+        return ret;
+    }
+
+    WriteFilePointer Filesystem::write_file(LineInfo li, const path& file_path)
+    {
+        std::error_code ec;
+        auto ret = this->write_file(file_path, ec);
+        if (ec)
+        {
+            Checks::exit_with_message(li, "Could not open file %s for writing (%s)", u8string(file_path), ec.message());
+        }
+
+        return ret;
+    }
+
     struct RealFilesystem final : Filesystem
     {
         virtual Expected<std::string> read_contents(const path& file_path) const override
         {
-            std::fstream file_stream(file_path, std::ios_base::in | std::ios_base::binary);
-            if (file_stream.fail())
+            std::error_code ec;
+            ReadFilePointer file{file_path, ec};
+            if (ec)
             {
                 Debug::print("Failed to open: ", vcpkg::u8string(file_path), '\n');
-                return std::make_error_code(std::errc::no_such_file_or_directory);
-            }
-
-            file_stream.seekg(0, file_stream.end);
-            auto length = file_stream.tellg();
-            file_stream.seekg(0, file_stream.beg);
-
-            if (length == std::streampos(-1))
-            {
-                return std::make_error_code(std::errc::io_error);
+                return ec;
             }
 
             std::string output;
-            output.resize(static_cast<size_t>(length));
-            file_stream.read(&output[0], length);
+            constexpr std::size_t buffer_size = 1024 * 32;
+            char buffer[buffer_size];
+            do
+            {
+                const auto this_read = file.read(buffer, 1, buffer_size);
+                if (this_read != 0)
+                {
+                    output.append(buffer, this_read);
+                }
+                else if (file.error())
+                {
+                    ec = std::io_errc::stream;
+                    return std::string();
+                }
+            } while (!file.eof());
 
             return output;
         }
         virtual Expected<std::vector<std::string>> read_lines(const path& file_path) const override
         {
-            std::fstream file_stream(file_path, std::ios_base::in | std::ios_base::binary);
-            if (file_stream.fail())
+            std::error_code ec;
+            ReadFilePointer file{file_path, ec};
+            if (ec)
             {
                 Debug::print("Failed to open: ", vcpkg::u8string(file_path), '\n');
-                return std::make_error_code(std::errc::no_such_file_or_directory);
+                return ec;
             }
-            std::vector<std::string> output;
-            std::string line;
-            while (std::getline(file_stream, line))
+
+            LinesCollector output;
+            constexpr std::size_t buffer_size = 1024 * 32;
+            char buffer[buffer_size];
+            do
             {
-                // Remove the trailing \r to accomodate Windows line endings.
-                if ((!line.empty()) && (line.back() == '\r')) line.pop_back();
+                const auto this_read = file.read(buffer, 1, buffer_size);
+                if (this_read != 0)
+                {
+                    output.append(buffer, this_read);
+                }
+                else if (file.error())
+                {
+                    ec = std::io_errc::stream;
+                    return std::vector<std::string>();
+                }
+            } while (!file.eof());
 
-                output.push_back(line);
-            }
-
-            return output;
+            return output.extract();
         }
+
         virtual path find_file_recursively_up(const path& starting_dir, const path& filename) const override
         {
             path current_dir = starting_dir;
@@ -909,24 +1036,17 @@ namespace vcpkg
                                  const std::vector<std::string>& lines,
                                  std::error_code& ec) override
         {
-            std::fstream output(file_path, std::ios_base::out | std::ios_base::binary | std::ios_base::trunc);
-            auto first = lines.begin();
-            const auto last = lines.end();
-            for (;;)
+            vcpkg::WriteFilePointer output{file_path, ec};
+            if (!ec)
             {
-                if (!output)
+                for (const auto& line : lines)
                 {
-                    ec.assign(static_cast<int>(std::errc::io_error), std::generic_category());
-                    return;
+                    if (output.write(line.c_str(), 1, line.size()) != line.size() || output.put('\n') != '\n')
+                    {
+                        ec.assign(errno, std::generic_category());
+                        return;
+                    }
                 }
-
-                if (first == last)
-                {
-                    return;
-                }
-
-                output << *first << "\n";
-                ++first;
             }
         }
         virtual void rename(const path& old_path, const path& new_path, std::error_code& ec) override
@@ -1496,6 +1616,16 @@ namespace vcpkg
             }
 
             return ret;
+        }
+
+        virtual ReadFilePointer read_file(const path& file_path, std::error_code& ec) const override
+        {
+            return ReadFilePointer{file_path, ec};
+        }
+
+        virtual WriteFilePointer write_file(const path& file_path, std::error_code& ec) override
+        {
+            return WriteFilePointer{file_path, ec};
         }
     };
 

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -823,10 +823,10 @@ namespace vcpkg
         }
     }
 
-    ReadFilePointer Filesystem::read_file(LineInfo li, const path& file_path) const
+    ReadFilePointer Filesystem::open_for_read(LineInfo li, const path& file_path) const
     {
         std::error_code ec;
-        auto ret = this->read_file(file_path, ec);
+        auto ret = this->open_for_read(file_path, ec);
         if (ec)
         {
             Checks::exit_with_message(li, "Could not open file %s for reading (%s)", u8string(file_path), ec.message());
@@ -835,10 +835,10 @@ namespace vcpkg
         return ret;
     }
 
-    WriteFilePointer Filesystem::write_file(LineInfo li, const path& file_path)
+    WriteFilePointer Filesystem::open_for_write(LineInfo li, const path& file_path)
     {
         std::error_code ec;
-        auto ret = this->write_file(file_path, ec);
+        auto ret = this->open_for_write(file_path, ec);
         if (ec)
         {
             Checks::exit_with_message(li, "Could not open file %s for writing (%s)", u8string(file_path), ec.message());
@@ -1564,12 +1564,12 @@ namespace vcpkg
             return ret;
         }
 
-        virtual ReadFilePointer read_file(const path& file_path, std::error_code& ec) const override
+        virtual ReadFilePointer open_for_read(const path& file_path, std::error_code& ec) const override
         {
             return ReadFilePointer{file_path, ec};
         }
 
-        virtual WriteFilePointer write_file(const path& file_path, std::error_code& ec) override
+        virtual WriteFilePointer open_for_write(const path& file_path, std::error_code& ec) override
         {
             return WriteFilePointer{file_path, ec};
         }

--- a/src/vcpkg/base/hash.cpp
+++ b/src/vcpkg/base/hash.cpp
@@ -666,7 +666,7 @@ namespace vcpkg::Hash
 
     std::string get_file_hash(const Filesystem& fs, const path& path, Algorithm algo, std::error_code& ec) noexcept
     {
-        auto file = fs.read_file(path, ec);
+        auto file = fs.open_for_read(path, ec);
         if (ec)
         {
             return std::string();

--- a/src/vcpkg/base/hash.cpp
+++ b/src/vcpkg/base/hash.cpp
@@ -664,37 +664,31 @@ namespace vcpkg::Hash
         return get_bytes_hash(sv.data(), sv.data() + sv.size(), algo);
     }
 
-    // TODO: use Filesystem to open a file
-    std::string get_file_hash(const Filesystem&, const path& target, Algorithm algo, std::error_code& ec) noexcept
+    std::string get_file_hash(const Filesystem& fs, const path& path, Algorithm algo, std::error_code& ec) noexcept
     {
-        auto file = std::fstream(target.c_str(), std::ios_base::in | std::ios_base::binary);
-        if (!file)
+        auto file = fs.read_file(path, ec);
+        if (ec)
         {
-            ec.assign(ENOENT, std::system_category());
-            return {};
+            return std::string();
         }
 
         return do_hash(algo, [&file, &ec](Hasher& hasher) {
             constexpr std::size_t buffer_size = 1024 * 32;
-            auto buffer = std::make_unique<char[]>(buffer_size);
-            for (;;)
+            char buffer[buffer_size];
+            do
             {
-                file.read(buffer.get(), buffer_size);
-                if (file.eof())
+                const auto this_read = file.read(buffer, 1, buffer_size);
+                if (this_read != 0)
                 {
-                    hasher.add_bytes(buffer.get(), buffer.get() + file.gcount());
-                    return hasher.get_hash();
+                    hasher.add_bytes(buffer, buffer + this_read);
                 }
-                else if (file)
-                {
-                    hasher.add_bytes(buffer.get(), buffer.get() + buffer_size);
-                }
-                else
+                else if (file.error())
                 {
                     ec = std::io_errc::stream;
                     return std::string();
                 }
-            }
+            } while (!file.eof());
+            return hasher.get_hash();
         });
     }
 }

--- a/src/vcpkg/base/strings.cpp
+++ b/src/vcpkg/base/strings.cpp
@@ -373,18 +373,20 @@ namespace vcpkg::Strings
 
             return result;
         }
+
+            struct LinesCollectorCallback
+        {
+            LinesCollector* parent;
+
+            void operator()(const StringView sv) const { parent->lines.push_back(sv.to_string()); }
+        };
     }
 
     std::string b32_encode(std::uint64_t x) noexcept { return b32_encode_implementation(x); }
 
-    struct LinesCollector::CB
-    {
-        LinesCollector* parent;
 
-        void operator()(const StringView sv) const { parent->lines.push_back(sv.to_string()); }
-    };
 
-    void LinesCollector::append(StringView sv) { stream.on_data(sv, CB{this}); }
+    void LinesCollector::on_data(StringView sv) { stream.on_data(sv, CB{this}); }
     std::vector<std::string> LinesCollector::extract()
     {
         stream.on_end(CB{this});

--- a/src/vcpkg/base/strings.cpp
+++ b/src/vcpkg/base/strings.cpp
@@ -377,4 +377,18 @@ namespace vcpkg::Strings
 
     std::string b32_encode(std::uint64_t x) noexcept { return b32_encode_implementation(x); }
 
+    struct LinesCollector::CB
+    {
+        LinesCollector* parent;
+
+        void operator()(const StringView sv) const { parent->lines.push_back(sv.to_string()); }
+    };
+
+    void LinesCollector::append(StringView sv) { stream.on_data(sv, CB{this}); }
+    std::vector<std::string> LinesCollector::extract()
+    {
+        stream.on_end(CB{this});
+        return std::move(this->lines);
+    }
+
 }

--- a/src/vcpkg/base/strings.cpp
+++ b/src/vcpkg/base/strings.cpp
@@ -373,18 +373,16 @@ namespace vcpkg::Strings
 
             return result;
         }
-
-            struct LinesCollectorCallback
-        {
-            LinesCollector* parent;
-
-            void operator()(const StringView sv) const { parent->lines.push_back(sv.to_string()); }
-        };
     }
 
     std::string b32_encode(std::uint64_t x) noexcept { return b32_encode_implementation(x); }
 
+    struct LinesCollector::CB
+    {
+        LinesCollector* parent;
 
+        void operator()(const StringView sv) const { parent->lines.push_back(sv.to_string()); }
+    };
 
     void LinesCollector::on_data(StringView sv) { stream.on_data(sv, CB{this}); }
     std::vector<std::string> LinesCollector::extract()

--- a/src/vcpkg/base/strings.cpp
+++ b/src/vcpkg/base/strings.cpp
@@ -7,7 +7,6 @@
 #include <stdio.h>
 
 #include <algorithm>
-#include <locale>
 #include <string>
 #include <vector>
 

--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -693,36 +693,41 @@ namespace vcpkg::Build
                                err.value());
         }
         auto stdoutlog = buildpath / ("stdout-" + triplet.canonical_name() + ".log");
-        std::ofstream out_file(stdoutlog.native().c_str(), std::ios::out | std::ios::binary | std::ios::trunc);
-        Checks::check_exit(VCPKG_LINE_INFO, out_file, "Failed to open '%s' for writing", vcpkg::u8string(stdoutlog));
         CompilerInfo compiler_info;
         std::string buf;
-        int rc = cmd_execute_and_stream_lines(
-            command,
-            [&](StringView s) {
-                static const StringLiteral s_hash_marker = "#COMPILER_HASH#";
-                if (Strings::starts_with(s, s_hash_marker))
-                {
-                    compiler_info.hash = s.data() + s_hash_marker.size();
-                }
-                static const StringLiteral s_version_marker = "#COMPILER_CXX_VERSION#";
-                if (Strings::starts_with(s, s_version_marker))
-                {
-                    compiler_info.version = s.data() + s_version_marker.size();
-                }
-                static const StringLiteral s_id_marker = "#COMPILER_CXX_ID#";
-                if (Strings::starts_with(s, s_id_marker))
-                {
-                    compiler_info.id = s.data() + s_id_marker.size();
-                }
-                Debug::print(s, '\n');
-                Strings::append(buf, s, '\n');
-                out_file.write(s.data(), s.size()).put('\n');
-                Checks::check_exit(
-                    VCPKG_LINE_INFO, out_file, "Error occurred while writing '%s'", vcpkg::u8string(stdoutlog));
-            },
-            env);
-        out_file.close();
+
+        int rc;
+        {
+            const auto out_file = fs.write_file(VCPKG_LINE_INFO, stdoutlog);
+            rc = cmd_execute_and_stream_lines(
+                command,
+                [&](StringView s) {
+                    static const StringLiteral s_hash_marker = "#COMPILER_HASH#";
+                    if (Strings::starts_with(s, s_hash_marker))
+                    {
+                        compiler_info.hash = s.data() + s_hash_marker.size();
+                    }
+                    static const StringLiteral s_version_marker = "#COMPILER_CXX_VERSION#";
+                    if (Strings::starts_with(s, s_version_marker))
+                    {
+                        compiler_info.version = s.data() + s_version_marker.size();
+                    }
+                    static const StringLiteral s_id_marker = "#COMPILER_CXX_ID#";
+                    if (Strings::starts_with(s, s_id_marker))
+                    {
+                        compiler_info.id = s.data() + s_id_marker.size();
+                    }
+                    Debug::print(s, '\n');
+                    const auto old_buf_size = buf.size();
+                    Strings::append(buf, s, '\n');
+                    const auto write_size = buf.size() - old_buf_size;
+                    Checks::check_exit(VCPKG_LINE_INFO,
+                                       out_file.write(buf.c_str() + old_buf_size, 1, write_size) == write_size,
+                                       "Error occurred while writing '%s'",
+                                       u8string(stdoutlog));
+                },
+                env);
+        } // close out_file
 
         if (compiler_info.hash.empty() || rc != 0)
         {
@@ -921,18 +926,20 @@ namespace vcpkg::Build
                                err.value());
         }
         auto stdoutlog = buildpath / ("stdout-" + action.spec.triplet().canonical_name() + ".log");
-        std::ofstream out_file(stdoutlog.native().c_str(), std::ios::out | std::ios::binary | std::ios::trunc);
-        Checks::check_exit(VCPKG_LINE_INFO, out_file, "Failed to open '%s' for writing", vcpkg::u8string(stdoutlog));
-        const int return_code = cmd_execute_and_stream_data(
-            command,
-            [&](StringView sv) {
-                print2(sv);
-                out_file.write(sv.data(), sv.size());
-                Checks::check_exit(
-                    VCPKG_LINE_INFO, out_file, "Error occurred while writing '%s'", vcpkg::u8string(stdoutlog));
-            },
-            env);
-        out_file.close();
+        int return_code;
+        {
+            auto out_file = fs.write_file(VCPKG_LINE_INFO, stdoutlog);
+            return_code = cmd_execute_and_stream_data(
+                command,
+                [&](StringView sv) {
+                    print2(sv);
+                    Checks::check_exit(VCPKG_LINE_INFO,
+                                       out_file.write(sv.data(), 1, sv.size()) == sv.size(),
+                                       "Error occurred while writing '%s'",
+                                       u8string(stdoutlog));
+                },
+                env);
+        } // close out_file
 
         // With the exception of empty packages, builds in "Download Mode" always result in failure.
         if (action.build_options.only_downloads == Build::OnlyDownloads::YES)

--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -698,7 +698,7 @@ namespace vcpkg::Build
 
         int rc;
         {
-            const auto out_file = fs.write_file(VCPKG_LINE_INFO, stdoutlog);
+            const auto out_file = fs.open_for_write(VCPKG_LINE_INFO, stdoutlog);
             rc = cmd_execute_and_stream_lines(
                 command,
                 [&](StringView s) {
@@ -928,7 +928,7 @@ namespace vcpkg::Build
         auto stdoutlog = buildpath / ("stdout-" + action.spec.triplet().canonical_name() + ".log");
         int return_code;
         {
-            auto out_file = fs.write_file(VCPKG_LINE_INFO, stdoutlog);
+            auto out_file = fs.open_for_write(VCPKG_LINE_INFO, stdoutlog);
             return_code = cmd_execute_and_stream_data(
                 command,
                 [&](StringView sv) {

--- a/src/vcpkg/commands.format-manifest.cpp
+++ b/src/vcpkg/commands.format-manifest.cpp
@@ -94,7 +94,7 @@ namespace
         };
     }
 
-    void write_file(Filesystem& fs, const ToWrite& data)
+    void open_for_write(Filesystem& fs, const ToWrite& data)
     {
         auto original_path_string = vcpkg::u8string(data.original_path);
         auto file_to_write_string = vcpkg::u8string(data.file_to_write);
@@ -267,7 +267,7 @@ namespace vcpkg::Commands::FormatManifest
 
         for (auto const& el : to_write)
         {
-            write_file(fs, el);
+            open_for_write(fs, el);
         }
 
         if (has_error)

--- a/src/vcpkg/metrics.cpp
+++ b/src/vcpkg/metrics.cpp
@@ -447,7 +447,7 @@ namespace vcpkg::Metrics
         const std::string payload = g_metricmessage.format_event_data_template();
         if (g_should_print_metrics)
         {
-            fprintf(stderr, "%s", payload.c_str());
+            fprintf(stderr, "%s\n", payload.c_str());
         }
 
         if (!g_should_send_metrics)

--- a/src/vcpkg/metrics.cpp
+++ b/src/vcpkg/metrics.cpp
@@ -425,7 +425,7 @@ namespace vcpkg::Metrics
 #ifndef NDEBUG
             __debugbreak();
             auto err = GetLastError();
-            std::cerr << "[DEBUG] failed to connect to server: " << err << "\n";
+            fprintf(stderr, "[DEBUG] failed to connect to server: %08lu\n", err);
 #endif // NDEBUG
         }
 
@@ -445,8 +445,15 @@ namespace vcpkg::Metrics
         }
 
         const std::string payload = g_metricmessage.format_event_data_template();
-        if (g_should_print_metrics) std::cerr << payload << "\n";
-        if (!g_should_send_metrics) return;
+        if (g_should_print_metrics)
+        {
+            fprintf(stderr, "%s", payload.c_str());
+        }
+
+        if (!g_should_send_metrics)
+        {
+            return;
+        }
 
 #if defined(_WIN32)
         wchar_t temp_folder[MAX_PATH];

--- a/src/vcpkg/postbuildlint.cpp
+++ b/src/vcpkg/postbuildlint.cpp
@@ -537,7 +537,7 @@ namespace vcpkg::PostBuildLint
                                file.extension() == dot_dll,
                                "The file extension was not .dll: %s",
                                generic_u8string(file));
-            const CoffFileReader::DllInfo info = CoffFileReader::read_dll(fs.read_file(VCPKG_LINE_INFO, file));
+            const CoffFileReader::DllInfo info = CoffFileReader::read_dll(fs.open_for_read(VCPKG_LINE_INFO, file));
             const std::string actual_architecture = get_actual_architecture(info.machine_type);
 
             if (expected_architecture != actual_architecture)
@@ -570,7 +570,7 @@ namespace vcpkg::PostBuildLint
                                file.extension() == dot_lib,
                                "The file extension was not .lib: %s",
                                generic_u8string(file));
-            CoffFileReader::LibInfo info = CoffFileReader::read_lib(fs.read_file(VCPKG_LINE_INFO, file));
+            CoffFileReader::LibInfo info = CoffFileReader::read_lib(fs.open_for_read(VCPKG_LINE_INFO, file));
 
             // This is zero for folly's debug library
             // TODO: Why?

--- a/src/vcpkg/postbuildlint.cpp
+++ b/src/vcpkg/postbuildlint.cpp
@@ -596,6 +596,7 @@ namespace vcpkg::PostBuildLint
 #endif
         (void)expected_architecture;
         (void)files;
+        (void)fs;
         return LintStatus::SUCCESS;
     }
 


### PR DESCRIPTION
I did this work as a prerequiste of z-applocal in attempt to reduce code size; on Windows anyway it doesn't help much because we still depend on std::regex which drags in all of the locale support stuff. I still think it's a good change though.