### PR TITLE
Always unset CLICOLOR_FORCE

### DIFF
--- a/azure-pipelines/end-to-end-tests-dir/tool-ports.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/tool-ports.ps1
@@ -19,13 +19,15 @@ else
 
 $env:VCPKG_FEATURE_FLAGS="-compilertracking"
 
-# Test native installation
+# Test native installation and isolation from CLICOLOR_FORCE=1
+$env:CLICOLOR_FORCE = 1
 Run-Vcpkg ($commonArgs + @("install", "tool-libb"))
 Throw-IfFailed
 @("tool-control", "tool-manifest", "tool-liba", "tool-libb") | % {
     Require-FileNotExists $installRoot/$targetTriplet/share/$_
     Require-FileExists $installRoot/$hostTriplet/share/$_
 }
+Remove-Item env:CLICOLOR_FORCE
 
 Refresh-TestRoot
 

--- a/src/vcpkg.cpp
+++ b/src/vcpkg.cpp
@@ -238,6 +238,7 @@ int main(const int argc, const char* const* const argv)
     }
 #endif
     set_environment_variable("VCPKG_COMMAND", get_exe_path_of_current_process().generic_u8string());
+    set_environment_variable("CLICOLOR_FORCE", {});
 
     Checks::register_global_shutdown_handler([]() {
         const auto elapsed_us_inner = LockGuardPtr<ElapsedTimer>(GlobalState::timer)->microseconds();


### PR DESCRIPTION
Fixes vpckg cmake output parsing breaking when cmake colorizes the output due to environment variable `CLICOLOR_FORCE`. 
- [x] Add test.
- [x] Fix issue.

Issue: https://github.com/microsoft/vcpkg/issues/20430