### PR TITLE
Teach vcpkg fetch to handle msi files

### DIFF
--- a/azure-pipelines/end-to-end-tests-dir/cli.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/cli.ps1
@@ -7,5 +7,5 @@ Throw-IfNotFailed
 Run-Vcpkg -TestArgs ($commonArgs + @("install", "zlib", "--vcpkg-rootttttt=C:\"))
 Throw-IfNotFailed
 
-Run-Vcpkg -TestArgs ($commonArgs + @("install", "zlib", "--fast")) # NB: --fast is not a switch
+Run-Vcpkg -TestArgs ($commonArgs + @("install", "zlib", "--fast")) # --fast is not a switch
 Throw-IfNotFailed

--- a/azure-pipelines/end-to-end-tests-dir/fetch.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/fetch.ps1
@@ -1,0 +1,37 @@
+. $PSScriptRoot/../end-to-end-tests-prelude.ps1
+
+if (-not $IsMacOS -and -not $IsLinux) {
+    "" | Out-File -enc ascii $(Join-Path $TestingRoot .vcpkg-root)
+
+    $Scripts = Join-Path $TestingRoot "scripts"
+    mkdir $Scripts | Out-Null
+
+@"
+<?xml version="1.0"?>
+<tools version="2">
+    <tool name="7zip" os="windows">
+        <version>19.00</version>
+        <exeRelativePath>Files\7-Zip\7z.exe</exeRelativePath>
+        <url>https://www.7-zip.org/a/7z1900-x64.msi</url>
+        <sha512>7837a8677a01eed9c3309923f7084bc864063ba214ee169882c5b04a7a8b198ed052c15e981860d9d7952c98f459a4fab87a72fd78e7d0303004dcb86f4324c8</sha512>
+        <archiveName>7z1900-x64.msi</archiveName>
+    </tool>
+    <tool name="ninja-testing" os="windows">
+        <version>1.10.2</version>
+        <exeRelativePath>ninja.exe</exeRelativePath>
+        <url>https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-win.zip</url>
+        <sha512>6004140d92e86afbb17b49c49037ccd0786ce238f340f7d0e62b4b0c29ed0d6ad0bab11feda2094ae849c387d70d63504393714ed0a1f4d3a1f155af7a4f1ba3</sha512>
+        <archiveName>ninja-win-1.10.2.zip</archiveName>
+    </tool>
+</tools>
+"@ | % { $_ -replace "`r","" } | Out-File -enc ascii $(Join-Path $Scripts "vcpkgTools.xml")
+
+    $env:VCPKG_DOWNLOADS = Join-Path $TestingRoot 'down loads'
+    Run-Vcpkg -TestArgs ($commonArgs + @("fetch", "7zip", "--vcpkg-root=$TestingRoot"))
+    Throw-IfFailed
+    Require-FileExists "$TestingRoot/down loads/tools/7zip-19.00-windows/Files/7-Zip/7z.exe"
+
+    Run-Vcpkg -TestArgs ($commonArgs + @("fetch", "ninja-testing", "--vcpkg-root=$TestingRoot"))
+    Throw-IfFailed
+    Require-FileExists "$TestingRoot/down loads/tools/ninja-testing-1.10.2-windows/ninja.exe"
+}

--- a/src/vcpkg/archives.cpp
+++ b/src/vcpkg/archives.cpp
@@ -63,7 +63,7 @@ namespace vcpkg::Archives
             Checks::check_exit(VCPKG_LINE_INFO,
                                code_and_output.exit_code == 0,
                                "Failed to extract '%s' with message:\n%s",
-                               vcpkg::u8string(archive),
+                               u8string(archive),
                                code_and_output.output);
             recursion_limiter_sevenzip_old = false;
         }
@@ -75,6 +75,7 @@ namespace vcpkg::Archives
                 Command{"cmd"}
                     .string_arg("/c")
                     .string_arg("msiexec")
+                    // "/a" is administrative mode, which unpacks without modifying the system
                     .string_arg("/a")
                     .path_arg(archive)
                     .string_arg("/qn")

--- a/src/vcpkg/archives.cpp
+++ b/src/vcpkg/archives.cpp
@@ -107,7 +107,7 @@ namespace vcpkg::Archives
             recursion_limiter_sevenzip = false;
         }
 #else
-        if (ext == ".gz" && ext.extension() != ".tar")
+        if (ext == ".gz")
         {
             const auto code =
                 cmd_execute(Command{"tar"}.string_arg("xzf").path_arg(archive), InWorkingDirectory{to_path_partial});
@@ -122,7 +122,7 @@ namespace vcpkg::Archives
         }
         else
         {
-            Checks::exit_maybe_upgrade(VCPKG_LINE_INFO, "Unexpected archive extension: %s", vcpkg::u8string(ext));
+            Checks::exit_maybe_upgrade(VCPKG_LINE_INFO, "Unexpected archive extension: %s", ext);
         }
 #endif
 


### PR DESCRIPTION
This PR adds `.msi` support to `vcpkg fetch` in order to enable upgrading 7zip to a more recent version (19.00). We must use the MSI package because it is one of the few formats that can be supported on a completely stock Windows machine.

Once this change is applied, we'll replace the 7zip entry in `vcpkgTools.xml` with:

```xml
    <tool name="7zip" os="windows">
        <version>19.00</version>
        <exeRelativePath>Files\7-Zip\7z.exe</exeRelativePath>
        <url>https://www.7-zip.org/a/7z1900-x64.msi</url>
        <sha512>7837a8677a01eed9c3309923f7084bc864063ba214ee169882c5b04a7a8b198ed052c15e981860d9d7952c98f459a4fab87a72fd78e7d0303004dcb86f4324c8</sha512>
        <archiveName>7z1900-x64.msi</archiveName>
    </tool>
```

As a side benefit, this allows us to use 7zip to unpack `.nupkg` files in the future, since we will no longer require nuget to unpack 7zip.