### PR TITLE
Consistently construct paths using host's separator

### DIFF
--- a/src/vcpkg-test/util.cpp
+++ b/src/vcpkg-test/util.cpp
@@ -94,7 +94,7 @@ namespace vcpkg::Test
     static Path internal_base_temporary_directory()
     {
 #if defined(_WIN32)
-        return vcpkg::get_environment_variable("TEMP").value_or_exit(VCPKG_LINE_INFO) + "/vcpkg-test";
+        return Path(vcpkg::get_environment_variable("TEMP").value_or_exit(VCPKG_LINE_INFO)) / "vcpkg-test";
 #else
         return "/tmp/vcpkg-test";
 #endif

--- a/src/vcpkg/postbuildlint.cpp
+++ b/src/vcpkg/postbuildlint.cpp
@@ -201,7 +201,7 @@ namespace vcpkg::PostBuildLint
 
     static LintStatus check_for_files_in_debug_include_directory(const Filesystem& fs, const Path& package_dir)
     {
-        const auto debug_include_dir = package_dir / "debug/include";
+        const auto debug_include_dir = package_dir / "debug" / "include";
 
         std::vector<Path> files_found = fs.get_regular_files_recursive(debug_include_dir, IgnoreErrors{});
 
@@ -221,7 +221,7 @@ namespace vcpkg::PostBuildLint
 
     static LintStatus check_for_files_in_debug_share_directory(const Filesystem& fs, const Path& package_dir)
     {
-        const auto debug_share = package_dir / "debug/share";
+        const auto debug_share = package_dir / "debug" / "share";
         if (fs.exists(debug_share, IgnoreErrors{}))
         {
             print2(Color::warning,
@@ -257,7 +257,7 @@ namespace vcpkg::PostBuildLint
 
     static LintStatus check_folder_lib_cmake(const Filesystem& fs, const Path& package_dir, const PackageSpec& spec)
     {
-        const auto lib_cmake = package_dir / "lib/cmake";
+        const auto lib_cmake = package_dir / "lib" / "cmake";
         if (fs.exists(lib_cmake, IgnoreErrors{}))
         {
             vcpkg::printf(Color::warning,
@@ -277,9 +277,9 @@ namespace vcpkg::PostBuildLint
     {
         std::vector<Path> dirs = {
             package_dir / "cmake",
-            package_dir / "debug/cmake",
-            package_dir / "lib/cmake",
-            package_dir / "debug/lib/cmake",
+            package_dir / "debug" / "cmake",
+            package_dir / "lib" / "cmake",
+            package_dir / "debug" / "lib" / "cmake",
         };
 
         std::vector<Path> misplaced_cmake_files;
@@ -664,7 +664,7 @@ namespace vcpkg::PostBuildLint
         if (policies.is_enabled(BuildPolicy::DLLS_IN_STATIC_LIBRARY)) return LintStatus::SUCCESS;
 
         const auto bin = package_dir / "bin";
-        const auto debug_bin = package_dir / "debug/bin";
+        const auto debug_bin = package_dir / "debug" / "bin";
 
         const bool bin_exists = fs.exists(bin, IgnoreErrors{});
         const bool debug_bin_exists = fs.exists(debug_bin, IgnoreErrors{});
@@ -975,9 +975,9 @@ namespace vcpkg::PostBuildLint
         error_count += check_for_exes(fs, package_dir);
         error_count += check_for_exes(fs, package_dir / "debug");
 
-        const auto debug_lib_dir = package_dir / "debug/lib";
+        const auto debug_lib_dir = package_dir / "debug" / "lib";
         const auto release_lib_dir = package_dir / "lib";
-        const auto debug_bin_dir = package_dir / "debug/bin";
+        const auto debug_bin_dir = package_dir / "debug" / "bin";
         const auto release_bin_dir = package_dir / "bin";
 
         std::vector<Path> debug_libs = fs.get_regular_files_recursive(debug_lib_dir, IgnoreErrors{});


### PR DESCRIPTION
To fix ugly mixed separator output in error messages on windows, e.g.
~~~
-- Performing post-build validation
Import libs were not present in F:\vcpkg\packages\lapack-reference_x64-windows\debug/lib
~~~
(from https://github.com/microsoft/vcpkg/issues/21060)