### PR TITLE
Report features and version on build error

### DIFF
--- a/include/vcpkg/build.h
+++ b/include/vcpkg/build.h
@@ -205,7 +205,7 @@ namespace vcpkg::Build
 
     const std::string& to_string(const BuildResult build_result);
     std::string create_error_message(const BuildResult build_result, const PackageSpec& spec);
-    std::string create_user_troubleshooting_message(const PackageSpec& spec);
+    std::string create_user_troubleshooting_message(const Dependencies::InstallPlanAction& action);
 
     /// <summary>
     /// Settings from the triplet file which impact the build environment and post-build checks

--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -163,7 +163,7 @@ namespace vcpkg::Build
         if (result.code != BuildResult::SUCCEEDED)
         {
             print2(Color::error, Build::create_error_message(result.code, spec), '\n');
-            print2(Build::create_user_troubleshooting_message(spec), '\n');
+            print2(Build::create_user_troubleshooting_message(*action), '\n');
             return 1;
         }
 
@@ -1315,13 +1315,20 @@ namespace vcpkg::Build
         return Strings::format("Error: Building package %s failed with: %s", spec, Build::to_string(build_result));
     }
 
-    std::string create_user_troubleshooting_message(const PackageSpec& spec)
+    std::string create_user_troubleshooting_message(const InstallPlanAction& action)
     {
 #if defined(_WIN32)
         auto vcpkg_update_cmd = ".\\vcpkg";
 #else
         auto vcpkg_update_cmd = "./vcpkg";
 #endif
+
+        std::string package = action.displayname();
+        if (auto scfl = action.source_control_file_location.get())
+        {
+            Strings::append(package, " -> ", scfl->to_versiont());
+        }
+
         return Strings::format("Please ensure you're using the latest portfiles with `%s update`, then\n"
                                "submit an issue at https://github.com/Microsoft/vcpkg/issues including:\n"
                                "  Package: %s\n"
@@ -1329,7 +1336,7 @@ namespace vcpkg::Build
                                "\n"
                                "Additionally, attach any relevant sections from the log files above.",
                                vcpkg_update_cmd,
-                               spec,
+                               package,
                                Commands::Version::version());
     }
 

--- a/src/vcpkg/install.cpp
+++ b/src/vcpkg/install.cpp
@@ -495,7 +495,7 @@ namespace vcpkg::Install
                 perform_install_plan_action(args, paths, action, status_db, binary_cache, build_logs_recorder);
             if (result.code != BuildResult::SUCCEEDED && keep_going == KeepGoing::NO)
             {
-                print2(Build::create_user_troubleshooting_message(action.spec), '\n');
+                print2(Build::create_user_troubleshooting_message(action), '\n');
                 Checks::exit_fail(VCPKG_LINE_INFO);
             }
 


### PR DESCRIPTION
When users report port build/install issues, it is often not obvious which features and package version they tried to install, even when they add command line output: versions and features are printed only early, for the "installation plan". This PR adds version and features to the *final output* statement, i.e. the instructions which information to include into an GH issue.

Tested with `install` and `build` command.

Example before this change:
~~~
$ ./vcpkg install qt5-base:x64-mingw-dynamic
Computing installation plan...
The following packages will be built and installed:
  * openssl[core]:x64-mingw-dynamic -> 1.1.1l#1
  * pcre2[core]:x64-mingw-dynamic -> 10.37
    qt5-base[core]:x64-mingw-dynamic -> 5.15.2#11
  * sqlite3[core]:x64-mingw-dynamic -> 3.36.0#1
  * zstd[core]:x64-mingw-dynamic -> 1.5.0
[... (too much to expect it to be posted in a typical GH issue) ...]
Error: Building package openssl:x64-mingw-dynamic failed with: BUILD_FAILED
Please ensure you're using the latest portfiles with `./vcpkg update`, then
submit an issue at https://github.com/Microsoft/vcpkg/issues including:
  Package: openssl:x64-mingw-dynamic
  Vcpkg version: 2021-09-10-unknownhash-debug

Additionally, attach any relevant sections from the log files above.
~~~

With this PR, the "Package" line in the final output changes to:
~~~
[...]
Error: Building package openssl:x64-mingw-dynamic failed with: BUILD_FAILED
Please ensure you're using the latest portfiles with `./vcpkg update`, then
submit an issue at https://github.com/Microsoft/vcpkg/issues including:
  Package: openssl[core]:x64-mingw-dynamic -> 1.1.1l#1
  Vcpkg version: 2021-09-10-unknownhash-debug

Additionally, attach any relevant sections from the log files above.
~~~
