### PR TITLE
Add new fields to vcpkg.json

### DIFF
--- a/include/vcpkg/sourceparagraph.h
+++ b/include/vcpkg/sourceparagraph.h
@@ -64,6 +64,7 @@ namespace vcpkg
         std::string version;
         int port_version = 0;
         std::vector<std::string> description;
+        std::vector<std::string> summary;
         std::vector<std::string> maintainers;
         std::string homepage;
         std::string documentation;
@@ -73,6 +74,8 @@ namespace vcpkg
         std::string license; // SPDX license expression
         Optional<std::string> builtin_baseline;
         Optional<Json::Object> vcpkg_configuration;
+        // Currently contacts is only a Json::Object but it will eventually be unified with maintainers
+        Json::Object contacts;
 
         Type type = {Type::PORT};
         PlatformExpression::Expr supports_expression;

--- a/src/vcpkg-test/configmetadata.cpp
+++ b/src/vcpkg-test/configmetadata.cpp
@@ -14,6 +14,7 @@ static constexpr StringLiteral KIND = "kind";
 static constexpr StringLiteral REPOSITORY = "repository";
 static constexpr StringLiteral PATH = "path";
 static constexpr StringLiteral BASELINE = "baseline";
+static constexpr StringLiteral NAME = "name";
 static constexpr StringLiteral LOCATION = "location";
 static constexpr StringLiteral CE_MESSAGE = "message";
 static constexpr StringLiteral CE_WARNING = "warning";
@@ -97,6 +98,7 @@ TEST_CASE ("config without ce metadata", "[ce-metadata]")
         },
         {
             "kind": "artifact",
+            "name": "vcpkg-artifacts",
             "location": "https://github.com/microsoft/vcpkg-artifacts"
         }
     ]
@@ -132,6 +134,7 @@ TEST_CASE ("config without ce metadata", "[ce-metadata]")
     const auto& artifact_registry = config.registry_set.registries()[2];
     auto serialized_art_registry = artifact_registry.implementation().serialize();
     check_string(serialized_art_registry, KIND, "artifact");
+    check_string(serialized_art_registry, NAME, "vcpkg-artifacts");
     check_string(serialized_art_registry, LOCATION, "https://github.com/microsoft/vcpkg-artifacts");
 
     auto raw_obj = parse_json_object(raw_config);

--- a/src/vcpkg-test/configmetadata.cpp
+++ b/src/vcpkg-test/configmetadata.cpp
@@ -14,6 +14,7 @@ static constexpr StringLiteral KIND = "kind";
 static constexpr StringLiteral REPOSITORY = "repository";
 static constexpr StringLiteral PATH = "path";
 static constexpr StringLiteral BASELINE = "baseline";
+static constexpr StringLiteral LOCATION = "location";
 static constexpr StringLiteral CE_MESSAGE = "message";
 static constexpr StringLiteral CE_WARNING = "warning";
 static constexpr StringLiteral CE_ERROR = "error";
@@ -93,6 +94,10 @@ TEST_CASE ("config without ce metadata", "[ce-metadata]")
             "kind": "filesystem",
             "path": "path/to/registry",
             "packages": [ "zlib" ]
+        },
+        {
+            "kind": "artifact",
+            "location": "https://github.com/microsoft/vcpkg-artifacts"
         }
     ]
 })json";
@@ -106,7 +111,7 @@ TEST_CASE ("config without ce metadata", "[ce-metadata]")
     check_string(default_registry, KIND, "builtin");
     check_string(default_registry, BASELINE, "843e0ba0d8f9c9c572e45564263eedfc7745e74f");
 
-    REQUIRE(config.registry_set.registries().size() == 2);
+    REQUIRE(config.registry_set.registries().size() == 3);
 
     const auto& git_registry = config.registry_set.registries()[0];
     auto serialized_git_registry = git_registry.implementation().serialize();
@@ -123,6 +128,11 @@ TEST_CASE ("config without ce metadata", "[ce-metadata]")
     check_string(serialized_fs_registry, PATH, "path/to/registry");
     REQUIRE(fs_registry.packages().size() == 1);
     REQUIRE(fs_registry.packages()[0] == "zlib");
+
+    const auto& artifact_registry = config.registry_set.registries()[2];
+    auto serialized_art_registry = artifact_registry.implementation().serialize();
+    check_string(serialized_art_registry, KIND, "artifact");
+    check_string(serialized_art_registry, LOCATION, "https://github.com/microsoft/vcpkg-artifacts");
 
     auto raw_obj = parse_json_object(raw_config);
     auto serialized_obj = serialize_configuration(config);

--- a/src/vcpkg-test/manifests.cpp
+++ b/src/vcpkg-test/manifests.cpp
@@ -60,9 +60,12 @@ TEST_CASE ("manifest construct minimum", "[manifests]")
     REQUIRE(pgh.core_paragraph->name == "zlib");
     REQUIRE(pgh.core_paragraph->version == "1.2.8");
     REQUIRE(pgh.core_paragraph->maintainers.empty());
+    REQUIRE(pgh.core_paragraph->contacts.is_empty());
+    REQUIRE(pgh.core_paragraph->summary.empty());
     REQUIRE(pgh.core_paragraph->description.empty());
     REQUIRE(pgh.core_paragraph->dependencies.empty());
     REQUIRE(!pgh.core_paragraph->builtin_baseline.has_value());
+    REQUIRE(!pgh.core_paragraph->vcpkg_configuration.has_value());
 
     REQUIRE(!pgh.check_against_feature_flags({}, feature_flags_without_versioning));
 }
@@ -640,6 +643,10 @@ TEST_CASE ("manifest embed configuration", "[manifests]")
                     "rapidjson",
                     "fmt"
                 ]
+            },
+            {
+                "kind": "artifact",
+                "location": "https://github.com/microsoft/vcpkg-artifacts"
             }
         ]
     })json";
@@ -707,6 +714,8 @@ TEST_CASE ("manifest construct maximum", "[manifests]")
         "name": "s",
         "version-string": "v",
         "maintainers": ["m"],
+        "contacts": { "a": { "aa": "aa" } },
+        "summary": "d",
         "description": "d",
         "dependencies": ["bd"],
         "default-features": ["df"],
@@ -738,6 +747,16 @@ TEST_CASE ("manifest construct maximum", "[manifests]")
     REQUIRE(pgh.core_paragraph->version == "v");
     REQUIRE(pgh.core_paragraph->maintainers.size() == 1);
     REQUIRE(pgh.core_paragraph->maintainers[0] == "m");
+    REQUIRE(pgh.core_paragraph->contacts.size() == 1);
+    auto contact_a = pgh.core_paragraph->contacts.get("a");
+    REQUIRE(contact_a);
+    REQUIRE(contact_a->is_object());
+    auto contact_a_aa = contact_a->object().get("aa");
+    REQUIRE(contact_a_aa);
+    REQUIRE(contact_a_aa->is_string());
+    REQUIRE(contact_a_aa->string() == "aa");
+    REQUIRE(pgh.core_paragraph->summary.size() == 1);
+    REQUIRE(pgh.core_paragraph->summary[0] == "d");
     REQUIRE(pgh.core_paragraph->description.size() == 1);
     REQUIRE(pgh.core_paragraph->description[0] == "d");
     REQUIRE(pgh.core_paragraph->dependencies.size() == 1);

--- a/src/vcpkg-test/manifests.cpp
+++ b/src/vcpkg-test/manifests.cpp
@@ -646,6 +646,7 @@ TEST_CASE ("manifest embed configuration", "[manifests]")
             },
             {
                 "kind": "artifact",
+                "name": "vcpkg-artifacts",
                 "location": "https://github.com/microsoft/vcpkg-artifacts"
             }
         ]

--- a/src/vcpkg.cpp
+++ b/src/vcpkg.cpp
@@ -2,7 +2,6 @@
 
 #include <vcpkg/base/chrono.h>
 #include <vcpkg/base/files.h>
-#include <vcpkg/base/hash.h>
 #include <vcpkg/base/pragmas.h>
 #include <vcpkg/base/strings.h>
 #include <vcpkg/base/system.debug.h>

--- a/src/vcpkg/configuration.cpp
+++ b/src/vcpkg/configuration.cpp
@@ -335,9 +335,14 @@ namespace
             for (const auto& reg : reg_view)
             {
                 auto reg_obj = reg.implementation().serialize();
-                auto& packages = reg_obj.insert(REGISTRY_PACKAGES, Json::Array{});
-                for (const auto& pkg : reg.packages())
-                    packages.push_back(Json::Value::string(pkg));
+                if (reg.packages().size())
+                {
+                    auto& packages = reg_obj.insert(REGISTRY_PACKAGES, Json::Array{});
+                    for (const auto& pkg : reg.packages())
+                    {
+                        packages.push_back(Json::Value::string(pkg));
+                    }
+                }
                 reg_arr.push_back(std::move(reg_obj));
             }
         }

--- a/src/vcpkg/configuration.cpp
+++ b/src/vcpkg/configuration.cpp
@@ -186,6 +186,8 @@ namespace
 
     Optional<Configuration> ConfigurationDeserializer::visit_object(Json::Reader& r, const Json::Object& obj)
     {
+        static const StringView ARTIFACT = "artifact";
+
         Json::Object extra_info;
 
         std::vector<std::string> comment_keys;
@@ -206,6 +208,10 @@ namespace
         std::unique_ptr<RegistryImplementation> default_registry;
         if (r.optional_object_field(obj, DEFAULT_REGISTRY, default_registry, *impl_des))
         {
+            if (default_registry && default_registry->kind() == ARTIFACT)
+            {
+                r.add_generic_error(type_name(), DEFAULT_REGISTRY, " cannot be of \"", ARTIFACT, "\" kind");
+            }
             registries.set_default_registry(std::move(default_registry));
         }
 

--- a/src/vcpkg/registries.cpp
+++ b/src/vcpkg/registries.cpp
@@ -806,7 +806,7 @@ namespace
 
     View<StringView> RegistryImplDeserializer::valid_fields() const
     {
-        static const StringView t[] = {KIND, BASELINE, PATH, REPO, REFERENCE};
+        static const StringView t[] = {KIND, BASELINE, PATH, REPO, REFERENCE, NAME, LOCATION};
         return t;
     }
     View<StringView> valid_builtin_fields()
@@ -928,9 +928,9 @@ namespace
             r.add_generic_error(type_name(),
                                 "Field \"kind\" did not have an expected value (expected one of: \"",
                                 Strings::join("\", \"", valid_kinds),
-                                "\", found \"",
+                                "\"; found \"",
                                 kind,
-                                "\").");
+                                "\")");
             return nullopt;
         }
 

--- a/src/vcpkg/registries.cpp
+++ b/src/vcpkg/registries.cpp
@@ -847,7 +847,7 @@ namespace
             RegistryImplDeserializer::LOCATION,
         };
         return t;
-    };
+    }
 
     Optional<std::unique_ptr<RegistryImplementation>> RegistryImplDeserializer::visit_null(Json::Reader&)
     {

--- a/src/vcpkg/registries.cpp
+++ b/src/vcpkg/registries.cpp
@@ -924,7 +924,7 @@ namespace
         }
         else
         {
-            StringLiteral valid_kinds[] = {KIND_BUILTIN, KIND_FILESYSTEM, KIND_GIT};
+            StringLiteral valid_kinds[] = {KIND_BUILTIN, KIND_FILESYSTEM, KIND_GIT, KIND_ARTIFACT};
             r.add_generic_error(type_name(),
                                 "Field \"kind\" did not have an expected value (expected one of: \"",
                                 Strings::join("\", \"", valid_kinds),

--- a/src/vcpkg/sourceparagraph.cpp
+++ b/src/vcpkg/sourceparagraph.cpp
@@ -683,6 +683,20 @@ namespace vcpkg
     };
     FeaturesFieldDeserializer FeaturesFieldDeserializer::instance;
 
+    struct ContactsDeserializer final : Json::IDeserializer<Json::Object>
+    {
+        virtual StringView type_name() const override { return "a dictionary of contacts"; }
+
+        virtual Optional<Json::Object> visit_object(Json::Reader& r, const Json::Object& obj) override
+        {
+            (void)r;
+            return obj;
+        }
+
+        static ContactsDeserializer instance;
+    };
+    ContactsDeserializer ContactsDeserializer::instance;
+
     static constexpr StringLiteral EXPRESSION_WORDS[] = {
         "WITH",
         "AND",
@@ -847,6 +861,8 @@ namespace vcpkg
 
         constexpr static StringLiteral NAME = "name";
         constexpr static StringLiteral MAINTAINERS = "maintainers";
+        constexpr static StringLiteral CONTACTS = "contacts";
+        constexpr static StringLiteral SUMMARY = "summary";
         constexpr static StringLiteral DESCRIPTION = "description";
         constexpr static StringLiteral HOMEPAGE = "homepage";
         constexpr static StringLiteral DOCUMENTATION = "documentation";
@@ -865,6 +881,8 @@ namespace vcpkg
             static const StringView u[] = {
                 NAME,
                 MAINTAINERS,
+                CONTACTS,
+                SUMMARY,
                 DESCRIPTION,
                 HOMEPAGE,
                 DOCUMENTATION,
@@ -900,7 +918,6 @@ namespace vcpkg
             }
 
             static Json::StringDeserializer url_deserializer{"a url"};
-
             r.required_object_field(type_name(), obj, NAME, spgh->name, Json::IdentifierDeserializer::instance);
             auto schemed_version = visit_required_schemed_deserializer(type_name(), r, obj, false);
             spgh->version = schemed_version.versiont.text();
@@ -908,6 +925,8 @@ namespace vcpkg
             spgh->port_version = schemed_version.versiont.port_version();
 
             r.optional_object_field(obj, MAINTAINERS, spgh->maintainers, Json::ParagraphDeserializer::instance);
+            r.optional_object_field(obj, CONTACTS, spgh->contacts, ContactsDeserializer::instance);
+            r.optional_object_field(obj, SUMMARY, spgh->summary, Json::ParagraphDeserializer::instance);
             r.optional_object_field(obj, DESCRIPTION, spgh->description, Json::ParagraphDeserializer::instance);
             r.optional_object_field(obj, HOMEPAGE, spgh->homepage, url_deserializer);
             r.optional_object_field(obj, DOCUMENTATION, spgh->documentation, url_deserializer);


### PR DESCRIPTION
This PR makes the following changes:

* Adds "summary" as a text field.
* Adds "contacts" as a generic object field. In the future we will merge this with the "maintainers" field and have a proposed schema for it.
* Adds initial support for artifact registries.

