### PR TITLE
Teach overrides to understand embedded port versions

### DIFF
--- a/include/vcpkg/versiondeserializers.h
+++ b/include/vcpkg/versiondeserializers.h
@@ -12,7 +12,6 @@ namespace vcpkg
 {
     Json::IDeserializer<VersionT>& get_versiont_deserializer_instance();
     Json::IDeserializer<VersionT>& get_versiontag_deserializer_instance();
-    std::unique_ptr<Json::IDeserializer<std::string>> make_version_deserializer(StringLiteral type_name);
 
     struct SchemedVersion
     {
@@ -25,12 +24,10 @@ namespace vcpkg
         VersionT versiont;
     };
 
-    Optional<SchemedVersion> visit_optional_schemed_deserializer(StringView parent_type,
-                                                                 Json::Reader& r,
-                                                                 const Json::Object& obj);
     SchemedVersion visit_required_schemed_deserializer(StringView parent_type,
                                                        Json::Reader& r,
-                                                       const Json::Object& obj);
+                                                       const Json::Object& obj,
+                                                       bool allow_hash_portversion = false);
     View<StringView> schemed_deserializer_fields();
 
     void serialize_schemed_version(Json::Object& out_obj,

--- a/src/vcpkg/help.cpp
+++ b/src/vcpkg/help.cpp
@@ -51,9 +51,6 @@ namespace vcpkg::Help
                  "your project from within your manifest file.");
         tbl.blank();
         tbl.blank();
-        tbl.text("** This feature is experimental and requires `--feature-flags=versions` **");
-        tbl.blank();
-        tbl.blank();
         tbl.header("Versions in vcpkg come in four primary flavors");
         tbl.format("version", "A dot-separated sequence of numbers (1.2.3.4)");
         tbl.format("version-date", "A date (2021-01-01.5)");

--- a/src/vcpkg/sourceparagraph.cpp
+++ b/src/vcpkg/sourceparagraph.cpp
@@ -566,7 +566,7 @@ namespace vcpkg
         {
             r.required_object_field(type_name, obj, NAME, name, Json::IdentifierDeserializer::instance);
 
-            auto schemed_version = visit_required_schemed_deserializer(type_name, r, obj);
+            auto schemed_version = visit_required_schemed_deserializer(type_name, r, obj, true);
             version = schemed_version.versiont.text();
             version_scheme = schemed_version.scheme;
             port_version = schemed_version.versiont.port_version();
@@ -932,9 +932,11 @@ namespace vcpkg
 
             static Json::StringDeserializer url_deserializer{"a url"};
 
-            constexpr static StringView inner_type_name = "vcpkg.json";
-            DependencyOverrideDeserializer::visit_impl(
-                inner_type_name, r, obj, spgh->name, spgh->version, spgh->version_scheme, spgh->port_version);
+            r.required_object_field(type_name(), obj, NAME, spgh->name, Json::IdentifierDeserializer::instance);
+            auto schemed_version = visit_required_schemed_deserializer(type_name(), r, obj, false);
+            spgh->version = schemed_version.versiont.text();
+            spgh->version_scheme = schemed_version.scheme;
+            spgh->port_version = schemed_version.versiont.port_version();
 
             r.optional_object_field(obj, MAINTAINERS, spgh->maintainers, Json::ParagraphDeserializer::instance);
             r.optional_object_field(obj, DESCRIPTION, spgh->description, Json::ParagraphDeserializer::instance);


### PR DESCRIPTION
See title -- this was found as a stumbling point for new users to versioning. They wanted to just type what they saw in the version list (e.g. "1.2.0#1") but were slightly frustrated that it doesn't work.

This PR specifically allows users to use the `#N` syntax in all version fields for `"overrides": ` objects.

As a drive by, this PR removes the experimental notice for versioning.