### PR TITLE
Show error instead of success if the package to remove is already not installed

### DIFF
--- a/src/vcpkg/remove.cpp
+++ b/src/vcpkg/remove.cpp
@@ -163,7 +163,7 @@ namespace vcpkg::Remove
         switch (action.plan_type)
         {
             case RemovePlanType::NOT_INSTALLED:
-                vcpkg::printf(Color::success, "Package %s is not installed\n", display_name);
+                vcpkg::printf(Color::error, "Package %s is not installed\n", display_name);
                 break;
             case RemovePlanType::REMOVE:
                 vcpkg::printf("Removing package %s...\n", display_name);


### PR DESCRIPTION
Just a small change, The output should be in red.