### PR TITLE
Add testing with gcc-6 and fix build breaks.

### DIFF
--- a/azure-pipelines/pipelines.yml
+++ b/azure-pipelines/pipelines.yml
@@ -40,7 +40,7 @@ jobs:
         git -C "$VCPKG_ROOT" checkout $VCPKG_REPO_COMMIT_SHA
       displayName: "Clone vcpkg repo to serve as root"
     - bash: |
-        cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -DVCPKG_DEVELOPMENT_WARNINGS=ON -DVCPKG_WARNINGS_AS_ERRORS=ON -DVCPKG_BUILD_FUZZING=ON -DCMAKE_CXX_COMPILER=g++-6 -B build.amd64.debug
+        cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -DVCPKG_DEVELOPMENT_WARNINGS=OFF -DVCPKG_WARNINGS_AS_ERRORS=OFF -DVCPKG_BUILD_FUZZING=ON -DCMAKE_CXX_COMPILER=g++-6 -B build.amd64.debug
         make -j 2 -C build.amd64.debug
       displayName: "Build vcpkg with CMake"
       failOnStderr: true

--- a/azure-pipelines/pipelines.yml
+++ b/azure-pipelines/pipelines.yml
@@ -27,6 +27,32 @@ jobs:
         arguments: '-Triplet x64-linux -WorkingRoot work -VcpkgRoot $(VCPKG_ROOT)'
         workingDirectory: '$(Build.SourcesDirectory)/build.amd64.debug'
         pwsh: true
+- job: linux_gcc_6
+  displayName: 'Ubuntu 18.04 with GCC 6'
+  pool:
+    name: 'vcpkg-gcc-6'
+  variables:
+    - name: 'VCPKG_ROOT'
+      value: $(Build.SourcesDirectory)/vcpkg-root
+  steps:
+    - bash: |
+        git clone https://github.com/microsoft/vcpkg "$VCPKG_ROOT" -n
+        git -C "$VCPKG_ROOT" checkout $VCPKG_REPO_COMMIT_SHA
+      displayName: "Clone vcpkg repo to serve as root"
+    - bash: |
+        cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -DVCPKG_DEVELOPMENT_WARNINGS=ON -DVCPKG_WARNINGS_AS_ERRORS=ON -DVCPKG_BUILD_FUZZING=ON -DCMAKE_CXX_COMPILER=g++-6 -B build.amd64.debug
+        make -j 2 -C build.amd64.debug
+      displayName: "Build vcpkg with CMake"
+      failOnStderr: true
+    - bash: build.amd64.debug/vcpkg-test
+      displayName: 'Run vcpkg tests'
+    - task: PowerShell@2
+      displayName: 'Run vcpkg end-to-end tests'
+      inputs:
+        filePath: 'azure-pipelines/end-to-end-tests.ps1'
+        arguments: '-Triplet x64-linux -WorkingRoot work -VcpkgRoot $(VCPKG_ROOT)'
+        workingDirectory: '$(Build.SourcesDirectory)/build.amd64.debug'
+        pwsh: true
 - job: linux_gcc_7
   displayName: 'Ubuntu 18.04 with GCC 7'
   pool:

--- a/azure-pipelines/pipelines.yml
+++ b/azure-pipelines/pipelines.yml
@@ -1,10 +1,10 @@
 variables:
   VCPKG_REPO_COMMIT_SHA: '261c458af6e3eed5d099144aff95d2b5035f656b'
 jobs:
-- job: linux
-  displayName: 'Linux'
+- job: linux_gcc_9
+  displayName: 'Ubuntu 20.04 with GCC 9'
   pool:
-    vmImage: 'ubuntu-latest'
+    vmImage: 'ubuntu-20.04'
   variables:
     - name: 'VCPKG_ROOT'
       value: $(Build.SourcesDirectory)/vcpkg-root
@@ -46,13 +46,6 @@ jobs:
       failOnStderr: true
     - bash: build.amd64.debug/vcpkg-test
       displayName: 'Run vcpkg tests'
-    - task: PowerShell@2
-      displayName: 'Run vcpkg end-to-end tests'
-      inputs:
-        filePath: 'azure-pipelines/end-to-end-tests.ps1'
-        arguments: '-Triplet x64-linux -WorkingRoot work -VcpkgRoot $(VCPKG_ROOT)'
-        workingDirectory: '$(Build.SourcesDirectory)/build.amd64.debug'
-        pwsh: true
 - job: linux_gcc_7
   displayName: 'Ubuntu 18.04 with GCC 7'
   pool:

--- a/azure-pipelines/setup-gcc6-vm.sh
+++ b/azure-pipelines/setup-gcc6-vm.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# This script is run by cloud-init on top of an Ubuntu 18.04 blank image to install prerequisites.
+sudo add-apt-repository universe
+sudo apt-get update
+sudo apt-get install -y g++-6 gcc-6 build-essential make
+curl -o cmake-3.21.1-linux-x86_64.sh -L https://github.com/Kitware/CMake/releases/download/v3.21.1/cmake-3.21.1-linux-x86_64.sh
+chmod +x cmake-3.21.1-linux-x86_64.sh
+sudo ./cmake-3.21.1-linux-x86_64.sh --skip-license --prefix=/

--- a/include/vcpkg/base/chrono.h
+++ b/include/vcpkg/base/chrono.h
@@ -6,7 +6,7 @@
 #include <chrono>
 #include <string>
 
-namespace vcpkg::Chrono
+namespace vcpkg
 {
     struct ElapsedTime
     {

--- a/include/vcpkg/base/fwd/lockguarded.h
+++ b/include/vcpkg/base/fwd/lockguarded.h
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace vcpkg::Util
+namespace vcpkg
 {
     template<class T>
     struct LockGuardPtr;

--- a/include/vcpkg/base/lockguarded.h
+++ b/include/vcpkg/base/lockguarded.h
@@ -4,14 +4,12 @@
 
 #include <mutex>
 
-namespace vcpkg::Util
+namespace vcpkg
 {
     template<class T>
     struct LockGuarded
     {
         friend struct LockGuardPtr<T>;
-
-        LockGuardPtr<T> lock() { return *this; }
 
     private:
         std::mutex m_mutex;

--- a/include/vcpkg/base/system.debug.h
+++ b/include/vcpkg/base/system.debug.h
@@ -21,7 +21,7 @@ namespace vcpkg::Debug
     {
         if (g_debugging)
         {
-            auto timer = Chrono::ElapsedTimer::create_started();
+            auto timer = ElapsedTimer::create_started();
             auto&& result = f();
             print2("[DEBUG] ", line, " took ", timer, '\n');
             return static_cast<R&&>(result);
@@ -35,7 +35,7 @@ namespace vcpkg::Debug
     {
         if (g_debugging)
         {
-            auto timer = Chrono::ElapsedTimer::create_started();
+            auto timer = ElapsedTimer::create_started();
             f();
             print2("[DEBUG] ", line, " took ", timer, '\n');
         }

--- a/include/vcpkg/globalstate.h
+++ b/include/vcpkg/globalstate.h
@@ -11,8 +11,8 @@ namespace vcpkg
 {
     struct GlobalState
     {
-        static Util::LockGuarded<Chrono::ElapsedTimer> timer;
-        static Util::LockGuarded<std::string> g_surveydate;
+        static LockGuarded<ElapsedTimer> timer;
+        static LockGuarded<std::string> g_surveydate;
 
         static std::atomic<int> g_init_console_cp;
         static std::atomic<int> g_init_console_output_cp;

--- a/include/vcpkg/install.h
+++ b/include/vcpkg/install.h
@@ -28,7 +28,7 @@ namespace vcpkg::Install
 
         PackageSpec spec;
         Build::ExtendedBuildResult build_result;
-        vcpkg::Chrono::ElapsedTime timing;
+        vcpkg::ElapsedTime timing;
 
         const Dependencies::InstallPlanAction* action;
     };

--- a/include/vcpkg/metrics.h
+++ b/include/vcpkg/metrics.h
@@ -6,7 +6,7 @@
 
 #include <string>
 
-namespace vcpkg::Metrics
+namespace vcpkg
 {
     struct Metrics
     {
@@ -31,7 +31,7 @@ namespace vcpkg::Metrics
         void flush(Filesystem& fs);
     };
 
-    extern Util::LockGuarded<Metrics> g_metrics;
+    extern LockGuarded<Metrics> g_metrics;
 
     std::string get_MAC_user();
 }

--- a/src/vcpkg-test/chrono.cpp
+++ b/src/vcpkg-test/chrono.cpp
@@ -2,12 +2,12 @@
 
 #include <vcpkg/base/chrono.h>
 
-namespace Chrono = vcpkg::Chrono;
+using namespace vcpkg;
 
 TEST_CASE ("parse time", "[chrono]")
 {
     auto timestring = "1990-02-03T04:05:06.0Z";
-    auto maybe_time = Chrono::CTime::parse(timestring);
+    auto maybe_time = CTime::parse(timestring);
 
     REQUIRE(maybe_time.has_value());
     REQUIRE(maybe_time.get()->to_string() == timestring);
@@ -15,15 +15,15 @@ TEST_CASE ("parse time", "[chrono]")
 
 TEST_CASE ("parse blank time", "[chrono]")
 {
-    auto maybe_time = Chrono::CTime::parse("");
+    auto maybe_time = CTime::parse("");
 
     REQUIRE_FALSE(maybe_time.has_value());
 }
 
 TEST_CASE ("difference of times", "[chrono]")
 {
-    auto maybe_time1 = Chrono::CTime::parse("1990-02-03T04:05:06.0Z");
-    auto maybe_time2 = Chrono::CTime::parse("1990-02-10T04:05:06.0Z");
+    auto maybe_time1 = CTime::parse("1990-02-03T04:05:06.0Z");
+    auto maybe_time2 = CTime::parse("1990-02-10T04:05:06.0Z");
 
     REQUIRE(maybe_time1.has_value());
     REQUIRE(maybe_time2.has_value());

--- a/src/vcpkg.cpp
+++ b/src/vcpkg.cpp
@@ -47,7 +47,7 @@ static void invalid_command(const std::string& cmd)
 
 static void inner(vcpkg::Filesystem& fs, const VcpkgCmdArguments& args)
 {
-    Metrics::g_metrics.lock()->track_property("command", args.command);
+    LockGuardPtr<Metrics>(g_metrics)->track_property("command", args.command);
     if (args.command.empty())
     {
         print_usage();
@@ -106,20 +106,20 @@ static void load_config(vcpkg::Filesystem& fs)
     // config file not found, could not be read, or invalid
     if (config.user_id.empty() || config.user_time.empty())
     {
-        ::vcpkg::Metrics::Metrics::init_user_information(config.user_id, config.user_time);
+        ::vcpkg::Metrics::init_user_information(config.user_id, config.user_time);
         write_config = true;
     }
 
 #if defined(_WIN32)
     if (config.user_mac.empty())
     {
-        config.user_mac = Metrics::get_MAC_user();
+        config.user_mac = get_MAC_user();
         write_config = true;
     }
 #endif
 
     {
-        auto locked_metrics = Metrics::g_metrics.lock();
+        LockGuardPtr<Metrics> locked_metrics(g_metrics);
         locked_metrics->set_user_information(config.user_id, config.user_time);
 #if defined(_WIN32)
         locked_metrics->track_property("user_mac", config.user_mac);
@@ -128,12 +128,12 @@ static void load_config(vcpkg::Filesystem& fs)
 
     if (config.last_completed_survey.empty())
     {
-        const auto now = Chrono::CTime::parse(config.user_time).value_or_exit(VCPKG_LINE_INFO);
-        const Chrono::CTime offset = now.add_hours(-SURVEY_INITIAL_OFFSET_IN_HOURS);
+        const auto now = CTime::parse(config.user_time).value_or_exit(VCPKG_LINE_INFO);
+        const CTime offset = now.add_hours(-SURVEY_INITIAL_OFFSET_IN_HOURS);
         config.last_completed_survey = offset.to_string();
     }
 
-    GlobalState::g_surveydate.lock()->assign(config.last_completed_survey);
+    LockGuardPtr<std::string>(GlobalState::g_surveydate)->assign(config.last_completed_survey);
 
     if (write_config)
     {
@@ -163,7 +163,7 @@ int main(const int argc, const char* const* const argv)
     if (argc == 0) std::abort();
 
     auto& fs = get_real_filesystem();
-    *GlobalState::timer.lock() = Chrono::ElapsedTimer::create_started();
+    *(LockGuardPtr<ElapsedTimer>(GlobalState::timer)) = ElapsedTimer::create_started();
 
 #if defined(_WIN32)
     GlobalState::g_init_console_cp = GetConsoleCP();
@@ -178,11 +178,11 @@ int main(const int argc, const char* const* const argv)
     set_environment_variable("VCPKG_COMMAND", get_exe_path_of_current_process().generic_u8string());
 
     Checks::register_global_shutdown_handler([]() {
-        const auto elapsed_us_inner = GlobalState::timer.lock()->microseconds();
+        const auto elapsed_us_inner = LockGuardPtr<ElapsedTimer>(GlobalState::timer)->microseconds();
 
         bool debugging = Debug::g_debugging;
 
-        auto metrics = Metrics::g_metrics.lock();
+        LockGuardPtr<Metrics> metrics(g_metrics);
         metrics->track_metric("elapsed_us", elapsed_us_inner);
         Debug::g_debugging = false;
         metrics->flush(get_real_filesystem());
@@ -195,17 +195,14 @@ int main(const int argc, const char* const* const argv)
         }
 #endif
 
-        auto elapsed_us = GlobalState::timer.lock()->microseconds();
+        auto elapsed_us = LockGuardPtr<ElapsedTimer>(GlobalState::timer)->microseconds();
         if (debugging)
             vcpkg::printf("[DEBUG] Exiting after %d us (%d us)\n",
                           static_cast<int>(elapsed_us),
                           static_cast<int>(elapsed_us_inner));
     });
 
-    {
-        auto locked_metrics = Metrics::g_metrics.lock();
-        locked_metrics->track_property("version", Commands::Version::version());
-    }
+    LockGuardPtr<Metrics>(g_metrics)->track_property("version", Commands::Version::version());
 
     register_console_ctrl_handler();
 
@@ -231,7 +228,7 @@ int main(const int argc, const char* const* const argv)
     args.check_feature_flag_consistency();
 
     {
-        auto metrics = Metrics::g_metrics.lock();
+        LockGuardPtr<Metrics> metrics(g_metrics);
         if (const auto p = args.disable_metrics.get())
         {
             metrics->set_disabled(*p);
@@ -260,7 +257,7 @@ int main(const int argc, const char* const* const argv)
         {
             print2(Color::warning, "Warning: passed --sendmetrics, but metrics are disabled.\n");
         }
-    } // unlock Metrics::g_metrics
+    } // unlock g_metrics
 
     args.debug_print_feature_flags();
     args.track_feature_flag_metrics();
@@ -285,7 +282,8 @@ int main(const int argc, const char* const* const argv)
     {
         exc_msg = "unknown error(...)";
     }
-    Metrics::g_metrics.lock()->track_property("error", exc_msg);
+
+    LockGuardPtr<Metrics>(g_metrics)->track_property("error", exc_msg);
 
     fflush(stdout);
     vcpkg::printf("vcpkg.exe has crashed.\n"

--- a/src/vcpkg/base/chrono.cpp
+++ b/src/vcpkg/base/chrono.cpp
@@ -1,7 +1,7 @@
 #include <vcpkg/base/checks.h>
 #include <vcpkg/base/chrono.h>
 
-namespace vcpkg::Chrono
+namespace vcpkg
 {
     static std::time_t get_current_time_as_time_since_epoch()
     {
@@ -175,6 +175,6 @@ namespace vcpkg::Chrono
     tm get_current_date_time_local()
     {
         const std::time_t now_time = get_current_time_as_time_since_epoch();
-        return Chrono::to_local_time(now_time);
+        return to_local_time(now_time);
     }
 }

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -742,7 +742,7 @@ namespace vcpkg
     // This implementation does collapse slashes because we primarily use it for shiny display purposes.
     void Path::make_preferred()
     {
-        char* first = m_str.data();
+        char* first = &m_str[0];
         char* last = first + m_str.size();
         char* after_root_name = const_cast<char*>(find_root_name_end(first, last));
         char* after_root_directory = std::find_if_not(after_root_name, last, is_slash);

--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -570,7 +570,7 @@ namespace vcpkg
 #if defined(_WIN32)
     void cmd_execute_background(const Command& cmd_line)
     {
-        auto timer = Chrono::ElapsedTimer::create_started();
+        auto timer = ElapsedTimer::create_started();
 
         auto process_info =
             windows_create_windowless_process(cmd_line.command_line(),
@@ -632,7 +632,7 @@ namespace vcpkg
 
     int cmd_execute(const Command& cmd_line, InWorkingDirectory wd, const Environment& env)
     {
-        auto timer = Chrono::ElapsedTimer::create_started();
+        auto timer = ElapsedTimer::create_started();
 #if defined(_WIN32)
         using vcpkg::g_ctrl_c_state;
         g_ctrl_c_state.transition_to_spawn_process();
@@ -690,7 +690,7 @@ namespace vcpkg
                                     std::function<void(StringView)> data_cb,
                                     const Environment& env)
     {
-        auto timer = Chrono::ElapsedTimer::create_started();
+        auto timer = ElapsedTimer::create_started();
 
 #if defined(_WIN32)
         using vcpkg::g_ctrl_c_state;

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -1277,7 +1277,7 @@ namespace
             auto maybe_cachepath = get_environment_variable("VCPKG_DEFAULT_BINARY_CACHE");
             if (auto p_str = maybe_cachepath.get())
             {
-                Metrics::g_metrics.lock()->track_property("VCPKG_DEFAULT_BINARY_CACHE", "defined");
+                LockGuardPtr<Metrics>(g_metrics)->track_property("VCPKG_DEFAULT_BINARY_CACHE", "defined");
                 Path path = *p_str;
                 path.make_preferred();
                 if (!get_real_filesystem().is_directory(path))
@@ -1705,7 +1705,7 @@ ExpectedS<Downloads::DownloadManagerConfig> vcpkg::parse_download_configuration(
 {
     if (!arg || arg.get()->empty()) return Downloads::DownloadManagerConfig{};
 
-    Metrics::g_metrics.lock()->track_property("asset-source", "defined");
+    LockGuardPtr<Metrics>(g_metrics)->track_property("asset-source", "defined");
 
     AssetSourcesState s;
     AssetSourcesParser parser(*arg.get(), Strings::concat("$", VcpkgCmdArguments::ASSET_SOURCES_ENV), &s);
@@ -1776,7 +1776,7 @@ ExpectedS<std::vector<std::unique_ptr<IBinaryProvider>>> vcpkg::create_binary_pr
     const std::string& env_string, View<std::string> args)
 {
     {
-        auto metrics = Metrics::g_metrics.lock();
+        LockGuardPtr<Metrics> metrics(g_metrics);
         if (!env_string.empty())
         {
             metrics->track_property("VCPKG_BINARY_SOURCES", "defined");
@@ -1816,7 +1816,7 @@ ExpectedS<std::vector<std::unique_ptr<IBinaryProvider>>> vcpkg::create_binary_pr
 
     if (s.m_cleared)
     {
-        Metrics::g_metrics.lock()->track_property("binarycaching-clear", "defined");
+        LockGuardPtr<Metrics>(g_metrics)->track_property("binarycaching-clear", "defined");
     }
 
     std::vector<std::unique_ptr<IBinaryProvider>> providers;
@@ -1836,14 +1836,14 @@ ExpectedS<std::vector<std::unique_ptr<IBinaryProvider>>> vcpkg::create_binary_pr
 
     if (!s.url_templates_to_get.empty())
     {
-        Metrics::g_metrics.lock()->track_property("binarycaching-url-get", "defined");
+        LockGuardPtr<Metrics>(g_metrics)->track_property("binarycaching-url-get", "defined");
         providers.push_back(std::make_unique<HttpGetBinaryProvider>(std::move(s.url_templates_to_get)));
     }
 
     if (!s.sources_to_read.empty() || !s.sources_to_write.empty() || !s.configs_to_read.empty() ||
         !s.configs_to_write.empty())
     {
-        Metrics::g_metrics.lock()->track_property("binarycaching-nuget", "defined");
+        LockGuardPtr<Metrics>(g_metrics)->track_property("binarycaching-nuget", "defined");
         providers.push_back(std::make_unique<NugetBinaryProvider>(std::move(s.sources_to_read),
                                                                   std::move(s.sources_to_write),
                                                                   std::move(s.configs_to_read),
@@ -1888,7 +1888,7 @@ details::NuGetRepoInfo details::get_nuget_repo_info_from_env()
     auto vcpkg_nuget_repository = get_environment_variable("VCPKG_NUGET_REPOSITORY");
     if (auto p = vcpkg_nuget_repository.get())
     {
-        Metrics::g_metrics.lock()->track_property("VCPKG_NUGET_REPOSITORY", "defined");
+        LockGuardPtr<Metrics>(g_metrics)->track_property("VCPKG_NUGET_REPOSITORY", "defined");
         return {std::move(*p)};
     }
 
@@ -1904,7 +1904,7 @@ details::NuGetRepoInfo details::get_nuget_repo_info_from_env()
         return {};
     }
 
-    Metrics::g_metrics.lock()->track_property("GITHUB_REPOSITORY", "defined");
+    LockGuardPtr<Metrics>(g_metrics)->track_property("GITHUB_REPOSITORY", "defined");
     return {Strings::concat(gh_server, '/', gh_repo, ".git"),
             get_environment_variable("GITHUB_REF").value_or(""),
             get_environment_variable("GITHUB_SHA").value_or("")};

--- a/src/vcpkg/commands.autocomplete.cpp
+++ b/src/vcpkg/commands.autocomplete.cpp
@@ -31,7 +31,7 @@ namespace vcpkg::Commands::Autocomplete
 
     void perform_and_exit(const VcpkgCmdArguments& args, const VcpkgPaths& paths)
     {
-        Metrics::g_metrics.lock()->set_send_metrics(false);
+        LockGuardPtr<Metrics>(g_metrics)->set_send_metrics(false);
         const std::string to_autocomplete = Strings::join(" ", args.command_arguments);
         const std::vector<std::string> tokens = Strings::split(to_autocomplete, ' ');
 

--- a/src/vcpkg/commands.ci.cpp
+++ b/src/vcpkg/commands.ci.cpp
@@ -114,11 +114,11 @@ namespace vcpkg::Commands::CI
     struct XunitTestResults
     {
     public:
-        XunitTestResults() { m_assembly_run_datetime = Chrono::CTime::get_current_date_time(); }
+        XunitTestResults() { m_assembly_run_datetime = CTime::get_current_date_time(); }
 
         void add_test_results(const std::string& spec,
                               const Build::BuildResult& build_result,
-                              const Chrono::ElapsedTime& elapsed_time,
+                              const ElapsedTime& elapsed_time,
                               const std::string& abi_tag,
                               const std::vector<std::string>& features)
         {
@@ -128,7 +128,7 @@ namespace vcpkg::Commands::CI
         // Starting a new test collection
         void push_collection(const std::string& name) { m_collections.push_back({name}); }
 
-        void collection_time(const vcpkg::Chrono::ElapsedTime& time) { m_collections.back().time = time; }
+        void collection_time(const vcpkg::ElapsedTime& time) { m_collections.back().time = time; }
 
         const std::string& build_xml()
         {
@@ -149,14 +149,14 @@ namespace vcpkg::Commands::CI
             return m_xml;
         }
 
-        void assembly_time(const vcpkg::Chrono::ElapsedTime& assembly_time) { m_assembly_time = assembly_time; }
+        void assembly_time(const vcpkg::ElapsedTime& assembly_time) { m_assembly_time = assembly_time; }
 
     private:
         struct XunitTest
         {
             std::string name;
             vcpkg::Build::BuildResult result;
-            vcpkg::Chrono::ElapsedTime time;
+            vcpkg::ElapsedTime time;
             std::string abi_tag;
             std::vector<std::string> features;
         };
@@ -164,7 +164,7 @@ namespace vcpkg::Commands::CI
         struct XunitCollection
         {
             std::string name;
-            vcpkg::Chrono::ElapsedTime time;
+            vcpkg::ElapsedTime time;
             std::vector<XunitTest> tests;
         };
 
@@ -262,8 +262,8 @@ namespace vcpkg::Commands::CI
                                      message_block);
         }
 
-        Optional<vcpkg::Chrono::CTime> m_assembly_run_datetime;
-        vcpkg::Chrono::ElapsedTime m_assembly_time;
+        Optional<vcpkg::CTime> m_assembly_run_datetime;
+        vcpkg::ElapsedTime m_assembly_time;
         std::vector<XunitCollection> m_collections;
 
         std::string m_xml;
@@ -343,7 +343,7 @@ namespace vcpkg::Commands::CI
 
         var_provider.load_tag_vars(install_specs, provider, host_triplet);
 
-        auto timer = Chrono::ElapsedTimer::create_started();
+        auto timer = ElapsedTimer::create_started();
 
         Checks::check_exit(VCPKG_LINE_INFO, action_plan.already_installed.empty());
         Checks::check_exit(VCPKG_LINE_INFO, action_plan.remove_actions.empty());
@@ -498,7 +498,7 @@ namespace vcpkg::Commands::CI
         std::vector<std::string> all_ports =
             Util::fmap(provider.load_all_control_files(), Paragraphs::get_name_of_control_file);
         std::vector<TripletAndSummary> results;
-        auto timer = Chrono::ElapsedTimer::create_started();
+        auto timer = ElapsedTimer::create_started();
 
         Input::check_triplet(target_triplet, paths);
 
@@ -551,7 +551,7 @@ namespace vcpkg::Commands::CI
         }
         else
         {
-            auto collection_timer = Chrono::ElapsedTimer::create_started();
+            auto collection_timer = ElapsedTimer::create_started();
             auto summary = Install::perform(args,
                                             action_plan,
                                             Install::KeepGoing::YES,
@@ -580,7 +580,7 @@ namespace vcpkg::Commands::CI
                 auto& port_features = split_specs->features.at(port.first);
                 xunitTestResults.add_test_results(port.first.to_string(),
                                                   port.second,
-                                                  Chrono::ElapsedTime{},
+                                                  ElapsedTime{},
                                                   split_specs->abi_map.at(port.first),
                                                   port_features);
             }

--- a/src/vcpkg/commands.contact.cpp
+++ b/src/vcpkg/commands.contact.cpp
@@ -36,7 +36,7 @@ namespace vcpkg::Commands::Contact
 
         if (Util::Sets::contains(parsed_args.switches, SWITCHES[0].name))
         {
-            auto maybe_now = Chrono::CTime::get_current_date_time();
+            auto maybe_now = CTime::get_current_date_time();
             if (const auto p_now = maybe_now.get())
             {
                 auto config = UserConfig::try_read_data(fs);

--- a/src/vcpkg/commands.integrate.cpp
+++ b/src/vcpkg/commands.integrate.cpp
@@ -416,7 +416,7 @@ With a project open, go to Tools->NuGet Package Manager->Package Manager Console
                           script_path.generic_u8string());
 
             {
-                auto locked_metrics = Metrics::g_metrics.lock();
+                auto locked_metrics = LockGuardPtr<Metrics>(g_metrics);
                 locked_metrics->track_property("error", "powershell script failed");
                 locked_metrics->track_property("title", TITLE);
             }

--- a/src/vcpkg/commands.setinstalled.cpp
+++ b/src/vcpkg/commands.setinstalled.cpp
@@ -166,7 +166,7 @@ namespace vcpkg::Commands::SetInstalled
         auto it_pkgsconfig = options.settings.find(OPTION_WRITE_PACKAGES_CONFIG);
         if (it_pkgsconfig != options.settings.end())
         {
-            Metrics::g_metrics.lock()->track_property("x-write-nuget-packages-config", "defined");
+            LockGuardPtr<Metrics>(g_metrics)->track_property("x-write-nuget-packages-config", "defined");
             pkgsconfig = it_pkgsconfig->second;
         }
 

--- a/src/vcpkg/commands.upload-metrics.cpp
+++ b/src/vcpkg/commands.upload-metrics.cpp
@@ -22,7 +22,7 @@ namespace vcpkg::Commands::UploadMetrics
         (void)args.parse_arguments(COMMAND_STRUCTURE);
         const auto& payload_path = args.command_arguments[0];
         auto payload = fs.read_contents(payload_path, VCPKG_LINE_INFO);
-        Metrics::g_metrics.lock()->upload(payload);
+        LockGuardPtr<Metrics>(g_metrics)->upload(payload);
         Checks::exit_success(VCPKG_LINE_INFO);
     }
 }

--- a/src/vcpkg/configuration.cpp
+++ b/src/vcpkg/configuration.cpp
@@ -74,8 +74,8 @@ namespace vcpkg
     {
         if (!flags.registries && registry_set.has_modifications())
         {
-            Metrics::g_metrics.lock()->track_property("registries-error-registry-modification-without-feature-flag",
-                                                      "defined");
+            LockGuardPtr<Metrics>(g_metrics)->track_property(
+                "registries-error-registry-modification-without-feature-flag", "defined");
             vcpkg::printf(Color::warning,
                           "Warning: configuration specified the \"registries\" or \"default-registries\" field, but "
                           "the %s feature flag was not enabled.\n",

--- a/src/vcpkg/export.cpp
+++ b/src/vcpkg/export.cpp
@@ -117,7 +117,7 @@ namespace vcpkg::Export
 
     static std::string create_export_id()
     {
-        const tm date_time = Chrono::get_current_date_time_local();
+        const tm date_time = get_current_date_time_local();
 
         // Format is: YYYYmmdd-HHMMSS
         // 15 characters + 1 null terminating character will be written for a total of 16 chars

--- a/src/vcpkg/export.ifw.cpp
+++ b/src/vcpkg/export.ifw.cpp
@@ -17,7 +17,7 @@ namespace vcpkg::Export::IFW
     {
         std::string create_release_date()
         {
-            const tm date_time = Chrono::get_current_date_time_local();
+            const tm date_time = get_current_date_time_local();
 
             // Format is: YYYY-mm-dd
             // 10 characters + 1 null terminating character will be written for a total of 11 chars

--- a/src/vcpkg/globalstate.cpp
+++ b/src/vcpkg/globalstate.cpp
@@ -4,8 +4,8 @@
 
 namespace vcpkg
 {
-    Util::LockGuarded<Chrono::ElapsedTimer> GlobalState::timer;
-    Util::LockGuarded<std::string> GlobalState::g_surveydate;
+    LockGuarded<ElapsedTimer> GlobalState::timer;
+    LockGuarded<std::string> GlobalState::g_surveydate;
 
     std::atomic<int> GlobalState::g_init_console_cp(0);
     std::atomic<int> GlobalState::g_init_console_output_cp(0);

--- a/src/vcpkg/input.cpp
+++ b/src/vcpkg/input.cpp
@@ -31,7 +31,7 @@ namespace vcpkg
         if (!paths.is_valid_triplet(t))
         {
             print2(Color::error, "Error: invalid triplet: ", t, '\n');
-            Metrics::g_metrics.lock()->track_property("error", "invalid triplet: " + t.to_string());
+            LockGuardPtr<Metrics>(g_metrics)->track_property("error", "invalid triplet: " + t.to_string());
             Help::help_topic_valid_triplet(paths);
             Checks::exit_fail(VCPKG_LINE_INFO);
         }

--- a/src/vcpkg/install.cpp
+++ b/src/vcpkg/install.cpp
@@ -425,7 +425,7 @@ namespace vcpkg::Install
     struct TrackedPackageInstallGuard
     {
         SpecSummary* current_summary = nullptr;
-        Chrono::ElapsedTimer build_timer = Chrono::ElapsedTimer::create_started();
+        ElapsedTimer build_timer = ElapsedTimer::create_started();
 
         TrackedPackageInstallGuard(const size_t action_index,
                                    const size_t action_count,
@@ -461,7 +461,7 @@ namespace vcpkg::Install
         const size_t action_count = action_plan.remove_actions.size() + action_plan.install_actions.size();
         size_t action_index = 1;
 
-        const auto timer = Chrono::ElapsedTimer::create_started();
+        const auto timer = ElapsedTimer::create_started();
         for (auto&& action : action_plan.remove_actions)
         {
             TrackedPackageInstallGuard this_install(action_index++, action_count, results, action.spec);
@@ -814,7 +814,7 @@ namespace vcpkg::Install
             auto it_pkgsconfig = options.settings.find(OPTION_WRITE_PACKAGES_CONFIG);
             if (it_pkgsconfig != options.settings.end())
             {
-                Metrics::g_metrics.lock()->track_property("x-write-nuget-packages-config", "defined");
+                LockGuardPtr<Metrics>(g_metrics)->track_property("x-write-nuget-packages-config", "defined");
                 pkgsconfig = Path(it_pkgsconfig->second);
             }
             const auto& manifest_path = paths.get_manifest_path().value_or_exit(VCPKG_LINE_INFO);
@@ -884,20 +884,20 @@ namespace vcpkg::Install
                     return dep.constraint.type != Versions::Constraint::Type::None;
                 }))
             {
-                Metrics::g_metrics.lock()->track_property("manifest_version_constraint", "defined");
+                LockGuardPtr<Metrics>(g_metrics)->track_property("manifest_version_constraint", "defined");
             }
 
             if (!manifest_scf.core_paragraph->overrides.empty())
             {
-                Metrics::g_metrics.lock()->track_property("manifest_overrides", "defined");
+                LockGuardPtr<Metrics>(g_metrics)->track_property("manifest_overrides", "defined");
             }
 
             if (auto p_baseline = manifest_scf.core_paragraph->builtin_baseline.get())
             {
-                Metrics::g_metrics.lock()->track_property("manifest_baseline", "defined");
+                LockGuardPtr<Metrics>(g_metrics)->track_property("manifest_baseline", "defined");
                 if (!is_git_commit_sha(*p_baseline))
                 {
-                    Metrics::g_metrics.lock()->track_property("versioning-error-baseline", "defined");
+                    LockGuardPtr<Metrics>(g_metrics)->track_property("versioning-error-baseline", "defined");
                     Checks::exit_maybe_upgrade(VCPKG_LINE_INFO,
                                                "Error: the top-level builtin-baseline (%s) was not a valid commit sha: "
                                                "expected 40 lowercase hexadecimal characters.\n%s\n",
@@ -1025,7 +1025,7 @@ namespace vcpkg::Install
         auto it_pkgsconfig = options.settings.find(OPTION_WRITE_PACKAGES_CONFIG);
         if (it_pkgsconfig != options.settings.end())
         {
-            Metrics::g_metrics.lock()->track_property("x-write-nuget-packages-config", "defined");
+            LockGuardPtr<Metrics>(g_metrics)->track_property("x-write-nuget-packages-config", "defined");
             Build::compute_all_abis(paths, action_plan, var_provider, status_db);
 
             auto pkgsconfig_path = paths.original_cwd / it_pkgsconfig->second;
@@ -1113,7 +1113,7 @@ namespace vcpkg::Install
         return nullptr;
     }
 
-    static std::string xunit_result(const PackageSpec& spec, Chrono::ElapsedTime time, BuildResult code)
+    static std::string xunit_result(const PackageSpec& spec, ElapsedTime time, BuildResult code)
     {
         std::string message_block;
         const char* result_string = "";
@@ -1187,6 +1187,6 @@ namespace vcpkg::Install
                                             Hash::get_string_hash(version_as_string, Hash::Algorithm::Sha256));
         }
 
-        Metrics::g_metrics.lock()->track_property("installplan_1", specs_string);
+        LockGuardPtr<Metrics>(g_metrics)->track_property("installplan_1", specs_string);
     }
 }

--- a/src/vcpkg/metrics.cpp
+++ b/src/vcpkg/metrics.cpp
@@ -14,13 +14,13 @@
 #pragma comment(lib, "winhttp")
 #endif
 
-namespace vcpkg::Metrics
+namespace vcpkg
 {
-    Util::LockGuarded<Metrics> g_metrics;
+    LockGuarded<Metrics> g_metrics;
 
-    static std::string get_current_date_time()
+    static std::string get_current_date_time_string()
     {
-        auto maybe_time = Chrono::CTime::get_current_date_time();
+        auto maybe_time = CTime::get_current_date_time();
         if (auto ptime = maybe_time.get())
         {
             return ptime->to_string();
@@ -147,7 +147,7 @@ namespace vcpkg::Metrics
     {
         std::string user_id = generate_random_UUID();
         std::string user_timestamp;
-        std::string timestamp = get_current_date_time();
+        std::string timestamp = get_current_date_time_string();
 
         Json::Object properties;
         Json::Object measurements;
@@ -252,7 +252,7 @@ namespace vcpkg::Metrics
     std::string get_MAC_user()
     {
 #if defined(_WIN32)
-        if (!g_metrics.lock()->metrics_enabled())
+        if (!LockGuardPtr<Metrics>(g_metrics)->metrics_enabled())
         {
             return "{}";
         }
@@ -290,7 +290,7 @@ namespace vcpkg::Metrics
     void Metrics::init_user_information(std::string& user_id, std::string& first_use_time)
     {
         user_id = generate_random_UUID();
-        first_use_time = get_current_date_time();
+        first_use_time = get_current_date_time_string();
     }
 
     void Metrics::set_send_metrics(bool should_send_metrics) { g_should_send_metrics = should_send_metrics; }

--- a/src/vcpkg/portfileprovider.cpp
+++ b/src/vcpkg/portfileprovider.cpp
@@ -199,7 +199,7 @@ namespace vcpkg::PortFileProvider
                     }
                     else
                     {
-                        Metrics::g_metrics.lock()->track_property("versioning-error-version", "defined");
+                        LockGuardPtr<Metrics>(g_metrics)->track_property("versioning-error-version", "defined");
                         return maybe_path.error();
                     }
                 }

--- a/src/vcpkg/registries.cpp
+++ b/src/vcpkg/registries.cpp
@@ -1020,6 +1020,8 @@ namespace
 
 namespace vcpkg
 {
+    constexpr StringLiteral VersionDbEntryDeserializer::GIT_TREE;
+    constexpr StringLiteral VersionDbEntryDeserializer::PATH;
     StringView VersionDbEntryDeserializer::type_name() const { return "a version database entry"; }
     View<StringView> VersionDbEntryDeserializer::valid_fields() const
     {

--- a/src/vcpkg/registries.cpp
+++ b/src/vcpkg/registries.cpp
@@ -80,7 +80,8 @@ namespace
                     paths.git_find_object_id_for_remote_registry_path(e.value(), registry_versions_dir_name);
                 if (!maybe_tree)
                 {
-                    Metrics::g_metrics.lock()->track_property("registries-error-no-versions-at-commit", "defined");
+                    LockGuardPtr<Metrics>(g_metrics)->track_property("registries-error-no-versions-at-commit",
+                                                                     "defined");
                     Checks::exit_with_message(
                         VCPKG_LINE_INFO,
                         "Error: could not find the git tree for `versions` in repo `%s` at commit `%s`: %s",
@@ -521,7 +522,8 @@ namespace
                 print2("Fetching baseline information from ", m_repo, "...\n");
                 if (auto err = paths.git_fetch(m_repo, m_baseline_identifier))
                 {
-                    Metrics::g_metrics.lock()->track_property("registries-error-could-not-find-baseline", "defined");
+                    LockGuardPtr<Metrics>(g_metrics)->track_property("registries-error-could-not-find-baseline",
+                                                                     "defined");
                     Checks::exit_with_message(
                         VCPKG_LINE_INFO,
                         "Error: Couldn't find baseline `\"%s\"` for repo %s:\n%s\nError: Failed to fetch %s:\n%s",
@@ -536,7 +538,7 @@ namespace
 
             if (!maybe_contents.has_value())
             {
-                Metrics::g_metrics.lock()->track_property("registries-error-could-not-find-baseline", "defined");
+                LockGuardPtr<Metrics>(g_metrics)->track_property("registries-error-could-not-find-baseline", "defined");
                 Checks::exit_with_message(VCPKG_LINE_INFO,
                                           "Error: Couldn't find baseline in commit `\"%s\"` from repo %s:\n%s\n",
                                           m_baseline_identifier,
@@ -554,7 +556,8 @@ namespace
                 }
                 else
                 {
-                    Metrics::g_metrics.lock()->track_property("registries-error-could-not-find-baseline", "defined");
+                    LockGuardPtr<Metrics>(g_metrics)->track_property("registries-error-could-not-find-baseline",
+                                                                     "defined");
                     Checks::exit_maybe_upgrade(
                         VCPKG_LINE_INFO,
                         "The baseline.json from commit `\"%s\"` in the repo %s did not contain a \"default\" field.",

--- a/src/vcpkg/sourceparagraph.cpp
+++ b/src/vcpkg/sourceparagraph.cpp
@@ -1039,7 +1039,7 @@ namespace vcpkg
                 {
                     if (dep.constraint.type != Versions::Constraint::Type::None)
                     {
-                        Metrics::g_metrics.lock()->track_property("error-versioning-disabled", "defined");
+                        LockGuardPtr<Metrics>(g_metrics)->track_property("error-versioning-disabled", "defined");
                         return Strings::concat(
                             origin,
                             " was rejected because it uses constraints and the `",
@@ -1060,7 +1060,7 @@ namespace vcpkg
 
             if (core_paragraph->overrides.size() != 0)
             {
-                Metrics::g_metrics.lock()->track_property("error-versioning-disabled", "defined");
+                LockGuardPtr<Metrics>(g_metrics)->track_property("error-versioning-disabled", "defined");
                 return Strings::concat(origin,
                                        " was rejected because it uses overrides and the `",
                                        VcpkgCmdArguments::VERSIONS_FEATURE,
@@ -1070,7 +1070,7 @@ namespace vcpkg
 
             if (core_paragraph->builtin_baseline.has_value())
             {
-                Metrics::g_metrics.lock()->track_property("error-versioning-disabled", "defined");
+                LockGuardPtr<Metrics>(g_metrics)->track_property("error-versioning-disabled", "defined");
                 return Strings::concat(
                     origin,
                     " was rejected because it uses builtin-baseline and the `",
@@ -1089,7 +1089,7 @@ namespace vcpkg
                                     return dependency.constraint.type != Versions::Constraint::Type::None;
                                 }))
                 {
-                    Metrics::g_metrics.lock()->track_property("error-versioning-no-baseline", "defined");
+                    LockGuardPtr<Metrics>(g_metrics)->track_property("error-versioning-no-baseline", "defined");
                     return Strings::concat(
                         origin,
                         " was rejected because it uses \"version>=\" and does not have a \"builtin-baseline\".\n",
@@ -1098,7 +1098,7 @@ namespace vcpkg
 
                 if (!core_paragraph->overrides.empty())
                 {
-                    Metrics::g_metrics.lock()->track_property("error-versioning-no-baseline", "defined");
+                    LockGuardPtr<Metrics>(g_metrics)->track_property("error-versioning-no-baseline", "defined");
                     return Strings::concat(
                         origin,
                         " was rejected because it uses \"overrides\" and does not have a \"builtin-baseline\".\n",

--- a/src/vcpkg/sourceparagraph.cpp
+++ b/src/vcpkg/sourceparagraph.cpp
@@ -992,6 +992,7 @@ namespace vcpkg
     constexpr StringLiteral ManifestDeserializer::DEFAULT_FEATURES;
     constexpr StringLiteral ManifestDeserializer::SUPPORTS;
     constexpr StringLiteral ManifestDeserializer::OVERRIDES;
+    constexpr StringLiteral ManifestDeserializer::BUILTIN_BASELINE;
 
     SourceControlFile SourceControlFile::clone() const
     {

--- a/src/vcpkg/sourceparagraph.cpp
+++ b/src/vcpkg/sourceparagraph.cpp
@@ -539,6 +539,7 @@ namespace vcpkg
     DependencyArrayDeserializer DependencyArrayDeserializer::instance;
 
     constexpr StringLiteral DependencyDeserializer::NAME;
+    constexpr StringLiteral DependencyDeserializer::HOST;
     constexpr StringLiteral DependencyDeserializer::FEATURES;
     constexpr StringLiteral DependencyDeserializer::DEFAULT_FEATURES;
     constexpr StringLiteral DependencyDeserializer::PLATFORM;

--- a/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/src/vcpkg/vcpkgcmdarguments.cpp
@@ -27,7 +27,8 @@ namespace vcpkg
                 if (place.has_value())
                 {
                     vcpkg::printf(Color::error, "Error: both %s and -%s were specified as feature flags\n", flag, flag);
-                    Metrics::g_metrics.lock()->track_property("error", "error feature flag +-" + flag.to_string());
+                    LockGuardPtr<Metrics>(g_metrics)->track_property("error",
+                                                                     "error feature flag +-" + flag.to_string());
                     Checks::exit_fail(VCPKG_LINE_INFO);
                 }
 
@@ -66,7 +67,7 @@ namespace vcpkg
         if (nullptr != option_field)
         {
             vcpkg::printf(Color::error, "Error: --%s specified multiple times\n", option_name);
-            Metrics::g_metrics.lock()->track_property("error", "error option specified multiple times");
+            LockGuardPtr<Metrics>(g_metrics)->track_property("error", "error option specified multiple times");
             print_usage();
             Checks::exit_fail(VCPKG_LINE_INFO);
         }
@@ -79,7 +80,7 @@ namespace vcpkg
         if (option_field && option_field != new_setting)
         {
             print2(Color::error, "Error: conflicting values specified for --", option_name, '\n');
-            Metrics::g_metrics.lock()->track_property("error", "error conflicting switches");
+            LockGuardPtr<Metrics>(g_metrics)->track_property("error", "error conflicting switches");
             print_usage();
             Checks::exit_fail(VCPKG_LINE_INFO);
         }
@@ -93,7 +94,7 @@ namespace vcpkg
         if (new_value.size() == 0)
         {
             print2(Color::error, "Error: expected value after ", option_name, '\n');
-            Metrics::g_metrics.lock()->track_property("error", "error option name");
+            LockGuardPtr<Metrics>(g_metrics)->track_property("error", "error option name");
             print_usage();
             Checks::exit_fail(VCPKG_LINE_INFO);
         }
@@ -108,7 +109,7 @@ namespace vcpkg
         if (new_value.size() == 0)
         {
             print2(Color::error, "Error: expected value after ", option_name, '\n');
-            Metrics::g_metrics.lock()->track_property("error", "error option name");
+            LockGuardPtr<Metrics>(g_metrics)->track_property("error", "error option name");
             print_usage();
             Checks::exit_fail(VCPKG_LINE_INFO);
         }
@@ -182,7 +183,7 @@ namespace vcpkg
                 }
 
                 print2(Color::error, "Error: expected value after ", option, '\n');
-                Metrics::g_metrics.lock()->track_property("error", "error option name");
+                LockGuardPtr<Metrics>(g_metrics)->track_property("error", "error option name");
                 print_usage();
                 Checks::exit_fail(VCPKG_LINE_INFO);
             }
@@ -251,7 +252,7 @@ namespace vcpkg
 
             if (basic_arg.size() >= 2 && basic_arg[0] == '-' && basic_arg[1] != '-')
             {
-                Metrics::g_metrics.lock()->track_property("error", "error short options are not supported");
+                LockGuardPtr<Metrics>(g_metrics)->track_property("error", "error short options are not supported");
                 Checks::exit_with_message(VCPKG_LINE_INFO, "Error: short options are not supported: %s", basic_arg);
             }
 
@@ -798,7 +799,7 @@ namespace vcpkg
                               el.flag,
                               el.option);
                 vcpkg::printf(Color::warning, "Warning: Defaulting to %s being on.\n", el.flag);
-                Metrics::g_metrics.lock()->track_property(
+                LockGuardPtr<Metrics>(g_metrics)->track_property(
                     "warning", Strings::format("warning %s alongside %s", el.flag, el.option));
             }
         }
@@ -846,7 +847,7 @@ namespace vcpkg
 
         for (const auto& flag : flags)
         {
-            Metrics::g_metrics.lock()->track_feature(flag.flag.to_string(), flag.enabled);
+            LockGuardPtr<Metrics>(g_metrics)->track_feature(flag.flag.to_string(), flag.enabled);
         }
     }
 

--- a/src/vcpkg/vcpkglib.cpp
+++ b/src/vcpkg/vcpkglib.cpp
@@ -115,7 +115,7 @@ namespace vcpkg
         if (!was_tracked)
         {
             was_tracked = true;
-            Metrics::g_metrics.lock()->track_property("listfile", "update to new format");
+            LockGuardPtr<Metrics>(g_metrics)->track_property("listfile", "update to new format");
         }
 
         // The files are sorted such that directories are placed just before the files they contain

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -189,7 +189,7 @@ namespace vcpkg
                     auto maybe_cachepath = get_environment_variable("X_VCPKG_REGISTRIES_CACHE");
                     if (auto p_str = maybe_cachepath.get())
                     {
-                        Metrics::g_metrics.lock()->track_property("X_VCPKG_REGISTRIES_CACHE", "defined");
+                        LockGuardPtr<Metrics>(g_metrics)->track_property("X_VCPKG_REGISTRIES_CACHE", "defined");
                         Path path = *p_str;
                         path.make_preferred();
                         const auto status = get_real_filesystem().status(path, VCPKG_LINE_INFO);
@@ -361,8 +361,7 @@ namespace vcpkg
         {
             auto default_registry = config_file.config.registry_set.default_registry();
             auto other_registries = config_file.config.registry_set.registries();
-            auto metrics = Metrics::g_metrics.lock();
-
+            LockGuardPtr<Metrics> metrics(g_metrics);
             if (default_registry)
             {
                 metrics->track_property("registries-default-registry-kind", default_registry->kind());
@@ -1140,9 +1139,10 @@ namespace vcpkg
             bool enabled;
         } flags[] = {{VcpkgCmdArguments::MANIFEST_MODE_FEATURE, manifest_mode_enabled()}};
 
+        LockGuardPtr<Metrics> metrics(g_metrics);
         for (const auto& flag : flags)
         {
-            Metrics::g_metrics.lock()->track_feature(flag.flag.to_string(), flag.enabled);
+            metrics->track_feature(flag.flag.to_string(), flag.enabled);
         }
     }
 


### PR DESCRIPTION
Resolves https://github.com/microsoft/vcpkg/issues/17897 after a tool update

* Remove LockGuarded::lock because GCC-6 doesn't appear to implement guaranteed copy elision
* Remove Util:: and Chrono:: from a few places to avoid the previous change exploding line lengths
* Remove Metrics:: because there is also a struct named Metrics (which was inside Metrics::) which made some things ambiguous.
* Add definitions for constexpr variables.