### PR TITLE
[tool cache] Add option to require exact versions for abi relevant tools

### DIFF
--- a/include/vcpkg/tools.h
+++ b/include/vcpkg/tools.h
@@ -28,11 +28,18 @@ namespace vcpkg
 
     struct ToolCache
     {
+        enum class RequireExactVersionsForAbiRelevantTools
+        {
+            YES,
+            NO,
+        };
+
         virtual ~ToolCache() { }
 
         virtual const Path& get_tool_path(const VcpkgPaths& paths, const std::string& tool) const = 0;
         virtual const std::string& get_tool_version(const VcpkgPaths& paths, const std::string& tool) const = 0;
     };
 
-    std::unique_ptr<ToolCache> get_tool_cache();
+    std::unique_ptr<ToolCache> get_tool_cache(
+        ToolCache::RequireExactVersionsForAbiRelevantTools abiToolVersionHandling);
 }

--- a/include/vcpkg/tools.h
+++ b/include/vcpkg/tools.h
@@ -28,7 +28,7 @@ namespace vcpkg
 
     struct ToolCache
     {
-        enum class RequireExactVersionsForAbiRelevantTools
+        enum class RequireExactVersions
         {
             YES,
             NO,
@@ -40,6 +40,5 @@ namespace vcpkg
         virtual const std::string& get_tool_version(const VcpkgPaths& paths, const std::string& tool) const = 0;
     };
 
-    std::unique_ptr<ToolCache> get_tool_cache(
-        ToolCache::RequireExactVersionsForAbiRelevantTools abiToolVersionHandling);
+    std::unique_ptr<ToolCache> get_tool_cache(ToolCache::RequireExactVersions abiToolVersionHandling);
 }

--- a/include/vcpkg/vcpkgcmdarguments.h
+++ b/include/vcpkg/vcpkgcmdarguments.h
@@ -161,6 +161,9 @@ namespace vcpkg
         constexpr static StringLiteral CMAKE_SCRIPT_ARG = "x-cmake-args";
         std::vector<std::string> cmake_args;
 
+        constexpr static StringLiteral EXACT_ABI_TOOLS_VERSIONS_SWITCH = "x-abi-relevant-tools-use-exact-versions";
+        Optional<bool> exact_abi_tools_versions;
+
         constexpr static StringLiteral DEBUG_SWITCH = "debug";
         Optional<bool> debug = nullopt;
         constexpr static StringLiteral SEND_METRICS_SWITCH = "sendmetrics";

--- a/include/vcpkg/vcpkgcmdarguments.h
+++ b/include/vcpkg/vcpkgcmdarguments.h
@@ -161,7 +161,7 @@ namespace vcpkg
         constexpr static StringLiteral CMAKE_SCRIPT_ARG = "x-cmake-args";
         std::vector<std::string> cmake_args;
 
-        constexpr static StringLiteral EXACT_ABI_TOOLS_VERSIONS_SWITCH = "x-abi-relevant-tools-use-exact-versions";
+        constexpr static StringLiteral EXACT_ABI_TOOLS_VERSIONS_SWITCH = "x-abi-tools-use-exact-versions";
         Optional<bool> exact_abi_tools_versions;
 
         constexpr static StringLiteral DEBUG_SWITCH = "debug";

--- a/src/vcpkg/tools.cpp
+++ b/src/vcpkg/tools.cpp
@@ -604,9 +604,8 @@ gsutil version: 4.58
                     {
                         return {"cmake", "0"};
                     }
-                    return get_path(paths,
-                                    CMakeProvider(),
-                                    abiToolVersionHandling == ToolCache::RequireExactVersions::YES);
+                    return get_path(
+                        paths, CMakeProvider(), abiToolVersionHandling == ToolCache::RequireExactVersions::YES);
                 }
                 if (tool == Tools::GIT)
                 {

--- a/src/vcpkg/tools.cpp
+++ b/src/vcpkg/tools.cpp
@@ -562,11 +562,11 @@ gsutil version: 4.58
 
     struct ToolCacheImpl final : ToolCache
     {
-        ToolCache::RequireExactVersionsForAbiRelevantTools abiToolVersionHandling;
+        ToolCache::RequireExactVersions abiToolVersionHandling;
         vcpkg::Cache<std::string, Path> path_only_cache;
         vcpkg::Cache<std::string, PathAndVersion> path_version_cache;
 
-        ToolCacheImpl(ToolCache::RequireExactVersionsForAbiRelevantTools abiToolVersionHandling)
+        ToolCacheImpl(ToolCache::RequireExactVersions abiToolVersionHandling)
             : abiToolVersionHandling(abiToolVersionHandling)
         {
         }
@@ -606,7 +606,7 @@ gsutil version: 4.58
                     }
                     return get_path(paths,
                                     CMakeProvider(),
-                                    abiToolVersionHandling == ToolCache::RequireExactVersionsForAbiRelevantTools::YES);
+                                    abiToolVersionHandling == ToolCache::RequireExactVersions::YES);
                 }
                 if (tool == Tools::GIT)
                 {
@@ -632,7 +632,7 @@ gsutil version: 4.58
                     }
                     return get_path(paths,
                                     PowerShellCoreProvider(),
-                                    abiToolVersionHandling == ToolCache::RequireExactVersionsForAbiRelevantTools::YES);
+                                    abiToolVersionHandling == ToolCache::RequireExactVersions::YES);
                 }
                 if (tool == Tools::NUGET) return get_path(paths, NuGetProvider());
                 if (tool == Tools::IFW_INSTALLER_BASE) return get_path(paths, IfwInstallerBaseProvider());
@@ -667,7 +667,7 @@ gsutil version: 4.58
         }
     };
 
-    std::unique_ptr<ToolCache> get_tool_cache(ToolCache::RequireExactVersionsForAbiRelevantTools abiToolVersionHandling)
+    std::unique_ptr<ToolCache> get_tool_cache(ToolCache::RequireExactVersions abiToolVersionHandling)
     {
         return std::make_unique<ToolCacheImpl>(abiToolVersionHandling);
     }

--- a/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/src/vcpkg/vcpkgcmdarguments.cpp
@@ -308,6 +308,7 @@ namespace vcpkg
                 {WAIT_FOR_LOCK_SWITCH, &VcpkgCmdArguments::wait_for_lock},
                 {IGNORE_LOCK_FAILURES_SWITCH, &VcpkgCmdArguments::ignore_lock_failures},
                 {JSON_SWITCH, &VcpkgCmdArguments::json},
+                {EXACT_ABI_TOOLS_VERSIONS_SWITCH, &VcpkgCmdArguments::exact_abi_tools_versions},
             };
 
             Optional<StringView> lookahead;
@@ -1034,4 +1035,5 @@ namespace vcpkg
     constexpr StringLiteral VcpkgCmdArguments::VERSIONS_FEATURE;
 
     constexpr StringLiteral VcpkgCmdArguments::CMAKE_SCRIPT_ARG;
+    constexpr StringLiteral VcpkgCmdArguments::EXACT_ABI_TOOLS_VERSIONS_SWITCH;
 }

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -233,7 +233,7 @@ namespace vcpkg
         {
             VcpkgPathsImpl(Filesystem& fs,
                            FeatureFlagSettings ff_settings,
-                           ToolCache::RequireExactVersionsForAbiRelevantTools abiToolsHandling)
+                           ToolCache::RequireExactVersions abiToolsHandling)
                 : fs_ptr(&fs)
                 , m_tool_cache(get_tool_cache(abiToolsHandling))
                 , m_env_cache(ff_settings.compiler_tracking)
@@ -283,7 +283,7 @@ namespace vcpkg
         : m_pimpl(std::make_unique<details::VcpkgPathsImpl>(
               filesystem,
               args.feature_flag_settings(),
-              Util::Enum::to_enum<ToolCache::RequireExactVersionsForAbiRelevantTools>(
+              Util::Enum::to_enum<ToolCache::RequireExactVersions>(
                   args.exact_abi_tools_versions.value_or(false))))
     {
         original_cwd = filesystem.current_path(VCPKG_LINE_INFO);

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -283,8 +283,7 @@ namespace vcpkg
         : m_pimpl(std::make_unique<details::VcpkgPathsImpl>(
               filesystem,
               args.feature_flag_settings(),
-              Util::Enum::to_enum<ToolCache::RequireExactVersions>(
-                  args.exact_abi_tools_versions.value_or(false))))
+              Util::Enum::to_enum<ToolCache::RequireExactVersions>(args.exact_abi_tools_versions.value_or(false))))
     {
         original_cwd = filesystem.current_path(VCPKG_LINE_INFO);
 #if defined(_WIN32)

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -231,9 +231,11 @@ namespace vcpkg
 
         struct VcpkgPathsImpl
         {
-            VcpkgPathsImpl(Filesystem& fs, FeatureFlagSettings ff_settings)
+            VcpkgPathsImpl(Filesystem& fs,
+                           FeatureFlagSettings ff_settings,
+                           ToolCache::RequireExactVersionsForAbiRelevantTools abiToolsHandling)
                 : fs_ptr(&fs)
-                , m_tool_cache(get_tool_cache())
+                , m_tool_cache(get_tool_cache(abiToolsHandling))
                 , m_env_cache(ff_settings.compiler_tracking)
                 , m_ff_settings(ff_settings)
             {
@@ -278,7 +280,11 @@ namespace vcpkg
     static Path lockfile_path(const VcpkgPaths& p) { return p.vcpkg_dir / "vcpkg-lock.json"; }
 
     VcpkgPaths::VcpkgPaths(Filesystem& filesystem, const VcpkgCmdArguments& args)
-        : m_pimpl(std::make_unique<details::VcpkgPathsImpl>(filesystem, args.feature_flag_settings()))
+        : m_pimpl(std::make_unique<details::VcpkgPathsImpl>(
+              filesystem,
+              args.feature_flag_settings(),
+              Util::Enum::to_enum<ToolCache::RequireExactVersionsForAbiRelevantTools>(
+                  args.exact_abi_tools_versions.value_or(false))))
     {
         original_cwd = filesystem.current_path(VCPKG_LINE_INFO);
 #if defined(_WIN32)


### PR DESCRIPTION
If a developer in a team has a different version of a abi relevant tool, the developer has
to rebuild every package because the developer only gets cache misses in the binary cache.
Add an option to force vcpkg to use the same version of a abi relevant tool so that you don't
get binary cache misses because of different abi relevant tools.