### PR TITLE
Allow --x-install-root to contain nonexistent directories.

### DIFF
--- a/src/vcpkg/vcpkglib.cpp
+++ b/src/vcpkg/vcpkglib.cpp
@@ -41,7 +41,7 @@ namespace vcpkg
 
         const auto updates_dir = paths.vcpkg_dir_updates;
 
-        fs.create_directory(paths.installed, VCPKG_LINE_INFO);
+        fs.create_directories(paths.installed, VCPKG_LINE_INFO);
         fs.create_directory(paths.vcpkg_dir, VCPKG_LINE_INFO);
         fs.create_directory(paths.vcpkg_dir_info, VCPKG_LINE_INFO);
         fs.create_directory(updates_dir, VCPKG_LINE_INFO);


### PR DESCRIPTION
This fixes an issue when using `--x-install-root=` with partially existing directories:
Before:
```
/workspaces/vcpkg$ mkdir x
/workspaces/vcpkg$ ./vcpkg install --x-install-root=/workspaces/vcpkg/x/y/z zlib
Computing installation plan...
create_directory(/workspaces/vcpkg/x/y/z): No such file or directory
```
After:
```
/workspaces/vcpkg$ mkdir x
/workspaces/vcpkg$ ./vcpkg install --x-install-root=/workspaces/vcpkg/x/y/z zlib
Computing installation plan...
The following packages will be built and installed:
    zlib[core]:x64-linux -> 1.2.11#13
Detecting compiler hash for triplet x64-linux...
Restored 1 packages from /workspaces/.cache/vcpkg in 7.007 ms. Use --debug to see more details.
Starting package 1/1: zlib:x64-linux
Installing package zlib[core]:x64-linux...
Elapsed time for package zlib:x64-linux: 1.116 ms

Total elapsed time: 233.4 ms

The package zlib is compatible with built-in CMake targets:

    find_package(ZLIB REQUIRED)
    target_link_libraries(main PRIVATE ZLIB::ZLIB)

```