### PR TITLE
vcpkg build: Fix missing cascade failure when host dependency on itself fails

### DIFF
--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -1215,7 +1215,7 @@ namespace vcpkg::Build
         {
             for (const FeatureSpec& fspec : kv.second)
             {
-                if (!(status_db.is_installed(fspec) || fspec.name() == name))
+                if (!status_db.is_installed(fspec) && !(fspec.name() == name && fspec.triplet() == spec.triplet()))
                 {
                     missing_fspecs.emplace_back(fspec);
                 }


### PR DESCRIPTION
Currently dependencies on itself were completely ignored, but they must not be ignored when
the triplet is different.

See crash of vcpkg [here](https://dev.azure.com/vcpkg/public/_build/results?buildId=61839&view=logs&jobId=3859ca13-59fe-57bd-13f9-449df7d191a6&j=3859ca13-59fe-57bd-13f9-449df7d191a6&t=03b21fcd-db83-5643-e95b-35d3afaab803)