### PR TITLE
Split instance locking into 4 output locks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.15)
 
 # ===============
 # === Options ===

--- a/include/vcpkg/vcpkgcmdarguments.h
+++ b/include/vcpkg/vcpkgcmdarguments.h
@@ -178,6 +178,9 @@ namespace vcpkg
         constexpr static StringLiteral IGNORE_LOCK_FAILURES_ENV = "X_VCPKG_IGNORE_LOCK_FAILURES";
         Optional<bool> ignore_lock_failures = nullopt;
 
+        constexpr static StringLiteral LOCK_INSTANCE_SWITCH = "x-lock-instance";
+        Optional<bool> lock_instance = nullopt;
+
         constexpr static StringLiteral JSON_SWITCH = "x-json";
         Optional<bool> json = nullopt;
 

--- a/include/vcpkg/vcpkgcmdarguments.h
+++ b/include/vcpkg/vcpkgcmdarguments.h
@@ -206,6 +206,7 @@ namespace vcpkg
         Optional<bool> versions_feature = nullopt;
 
         constexpr static StringLiteral RECURSIVE_DATA_ENV = "X_VCPKG_RECURSIVE_DATA";
+        bool is_recursive = false;
 
         bool binary_caching_enabled() const { return binary_caching.value_or(true); }
         bool compiler_tracking_enabled() const { return compiler_tracking.value_or(true); }

--- a/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/src/vcpkg/vcpkgcmdarguments.cpp
@@ -726,6 +726,8 @@ namespace vcpkg
         auto maybe_vcpkg_recursive_data = get_environment_variable(RECURSIVE_DATA_ENV);
         if (auto vcpkg_recursive_data = maybe_vcpkg_recursive_data.get())
         {
+            args.is_recursive = true;
+
             auto rec_doc = Json::parse(*vcpkg_recursive_data).value_or_exit(VCPKG_LINE_INFO).first;
             const auto& obj = rec_doc.object();
 
@@ -747,16 +749,6 @@ namespace vcpkg
             if (auto entry = obj.get(DISABLE_METRICS_ENV))
             {
                 args.disable_metrics = entry->boolean();
-            }
-
-            if (auto entry = obj.get(IGNORE_LOCK_FAILURES_ENV))
-            {
-                args.ignore_lock_failures = entry->boolean();
-            }
-
-            if (auto entry = obj.get("lock_instance"))
-            {
-                args.lock_instance = entry->boolean();
             }
 
             // Setting the recursive data to 'poison' prevents more than one level of recursion because
@@ -784,16 +776,6 @@ namespace vcpkg
             if (args.disable_metrics.value_or(false))
             {
                 obj.insert(DISABLE_METRICS_ENV, Json::Value::boolean(true));
-            }
-
-            if (auto entry = args.ignore_lock_failures.get())
-            {
-                obj.insert(IGNORE_LOCK_FAILURES_ENV, Json::Value::boolean(*entry));
-            }
-
-            if (auto entry = args.lock_instance.get())
-            {
-                obj.insert("lock_instance", Json::Value::boolean(*entry));
             }
 
             set_environment_variable(RECURSIVE_DATA_ENV, Json::stringify(obj, Json::JsonStyle::with_spaces(0)));

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -283,6 +283,15 @@ namespace vcpkg
 
     static std::unique_ptr<IExclusiveFileLock> take_lock(const Path& p, Filesystem& fs, const VcpkgCmdArguments& args)
     {
+        if (args.is_recursive)
+        {
+            Checks::exit_with_message(
+                VCPKG_LINE_INFO,
+                "Error: attempted to take a filesystem lock inside a recursive invocation.\nThis is an error because "
+                "there are no supported recursive uses that need locks.\nPlease report this as an issue to the vcpkg "
+                "GitHub: https://github.com/Microsoft/vcpkg/issues");
+        }
+
         std::error_code ec;
         std::unique_ptr<IExclusiveFileLock> ret;
         if (args.wait_for_lock.value_or(false))

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -429,6 +429,10 @@ namespace vcpkg
         if (!manifest_root_dir.empty())
         {
             // Default locking behavior is only supported in manifest mode
+            filesystem.create_directory(downloads, IgnoreErrors{});
+            filesystem.create_directory(installed, IgnoreErrors{});
+            filesystem.create_directory(packages, IgnoreErrors{});
+            filesystem.create_directory(buildtrees, IgnoreErrors{});
             m_pimpl->downloads_lock = take_lock(downloads / ".lock", filesystem, args);
             m_pimpl->installed_lock = take_lock(installed / ".lock", filesystem, args);
             m_pimpl->packages_lock = take_lock(packages / ".lock", filesystem, args);


### PR DESCRIPTION
This PR contains one primary change and four drive-bys:
1. We now lock `packages`, `buildtrees`, `installed`, and `downloads` instead of a single instance lock. This enables "read-only" vcpkg instances by redirecting all output folders.
2. I've added an `--x-lock-instance` workaround in case this is insufficient; users can pass this to reenable the previous behavior (even in classic mode!) while waiting for a tool update that fixes the bug.
3. Push the cmake version required to 3.15 to support `CMAKE_MSVC_RUNTIME_LIBRARY` on the configure cli
4. Fix propagation of disable metrics to actually propagate the bool instead of assuming true
5. Add explicit guards against performing file locks inside a recursive vcpkg invocation.

I've tested this locally by doing:
```
$ vcpkg install --debug >log1 & vcpkg install --debug >log2
```

which results in log2 containing the expected extra line:
> [DEBUG] Waiting to take filesystem lock on /workspaces/vcpkg/downloads/.lock...

Note that since we're now using multiple locks, lock ordering is important. Future tool updates must either preserve the lock order or implement a "safe multiple locking" algorithm.