### PR TITLE
In filesystem::remove, handle readonly bits correctly on Windows.

### DIFF
--- a/src/vcpkg-test/files.cpp
+++ b/src/vcpkg-test/files.cpp
@@ -180,8 +180,6 @@ namespace
         fs.create_symlink(target_file, target_symlink, ec);
         if (ec)
         {
-            // if we get not supported or permission denied, assume symlinks aren't supported
-            // on this system and the test is a no-op
             REQUIRE(is_valid_symlink_failure(ec));
         }
         else

--- a/src/vcpkg-test/files.cpp
+++ b/src/vcpkg-test/files.cpp
@@ -33,13 +33,16 @@ namespace
 
     std::string get_random_filename(urbg_t& urbg) { return Strings::b32_encode(urbg()); }
 
-#if defined(_WIN32)
     bool is_valid_symlink_failure(const std::error_code& ec) noexcept
     {
+#if defined(_WIN32)
         // on Windows, creating symlinks requires admin rights, so we ignore such failures
         return ec == std::error_code(ERROR_PRIVILEGE_NOT_HELD, std::system_category());
+#else  // ^^^ _WIN32 // !_WIN32
+        (void)ec;
+        return false; // symlinks should always work on non-windows
+#endif // ^^^ !_WIN32
     }
-#endif // ^^^ _WIN32
 
     void create_directory_tree(urbg_t& urbg, Filesystem& fs, const Path& base, std::uint32_t remaining_depth = 5)
     {

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -422,7 +422,10 @@ namespace
         if (!SetFileAttributesW(file_name, dw_attributes))
         {
             ec.assign(GetLastError(), std::system_category());
+            return;
         }
+
+        ec.clear();
     }
 
     // Custom implementation of stdfs::remove_all intended to be resilient to transient issues


### PR DESCRIPTION
Resolves https://github.com/microsoft/vcpkg/issues/20546