### PR TITLE
increase timeouts for downloads

### DIFF
--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -99,7 +99,8 @@ namespace vcpkg::Downloads
             ret.m_hSession.reset(h);
 
             // Increase default timeouts to help connections behind proxies
-            //WinHttpSetTimeouts(HINTERNET hInternet, int nResolveTimeout, int nConnectTimeout, int nSendTimeout, int nReceiveTimeout);
+            // WinHttpSetTimeouts(HINTERNET hInternet, int nResolveTimeout, int nConnectTimeout, int nSendTimeout, int
+            // nReceiveTimeout);
             WinHttpSetTimeouts(h, 0, 120000, 120000, 120000);
 
             // If the environment variable HTTPS_PROXY is set

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -98,6 +98,10 @@ namespace vcpkg::Downloads
             WinHttpSession ret;
             ret.m_hSession.reset(h);
 
+            // Increase default timeouts to help connections behind proxies
+            //WinHttpSetTimeouts(HINTERNET hInternet, int nResolveTimeout, int nConnectTimeout, int nSendTimeout, int nReceiveTimeout);
+            WinHttpSetTimeouts(h, 0, 120000, 120000, 120000);
+
             // If the environment variable HTTPS_PROXY is set
             // use that variable as proxy. This situation might exist when user is in a company network
             // with restricted network/proxy settings


### PR DESCRIPTION
it might ease with errors like https://github.com/microsoft/vcpkg/issues/7207, https://github.com/microsoft/vcpkg/issues/18734

see also https://github.com/microsoft/vcpkg/pull/18171 for related issues with using vcpkg as a download tool