### PR TITLE
[ci command] Dont exit when a port is not supported for given triplet

### DIFF
--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -1324,7 +1324,7 @@ namespace vcpkg::Build
 #endif
 
         std::string package = action.displayname();
-        if (auto scfl = action.source_control_file_location.get())
+        if (auto scfl = action.source_control_file_and_location.get())
         {
             Strings::append(package, " -> ", scfl->to_versiont());
         }

--- a/src/vcpkg/commands.ci.cpp
+++ b/src/vcpkg/commands.ci.cpp
@@ -524,7 +524,8 @@ namespace vcpkg::Commands::CI
             return FullPackageSpec{spec, std::move(default_features)};
         });
 
-        Dependencies::CreateInstallPlanOptions serialize_options(host_triplet);
+        Dependencies::CreateInstallPlanOptions serialize_options(host_triplet,
+                                                                 Dependencies::UnsupportedPortAction::Warn);
 
         struct RandomizerInstance : Graphs::Randomizer
         {


### PR DESCRIPTION
Before:
```
➜  vcpkg git:(update-proj4) ✗ vcpkg ci x64-osx
'vcpkg ci' is an internal command which will change incompatibly or be removed at any time.
Loading dependency information for 150 packages...
Error: v8[core] is only supported on '!(arm | arm64 | uwp | osx)'
```
After:
```
➜  vcpkg git:(update-proj4) ✗ vcpkg ci x64-osx
'vcpkg ci' is an internal command which will change incompatibly or be removed at any time.
Loading dependency information for 150 packages...
Loading dependency information for 408 packages...
Error: Unreachable code was reached
/Users/leanderSchulten/git_projekte/vcpkg-tool/src/vcpkg/platform-expression.cpp(415)
[1]    53038 abort      vcpkg ci x64-osx
```
The last error gets fixed in #147