### PR TITLE
Manifests: Remove support for declaring features as lists

### DIFF
--- a/src/vcpkg-test/manifests.cpp
+++ b/src/vcpkg-test/manifests.cpp
@@ -621,9 +621,8 @@ TEST_CASE ("manifest construct maximum", "[manifests]")
         "description": "d",
         "dependencies": ["bd"],
         "default-features": ["df"],
-        "features": [
-            {
-                "name": "iroh",
+        "features": {
+            "iroh" : {
                 "description": "zuko's uncle",
                 "dependencies": [
                     "firebending",
@@ -637,11 +636,10 @@ TEST_CASE ("manifest construct maximum", "[manifests]")
                     }
                 ]
             },
-            {
-                "name": "zuko",
+            "zuko": {
                 "description": ["son of the fire lord", "firebending 師父"]
             }
-        ]
+        }
     })json");
     REQUIRE(m_pgh.has_value());
     auto& pgh = **m_pgh.get();

--- a/src/vcpkg/sourceparagraph.cpp
+++ b/src/vcpkg/sourceparagraph.cpp
@@ -641,50 +641,11 @@ namespace vcpkg
     constexpr StringLiteral FeatureDeserializer::DESCRIPTION;
     constexpr StringLiteral FeatureDeserializer::DEPENDENCIES;
 
-    struct ArrayFeatureDeserializer : Json::IDeserializer<std::unique_ptr<FeatureParagraph>>
-    {
-        virtual StringView type_name() const override { return "a feature"; }
-
-        virtual Span<const StringView> valid_fields() const override
-        {
-            static const StringView t[] = {
-                FeatureDeserializer::NAME,
-                FeatureDeserializer::DESCRIPTION,
-                FeatureDeserializer::DEPENDENCIES,
-            };
-            return t;
-        }
-
-        virtual Optional<std::unique_ptr<FeatureParagraph>> visit_object(Json::Reader& r,
-                                                                         const Json::Object& obj) override
-        {
-            std::string name;
-            r.required_object_field(
-                type_name(), obj, FeatureDeserializer::NAME, name, Json::IdentifierDeserializer::instance);
-            auto opt = FeatureDeserializer::instance.visit_object(r, obj);
-            if (auto p = opt.get())
-            {
-                p->get()->name = std::move(name);
-            }
-            return opt;
-        }
-
-        static Json::ArrayDeserializer<ArrayFeatureDeserializer> array_instance;
-    };
-    Json::ArrayDeserializer<ArrayFeatureDeserializer> ArrayFeatureDeserializer::array_instance{
-        "an array of feature objects"};
-
     struct FeaturesFieldDeserializer : Json::IDeserializer<std::vector<std::unique_ptr<FeatureParagraph>>>
     {
         virtual StringView type_name() const override { return "a set of features"; }
 
         virtual Span<const StringView> valid_fields() const override { return {}; }
-
-        virtual Optional<std::vector<std::unique_ptr<FeatureParagraph>>> visit_array(Json::Reader& r,
-                                                                                     const Json::Array& arr) override
-        {
-            return ArrayFeatureDeserializer::array_instance.visit_array(r, arr);
-        }
 
         virtual Optional<std::vector<std::unique_ptr<FeatureParagraph>>> visit_object(Json::Reader& r,
                                                                                       const Json::Object& obj) override


### PR DESCRIPTION
It is not used and not described in the docs. I used `vcpkg format-manifest --all` with the new version and it doesn't reported a wrong file. 