### PR TITLE
Remove all uses of std::io_errc

### DIFF
--- a/include/vcpkg/base/files.h
+++ b/include/vcpkg/base/files.h
@@ -173,7 +173,7 @@ namespace vcpkg
             return this->seek(static_cast<long long>(offset), origin);
         }
         int eof() const noexcept { return ::feof(m_fs); }
-        int error() const noexcept { return ::ferror(m_fs); }
+        std::error_code error() const noexcept { return std::error_code(::ferror(m_fs), std::generic_category()); }
 
         ~FilePointer()
         {

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -1467,9 +1467,8 @@ namespace vcpkg
                 {
                     output.append(buffer, this_read);
                 }
-                else if (file.error())
+                else if ((ec = file.error()))
                 {
-                    ec = std::io_errc::stream;
                     return std::string();
                 }
             } while (!file.eof());
@@ -1495,9 +1494,8 @@ namespace vcpkg
                 {
                     output.on_data({buffer, this_read});
                 }
-                else if (file.error())
+                else if ((ec = file.error()))
                 {
-                    ec = std::io_errc::stream;
                     return std::vector<std::string>();
                 }
             } while (!file.eof());

--- a/src/vcpkg/base/hash.cpp
+++ b/src/vcpkg/base/hash.cpp
@@ -582,9 +582,8 @@ namespace vcpkg::Hash
                 {
                     hasher.add_bytes(buffer, buffer + this_read);
                 }
-                else if (file.error())
+                else if ((ec = file.error()))
                 {
-                    ec = std::io_errc::stream;
                     return std::string();
                 }
             } while (!file.eof());


### PR DESCRIPTION
This is a follow-up to #141 which fixes a build break for conda-forge.

@wolfv can you try this PR out and confirm it fixes the conda-forge build?

See also https://github.com/microsoft/vcpkg-tool/pull/141#issuecomment-898264018.