### PR TITLE
Display usage information after installing in manifest mode

### DIFF
--- a/include/vcpkg/install.h
+++ b/include/vcpkg/install.h
@@ -102,6 +102,7 @@ namespace vcpkg::Install
     };
 
     CMakeUsageInfo get_cmake_usage(const BinaryParagraph& bpgh, const VcpkgPaths& paths);
+    void print_usage_information(const BinaryParagraph& bpgh, const VcpkgPaths& paths);
 
     extern const CommandStructure COMMAND_STRUCTURE;
 

--- a/src/vcpkg-test/dependencies.cpp
+++ b/src/vcpkg-test/dependencies.cpp
@@ -486,6 +486,7 @@ TEST_CASE ("version install string port version 2", "[versionplan]")
 
     REQUIRE(install_plan.size() == 1);
     check_name_and_version(install_plan.install_actions[0], "a", {"2", 1});
+    CHECK(install_plan.install_actions[0].request_type == Dependencies::RequestType::USER_REQUESTED);
 }
 
 TEST_CASE ("version install transitive string", "[versionplan]")
@@ -517,7 +518,9 @@ TEST_CASE ("version install transitive string", "[versionplan]")
 
     REQUIRE(install_plan.size() == 2);
     check_name_and_version(install_plan.install_actions[0], "b", {"2", 0});
+    CHECK(install_plan.install_actions[0].request_type == Dependencies::RequestType::AUTO_SELECTED);
     check_name_and_version(install_plan.install_actions[1], "a", {"2", 1});
+    CHECK(install_plan.install_actions[1].request_type == Dependencies::RequestType::USER_REQUESTED);
 }
 
 TEST_CASE ("version install simple relaxed", "[versionplan]")
@@ -1296,8 +1299,11 @@ TEST_CASE ("version install transitive feature versioned", "[versionplan]")
 
     REQUIRE(install_plan.size() == 3);
     check_name_and_version(install_plan.install_actions[0], "c", {"1", 0});
+    CHECK(install_plan.install_actions[0].request_type == Dependencies::RequestType::AUTO_SELECTED);
     check_name_and_version(install_plan.install_actions[1], "b", {"2", 0}, {"y"});
+    CHECK(install_plan.install_actions[1].request_type == Dependencies::RequestType::AUTO_SELECTED);
     check_name_and_version(install_plan.install_actions[2], "a", {"1", 0}, {"x"});
+    CHECK(install_plan.install_actions[2].request_type == Dependencies::RequestType::USER_REQUESTED);
 }
 
 TEST_CASE ("version install constraint-reduction", "[versionplan]")
@@ -1764,8 +1770,10 @@ TEST_CASE ("version install host tool", "[versionplan]")
         REQUIRE(install_plan.size() == 2);
         check_name_and_version(install_plan.install_actions[0], "a", {"1", 0});
         REQUIRE(install_plan.install_actions[0].spec.triplet() == Test::ARM_UWP);
+        CHECK(install_plan.install_actions[0].request_type == Dependencies::RequestType::AUTO_SELECTED);
         check_name_and_version(install_plan.install_actions[1], "b", {"1", 0});
         REQUIRE(install_plan.install_actions[1].spec.triplet() == Test::X86_WINDOWS);
+        CHECK(install_plan.install_actions[1].request_type == Dependencies::RequestType::USER_REQUESTED);
     }
     SECTION ("transitive 2")
     {
@@ -1777,8 +1785,10 @@ TEST_CASE ("version install host tool", "[versionplan]")
         REQUIRE(install_plan.size() == 2);
         check_name_and_version(install_plan.install_actions[0], "a", {"1", 0});
         REQUIRE(install_plan.install_actions[0].spec.triplet() == Test::ARM_UWP);
+        CHECK(install_plan.install_actions[0].request_type == Dependencies::RequestType::AUTO_SELECTED);
         check_name_and_version(install_plan.install_actions[1], "c", {"1", 0});
         REQUIRE(install_plan.install_actions[1].spec.triplet() == Test::ARM_UWP);
+        CHECK(install_plan.install_actions[1].request_type == Dependencies::RequestType::USER_REQUESTED);
     }
     SECTION ("self-reference")
     {
@@ -1787,8 +1797,10 @@ TEST_CASE ("version install host tool", "[versionplan]")
         REQUIRE(install_plan.size() == 2);
         check_name_and_version(install_plan.install_actions[0], "d", {"1", 0});
         REQUIRE(install_plan.install_actions[0].spec.triplet() == Test::ARM_UWP);
+        CHECK(install_plan.install_actions[0].request_type == Dependencies::RequestType::AUTO_SELECTED);
         check_name_and_version(install_plan.install_actions[1], "d", {"1", 0});
         REQUIRE(install_plan.install_actions[1].spec.triplet() == Test::X86_WINDOWS);
+        CHECK(install_plan.install_actions[1].request_type == Dependencies::RequestType::USER_REQUESTED);
     }
 }
 TEST_CASE ("version overlay ports", "[versionplan]")

--- a/src/vcpkg/dependencies.cpp
+++ b/src/vcpkg/dependencies.cpp
@@ -1275,6 +1275,7 @@ namespace vcpkg::Dependencies
                 Optional<std::unique_ptr<VersionSchemeInfo>> date;
                 std::set<std::string> features;
                 bool default_features = true;
+                bool user_requested = false;
 
                 VersionSchemeInfo* get_node(const Versions::Version& ver);
                 VersionSchemeInfo& emplace_node(Versions::Scheme scheme, const Versions::Version& ver);
@@ -1738,6 +1739,7 @@ namespace vcpkg::Dependencies
                 auto spec = dep_to_spec(dep);
 
                 auto& node = emplace_package(spec);
+                node.second.user_requested = true;
 
                 auto maybe_overlay = m_o_provider.get_control_file(dep.name);
                 auto over_it = m_overrides.find(dep.name);
@@ -1912,8 +1914,12 @@ namespace vcpkg::Dependencies
                     // -> Add stack frame
                     auto maybe_vars = m_var_provider.get_dep_info_vars(spec);
 
-                    InstallPlanAction ipa(
-                        spec, *p_vnode->scfl, RequestType::USER_REQUESTED, m_host_triplet, std::move(p_vnode->deps));
+                    InstallPlanAction ipa(spec,
+                                          *p_vnode->scfl,
+                                          node.user_requested ? RequestType::USER_REQUESTED
+                                                              : RequestType::AUTO_SELECTED,
+                                          m_host_triplet,
+                                          std::move(p_vnode->deps));
                     std::vector<DepSpec> deps;
                     for (auto&& f : ipa.feature_list)
                     {

--- a/src/vcpkg/install.cpp
+++ b/src/vcpkg/install.cpp
@@ -593,7 +593,7 @@ namespace vcpkg::Install
         nullptr,
     };
 
-    static void print_cmake_information(const BinaryParagraph& bpgh, const VcpkgPaths& paths)
+    void print_usage_information(const BinaryParagraph& bpgh, const VcpkgPaths& paths)
     {
         auto usage = get_cmake_usage(bpgh, paths);
 
@@ -1088,7 +1088,7 @@ namespace vcpkg::Install
             if (result.action->request_type != RequestType::USER_REQUESTED) continue;
             auto bpgh = result.get_binary_paragraph();
             if (!bpgh) continue;
-            print_cmake_information(*bpgh, paths);
+            print_usage_information(*bpgh, paths);
         }
 
         Checks::exit_success(VCPKG_LINE_INFO);


### PR DESCRIPTION
This PR adds tracking of top-level dependencies versus transitive dependencies through the versioned install planner. Then, after completing the "set-installed" algorithm, we print usage information for all top-level package specs.

Before:
```
PS C:\src\vcpkg\mtest> vcpkg install
Detecting compiler hash for triplet x86-windows...
All requested packages are currently installed.

Total elapsed time: 3.2 us
```
After:
```
PS C:\src\vcpkg\mtest> vcpkg install
Detecting compiler hash for triplet x86-windows...
All requested packages are currently installed.

Total elapsed time: 3.2 us

The package cpprestsdk:x86-windows provides CMake targets:

    find_package(cpprestsdk CONFIG REQUIRED)
    target_link_libraries(main PRIVATE cpprestsdk::cpprest cpprestsdk::cpprestsdk_zlib_internal cpprestsdk::cpprestsdk_brotli_internal)
```

Note that in the example, there are three installed packages (`cpprestsdk`, `zlib`, `brotli`) but usage information is only shown for the top level dependency `cpprestsdk`.