### PR TITLE
Fix wrong "Total elapsed time" messages

### DIFF
--- a/include/vcpkg/install.h
+++ b/include/vcpkg/install.h
@@ -38,7 +38,6 @@ namespace vcpkg::Install
     struct InstallSummary
     {
         std::vector<SpecSummary> results;
-        std::string total_elapsed_time;
 
         void print() const;
         std::string xunit_results() const;

--- a/src/vcpkg/commands.ci.cpp
+++ b/src/vcpkg/commands.ci.cpp
@@ -1,6 +1,7 @@
 #include <vcpkg/base/cache.h>
 #include <vcpkg/base/files.h>
 #include <vcpkg/base/graphs.h>
+#include <vcpkg/base/lockguarded.h>
 #include <vcpkg/base/stringliteral.h>
 #include <vcpkg/base/system.debug.h>
 #include <vcpkg/base/system.h>
@@ -646,7 +647,7 @@ namespace vcpkg::Commands::CI
         for (auto&& result : results)
         {
             print2("\nTriplet: ", result.triplet, "\n");
-            print2("Total elapsed time: ", result.summary.total_elapsed_time, "\n");
+            print2("Total elapsed time: ", LockGuardPtr<ElapsedTimer>(GlobalState::timer)->to_string(), "\n");
             result.summary.print();
         }
 

--- a/src/vcpkg/commands.setinstalled.cpp
+++ b/src/vcpkg/commands.setinstalled.cpp
@@ -123,7 +123,7 @@ namespace vcpkg::Commands::SetInstalled
                                               Build::null_build_logs_recorder(),
                                               cmake_vars);
 
-        print2("\nTotal elapsed time: ", summary.total_elapsed_time, "\n\n");
+        print2("\nTotal elapsed time: ", LockGuardPtr<ElapsedTimer>(GlobalState::timer)->to_string(), "\n\n");
 
         std::set<std::string> printed_usages;
         for (auto&& ur_spec : user_requested_specs)

--- a/src/vcpkg/commands.upgrade.cpp
+++ b/src/vcpkg/commands.upgrade.cpp
@@ -1,3 +1,4 @@
+#include <vcpkg/base/lockguarded.h>
 #include <vcpkg/base/system.print.h>
 #include <vcpkg/base/util.h>
 
@@ -206,7 +207,7 @@ namespace vcpkg::Commands::Upgrade
                                                                  Build::null_build_logs_recorder(),
                                                                  var_provider);
 
-        print2("\nTotal elapsed time: ", summary.total_elapsed_time, "\n\n");
+        print2("\nTotal elapsed time: ", LockGuardPtr<ElapsedTimer>(GlobalState::timer)->to_string(), "\n\n");
 
         if (keep_going == KeepGoing::YES)
         {

--- a/src/vcpkg/install.cpp
+++ b/src/vcpkg/install.cpp
@@ -472,7 +472,6 @@ namespace vcpkg::Install
         const size_t action_count = action_plan.remove_actions.size() + action_plan.install_actions.size();
         size_t action_index = 1;
 
-        const auto timer = ElapsedTimer::create_started();
         for (auto&& action : action_plan.remove_actions)
         {
             TrackedPackageInstallGuard this_install(action_index++, action_count, results, action.spec);
@@ -503,7 +502,7 @@ namespace vcpkg::Install
             this_install.current_summary->build_result = std::move(result);
         }
 
-        return InstallSummary{std::move(results), timer.to_string()};
+        return InstallSummary{std::move(results)};
     }
 
     static constexpr StringLiteral OPTION_DRY_RUN = "dry-run";
@@ -1086,7 +1085,7 @@ namespace vcpkg::Install
                                                Build::null_build_logs_recorder(),
                                                var_provider);
 
-        print2("\nTotal elapsed time: ", summary.total_elapsed_time, "\n\n");
+        print2("\nTotal elapsed time: ", LockGuardPtr<ElapsedTimer>(GlobalState::timer)->to_string(), "\n\n");
 
         if (keep_going == KeepGoing::YES)
         {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/16850

Maybe somewhere internally a function need the current printed time, but as an end user I am only interested in the real "total elapsed time" and not how long some internally sub function needs. 