### PR TITLE
remove CMake and PowerShell versions from ABI info

### DIFF
--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -1087,12 +1087,6 @@ namespace vcpkg::Build
             }
         }
 
-        abi_tag_entries.emplace_back("cmake", paths.get_tool_version(Tools::CMAKE));
-
-#if defined(_WIN32)
-        abi_tag_entries.emplace_back("powershell", paths.get_tool_version("powershell-core"));
-#endif
-
         auto& helpers = paths.get_cmake_script_hashes();
         auto portfile_contents = fs.read_contents(port_dir / "portfile.cmake", VCPKG_LINE_INFO);
         for (auto&& helper : helpers)


### PR DESCRIPTION
Neither of these actually affect the ABI. Including these in the ABI info is problematic because it requires using the exact same
versions of these tools on build servers as developers' local build environments to get binary caching to use cached packages
built on a server.

This is an alternative solution to https://github.com/microsoft/vcpkg/issues/16615. Unlike #223 it avoids vcpkg needing to download exact versions of CMake and PowerShell if a newer version than vcpkg's minimum requirement is already available from the system.

I don't particularly care whether this or #223 is merged; I just want some solution to https://github.com/microsoft/vcpkg/issues/16615.