### PR TITLE
stdfs::copy_options -> copy_options

### DIFF
--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -1315,7 +1315,7 @@ namespace vcpkg::Build
                                                       ec.value()));
         }
 
-        filesystem.copy_file(abi_file, abi_file_in_package, stdfs::copy_options::none, ec);
+        filesystem.copy_file(abi_file, abi_file_in_package, copy_options::none, ec);
         if (ec)
         {
             Checks::exit_with_message(VCPKG_LINE_INFO,

--- a/src/vcpkg/commands.ci.cpp
+++ b/src/vcpkg/commands.ci.cpp
@@ -64,7 +64,7 @@ namespace
                 for (const path& p : children)
                 {
                     filesystem.copy_file(
-                        p, target_path / p.filename(), stdfs::copy_options::overwrite_existing, VCPKG_LINE_INFO);
+                        p, target_path / p.filename(), copy_options::overwrite_existing, VCPKG_LINE_INFO);
                 }
             }
         }

--- a/src/vcpkg/commands.integrate.cpp
+++ b/src/vcpkg/commands.integrate.cpp
@@ -259,8 +259,7 @@ namespace vcpkg::Commands::Integrate
                               VCPKG_LINE_INFO);
             auto appdata_dst_path = get_appdata_targets_path();
 
-            const auto rc =
-                fs.copy_file(appdata_src_path, appdata_dst_path, stdfs::copy_options::overwrite_existing, ec);
+            const auto rc = fs.copy_file(appdata_src_path, appdata_dst_path, copy_options::overwrite_existing, ec);
 
             if (!rc || ec)
             {
@@ -279,8 +278,7 @@ namespace vcpkg::Commands::Integrate
                               VCPKG_LINE_INFO);
             auto appdata_dst_path2 = get_appdata_props_path();
 
-            const auto rc2 =
-                fs.copy_file(appdata_src_path2, appdata_dst_path2, stdfs::copy_options::overwrite_existing, ec);
+            const auto rc2 = fs.copy_file(appdata_src_path2, appdata_dst_path2, copy_options::overwrite_existing, ec);
 
             if (!rc2 || ec)
             {

--- a/src/vcpkg/export.cpp
+++ b/src/vcpkg/export.cpp
@@ -264,7 +264,7 @@ namespace vcpkg::Export
             const path source = paths.root / file;
             path destination = raw_exported_dir_path / file;
             fs.create_directories(destination.parent_path(), ignore_errors);
-            fs.copy_file(source, destination, stdfs::copy_options::overwrite_existing, VCPKG_LINE_INFO);
+            fs.copy_file(source, destination, copy_options::overwrite_existing, VCPKG_LINE_INFO);
         }
         fs.write_contents(raw_exported_dir_path / vcpkg::u8path(".vcpkg-root"), "", VCPKG_LINE_INFO);
     }

--- a/src/vcpkg/export.ifw.cpp
+++ b/src/vcpkg/export.ifw.cpp
@@ -307,7 +307,7 @@ namespace vcpkg::Export::IFW
                                !ec,
                                "Could not create directory for package file %s",
                                vcpkg::generic_u8string(tempmaintenancetool));
-            fs.copy_file(installerbase_exe, tempmaintenancetool, stdfs::copy_options::overwrite_existing, ec);
+            fs.copy_file(installerbase_exe, tempmaintenancetool, copy_options::overwrite_existing, ec);
             Checks::check_exit(
                 VCPKG_LINE_INFO, !ec, "Could not write package file %s", vcpkg::generic_u8string(tempmaintenancetool));
 
@@ -336,7 +336,7 @@ namespace vcpkg::Export::IFW
                               VCPKG_LINE_INFO);
             const path script_source = paths.root / "scripts" / "ifw" / "maintenance.qs";
             const path script_destination = ifw_packages_dir_path / "maintenance" / "meta" / "maintenance.qs";
-            fs.copy_file(script_source, script_destination, stdfs::copy_options::overwrite_existing, ec);
+            fs.copy_file(script_source, script_destination, copy_options::overwrite_existing, ec);
             Checks::check_exit(
                 VCPKG_LINE_INFO, !ec, "Could not write package file %s", vcpkg::generic_u8string(script_destination));
 

--- a/src/vcpkg/export.prefab.cpp
+++ b/src/vcpkg/export.prefab.cpp
@@ -444,7 +444,7 @@ namespace vcpkg::Export::Prefab
 
             utils.copy_file(share_root / "share" / name / "copyright",
                             meta_dir / "LICENSE",
-                            stdfs::copy_options::overwrite_existing,
+                            copy_options::overwrite_existing,
                             error_code);
 
             PackageMetadata pm;
@@ -560,7 +560,7 @@ namespace vcpkg::Export::Prefab
                     path module_meta_path = module_dir / vcpkg::u8path("module.json");
                     utils.write_contents(module_meta_path, meta.to_json(), VCPKG_LINE_INFO);
 
-                    utils.copy(installed_headers_dir, exported_headers_dir, stdfs::copy_options::recursive);
+                    utils.copy(installed_headers_dir, exported_headers_dir, copy_options::recursive);
                     break;
                 }
                 else
@@ -604,10 +604,8 @@ namespace vcpkg::Export::Prefab
                         path installed_module_path = libs / module.filename();
                         path exported_module_path = module_libs_dir / module.filename();
 
-                        utils.copy_file(installed_module_path,
-                                        exported_module_path,
-                                        stdfs::copy_options::overwrite_existing,
-                                        error_code);
+                        utils.copy_file(
+                            installed_module_path, exported_module_path, copy_options::overwrite_existing, error_code);
                         if (prefab_options.enable_debug)
                         {
                             print2(Strings::format("\tCopying libs\n\tFrom %s\n\tTo %s\n",
@@ -624,7 +622,7 @@ namespace vcpkg::Export::Prefab
                                                    vcpkg::generic_u8string(exported_headers_dir)));
                         }
 
-                        utils.copy(installed_headers_dir, exported_headers_dir, stdfs::copy_options::recursive);
+                        utils.copy(installed_headers_dir, exported_headers_dir, copy_options::recursive);
 
                         ModuleMetadata meta;
 

--- a/src/vcpkg/install.cpp
+++ b/src/vcpkg/install.cpp
@@ -123,7 +123,7 @@ namespace vcpkg::Install
                                vcpkg::u8string(target),
                                " was already present and will be overwritten\n");
                     }
-                    fs.copy_file(file, target, stdfs::copy_options::overwrite_existing, ec);
+                    fs.copy_file(file, target, copy_options::overwrite_existing, ec);
                     if (ec)
                     {
                         vcpkg::printf(Color::error, "failed: %s: %s\n", vcpkg::u8string(target), ec.message());

--- a/src/vcpkg/metrics.cpp
+++ b/src/vcpkg/metrics.cpp
@@ -468,7 +468,7 @@ namespace vcpkg::Metrics
 #if defined(_WIN32)
         fs.create_directories(temp_folder_path, ec);
         if (ec) return;
-        fs.copy_file(get_exe_path_of_current_process(), temp_folder_path_exe, stdfs::copy_options::skip_existing, ec);
+        fs.copy_file(get_exe_path_of_current_process(), temp_folder_path_exe, copy_options::skip_existing, ec);
         if (ec) return;
 #else
         if (!fs.exists("/tmp")) return;


### PR DESCRIPTION
In keeping with our desire to not say stdfs outside of files.h machinery, this PR removes unnecessary stdfs:: qualifications from copy_options.