### PR TITLE
Implemented base CMake installation support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,12 @@ if(APPLE)
     set(CMAKE_CXX_ARCHIVE_FINISH "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
 endif()
 
+# =======================
+# === Paths detection ===
+# =======================
+
+include(GNUInstallDirs)
+
 # ===============
 # === Targets ===
 # ===============
@@ -238,3 +244,12 @@ if(CLANG_FORMAT)
         COMMAND "${CLANG_FORMAT}" -i -verbose ${TLS12_DOWNLOAD_SOURCES}
     )
 endif()
+
+# ====================
+# === Installation ===
+# ====================
+
+install(TARGETS vcpkg
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    BUNDLE DESTINATION ${CMAKE_INSTALL_BINDIR}
+)


### PR DESCRIPTION
Now this project can be easily installed with CMake:

```
cmake --install build --prefix install
```

Closes https://github.com/microsoft/vcpkg/issues/19114.