### PR TITLE
Fix copy_symlink on old libstdc++.

### DIFF
--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -2761,7 +2761,7 @@ namespace vcpkg
                 if (static_cast<size_t>(result) == buffer.size())
                 {
                     // we might not have used a big enough buffer, grow and retry
-                    buffer.append(PATH_MAX, '\0');
+                    buffer.append(buffer.size(), '\0');
                     continue;
                 }
 


### PR DESCRIPTION
`copy_symlink` had assumptions that `std::string` implements the small string optimization, and thus we would never call `readlink` with a buffer length of 0. Unfortunately, the old libstdc++ we want to use for old Linux uses the COW form where the initial capacity is 0, which caused `readlink` to fail with `EINVAL`.

This change makes us always start with `PATH_MAX`.