### PR TITLE
Improve error messages around versioning baselines

### DIFF
--- a/include/vcpkg/vcpkgpaths.h
+++ b/include/vcpkg/vcpkgpaths.h
@@ -131,7 +131,7 @@ namespace vcpkg
 
         // Git manipulation in the vcpkg directory
         ExpectedS<std::string> get_current_git_sha() const;
-        std::string get_current_git_sha_message() const;
+        std::string get_current_git_sha_baseline_message() const;
         ExpectedS<path> git_checkout_baseline(StringView commit_sha) const;
         ExpectedS<path> git_checkout_port(StringView port_name, StringView git_tree, const path& dot_git_dir) const;
         ExpectedS<std::string> git_show(const std::string& treeish, const path& dot_git_dir) const;

--- a/src/vcpkg/help.cpp
+++ b/src/vcpkg/help.cpp
@@ -71,9 +71,9 @@ namespace vcpkg::Help
         tbl.header("Manifests can place three kinds of constraints upon the versions used");
         tbl.format("builtin-baseline",
                    "The baseline references a commit within the vcpkg repository that establishes a minimum version on "
-                   "every dependency in the graph. If no other constraints are specified (directly or transitively), "
-                   "then the version from the baseline of the top level manifest will be used. Baselines of transitive "
-                   "dependencies are ignored.");
+                   "every dependency in the graph. For example, if no other constraints are specified (directly or "
+                   "transitively), then the version will resolve to the baseline of the top level manifest. Baselines "
+                   "of transitive dependencies are ignored.");
         tbl.blank();
         tbl.format("version>=",
                    "Within the \"dependencies\" field, each dependency can have a minimum constraint listed. These "

--- a/src/vcpkg/install.cpp
+++ b/src/vcpkg/install.cpp
@@ -905,16 +905,14 @@ namespace vcpkg::Install
             if (auto p_baseline = manifest_scf.core_paragraph->builtin_baseline.get())
             {
                 Metrics::g_metrics.lock()->track_property("manifest_baseline", "defined");
-                if (p_baseline->size() != 40 || !std::all_of(p_baseline->begin(), p_baseline->end(), [](char ch) {
-                        return (ch >= 'a' || ch <= 'f') || Parse::ParserBase::is_ascii_digit(ch);
-                    }))
+                if (!is_git_commit_sha(*p_baseline))
                 {
                     Metrics::g_metrics.lock()->track_property("versioning-error-baseline", "defined");
                     Checks::exit_maybe_upgrade(VCPKG_LINE_INFO,
                                                "Error: the top-level builtin-baseline (%s) was not a valid commit sha: "
                                                "expected 40 lowercase hexadecimal characters.\n%s\n",
                                                *p_baseline,
-                                               paths.get_current_git_sha_message());
+                                               paths.get_current_git_sha_baseline_message());
                 }
 
                 paths.get_configuration().registry_set.set_default_builtin_registry_baseline(*p_baseline);

--- a/src/vcpkg/registries.cpp
+++ b/src/vcpkg/registries.cpp
@@ -358,42 +358,26 @@ namespace
         return nullptr;
     }
 
-    ExpectedS<Baseline> try_parse_builtin_baseline(const VcpkgPaths& paths, StringView baseline_identifier)
-    {
-        if (baseline_identifier.size() == 0) return Baseline{};
-
-        auto maybe_path = paths.git_checkout_baseline(baseline_identifier);
-        if (!maybe_path.has_value())
-        {
-            return Strings::concat(maybe_path.error(), "\n\n", paths.get_current_git_sha_baseline_message());
-        }
-
-        auto res_baseline = load_baseline_versions(paths, *maybe_path.get());
-        if (!res_baseline.has_value())
-        {
-            return res_baseline.error();
-        }
-        auto opt_baseline = res_baseline.get();
-        if (auto p = opt_baseline->get())
-        {
-            return std::move(*p);
-        }
-
-        return Strings::concat(
-            "Error: The baseline file at commit ", baseline_identifier, " was invalid (no \"default\" field)");
-    }
-
-    Baseline parse_builtin_baseline(const VcpkgPaths& paths, StringView baseline_identifier)
-    {
-        auto maybe_baseline = try_parse_builtin_baseline(paths, baseline_identifier);
-        return maybe_baseline.value_or_exit(VCPKG_LINE_INFO);
-    }
     Optional<VersionT> BuiltinRegistry::get_baseline_version(const VcpkgPaths& paths, StringView port_name) const
     {
         if (!m_baseline_identifier.empty())
         {
-            const auto& baseline = m_baseline.get(
-                [this, &paths]() -> Baseline { return parse_builtin_baseline(paths, m_baseline_identifier); });
+            const auto& baseline = m_baseline.get([this, &paths]() -> Baseline {
+                auto maybe_path = paths.git_checkout_baseline(m_baseline_identifier);
+                if (!maybe_path.has_value())
+                {
+                    Checks::exit_with_message(
+                        VCPKG_LINE_INFO, "%s\n\n%s", maybe_path.error(), paths.get_current_git_sha_baseline_message());
+                }
+                auto b = load_baseline_versions(paths, *maybe_path.get()).value_or_exit(VCPKG_LINE_INFO);
+                if (auto p = b.get())
+                {
+                    return std::move(*p);
+                }
+                Checks::exit_with_message(VCPKG_LINE_INFO,
+                                          "Error: The baseline file at commit %s was invalid (no \"default\" field)",
+                                          m_baseline_identifier);
+            });
 
             auto it = baseline.find(port_name);
             if (it != baseline.end())
@@ -1293,9 +1277,17 @@ namespace vcpkg
         return maybe_versions.error();
     }
 
-    ExpectedS<std::map<std::string, VersionT, std::less<>>> get_builtin_baseline(const VcpkgPaths& paths)
+    ExpectedS<Baseline> get_builtin_baseline(const VcpkgPaths& paths)
     {
-        return try_parse_builtin_baseline(paths, "default");
+        return load_baseline_versions(paths, paths.builtin_registry_versions / vcpkg::u8path("baseline.json"))
+            .then([&](Optional<Baseline>&& b) -> ExpectedS<Baseline> {
+                if (auto p = b.get())
+                {
+                    return std::move(*p);
+                }
+                return Strings::concat(
+                    "Error: The baseline file at versions/baseline.json was invalid (no \"default\" field)");
+            });
     }
 
     bool is_git_commit_sha(StringView sv)

--- a/src/vcpkg/sourceparagraph.cpp
+++ b/src/vcpkg/sourceparagraph.cpp
@@ -1088,7 +1088,7 @@ namespace vcpkg
                     Metrics::g_metrics.lock()->track_property("error-versioning-no-baseline", "defined");
                     return Strings::concat(
                         vcpkg::u8string(origin),
-                        " was rejected because it uses \"version>=\" without setting a \"builtin-baseline\".\n",
+                        " was rejected because it uses \"version>=\" and does not have a \"builtin-baseline\".\n",
                         s_extended_help);
                 }
 
@@ -1097,7 +1097,7 @@ namespace vcpkg
                     Metrics::g_metrics.lock()->track_property("error-versioning-no-baseline", "defined");
                     return Strings::concat(
                         vcpkg::u8string(origin),
-                        " was rejected because it uses \"overrides\" without setting a \"builtin-baseline\".\n",
+                        " was rejected because it uses \"overrides\" and does not have a \"builtin-baseline\".\n",
                         s_extended_help);
                 }
             }

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -641,12 +641,13 @@ namespace vcpkg
             return {Strings::trim(std::move(output.output)), expected_left_tag};
         }
     }
-    std::string VcpkgPaths::get_current_git_sha_message() const
+    std::string VcpkgPaths::get_current_git_sha_baseline_message() const
     {
         auto maybe_cur_sha = get_current_git_sha();
         if (auto p_sha = maybe_cur_sha.get())
         {
-            return Strings::concat("The current commit is \"", *p_sha, '"');
+            return Strings::concat(
+                "You can use the current commit as a baseline, which is:\n    \"builtin-baseline\": \"", *p_sha, '"');
         }
         else
         {
@@ -756,9 +757,10 @@ namespace vcpkg
             }
             else
             {
-                return {Strings::format("Error: while checking out baseline '%s':\n%s\nThis may be fixed by updating "
-                                        "vcpkg to the latest master via `git pull`.",
-                                        treeish,
+                return {Strings::format("Error: while checking out baseline from commit '%s' at subpath "
+                                        "'versions/baseline.json':\n%s\nThis may be fixed by updating vcpkg to the "
+                                        "latest master via `git pull` or fetching commits via `git fetch`.",
+                                        commit_sha,
                                         maybe_contents.error()),
                         expected_right_tag};
             }


### PR DESCRIPTION
See title. Many of the error messages presented when working with baselines are confusing to first time users.

As a drive by, this also rewords `vcpkg help versioning` for more clarity (see code for exact changes).

I've also removed dead code left around by the pre-GA baseline specification of multiple baseline objects within the builtin baseline file. Today, `"builtin-baseline"` is required to be a git SHA and should never activate that code path.

### Ex1: Specify a baseline that doesn't exist
_Before_
```
PS C:\src\vcpkg\mtest> vcpkg.old install
Error: Couldn't find explicitly specified baseline `"56bb45d27d8d5ddf8b66daa2a14d6293223f1cf5"` in the baseline file, and there was no baseline at that commit or the commit didn't exist.                                                                                                              hat commit or th
Error: while checking out baseline '56bb45d27d8d5ddf8b66daa2a14d6293223f1cf5:versions/baseline.json':
fatal: path 'versions/baseline.json' exists on disk, but not in '56bb45d27d8d5ddf8b66daa2a14d6293223f1cf5'

This may be fixed by updating vcpkg to the latest master via `git pull`.
The current commit is "56bb45d27d8d5ddf8b66daa2a14d6293223f1cf4"
```
_After_
```
PS C:\src\vcpkg\mtest> vcpkg.new install
Error: while checking out baseline from commit '56bb45d27d8d5ddf8b66daa2a14d6293223f1cf5' at subpath 'versions/baseline.json':
fatal: path 'versions/baseline.json' exists on disk, but not in '56bb45d27d8d5ddf8b66daa2a14d6293223f1cf5'

This may be fixed by updating vcpkg to the latest master via `git pull` or fetching commits via `git fetch`.

You can use the current commit as a baseline, which is:
    "builtin-baseline": "56bb45d27d8d5ddf8b66daa2a14d6293223f1cf4"
```

### Ex2: Use `"overrides"`/`"version>="` without specifying a baseline
_Before_
```
PS C:\src\vcpkg\mtest> vcpkg.old install
C:\src\vcpkg\mtest\vcpkg.json was rejected because it uses "overrides" without setting a "builtin-baseline".
See `vcpkg help versioning` for more information.
```
_After_
```
PS C:\src\vcpkg\mtest> vcpkg.new install
C:\src\vcpkg\mtest\vcpkg.json was rejected because it uses "overrides" and does not have a "builtin-baseline".
See `vcpkg help versioning` for more information.
```