### PR TITLE
change the vcpkglib library to an object library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,7 @@ endif()
 
 # === Target: vcpkglib ===
 
-add_library(vcpkglib
+add_library(vcpkglib OBJECT
     ${VCPKGLIB_BASE_SOURCES}
     ${VCPKGLIB_SOURCES}
     ${VCPKGLIB_BASE_INCLUDES}


### PR DESCRIPTION
this is in line with that vcpkglib is _not_ a thing we want to ship

See the comments on PR #132 