### PR TITLE
Remove "return std::move(local);"s.

### DIFF
--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -58,7 +58,7 @@ namespace vcpkg::Downloads
             if (!bResults) return Strings::concat("WinHttpQueryHeaders() failed: ", GetLastError());
             if (dwStatusCode < 200 || dwStatusCode >= 300) return Strings::concat("failed: status code ", dwStatusCode);
 
-            return std::move(ret);
+            return ret;
         }
 
         template<class F>

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -282,7 +282,7 @@ namespace vcpkg
         }
 
         // "The result of normalization is a path in normal form, which is said to be normalized."
-        return std::move(normalized);
+        return normalized;
     }
 
     ReadFilePointer::ReadFilePointer(const path& file_path, std::error_code& ec) noexcept

--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -554,12 +554,10 @@ namespace vcpkg
         if (auto proc_info = maybe_proc_info.get())
         {
             ret.proc_info = std::move(*proc_info);
-            return std::move(ret);
+            return ret;
         }
-        else
-        {
-            return maybe_proc_info.error();
-        }
+
+        return maybe_proc_info.error();
     }
 #endif
 

--- a/src/vcpkg/registries.cpp
+++ b/src/vcpkg/registries.cpp
@@ -859,8 +859,7 @@ namespace
             return nullopt;
         }
 
-        // the following redundant std::move is a workaround for a bug in gcc-7:
-        return std::move(res);
+        return std::move(res);  // gcc-7 bug workaround redundant move
     }
 
     View<StringView> RegistryDeserializer::valid_fields() const

--- a/src/vcpkg/registries.cpp
+++ b/src/vcpkg/registries.cpp
@@ -707,7 +707,7 @@ namespace
                 result.emplace(pr.first.to_string(), std::move(version));
             }
 
-            return std::move(result);
+            return result;
         }
 
         static BaselineDeserializer instance;
@@ -859,7 +859,7 @@ namespace
             return nullopt;
         }
 
-        return std::move(res);
+        return res;
     }
 
     View<StringView> RegistryDeserializer::valid_fields() const

--- a/src/vcpkg/registries.cpp
+++ b/src/vcpkg/registries.cpp
@@ -859,7 +859,7 @@ namespace
             return nullopt;
         }
 
-        return std::move(res);  // gcc-7 bug workaround redundant move
+        return std::move(res); // gcc-7 bug workaround redundant move
     }
 
     View<StringView> RegistryDeserializer::valid_fields() const

--- a/src/vcpkg/registries.cpp
+++ b/src/vcpkg/registries.cpp
@@ -859,7 +859,8 @@ namespace
             return nullopt;
         }
 
-        return res;
+        // the following redundant std::move is a workaround for a bug in gcc-7:
+        return std::move(res);
     }
 
     View<StringView> RegistryDeserializer::valid_fields() const

--- a/src/vcpkg/sourceparagraph.cpp
+++ b/src/vcpkg/sourceparagraph.cpp
@@ -395,8 +395,9 @@ namespace vcpkg
 
         if (auto maybe_error = canonicalize(*control_file))
         {
-            return std::move(maybe_error);
+            return maybe_error;
         }
+
         return control_file;
     }
 
@@ -630,7 +631,7 @@ namespace vcpkg
                 type_name(), obj, DESCRIPTION, feature->description, Json::ParagraphDeserializer::instance);
             r.optional_object_field(obj, DEPENDENCIES, feature->dependencies, DependencyArrayDeserializer::instance);
 
-            return std::move(feature);
+            return feature;
         }
         static FeatureDeserializer instance;
     };
@@ -709,7 +710,7 @@ namespace vcpkg
                 }
             }
 
-            return std::move(res);
+            return res;
         }
 
         static FeaturesFieldDeserializer instance;
@@ -970,7 +971,8 @@ namespace vcpkg
             {
                 Checks::exit_with_message(VCPKG_LINE_INFO, maybe_error->error);
             }
-            return std::move(control_file);
+
+            return control_file;
         }
 
         static ManifestDeserializer instance;
@@ -1013,7 +1015,7 @@ namespace vcpkg
             auto err = std::make_unique<ParseControlErrorInfo>();
             err->name = origin;
             err->other_errors = std::move(reader.errors());
-            return std::move(err);
+            return err;
         }
         else if (auto p = res.get())
         {

--- a/src/vcpkg/sourceparagraph.cpp
+++ b/src/vcpkg/sourceparagraph.cpp
@@ -631,7 +631,7 @@ namespace vcpkg
                 type_name(), obj, DESCRIPTION, feature->description, Json::ParagraphDeserializer::instance);
             r.optional_object_field(obj, DEPENDENCIES, feature->dependencies, DependencyArrayDeserializer::instance);
 
-            return feature;
+            return std::move(feature); // gcc-7 bug workaround redundant move
         }
         static FeatureDeserializer instance;
     };
@@ -710,7 +710,7 @@ namespace vcpkg
                 }
             }
 
-            return res;
+            return std::move(res); // gcc-7 bug workaround redundant move
         }
 
         static FeaturesFieldDeserializer instance;
@@ -972,7 +972,7 @@ namespace vcpkg
                 Checks::exit_with_message(VCPKG_LINE_INFO, maybe_error->error);
             }
 
-            return control_file;
+            return std::move(control_file); // gcc-7 bug workaround redundant move
         }
 
         static ManifestDeserializer instance;

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -985,7 +985,7 @@ namespace vcpkg
         auto git_tree_final = m_pimpl->registries_git_trees / vcpkg::u8path(object);
         if (fs.exists(git_tree_final, IgnoreErrors{}))
         {
-            return std::move(git_tree_final);
+            return git_tree_final;
         }
 
         auto pid = get_process_id();

--- a/src/vcpkg/versiondeserializers.cpp
+++ b/src/vcpkg/versiondeserializers.cpp
@@ -57,7 +57,7 @@ namespace
                                         "?");
                 }
             }
-            return std::move(ret);
+            return ret;
         }
         StringLiteral m_type;
         bool m_allow_hash_portversion;


### PR DESCRIPTION
These std::moves either had no effect or inhibited elision. See http://eel.is/c++draft/class.init#class.copy.elision-3