### PR TITLE
Explicitly default CStringView copy-assignment

### DIFF
--- a/include/vcpkg/base/cstringview.h
+++ b/include/vcpkg/base/cstringview.h
@@ -12,6 +12,8 @@ namespace vcpkg
         constexpr CStringView(const CStringView&) = default;
         CStringView(const std::string& str) : cstr(str.c_str()) { }
 
+        CStringView& operator=(const CStringView& cstr) = default;
+
         constexpr const char* c_str() const { return cstr; }
 
         void to_string(std::string& str) const { str.append(cstr); }


### PR DESCRIPTION
This is good form, since the class has a user-declared copy constructor.
Without this, clang emits the following warning:

warning: definition of implicit copy assignment operator for 'CStringView'
is deprecated because it has a user-declared copy constructor [-Wdeprecated-copy]