### PR TITLE
[platform-expression] add arm32 platform identifier

### DIFF
--- a/src/vcpkg-test/platform-expression.cpp
+++ b/src/vcpkg-test/platform-expression.cpp
@@ -10,10 +10,96 @@ static vcpkg::ExpectedS<Expr> parse_expr(StringView s)
     return parse_platform_expression(s, MultipleBinaryOperators::Deny);
 }
 
-TEST_CASE ("platform-expression-identifier", "[platform-expression]")
+TEST_CASE ("platform-expression-identifier-os", "[platform-expression]")
 {
     auto m_windows = parse_expr("windows");
     REQUIRE(m_windows);
+    auto m_osx = parse_expr("osx");
+    REQUIRE(m_osx);
+    auto m_linux = parse_expr("linux");
+    REQUIRE(m_linux);
+
+    auto& windows = *m_windows.get();
+    auto& osx = *m_osx.get();
+    auto& linux = *m_linux.get();
+
+    CHECK(windows.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", ""}}));
+    CHECK(windows.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "WindowsStore"}}));
+    CHECK_FALSE(windows.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "Linux"}}));
+    CHECK_FALSE(windows.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "Darwin"}}));
+
+    CHECK_FALSE(osx.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", ""}}));
+    CHECK_FALSE(osx.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "WindowsStore"}}));
+    CHECK_FALSE(osx.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "Linux"}}));
+    CHECK(osx.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "Darwin"}}));
+
+    CHECK_FALSE(linux.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", ""}}));
+    CHECK_FALSE(linux.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "WindowsStore"}}));
+    CHECK(linux.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "Linux"}}));
+    CHECK_FALSE(linux.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "Darwin"}}));
+}
+
+TEST_CASE ("platform-expression-identifier-arch", "[platform-expression]")
+{
+    auto m_arm = parse_expr("arm");
+    REQUIRE(m_arm);
+    auto m_arm32 = parse_expr("arm32");
+    REQUIRE(m_arm32);
+    auto m_arm64 = parse_expr("arm64");
+    REQUIRE(m_arm64);
+    auto m_x86 = parse_expr("x86");
+    REQUIRE(m_x86);
+    auto m_x64 = parse_expr("x64");
+    REQUIRE(m_x64);
+    auto m_wasm32 = parse_expr("wasm32");
+    REQUIRE(m_wasm32);
+
+    auto& arm = *m_arm.get();
+    auto& arm32 = *m_arm32.get();
+    auto& arm64 = *m_arm64.get();
+    auto& x86 = *m_x86.get();
+    auto& x64 = *m_x64.get();
+    auto& wasm32 = *m_wasm32.get();
+
+    CHECK(arm.evaluate({{"VCPKG_TARGET_ARCHITECTURE", "arm"}}));
+    CHECK(arm.evaluate({{"VCPKG_TARGET_ARCHITECTURE", "arm64"}}));
+    CHECK_FALSE(arm.evaluate({{"VCPKG_TARGET_ARCHITECTURE", "x86"}}));
+    CHECK_FALSE(arm.evaluate({{"VCPKG_TARGET_ARCHITECTURE", "x64"}}));
+    CHECK_FALSE(arm.evaluate({{"VCPKG_TARGET_ARCHITECTURE", "wasm32"}}));
+
+    CHECK(arm32.evaluate({{"VCPKG_TARGET_ARCHITECTURE", "arm"}}));
+    CHECK_FALSE(arm32.evaluate({{"VCPKG_TARGET_ARCHITECTURE", "arm64"}}));
+    CHECK_FALSE(arm32.evaluate({{"VCPKG_TARGET_ARCHITECTURE", "x86"}}));
+    CHECK_FALSE(arm32.evaluate({{"VCPKG_TARGET_ARCHITECTURE", "x64"}}));
+    CHECK_FALSE(arm32.evaluate({{"VCPKG_TARGET_ARCHITECTURE", "wasm32"}}));
+
+    CHECK_FALSE(arm64.evaluate({{"VCPKG_TARGET_ARCHITECTURE", "arm"}}));
+    CHECK(arm64.evaluate({{"VCPKG_TARGET_ARCHITECTURE", "arm64"}}));
+    CHECK_FALSE(arm64.evaluate({{"VCPKG_TARGET_ARCHITECTURE", "x86"}}));
+    CHECK_FALSE(arm64.evaluate({{"VCPKG_TARGET_ARCHITECTURE", "x64"}}));
+    CHECK_FALSE(arm64.evaluate({{"VCPKG_TARGET_ARCHITECTURE", "wasm32"}}));
+
+    CHECK_FALSE(x86.evaluate({{"VCPKG_TARGET_ARCHITECTURE", "arm"}}));
+    CHECK_FALSE(x86.evaluate({{"VCPKG_TARGET_ARCHITECTURE", "arm64"}}));
+    CHECK(x86.evaluate({{"VCPKG_TARGET_ARCHITECTURE", "x86"}}));
+    CHECK_FALSE(x86.evaluate({{"VCPKG_TARGET_ARCHITECTURE", "x64"}}));
+    CHECK_FALSE(x86.evaluate({{"VCPKG_TARGET_ARCHITECTURE", "wasm32"}}));
+
+    CHECK_FALSE(x64.evaluate({{"VCPKG_TARGET_ARCHITECTURE", "arm"}}));
+    CHECK_FALSE(x64.evaluate({{"VCPKG_TARGET_ARCHITECTURE", "arm64"}}));
+    CHECK_FALSE(x64.evaluate({{"VCPKG_TARGET_ARCHITECTURE", "x86"}}));
+    CHECK(x64.evaluate({{"VCPKG_TARGET_ARCHITECTURE", "x64"}}));
+    CHECK_FALSE(x64.evaluate({{"VCPKG_TARGET_ARCHITECTURE", "wasm32"}}));
+
+    CHECK_FALSE(wasm32.evaluate({{"VCPKG_TARGET_ARCHITECTURE", "arm"}}));
+    CHECK_FALSE(wasm32.evaluate({{"VCPKG_TARGET_ARCHITECTURE", "arm64"}}));
+    CHECK_FALSE(wasm32.evaluate({{"VCPKG_TARGET_ARCHITECTURE", "x86"}}));
+    CHECK_FALSE(wasm32.evaluate({{"VCPKG_TARGET_ARCHITECTURE", "x64"}}));
+    CHECK(wasm32.evaluate({{"VCPKG_TARGET_ARCHITECTURE", "wasm32"}}));
+}
+
+TEST_CASE ("platform-expression-identifier-misc", "[platform-expression]")
+{
     auto m_native = parse_expr("native");
     REQUIRE(m_native);
     auto m_staticlink = parse_expr("static");
@@ -21,15 +107,9 @@ TEST_CASE ("platform-expression-identifier", "[platform-expression]")
     auto m_staticcrt = parse_expr("staticcrt");
     REQUIRE(m_staticcrt);
 
-    auto& windows = *m_windows.get();
     auto& native = *m_native.get();
     auto& staticlink = *m_staticlink.get();
     auto& staticcrt = *m_staticcrt.get();
-
-    CHECK(windows.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", ""}}));
-    CHECK(windows.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "WindowsStore"}}));
-    CHECK_FALSE(windows.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "Linux"}}));
-    CHECK_FALSE(windows.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "Darwin"}}));
 
     CHECK(native.evaluate({{"Z_VCPKG_IS_NATIVE", "1"}}));
     CHECK_FALSE(native.evaluate({{"Z_VCPKG_IS_NATIVE", "0"}}));

--- a/src/vcpkg/platform-expression.cpp
+++ b/src/vcpkg/platform-expression.cpp
@@ -19,6 +19,7 @@ namespace vcpkg::PlatformExpression
         x86,
         x64,
         arm,
+        arm32,
         arm64,
         wasm32,
 
@@ -43,6 +44,7 @@ namespace vcpkg::PlatformExpression
             {"x86", Identifier::x86},
             {"x64", Identifier::x64},
             {"arm", Identifier::arm},
+            {"arm32", Identifier::arm32},
             {"arm64", Identifier::arm64},
             {"wasm32", Identifier::wasm32},
             {"windows", Identifier::windows},
@@ -386,6 +388,7 @@ namespace vcpkg::PlatformExpression
                             // This is because it previously was only checking for a substring.
                             return true_if_exists_and_equal("VCPKG_TARGET_ARCHITECTURE", "arm") ||
                                    true_if_exists_and_equal("VCPKG_TARGET_ARCHITECTURE", "arm64");
+                        case Identifier::arm32: return true_if_exists_and_equal("VCPKG_TARGET_ARCHITECTURE", "arm");
                         case Identifier::arm64: return true_if_exists_and_equal("VCPKG_TARGET_ARCHITECTURE", "arm64");
                         case Identifier::windows:
                             return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "") ||


### PR DESCRIPTION
I've noticed people writing `arm & !arm64`, which just seems really unfortunate. Add an `arm32` platform identifier to mean exactly this.