### PR TITLE
Limit time to live for cache unavailability during ci command

### DIFF
--- a/include/vcpkg/binarycaching.h
+++ b/include/vcpkg/binarycaching.h
@@ -3,6 +3,7 @@
 #include <vcpkg/fwd/dependencies.h>
 #include <vcpkg/fwd/vcpkgpaths.h>
 
+#include <vcpkg/base/chrono.h>
 #include <vcpkg/base/downloads.h>
 #include <vcpkg/base/expected.h>
 #include <vcpkg/base/files.h>
@@ -119,9 +120,18 @@ namespace vcpkg
         /// Returns a vector where each index corresponds to the matching index in `actions`.
         std::vector<CacheAvailability> precheck(const VcpkgPaths& paths, View<Dependencies::InstallPlanAction> actions);
 
+        /// Sets the time in seconds from now after which "unavailable" entries will be checked again.
+        /// A non-positive value disables re-checking.
+        void set_ttl_for_unavailable(int seconds);
+
     private:
+        /// Returns true when the lifetime for "unvailable" entries is exceeded.
+        bool must_recheck_unavailable_entries() const noexcept;
+
         std::unordered_map<std::string, CacheStatus> m_status;
         std::vector<std::unique_ptr<IBinaryProvider>> m_providers;
+        ElapsedTimer m_ttl_elapsed;
+        int m_ttl_for_unavailable = 0;
     };
 
     ExpectedS<Downloads::DownloadManagerConfig> parse_download_configuration(const Optional<std::string>& arg);

--- a/src/vcpkg/commands.ci.cpp
+++ b/src/vcpkg/commands.ci.cpp
@@ -600,6 +600,7 @@ namespace vcpkg::Commands::CI
             StatusParagraphs status_db = database_load_check(paths);
 
             auto collection_timer = ElapsedTimer::create_started();
+            binary_cache.set_ttl_for_unavailable(120);
             auto summary = Install::perform(args,
                                             action_plan,
                                             Install::KeepGoing::YES,


### PR DESCRIPTION
Picking up an issue and an idea I discussed in a previous conversation with @BillyONeal:

- PR CI builds check cache availability only at the beginning of the ci command. 
- After significant changes to vcpkg repo master, many ports are not available in the binary cache. 
- PR CI runs scheduled within a short time frame after master update will thus identify the same (unrelated) ports as *not available*.
- However, this information is outdated when a CI run actually reaches the point of installing a particular port (minutes or even hours later) because other PRs may have created the cache artifact in the meantime. If the cache artifact isn't used, CI wastes rare build resources in peak times.

Attaching time-to-live to the binary cache used during CI may allow rechecking availability without overloading the cache provider.
It is not a perfect solution. Without randomization in build order, parallel builds may run into the same set of unavailable ports with lonbg build times.

This PR compiles, but wasn't tested or verified so far.
