### PR TITLE
Use /MT and CMake 3.15.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.15) # 3.15 for MSVC_RUNTIME_LIBRARY, removing default warning flags
 
 cmake_policy(SET CMP0091 NEW)
+cmake_policy(SET CMP0092 NEW)
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
 # ===============
 # === Options ===
@@ -27,9 +29,7 @@ endif()
 
 set(LANGUAGES "CXX")
 if(VCPKG_BUILD_TLS12_DOWNLOADER)
-    # 3.16 for MSVC_RUNTIME_LIBRARY
     list(APPEND LANGUAGES "C")
-    cmake_minimum_required(VERSION 3.16)
 endif()
 
 project(vcpkg
@@ -96,7 +96,6 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 17)
 if(MSVC)
-    string(REGEX REPLACE "[-/]W[0-4]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
     if(CMAKE_BUILD_TYPE STREQUAL "Release")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zi /guard:cf")
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /DEBUG /debugtype:cv,fixup /guard:cf")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.15) # 3.15 for MSVC_RUNTIME_LIBRARY, removing d
 
 cmake_policy(SET CMP0091 NEW)
 cmake_policy(SET CMP0092 NEW)
-set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+if(NOT CMAKE_MSVC_RUNTIME_LIBRARY)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif()
 
 # ===============
 # === Options ===

--- a/cmake/utilities.cmake
+++ b/cmake/utilities.cmake
@@ -192,18 +192,13 @@ function(vcpkg_target_add_warning_options TARGET)
         if(VCPKG_DEVELOPMENT_WARNINGS)
             target_compile_options(${TARGET} PRIVATE -W4)
             if(VCPKG_COMPILER STREQUAL "clang")
-                # -Wno-range-loop-analysis is due to an LLVM bug which will be fixed in a
-                # future version of clang https://reviews.llvm.org/D73007
                 target_compile_options(${TARGET} PRIVATE
                     -Wmissing-prototypes
                     -Wno-missing-field-initializers
-                    -Wno-range-loop-analysis
                     )
             else()
                 target_compile_options(${TARGET} PRIVATE -analyze -analyze:stacksize 39000)
             endif()
-        else()
-            target_compile_options(${TARGET} PRIVATE -W3)
         endif()
 
         if(VCPKG_WARNINGS_AS_ERRORS)


### PR DESCRIPTION
CMakeLists.txt:
1 Bump to 3.15
4 Turn on policy CMP0092 to disable default cmake warnings.
30 Remove previous now-redundant use of MSVC_RUNTIME_LIBRARY
99 Remove regex obsoleted by CMP0092

utilities.cmake
194 Remove clang 9.x development warnings workaround.
203 Remove /W3 when development warnings are off.