### PR TITLE
restore packages from nuget if X_VCPKG_NUGET_ID_PREFIX set

### DIFF
--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -798,7 +798,7 @@ namespace
                 Util::erase_remove_if(attempts, [&](const NuGetPrefetchAttempt& nuget_ref) -> bool {
                     // note that we would like the nupkg downloaded to buildtrees, but nuget.exe downloads it to the
                     // output directory
-                    auto nupkg_path = paths.packages / nuget_ref.reference.id / nuget_ref.reference.id + ".nupkg";
+                    const auto nupkg_path = paths.packages / nuget_ref.reference.id / nuget_ref.reference.id + ".nupkg";
                     if (fs.exists(nupkg_path, IgnoreErrors{}))
                     {
                         fs.remove(nupkg_path, VCPKG_LINE_INFO);
@@ -806,17 +806,12 @@ namespace
                                            !fs.exists(nupkg_path, IgnoreErrors{}),
                                            "Unable to remove nupkg after restoring: %s",
                                            nupkg_path);
-                        if (!get_nuget_prefix().empty())
+                        const auto nuget_dir = nuget_ref.spec.dir();
+                        if (nuget_dir != nuget_ref.reference.id)
                         {
-                            auto path_from = paths.packages / nuget_ref.reference.id;
-                            auto path_to = paths.packages / nuget_ref.spec.dir();
-                            std::error_code ec;
-                            fs.rename(path_from, path_to, ec);
-                            Checks::check_exit(VCPKG_LINE_INFO,
-                                               !ec,
-                                               "Unable to rename package %s after restoring: %s",
-                                               path_from,
-                                               ec.message());
+                            const auto path_from = paths.packages / nuget_ref.reference.id;
+                            const auto path_to = paths.packages / nuget_dir;
+                            fs.rename(path_from, path_to, VCPKG_LINE_INFO);
                         }
                         cache_status[nuget_ref.result_index]->mark_restored();
                         return true;

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -798,7 +798,7 @@ namespace
                 Util::erase_remove_if(attempts, [&](const NuGetPrefetchAttempt& nuget_ref) -> bool {
                     // note that we would like the nupkg downloaded to buildtrees, but nuget.exe downloads it to the
                     // output directory
-                    auto nupkg_path = paths.package_dir(nuget_ref.spec) / nuget_ref.reference.id + ".nupkg";
+                    auto nupkg_path = paths.packages / nuget_ref.reference.id / nuget_ref.reference.id + ".nupkg";
                     if (fs.exists(nupkg_path, IgnoreErrors{}))
                     {
                         fs.remove(nupkg_path, VCPKG_LINE_INFO);
@@ -806,6 +806,18 @@ namespace
                                            !fs.exists(nupkg_path, IgnoreErrors{}),
                                            "Unable to remove nupkg after restoring: %s",
                                            nupkg_path);
+                        if (!get_nuget_prefix().empty())
+                        {
+                            auto path_from = paths.packages / nuget_ref.reference.id;
+                            auto path_to = paths.packages / nuget_ref.spec.dir();
+                            std::error_code ec;
+                            fs.rename(path_from, path_to, ec);
+                            Checks::check_exit(VCPKG_LINE_INFO,
+                                               !ec,
+                                               "Unable to rename package %s after restoring: %s",
+                                               path_from,
+                                               ec.message());
+                        }
                         cache_status[nuget_ref.result_index]->mark_restored();
                         return true;
                     }


### PR DESCRIPTION
After #40 we can set different prefixes for caching packages in nuget. It's working fine for push to cache. But restore from cache don`t working:
1. nuget download package with prefix from cache
2. but vcpkg don't see him - `Restored 0 packages from NuGet. Use --debug for more information.`

fix https://github.com/microsoft/vcpkg/issues/19095 and https://github.com/microsoft/vcpkg/discussions/19103