### PR TITLE
return verbose error when json contains object with duplicated keys

### DIFF
--- a/src/vcpkg-test/json.cpp
+++ b/src/vcpkg-test/json.cpp
@@ -240,3 +240,14 @@ TEST_CASE ("JSON track newlines", "[json]")
                   ^
 )");
 }
+
+TEST_CASE ("JSON duplicated object keys", "[json]")
+{
+    auto res = Json::parse("{\"name\": 1, \"name\": 2}", "filename");
+    REQUIRE(!res);
+    REQUIRE(res.error()->format() ==
+            R"(filename:1:13: error: Duplicated key "name" in an object
+   on expression: {"name": 1, "name": 2}
+                              ^
+)");
+}

--- a/src/vcpkg/base/json.cpp
+++ b/src/vcpkg/base/json.cpp
@@ -940,7 +940,13 @@ namespace vcpkg::Json
                         add_error("Unexpected character; expected comma or close brace");
                     }
 
+                    auto keyPairLoc = cur_loc();
                     auto val = parse_kv_pair();
+                    if (obj.contains(val.first))
+                    {
+                        add_error(Strings::format("Duplicated key \"%s\" in an object", val.first), keyPairLoc);
+                        return Value();
+                    }
                     obj.insert(std::move(val.first), std::move(val.second));
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/20837.

It looks that parsing vcpkg.json may require more error handling.