### PR TITLE
[x-add-version] ignore files in ports dir

### DIFF
--- a/src/vcpkg/commands.add-version.cpp
+++ b/src/vcpkg/commands.add-version.cpp
@@ -308,7 +308,7 @@ namespace vcpkg::Commands::AddVersion
                 Checks::exit_fail(VCPKG_LINE_INFO);
             }
 
-            for (auto&& port_dir : fs.get_files_non_recursive(paths.builtin_ports_directory(), VCPKG_LINE_INFO))
+            for (auto&& port_dir : fs.get_directories_non_recursive(paths.builtin_ports_directory(), VCPKG_LINE_INFO))
             {
                 port_names.emplace_back(port_dir.stem().to_string());
             }


### PR DESCRIPTION
This was the behavior before #126 got merged. This also solves https://github.com/microsoft/vcpkg/issues/16520#issuecomment-963141566 