### PR TITLE
Don't print duplicate usage messages.

### DIFF
--- a/include/vcpkg/install.h
+++ b/include/vcpkg/install.h
@@ -105,7 +105,7 @@ namespace vcpkg::Install
 
     CMakeUsageInfo get_cmake_usage(const BinaryParagraph& bpgh, const VcpkgPaths& paths);
     void print_usage_information(const BinaryParagraph& bpgh,
-                                 std::set<std::string>& printed_usage,
+                                 std::set<std::string>& printed_usages,
                                  const VcpkgPaths& paths);
 
     extern const CommandStructure COMMAND_STRUCTURE;

--- a/include/vcpkg/install.h
+++ b/include/vcpkg/install.h
@@ -8,6 +8,8 @@
 #include <vcpkg/vcpkgcmdarguments.h>
 #include <vcpkg/vcpkgpaths.h>
 
+#include <set>
+#include <string>
 #include <vector>
 
 namespace vcpkg::Install
@@ -102,7 +104,9 @@ namespace vcpkg::Install
     };
 
     CMakeUsageInfo get_cmake_usage(const BinaryParagraph& bpgh, const VcpkgPaths& paths);
-    void print_usage_information(const BinaryParagraph& bpgh, const VcpkgPaths& paths);
+    void print_usage_information(const BinaryParagraph& bpgh,
+                                 std::set<std::string>& printed_usage,
+                                 const VcpkgPaths& paths);
 
     extern const CommandStructure COMMAND_STRUCTURE;
 

--- a/src/vcpkg/commands.setinstalled.cpp
+++ b/src/vcpkg/commands.setinstalled.cpp
@@ -125,12 +125,13 @@ namespace vcpkg::Commands::SetInstalled
 
         print2("\nTotal elapsed time: ", summary.total_elapsed_time, "\n\n");
 
+        std::set<std::string> printed_usage;
         for (auto&& ur_spec : user_requested_specs)
         {
             auto it = status_db.find_installed(ur_spec);
             if (it != status_db.end())
             {
-                Install::print_usage_information(it->get()->package, paths);
+                Install::print_usage_information(it->get()->package, printed_usage, paths);
             }
         }
 

--- a/src/vcpkg/commands.setinstalled.cpp
+++ b/src/vcpkg/commands.setinstalled.cpp
@@ -125,13 +125,13 @@ namespace vcpkg::Commands::SetInstalled
 
         print2("\nTotal elapsed time: ", summary.total_elapsed_time, "\n\n");
 
-        std::set<std::string> printed_usage;
+        std::set<std::string> printed_usages;
         for (auto&& ur_spec : user_requested_specs)
         {
             auto it = status_db.find_installed(ur_spec);
             if (it != status_db.end())
             {
-                Install::print_usage_information(it->get()->package, printed_usage, paths);
+                Install::print_usage_information(it->get()->package, printed_usages, paths);
             }
         }
 

--- a/src/vcpkg/install.cpp
+++ b/src/vcpkg/install.cpp
@@ -595,18 +595,17 @@ namespace vcpkg::Install
     };
 
     void print_usage_information(const BinaryParagraph& bpgh,
-                                 std::set<std::string>& printed_usage,
+                                 std::set<std::string>& printed_usages,
                                  const VcpkgPaths& paths)
     {
-        auto usage = get_cmake_usage(bpgh, paths);
-        const auto& message = usage.message;
+        auto message = get_cmake_usage(bpgh, paths).message;
         if (!message.empty())
         {
-            auto existing = printed_usage.lower_bound(message);
-            if (existing == printed_usage.end() || *existing != message)
+            auto existing = printed_usages.lower_bound(message);
+            if (existing == printed_usages.end() || *existing != message)
             {
-                printed_usage.insert(existing, message);
                 print2(message);
+                printed_usages.insert(existing, std::move(message));
             }
         }
     }
@@ -1091,14 +1090,14 @@ namespace vcpkg::Install
             fs.write_contents(it_xunit->second, xunit_doc, VCPKG_LINE_INFO);
         }
 
-        std::set<std::string> printed_usage;
+        std::set<std::string> printed_usages;
         for (auto&& result : summary.results)
         {
             if (!result.action) continue;
             if (result.action->request_type != RequestType::USER_REQUESTED) continue;
             auto bpgh = result.get_binary_paragraph();
             if (!bpgh) continue;
-            print_usage_information(*bpgh, printed_usage, paths);
+            print_usage_information(*bpgh, printed_usages, paths);
         }
 
         Checks::exit_success(VCPKG_LINE_INFO);

--- a/src/vcpkg/install.cpp
+++ b/src/vcpkg/install.cpp
@@ -594,13 +594,20 @@ namespace vcpkg::Install
         nullptr,
     };
 
-    void print_usage_information(const BinaryParagraph& bpgh, const VcpkgPaths& paths)
+    void print_usage_information(const BinaryParagraph& bpgh,
+                                 std::set<std::string>& printed_usage,
+                                 const VcpkgPaths& paths)
     {
         auto usage = get_cmake_usage(bpgh, paths);
-
-        if (!usage.message.empty())
+        const auto& message = usage.message;
+        if (!message.empty())
         {
-            print2(usage.message);
+            auto existing = printed_usage.find(message);
+            if (existing == printed_usage.end())
+            {
+                printed_usage.insert(existing, message);
+                print2(message);
+            }
         }
     }
 
@@ -1084,13 +1091,14 @@ namespace vcpkg::Install
             fs.write_contents(it_xunit->second, xunit_doc, VCPKG_LINE_INFO);
         }
 
+        std::set<std::string> printed_usage;
         for (auto&& result : summary.results)
         {
             if (!result.action) continue;
             if (result.action->request_type != RequestType::USER_REQUESTED) continue;
             auto bpgh = result.get_binary_paragraph();
             if (!bpgh) continue;
-            print_usage_information(*bpgh, paths);
+            print_usage_information(*bpgh, printed_usage, paths);
         }
 
         Checks::exit_success(VCPKG_LINE_INFO);

--- a/src/vcpkg/install.cpp
+++ b/src/vcpkg/install.cpp
@@ -602,8 +602,8 @@ namespace vcpkg::Install
         const auto& message = usage.message;
         if (!message.empty())
         {
-            auto existing = printed_usage.find(message);
-            if (existing == printed_usage.end())
+            auto existing = printed_usage.lower_bound(message);
+            if (existing == printed_usage.end() || *existing != message)
             {
                 printed_usage.insert(existing, message);
                 print2(message);


### PR DESCRIPTION
```
C:\Dev\vcpkg>.\vcpkg.exe x-set-installed zlib:x86-windows zlib:x64-windows
Detecting compiler hash for triplet x64-windows...
Detecting compiler hash for triplet x86-windows...
The following packages will be built and installed:
    zlib[core]:x64-windows -> 1.2.11#11
    zlib[core]:x86-windows -> 1.2.11#11
Using cached binary package: C:\Users\bion\AppData\Local\vcpkg\archives\ab\ab679b37f1c29aae19233bf1444eed9a72fe2e7e6e4b9f303b98b3ca7400129a.zip
Using cached binary package: C:\Users\bion\AppData\Local\vcpkg\archives\f9\f93940bf2cd0ef0a76754ef745b2139740e0a022fd1d67a6f05fe2d00e7a288c.zip
Starting package 1/2: zlib:x64-windows
Building package zlib[core]:x64-windows...
Building package zlib[core]:x64-windows... done
Installing package zlib[core]:x64-windows...
Installing package zlib[core]:x64-windows... done
Elapsed time for package zlib:x64-windows: 25.46 ms
Starting package 2/2: zlib:x86-windows
Building package zlib[core]:x86-windows...
Building package zlib[core]:x86-windows... done
Installing package zlib[core]:x86-windows...
Installing package zlib[core]:x86-windows... done
Elapsed time for package zlib:x86-windows: 23.27 ms

Total elapsed time: 133.2 ms

The package zlib is compatible with built-in CMake targets:

    find_package(ZLIB REQUIRED)
    target_link_libraries(main PRIVATE ZLIB::ZLIB)

The package zlib is compatible with built-in CMake targets:

    find_package(ZLIB REQUIRED)
    target_link_libraries(main PRIVATE ZLIB::ZLIB)

C:\Dev\vcpkg>.\vcpkg.exe x-set-installed
The following packages will be removed:
    zlib:x64-windows
    zlib:x86-windows
Starting package 1/2: zlib:x64-windows
Removing package zlib:x64-windows...
Removing package zlib:x64-windows... done
Elapsed time for package zlib:x64-windows: 9.236 ms
Starting package 2/2: zlib:x86-windows
Removing package zlib:x86-windows...
Removing package zlib:x86-windows... done
Elapsed time for package zlib:x86-windows: 9.371 ms

Total elapsed time: 18.73 ms

C:\Dev\vcpkg>..\vcpkg-tool\out\build\x64-Debug\vcpkg.exe x-set-installed zlib:x86-windows zlib:x64-windows
Detecting compiler hash for triplet x64-windows...
Detecting compiler hash for triplet x86-windows...
The following packages will be built and installed:
    zlib[core]:x64-windows -> 1.2.11#11
    zlib[core]:x86-windows -> 1.2.11#11
Restored 2 packages from C:\Users\bion\AppData\Local\vcpkg\archives in 55.47 ms. Use --debug to see more details.
Starting package 1/2: zlib:x64-windows
Installing package zlib[core]:x64-windows...
Elapsed time for package zlib:x64-windows: 26.84 ms
Starting package 2/2: zlib:x86-windows
Installing package zlib[core]:x86-windows...
Elapsed time for package zlib:x86-windows: 27.06 ms

Total elapsed time: 109.8 ms

The package zlib is compatible with built-in CMake targets:

    find_package(ZLIB REQUIRED)
    target_link_libraries(main PRIVATE ZLIB::ZLIB)

C:\Dev\vcpkg>cd ..\vcpkg-tool

C:\Dev\vcpkg-tool>git switch -c dedupe-usage
Switched to a new branch 'dedupe-usage'

C:\Dev\vcpkg-tool>.\azure-pipelines\Format-CxxCode.ps1

C:\Dev\vcpkg-tool>pwsh .\azure-pipelines\Format-CxxCode.ps1
Using clang-format version 12.0.0 located at C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\Llvm\x64\bin\clang-format.exe

C:\Dev\vcpkg-tool>
```