### PR TITLE
Fix incorrect ordering in ci ExclusionPredicate 

### DIFF
--- a/src/vcpkg/commands.ci.cpp
+++ b/src/vcpkg/commands.ci.cpp
@@ -300,8 +300,8 @@ namespace vcpkg::Commands::CI
     {
         std::set<std::string> exclusions;
         std::set<std::string> host_exclusions;
-        Triplet host_triplet;
         Triplet target_triplet;
+        Triplet host_triplet;
 
         bool operator()(const PackageSpec& spec) const
         {


### PR DESCRIPTION
... that broke attempting to update vcpkg-tool in the normal repo.