### PR TITLE
Make symlink tests work on all Windows versions

### DIFF
--- a/cmake/utilities.cmake
+++ b/cmake/utilities.cmake
@@ -158,14 +158,7 @@ int main() {}
             # We don't support versions of libc++ < 7.0.0, and libc++ 7.0.0 has <filesystem>
             set(_VCPKG_USE_STD_FILESYSTEM ON)
         elseif(VCPKG_STANDARD_LIBRARY STREQUAL "msvc-stl")
-            check_cxx_source_compiles(
-                "#include <ciso646>
-                #if !defined(_MSVC_STL_UPDATE) || _MSVC_STL_UPDATE < 201803
-                #error \"MSVC STL before 15.7 does not support <filesystem>\"
-                #endif
-                int main() {}"
-                _VCPKG_USE_STD_FILESYSTEM)
-
+            set(_VCPKG_USE_STD_FILESYSTEM ON)
             set(_VCPKG_CXXFS_LIBRARY OFF)
         endif()
 
@@ -194,12 +187,7 @@ endfunction()
 function(vcpkg_target_add_warning_options TARGET)
     if(MSVC)
         # either MSVC, or clang-cl
-        target_compile_options(${TARGET} PRIVATE -FC)
-
-        if (MSVC_VERSION GREATER 1900)
-            # Visual Studio 2017 or later
-            target_compile_options(${TARGET} PRIVATE -permissive- -utf-8)
-        endif()
+        target_compile_options(${TARGET} PRIVATE -FC -permissive- -utf-8)
 
         if(VCPKG_DEVELOPMENT_WARNINGS)
             target_compile_options(${TARGET} PRIVATE -W4)

--- a/include/vcpkg-test/util.h
+++ b/include/vcpkg-test/util.h
@@ -121,26 +121,5 @@ namespace vcpkg::Test
         }
     }
 
-    struct AllowSymlinks
-    {
-        enum Tag : bool
-        {
-            No = false,
-            Yes = true,
-        } tag;
-
-        constexpr AllowSymlinks(Tag tag) noexcept : tag(tag) { }
-
-        constexpr explicit AllowSymlinks(bool b) noexcept : tag(b ? Yes : No) { }
-
-        constexpr operator bool() const noexcept { return tag == Yes; }
-    };
-
-    AllowSymlinks can_create_symlinks() noexcept;
-
     const path& base_temporary_directory() noexcept;
-
-    void create_symlink(const path& file, const path& target, std::error_code& ec);
-
-    void create_directory_symlink(const path& file, const path& target, std::error_code& ec);
 }

--- a/include/vcpkg/base/files.h
+++ b/include/vcpkg/base/files.h
@@ -41,6 +41,8 @@ namespace vcpkg
 
     using stdfs::copy_options;
     using stdfs::path;
+    using stdfs::file_type;
+    using stdfs::file_status;
 
     path u8path(StringView s);
     inline path u8path(const char* first, const char* last) { return u8path(StringView{first, last}); }
@@ -60,41 +62,6 @@ namespace vcpkg
     path lexically_normal(const path& p);
 
 #if defined(_WIN32)
-    enum class file_type
-    {
-        none = 0,
-        not_found = -1,
-        regular = 1,
-        directory = 2,
-        symlink = 3,
-        block = 4,
-        character = 5,
-        fifo = 6,
-        socket = 7,
-        unknown = 8,
-        // also stands for a junction
-        directory_symlink = 42
-    };
-
-    struct file_status
-    {
-        explicit file_status(file_type type = file_type::none,
-                             stdfs::perms permissions = stdfs::perms::unknown) noexcept
-            : m_type(type), m_permissions(permissions)
-        {
-        }
-
-        file_type type() const noexcept { return m_type; }
-        void type(file_type type) noexcept { m_type = type; }
-
-        stdfs::perms permissions() const noexcept { return m_permissions; }
-        void permissions(stdfs::perms perm) noexcept { m_permissions = perm; }
-
-    private:
-        file_type m_type;
-        stdfs::perms m_permissions;
-    };
-
     struct SystemHandle
     {
         using type = intptr_t; // HANDLE
@@ -102,19 +69,7 @@ namespace vcpkg
 
         bool is_valid() const { return system_handle != -1; }
     };
-
 #else
-
-    using stdfs::file_type;
-    // to set up ADL correctly on `file_status` objects, we are defining
-    // this in our own namespace
-    struct file_status : private stdfs::file_status
-    {
-        using stdfs::file_status::file_status;
-        using stdfs::file_status::permissions;
-        using stdfs::file_status::type;
-    };
-
     struct SystemHandle
     {
         using type = int; // file descriptor
@@ -131,13 +86,7 @@ namespace vcpkg
     }
     inline bool operator!=(SystemHandle lhs, SystemHandle rhs) noexcept { return !(lhs == rhs); }
 
-    inline bool is_symlink(file_status s) noexcept
-    {
-#if defined(_WIN32)
-        if (s.type() == file_type::directory_symlink) return true;
-#endif
-        return s.type() == file_type::symlink;
-    }
+    inline bool is_symlink(file_status s) { return stdfs::is_symlink(s); }
     inline bool is_regular_file(file_status s) { return s.type() == file_type::regular; }
     inline bool is_directory(file_status s) { return s.type() == file_type::directory; }
     inline bool exists(file_status s) { return s.type() != file_type::not_found && s.type() != file_type::none; }
@@ -289,6 +238,11 @@ namespace vcpkg
         bool create_directories(const path& new_directory, ignore_errors_t);
         bool create_directories(const path& new_directory, LineInfo);
         virtual void create_symlink(const path& to, const path& from, std::error_code& ec) = 0;
+        void create_symlink(const path& to, const path& from, ignore_errors_t);
+        void create_symlink(const path& to, const path& from, LineInfo);
+        virtual void create_directory_symlink(const path& to, const path& from, std::error_code& ec) = 0;
+        void create_directory_symlink(const path& to, const path& from, ignore_errors_t);
+        void create_directory_symlink(const path& to, const path& from, LineInfo);
         virtual void create_hard_link(const path& to, const path& from, std::error_code& ec) = 0;
         void create_best_link(const path& to, const path& from, std::error_code& ec);
         void create_best_link(const path& to, const path& from, LineInfo);

--- a/include/vcpkg/base/files.h
+++ b/include/vcpkg/base/files.h
@@ -40,9 +40,9 @@ namespace vcpkg
     constexpr IsSlash is_slash;
 
     using stdfs::copy_options;
-    using stdfs::path;
-    using stdfs::file_type;
     using stdfs::file_status;
+    using stdfs::file_type;
+    using stdfs::path;
 
     path u8path(StringView s);
     inline path u8path(const char* first, const char* last) { return u8path(StringView{first, last}); }

--- a/include/vcpkg/base/hash.h
+++ b/include/vcpkg/base/hash.h
@@ -8,7 +8,6 @@ namespace vcpkg::Hash
 {
     enum class Algorithm
     {
-        Sha1,
         Sha256,
         Sha512,
     };

--- a/src/vcpkg-test/files.cpp
+++ b/src/vcpkg-test/files.cpp
@@ -46,7 +46,6 @@ namespace
         // each of the remaining ~30% to be regular files, directory symlinks,
         // and regular symlinks
         constexpr std::uint32_t directory_min_tag = 0;
-        constexpr std::uint32_t directory_max_tag = 6;
         constexpr std::uint32_t regular_file_tag = 7;
         constexpr std::uint32_t regular_symlink_tag = 8;
         constexpr std::uint32_t directory_symlink_tag = 9;

--- a/src/vcpkg-test/files.cpp
+++ b/src/vcpkg-test/files.cpp
@@ -1,3 +1,5 @@
+#include <vcpkg/base/system_headers.h>
+
 #include <catch2/catch.hpp>
 
 #include <vcpkg/base/files.h>
@@ -9,9 +11,7 @@
 
 #include <vcpkg-test/util.h>
 
-using vcpkg::Test::AllowSymlinks;
 using vcpkg::Test::base_temporary_directory;
-using vcpkg::Test::can_create_symlinks;
 
 #define CHECK_EC_ON_FILE(file, ec)                                                                                     \
     do                                                                                                                 \
@@ -24,66 +24,43 @@ using vcpkg::Test::can_create_symlinks;
 
 namespace
 {
-    using uid_t = std::uniform_int_distribution<std::uint64_t>;
     using urbg_t = std::mt19937_64;
 
-    urbg_t get_urbg(std::uint64_t index)
+    std::string get_random_filename(urbg_t& urbg) { return vcpkg::Strings::b32_encode(urbg()); }
+
+#if defined(_WIN32)
+    bool is_valid_symlink_failure(const std::error_code& ec) noexcept
     {
-        // smallest prime > 2**63 - 1
-        return urbg_t{index + 9223372036854775837ULL};
+        // on Windows, creating symlinks requires admin rights, so we ignore such failures
+        return ec == std::error_code(ERROR_PRIVILEGE_NOT_HELD, std::system_category());
     }
-
-    std::string get_random_filename(urbg_t& urbg) { return vcpkg::Strings::b32_encode(uid_t{}(urbg)); }
-
-    struct MaxDepth
-    {
-        std::uint64_t i;
-        explicit MaxDepth(std::uint64_t i) : i(i) { }
-        operator uint64_t() const { return i; }
-    };
-
-    struct Width
-    {
-        std::uint64_t i;
-        explicit Width(std::uint64_t i) : i(i) { }
-        operator uint64_t() const { return i; }
-    };
-
-    struct CurrentDepth
-    {
-        std::uint64_t i;
-        explicit CurrentDepth(std::uint64_t i) : i(i) { }
-        operator uint64_t() const { return i; }
-        CurrentDepth incremented() const { return CurrentDepth{i + 1}; }
-    };
+#endif // ^^^ _WIN32
 
     void create_directory_tree(urbg_t& urbg,
                                vcpkg::Filesystem& fs,
                                const vcpkg::path& base,
-                               MaxDepth max_depth,
-                               AllowSymlinks allow_symlinks = AllowSymlinks::Yes,
-                               Width width = Width{5},
-                               CurrentDepth current_depth = CurrentDepth{0})
+                               std::uint32_t remaining_depth = 5)
     {
+        using uid_t = std::uniform_int_distribution<std::uint32_t>;
         // we want ~70% of our "files" to be directories, and then a third
         // each of the remaining ~30% to be regular files, directory symlinks,
         // and regular symlinks
-        constexpr std::uint64_t directory_min_tag = 0;
-        constexpr std::uint64_t directory_max_tag = 6;
-        constexpr std::uint64_t regular_file_tag = 7;
-        constexpr std::uint64_t regular_symlink_tag = 8;
-        constexpr std::uint64_t directory_symlink_tag = 9;
+        constexpr std::uint32_t directory_min_tag = 0;
+        constexpr std::uint32_t directory_max_tag = 6;
+        constexpr std::uint32_t regular_file_tag = 7;
+        constexpr std::uint32_t regular_symlink_tag = 8;
+        constexpr std::uint32_t directory_symlink_tag = 9;
 
-        allow_symlinks = AllowSymlinks{allow_symlinks && can_create_symlinks()};
-
-        // if we're at the max depth, we only want to build non-directories
-        std::uint64_t file_type;
-        if (current_depth >= max_depth)
+        std::uint32_t file_type;
+        if (remaining_depth <= 1)
         {
+            // if we're at the max depth, we only want to create non-directories
             file_type = uid_t{regular_file_tag, directory_symlink_tag}(urbg);
         }
-        else if (current_depth < 2)
+        else if (remaining_depth >= 3)
         {
+            // if we are far away from the max depth, always create directories
+            // to make reaching the max depth likely
             file_type = directory_min_tag;
         }
         else
@@ -91,54 +68,69 @@ namespace
             file_type = uid_t{directory_min_tag, regular_symlink_tag}(urbg);
         }
 
-        if (!allow_symlinks && file_type > regular_file_tag)
-        {
-            file_type = regular_file_tag;
-        }
-
         std::error_code ec;
-        if (file_type <= directory_max_tag)
+        if (file_type == regular_symlink_tag)
         {
-            fs.create_directory(base, ec);
+            // regular symlink
+            auto base_target = base;
+            base_target.replace_filename(vcpkg::u8path(vcpkg::u8string(base.filename()) + "-target"));
+            fs.write_contents(base_target, "", ec);
+            CHECK_EC_ON_FILE(base_target, ec);
+            fs.create_symlink(base_target, base, ec);
+
             if (ec)
             {
-                CHECK_EC_ON_FILE(base, ec);
+#if defined(_WIN32)
+                if (is_valid_symlink_failure(ec))
+                {
+                    fs.write_contents(base, "", ec);
+                    CHECK_EC_ON_FILE(base, ec);
+                }
+                else
+#endif // ^^^ _WIN32
+                {
+                    FAIL(base << ": " << ec.message());
+                }
             }
-
-            for (std::uint64_t i = 0; i < width; ++i)
+        }
+        else if (file_type == directory_symlink_tag)
+        {
+            // directory symlink
+            auto parent = base;
+            parent.remove_filename();
+            fs.create_directory_symlink(parent, base, ec);
+            if (ec)
             {
-                create_directory_tree(urbg,
-                                      fs,
-                                      base / get_random_filename(urbg),
-                                      max_depth,
-                                      allow_symlinks,
-                                      width,
-                                      current_depth.incremented());
+#if defined(_WIN32)
+                if (is_valid_symlink_failure(ec))
+                {
+                    fs.create_directory(base, ec);
+                    CHECK_EC_ON_FILE(base, ec);
+                }
+                else
+#endif // ^^^ _WIN32
+                {
+                    FAIL(base << ": " << ec.message());
+                }
             }
         }
         else if (file_type == regular_file_tag)
         {
             // regular file
             fs.write_contents(base, "", ec);
+            CHECK_EC_ON_FILE(base, ec);
         }
-        else if (file_type == regular_symlink_tag)
+        else
         {
-            // regular symlink
-            auto base_link = base;
-            base_link.replace_filename(vcpkg::u8string(base.filename()) + "-orig");
-            fs.write_contents(base_link, "", ec);
-            CHECK_EC_ON_FILE(base_link, ec);
-            vcpkg::Test::create_symlink(base_link, base, ec);
-        }
-        else // file_type == directory_symlink_tag
-        {
-            // directory symlink
-            auto parent = base;
-            parent.remove_filename();
-            vcpkg::Test::create_directory_symlink(parent, base, ec);
+            // regular directory
+            fs.create_directory(base, ec);
+            CHECK_EC_ON_FILE(base, ec);
+            for (int i = 0; i < 5; ++i)
+            {
+                create_directory_tree(urbg, fs, base / get_random_filename(urbg), remaining_depth - 1);
+            }
         }
 
-        CHECK_EC_ON_FILE(base, ec);
         REQUIRE(vcpkg::exists(fs.symlink_status(base, ec)));
         CHECK_EC_ON_FILE(base, ec);
     }
@@ -175,14 +167,14 @@ TEST_CASE ("vcpkg::combine works correctly", "[filesystem][files]")
 
 TEST_CASE ("remove all", "[files]")
 {
-    auto urbg = get_urbg(0);
+    urbg_t urbg;
 
     auto& fs = setup();
 
     vcpkg::path temp_dir = base_temporary_directory() / get_random_filename(urbg);
     INFO("temp dir is: " << temp_dir);
 
-    create_directory_tree(urbg, fs, temp_dir, MaxDepth{5});
+    create_directory_tree(urbg, fs, temp_dir);
 
     std::error_code ec;
     vcpkg::path fp;
@@ -374,7 +366,7 @@ TEST_CASE ("win32_fix_path_case", "[files]")
 #if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
 TEST_CASE ("remove all -- benchmarks", "[files][!benchmark]")
 {
-    auto urbg = get_urbg(1);
+    urbg_t urbg;
     auto& fs = setup();
 
     struct
@@ -382,14 +374,14 @@ TEST_CASE ("remove all -- benchmarks", "[files][!benchmark]")
         urbg_t& urbg;
         vcpkg::Filesystem& fs;
 
-        void operator()(Catch::Benchmark::Chronometer& meter, MaxDepth max_depth, AllowSymlinks allow_symlinks) const
+        void operator()(Catch::Benchmark::Chronometer& meter, std::uint32_t max_depth) const
         {
             std::vector<path> temp_dirs;
             temp_dirs.resize(meter.runs());
 
             std::generate(begin(temp_dirs), end(temp_dirs), [&] {
                 path temp_dir = base_temporary_directory() / get_random_filename(urbg);
-                create_directory_tree(urbg, fs, temp_dir, max_depth, allow_symlinks);
+                create_directory_tree(urbg, fs, temp_dir, max_depth);
                 return temp_dir;
             });
 
@@ -411,27 +403,8 @@ TEST_CASE ("remove all -- benchmarks", "[files][!benchmark]")
         }
     } do_benchmark = {urbg, fs};
 
-    BENCHMARK_ADVANCED("small directory, no symlinks")(Catch::Benchmark::Chronometer meter)
-    {
-        do_benchmark(meter, MaxDepth{2}, AllowSymlinks::No);
-    };
+    BENCHMARK_ADVANCED("small directory")(Catch::Benchmark::Chronometer meter) { do_benchmark(meter, 2); };
 
-    BENCHMARK_ADVANCED("large directory, no symlinks")(Catch::Benchmark::Chronometer meter)
-    {
-        do_benchmark(meter, MaxDepth{5}, AllowSymlinks::No);
-    };
-
-    if (can_create_symlinks())
-    {
-        BENCHMARK_ADVANCED("small directory, symlinks")(Catch::Benchmark::Chronometer meter)
-        {
-            do_benchmark(meter, MaxDepth{2}, AllowSymlinks::Yes);
-        };
-
-        BENCHMARK_ADVANCED("large directory, symlinks")(Catch::Benchmark::Chronometer meter)
-        {
-            do_benchmark(meter, MaxDepth{5}, AllowSymlinks::Yes);
-        };
-    }
+    BENCHMARK_ADVANCED("large directory")(Catch::Benchmark::Chronometer meter) { do_benchmark(meter, 5); };
 }
 #endif

--- a/src/vcpkg-test/hash.cpp
+++ b/src/vcpkg-test/hash.cpp
@@ -58,27 +58,6 @@ using vcpkg::StringView;
         REQUIRE(hasher->get_hash() == real_hash);                                                                      \
     } while (0)
 
-TEST_CASE ("SHA1: basic tests", "[hash][sha1]")
-{
-    const auto algorithm = Hash::Algorithm::Sha1;
-
-    CHECK_HASH_STRING("", "da39a3ee5e6b4b0d3255bfef95601890afd80709");
-    CHECK_HASH_STRING(";", "2d14ab97cc3dc294c51c0d6814f4ea45f4b4e312");
-    CHECK_HASH_STRING("asdifasdfnas", "b77eb8a1b4c2ef6716d7d302647e4511b1a638a6");
-    CHECK_HASH_STRING("asdfanvoinaoifawenflawenfiwnofvnasfjvnaslkdfjlkasjdfanm,"
-                      "werflawoienfowanevoinwai32910u2740918741o;j;wejfqwioaher9283hrpf;asd",
-                      "c69bcd30c196c7050906d212722dd7a7659aad04");
-}
-
-TEST_CASE ("SHA1: NIST test cases (small)", "[hash][sha1]")
-{
-    const auto algorithm = Hash::Algorithm::Sha1;
-
-    CHECK_HASH_STRING("abc", "a9993e364706816aba3e25717850c26c9cd0d89d");
-    CHECK_HASH_STRING("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq",
-                      "84983e441c3bd26ebaae4aa1f95129e5e54670f1");
-}
-
 TEST_CASE ("SHA256: basic tests", "[hash][sha256]")
 {
     const auto algorithm = Hash::Algorithm::Sha256;
@@ -202,30 +181,6 @@ void benchmark_hasher(Chronometer& meter, Hash::Hasher& hasher, std::uint64_t si
         }
         hasher.get_hash();
     });
-}
-
-TEST_CASE ("SHA1: benchmark", "[.][hash][sha256][!benchmark]")
-{
-    using Catch::Benchmark::Chronometer;
-
-    auto hasher = Hash::get_hasher_for(Hash::Algorithm::Sha1);
-
-    BENCHMARK_ADVANCED("0 x 1'000'000")(Catch::Benchmark::Chronometer meter)
-    {
-        benchmark_hasher(meter, *hasher, 1'000'000, 0);
-    };
-    BENCHMARK_ADVANCED("'Z' x 0x2000'0000")(Catch::Benchmark::Chronometer meter)
-    {
-        benchmark_hasher(meter, *hasher, 0x2000'0000, 'Z');
-    };
-    BENCHMARK_ADVANCED("0 x 0x4100'0000")(Catch::Benchmark::Chronometer meter)
-    {
-        benchmark_hasher(meter, *hasher, 0x4100'0000, 0);
-    };
-    BENCHMARK_ADVANCED("'B' x 0x6000'003E")(Catch::Benchmark::Chronometer meter)
-    {
-        benchmark_hasher(meter, *hasher, 0x6000'003E, 'B');
-    };
 }
 
 TEST_CASE ("SHA256: benchmark", "[.][hash][sha256][!benchmark]")

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -1462,7 +1462,7 @@ namespace vcpkg
 
     bool has_invalid_chars_for_filesystem(const std::string& s)
     {
-        return s.find_first_of(R"([/\:*"<>|])") == std::string::npos;
+        return s.find_first_of(R"([/\:*"<>|])") != std::string::npos;
     }
 
     void print_paths(const std::vector<path>& paths)

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -282,7 +282,7 @@ namespace vcpkg
     {
 #if defined(_WIN32)
         ec.assign(::_wfopen_s(&m_fs, file_path.c_str(), L"rb"), std::generic_category());
-#else  // ^^^ _WIN32 / !_WIN32 vvv
+#else // ^^^ _WIN32 / !_WIN32 vvv
         m_fs = ::fopen(file_path.c_str(), "rb");
         if (m_fs)
         {
@@ -299,7 +299,7 @@ namespace vcpkg
     {
 #if defined(_WIN32)
         ec.assign(::_wfopen_s(&m_fs, file_path.c_str(), L"wb"), std::generic_category());
-#else  // ^^^ _WIN32 / !_WIN32 vvv
+#else // ^^^ _WIN32 / !_WIN32 vvv
         m_fs = ::fopen(file_path.c_str(), "wb");
         if (m_fs)
         {
@@ -340,7 +340,7 @@ namespace vcpkg
             {
                 ec.assign(GetLastError(), std::system_category());
             }
-#else  // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
+#else // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
             struct stat s;
             if (lstat(target.c_str(), &s))
             {
@@ -938,7 +938,7 @@ namespace vcpkg
                 auto written_bytes = sendfile(o_fd, i_fd, &bytes, info.st_size);
 #elif defined(__APPLE__)
                 auto written_bytes = fcopyfile(i_fd, o_fd, 0, COPYFILE_ALL);
-#else  // ^^^ defined(__APPLE__) // !(defined(__APPLE__) || defined(__linux__)) vvv
+#else // ^^^ defined(__APPLE__) // !(defined(__APPLE__) || defined(__linux__)) vvv
                 ssize_t written_bytes = 0;
                 {
                     constexpr std::size_t buffer_length = 4096;
@@ -1035,7 +1035,7 @@ namespace vcpkg
                         {
                             ec.assign(GetLastError(), std::system_category());
                         }
-#else  // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
+#else // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
                         if (rmdir(current_path.c_str()))
                         {
                             ec.assign(errno, std::system_category());
@@ -1048,7 +1048,7 @@ namespace vcpkg
                         stdfs::remove(current_path, ec);
                         if (check_ec(ec, current_path, err)) return;
                     }
-#else  // ^^^  VCPKG_USE_STD_FILESYSTEM // !VCPKG_USE_STD_FILESYSTEM vvv
+#else // ^^^  VCPKG_USE_STD_FILESYSTEM // !VCPKG_USE_STD_FILESYSTEM vvv
                     else
                     {
                         if (unlink(current_path.c_str()))
@@ -1239,7 +1239,7 @@ namespace vcpkg
         {
 #if VCPKG_USE_STD_FILESYSTEM
             return stdfs::absolute(target, ec);
-#else  // ^^^ VCPKG_USE_STD_FILESYSTEM  /  !VCPKG_USE_STD_FILESYSTEM  vvv
+#else // ^^^ VCPKG_USE_STD_FILESYSTEM  /  !VCPKG_USE_STD_FILESYSTEM  vvv
             if (target.is_absolute())
             {
                 return target;
@@ -1419,7 +1419,7 @@ namespace vcpkg
         {
 #if defined(_WIN32)
             static constexpr wchar_t const* EXTS[] = {L".cmd", L".exe", L".bat"};
-#else  // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
+#else // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
             static constexpr char const* EXTS[] = {""};
 #endif // ^^^!defined(_WIN32)
             const auto pname = vcpkg::u8path(name);
@@ -1491,7 +1491,7 @@ namespace vcpkg
     {
 #if VCPKG_USE_STD_FILESYSTEM
         return lhs / rhs;
-#else  // ^^^ std::filesystem // std::experimental::filesystem vvv
+#else // ^^^ std::filesystem // std::experimental::filesystem vvv
         if (rhs.is_absolute())
         {
             return rhs;

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -1462,18 +1462,7 @@ namespace vcpkg
 
     bool has_invalid_chars_for_filesystem(const std::string& s)
     {
-        for (const char& c : s)
-        {
-            for (const char& invalid : {'[', '/', '\\', ':', '*', '"', '<', '>', '|', ']'})
-            {
-                if (c == invalid)
-                {
-                    return true;
-                }
-            }
-        }
-
-        return false;
+        return s.find_first_of(R"([/\:*"<>|])") == std::string::npos;
     }
 
     void print_paths(const std::vector<path>& paths)

--- a/src/vcpkg/base/hash.cpp
+++ b/src/vcpkg/base/hash.cpp
@@ -192,10 +192,6 @@ namespace vcpkg::Hash
         }
 
         static std::uint32_t shr32(std::uint32_t value, int by) noexcept { return value >> by; }
-        static std::uint32_t rol32(std::uint32_t value, int by) noexcept
-        {
-            return (value << by) | (value >> (32 - by));
-        }
         static std::uint32_t ror32(std::uint32_t value, int by) noexcept
         {
             return (value >> by) | (value << (32 - by));

--- a/src/vcpkg/base/hash.cpp
+++ b/src/vcpkg/base/hash.cpp
@@ -21,10 +21,6 @@ namespace vcpkg::Hash
 
     Optional<Algorithm> algorithm_from_string(StringView sv) noexcept
     {
-        if (Strings::case_insensitive_ascii_equals(sv, "SHA1"))
-        {
-            return {Algorithm::Sha1};
-        }
         if (Strings::case_insensitive_ascii_equals(sv, "SHA256"))
         {
             return {Algorithm::Sha256};
@@ -41,7 +37,6 @@ namespace vcpkg::Hash
     {
         switch (algo)
         {
-            case Algorithm::Sha1: return "SHA1";
             case Algorithm::Sha256: return "SHA256";
             case Algorithm::Sha512: return "SHA512";
             default: vcpkg::Checks::exit_fail(VCPKG_LINE_INFO);
@@ -111,7 +106,6 @@ namespace vcpkg::Hash
 
         struct BCryptHasher : Hasher
         {
-            static const BCRYPT_ALG_HANDLE sha1_alg_handle;
             static const BCRYPT_ALG_HANDLE sha256_alg_handle;
             static const BCRYPT_ALG_HANDLE sha512_alg_handle;
 
@@ -119,7 +113,6 @@ namespace vcpkg::Hash
             {
                 switch (algo)
                 {
-                    case Algorithm::Sha1: alg_handle = sha1_alg_handle; break;
                     case Algorithm::Sha256: alg_handle = sha256_alg_handle; break;
                     case Algorithm::Sha512: alg_handle = sha512_alg_handle; break;
                     default: Checks::unreachable(VCPKG_LINE_INFO);
@@ -188,7 +181,6 @@ namespace vcpkg::Hash
             BCRYPT_ALG_HANDLE alg_handle = nullptr;
         };
 
-        const BCRYPT_ALG_HANDLE BCryptHasher::sha1_alg_handle = get_alg_handle(BCRYPT_SHA1_ALGORITHM);
         const BCRYPT_ALG_HANDLE BCryptHasher::sha256_alg_handle = get_alg_handle(BCRYPT_SHA256_ALGORITHM);
         const BCRYPT_ALG_HANDLE BCryptHasher::sha512_alg_handle = get_alg_handle(BCRYPT_SHA512_ALGORITHM);
 #else
@@ -338,88 +330,6 @@ namespace vcpkg::Hash
                 }
             }
         }
-
-        struct Sha1Algorithm
-        {
-            using underlying_type = std::uint32_t;
-            using message_length_type = std::uint64_t;
-            constexpr static std::size_t chunk_size = 64; // = 512 / 8
-            constexpr static std::size_t number_of_rounds = 80;
-
-            Sha1Algorithm() noexcept { clear(); }
-
-            void process_full_chunk(const std::array<uchar, chunk_size>& chunk) noexcept
-            {
-                std::uint32_t words[80];
-
-                sha_fill_initial_words(&chunk[0], words);
-                for (std::size_t i = 16; i < number_of_rounds; ++i)
-                {
-                    const auto sum = words[i - 3] ^ words[i - 8] ^ words[i - 14] ^ words[i - 16];
-                    words[i] = rol32(sum, 1);
-                }
-
-                std::uint32_t a = m_digest[0];
-                std::uint32_t b = m_digest[1];
-                std::uint32_t c = m_digest[2];
-                std::uint32_t d = m_digest[3];
-                std::uint32_t e = m_digest[4];
-
-                for (std::size_t i = 0; i < number_of_rounds; ++i)
-                {
-                    std::uint32_t f;
-                    std::uint32_t k;
-
-                    if (i < 20)
-                    {
-                        f = (b & c) | (~b & d);
-                        k = 0x5A827999;
-                    }
-                    else if (i < 40)
-                    {
-                        f = b ^ c ^ d;
-                        k = 0x6ED9EBA1;
-                    }
-                    else if (i < 60)
-                    {
-                        f = (b & c) | (b & d) | (c & d);
-                        k = 0x8F1BBCDC;
-                    }
-                    else
-                    {
-                        f = b ^ c ^ d;
-                        k = 0xCA62C1D6;
-                    }
-
-                    auto tmp = rol32(a, 5) + f + e + k + words[i];
-                    e = d;
-                    d = c;
-                    c = rol32(b, 30);
-                    b = a;
-                    a = tmp;
-                }
-
-                m_digest[0] += a;
-                m_digest[1] += b;
-                m_digest[2] += c;
-                m_digest[3] += d;
-                m_digest[4] += e;
-            }
-
-            void clear() noexcept
-            {
-                m_digest[0] = 0x67452301;
-                m_digest[1] = 0xEFCDAB89;
-                m_digest[2] = 0x98BADCFE;
-                m_digest[3] = 0x10325476;
-                m_digest[4] = 0xC3D2E1F0;
-            }
-
-            const std::uint32_t* begin() const noexcept { return &m_digest[0]; }
-            const std::uint32_t* end() const noexcept { return &m_digest[5]; }
-
-            std::uint32_t m_digest[5];
-        };
 
         struct Sha256Algorithm
         {
@@ -614,7 +524,6 @@ namespace vcpkg::Hash
 #else
         switch (algo)
         {
-            case Algorithm::Sha1: return std::make_unique<ShaHasher<Sha1Algorithm>>();
             case Algorithm::Sha256: return std::make_unique<ShaHasher<Sha256Algorithm>>();
             case Algorithm::Sha512: return std::make_unique<ShaHasher<Sha512Algorithm>>();
             default: vcpkg::Checks::exit_with_message(VCPKG_LINE_INFO, "Unknown hashing algorithm: %s", algo);
@@ -631,11 +540,6 @@ namespace vcpkg::Hash
 #else
         switch (algo)
         {
-            case Algorithm::Sha1:
-            {
-                auto hasher = ShaHasher<Sha1Algorithm>();
-                return f(hasher);
-            }
             case Algorithm::Sha256:
             {
                 auto hasher = ShaHasher<Sha256Algorithm>();

--- a/src/vcpkg/base/strings.cpp
+++ b/src/vcpkg/base/strings.cpp
@@ -346,41 +346,29 @@ size_t Strings::byte_edit_distance(StringView a, StringView b)
 
 namespace vcpkg::Strings
 {
-    namespace
+    std::string b32_encode(std::uint64_t value) noexcept
     {
-        template<class Integral>
-        std::string b32_encode_implementation(Integral x)
+        // 32 values, plus the implicit \0
+        constexpr static char map[33] = "ABCDEFGHIJKLMNOP"
+                                        "QRSTUVWXYZ234567";
+
+        // log2(32)
+        constexpr static int shift = 5;
+        // 32 - 1
+        constexpr static auto mask = 31;
+
+        // ceiling(bitsize(Integral) / log2(32))
+        constexpr static auto result_size = (sizeof(value) * CHAR_BIT + shift - 1) / shift;
+
+        std::string result;
+        for (std::size_t i = 0; i < result_size; ++i)
         {
-            static_assert(std::is_integral<Integral>::value, "b64url_encode must take an integer type");
-            using Unsigned = std::make_unsigned_t<Integral>;
-            auto value = static_cast<Unsigned>(x);
-
-            // 32 values, plus the implicit \0
-            constexpr static char map[33] = "ABCDEFGHIJKLMNOP"
-                                            "QRSTUVWXYZ234567";
-
-            // log2(32)
-            constexpr static int shift = 5;
-            // 32 - 1
-            constexpr static auto mask = 31;
-
-            // ceiling(bitsize(Integral) / log2(32))
-            constexpr static auto result_size = (sizeof(value) * 8 + shift - 1) / shift;
-
-            std::string result;
-            result.reserve(result_size);
-
-            for (std::size_t i = 0; i < result_size; ++i)
-            {
-                result.push_back(map[value & mask]);
-                value >>= shift;
-            }
-
-            return result;
+            result.push_back(map[value & mask]);
+            value >>= shift;
         }
-    }
 
-    std::string b32_encode(std::uint64_t x) noexcept { return b32_encode_implementation(x); }
+        return result;
+    }
 
     struct LinesCollector::CB
     {


### PR DESCRIPTION
test/files.cpp
Rather than try to read windows client specific registry keys as a means of predicting whether symlinks work, now that we distribute vcpkg in binary forms on Windows, we can assume it is built with a modern compiler, and thus with std::filesystem. This means we can detect the problematic condition by just attempting to create the symlink, and testing if we get ERROR_PRIVILEGE_NOT_HELD back.

utilities.cmake:
Delete handling for old compilers on Windows.

files.h and base/files.cpp:
Add create_directory_symlink called by tests, and the missing overloads of create_symlink.
Delete code blocks looking for defined(_WIN32) && !VCPKG_USE_STD_FILESYSTEM.
Fix bad format string in create_directory error message without enough %s.
Remove unnecessary regex_search for invalid chars.

util.h and util.cpp:
Delete extra copy of create_symlink infrastructure and mechanism to guess if create_symlink works.

strings.cpp:
Inline b32_encode

hash.h and hash.cpp and hash.cpp:
Drive by delete SHA1.