### PR TITLE
Performance work on `vcpkg search` (30x improvement)

### DIFF
--- a/include/vcpkg/base/files.h
+++ b/include/vcpkg/base/files.h
@@ -204,6 +204,8 @@ namespace vcpkg
         virtual ~IExclusiveFileLock() = default;
     };
 
+    uint64_t get_filesystem_stats();
+
     struct Filesystem
     {
         virtual std::string read_contents(const Path& file_path, std::error_code& ec) const = 0;

--- a/include/vcpkg/base/json.h
+++ b/include/vcpkg/base/json.h
@@ -298,4 +298,6 @@ namespace vcpkg::Json
     std::string stringify(const Value&, JsonStyle style);
     std::string stringify(const Object&, JsonStyle style);
     std::string stringify(const Array&, JsonStyle style);
+
+    uint64_t get_json_parsing_stats();
 }

--- a/include/vcpkg/base/jsonreader.h
+++ b/include/vcpkg/base/jsonreader.h
@@ -2,6 +2,7 @@
 
 #include <vcpkg/base/fwd/json.h>
 
+#include <vcpkg/base/chrono.h>
 #include <vcpkg/base/json.h>
 #include <vcpkg/base/optional.h>
 #include <vcpkg/base/strings.h>
@@ -45,6 +46,8 @@ namespace vcpkg::Json
 
     struct Reader
     {
+        Reader();
+
         const std::vector<std::string>& errors() const { return m_errors; }
         std::vector<std::string>& errors() { return m_errors; }
 
@@ -196,6 +199,11 @@ namespace vcpkg::Json
 
             return result;
         }
+
+        static uint64_t get_reader_stats();
+
+    private:
+        StatsTimer m_stat_timer;
     };
 
     VCPKG_MSVC_WARNING(push)

--- a/include/vcpkg/base/system.process.h
+++ b/include/vcpkg/base/system.process.h
@@ -147,6 +147,8 @@ namespace vcpkg
         return cmd_execute_and_stream_data(cmd_line, InWorkingDirectory{Path()}, std::move(data_cb), env);
     }
 
+    uint64_t get_subproccess_stats();
+
     void register_console_ctrl_handler();
 #if defined(_WIN32)
     void initialize_global_job_object();

--- a/include/vcpkg/base/unicode.h
+++ b/include/vcpkg/base/unicode.h
@@ -97,7 +97,7 @@ namespace vcpkg::Unicode
 
         constexpr inline bool is_eof() const noexcept { return current_ == end_of_file; }
 
-        void next(std::error_code& ec);
+        [[nodiscard]] utf8_errc next();
 
         Utf8Decoder& operator=(sentinel) noexcept;
 

--- a/include/vcpkg/base/unicode.h
+++ b/include/vcpkg/base/unicode.h
@@ -20,12 +20,18 @@ namespace vcpkg::Unicode
 
     int utf8_encode_code_point(char (&array)[4], char32_t code_point) noexcept;
 
-    template<class String>
-    String& utf8_append_code_point(String& str, char32_t code_point)
+    inline std::string& utf8_append_code_point(std::string& str, char32_t code_point)
     {
-        char buf[4] = {};
-        int count = ::vcpkg::Unicode::utf8_encode_code_point(buf, code_point);
-        str.append(buf, buf + count);
+        if (static_cast<uint32_t>(code_point) < 0x80)
+        {
+            str.push_back(static_cast<char>(code_point));
+        }
+        else
+        {
+            char buf[4] = {};
+            int count = ::vcpkg::Unicode::utf8_encode_code_point(buf, code_point);
+            str.append(buf, buf + count);
+        }
         return str;
     }
 
@@ -89,7 +95,7 @@ namespace vcpkg::Unicode
         {
         };
 
-        bool is_eof() const noexcept;
+        constexpr inline bool is_eof() const noexcept { return current_ == end_of_file; }
 
         void next(std::error_code& ec);
 
@@ -97,7 +103,14 @@ namespace vcpkg::Unicode
 
         char const* pointer_to_current() const noexcept;
 
-        char32_t operator*() const noexcept;
+        char32_t operator*() const noexcept
+        {
+            if (is_eof())
+            {
+                Checks::exit_with_message(VCPKG_LINE_INFO, "Dereferenced Utf8Decoder on the end of a string");
+            }
+            return current_;
+        }
 
         Utf8Decoder& operator++() noexcept;
         Utf8Decoder operator++(int) noexcept

--- a/include/vcpkg/globalstate.h
+++ b/include/vcpkg/globalstate.h
@@ -11,7 +11,7 @@ namespace vcpkg
 {
     struct GlobalState
     {
-        static LockGuarded<ElapsedTimer> timer;
+        static ElapsedTimer timer;
         static LockGuarded<std::string> g_surveydate;
 
         static std::atomic<int> g_init_console_cp;

--- a/include/vcpkg/paragraphs.h
+++ b/include/vcpkg/paragraphs.h
@@ -15,6 +15,8 @@ namespace vcpkg::Paragraphs
 {
     using Paragraph = Parse::Paragraph;
 
+    uint64_t get_load_ports_stats();
+
     ExpectedS<Paragraph> parse_single_paragraph(StringView str, StringView origin);
     ExpectedS<Paragraph> get_single_paragraph(const Filesystem& fs, const Path& control_path);
 

--- a/include/vcpkg/registries.h
+++ b/include/vcpkg/registries.h
@@ -71,6 +71,8 @@ namespace vcpkg
 
         virtual Optional<VersionT> get_baseline_version(const VcpkgPaths& paths, StringView port_name) const = 0;
 
+        virtual Optional<Path> get_path_to_baseline_version(const VcpkgPaths& paths, StringView port_name) const;
+
         virtual Json::Object serialize() const;
 
         virtual ~RegistryImplementation() = default;

--- a/include/vcpkg/registries.h
+++ b/include/vcpkg/registries.h
@@ -120,7 +120,7 @@ namespace vcpkg
         void set_default_registry(std::unique_ptr<RegistryImplementation>&& r);
         void set_default_registry(std::nullptr_t r);
         bool is_default_builtin_registry() const;
-        void set_default_builtin_registry_baseline(StringView baseline) const;
+        void set_default_builtin_registry_baseline(StringView baseline);
 
         // returns whether the registry set has any modifications to the default
         // (i.e., whether `default_registry` was set, or `registries` had any entries)

--- a/include/vcpkg/vcpkgpaths.h
+++ b/include/vcpkg/vcpkgpaths.h
@@ -156,6 +156,7 @@ namespace vcpkg
         Optional<const Json::Object&> get_manifest() const;
         Optional<const Path&> get_manifest_path() const;
         const Configuration& get_configuration() const;
+        void set_builtin_baseline(const std::string& baseline) const;
 
         // Retrieve a toolset matching the requirements in prebuildinfo
         const Toolset& get_toolset(const Build::PreBuildInfo& prebuildinfo) const;

--- a/src/vcpkg.cpp
+++ b/src/vcpkg.cpp
@@ -36,10 +36,6 @@ using namespace vcpkg;
 namespace
 {
     DECLARE_AND_REGISTER_MESSAGE(VcpkgInvalidCommand, (msg::value), "", "invalid command: {value}");
-    DECLARE_AND_REGISTER_MESSAGE(VcpkgDebugTimeTaken,
-                                 (msg::pretty_value, msg::value),
-                                 "{LOCKED}",
-                                 "[DEBUG] Exiting after {pretty_value} ({value} us)\n");
     DECLARE_AND_REGISTER_MESSAGE(VcpkgSendMetricsButDisabled,
                                  (),
                                  "",
@@ -161,7 +157,7 @@ int main(const int argc, const char* const* const argv)
         }
     }
 
-    *(LockGuardPtr<ElapsedTimer>(GlobalState::timer)) = ElapsedTimer::create_started();
+    GlobalState::timer = ElapsedTimer::create_started();
 
 #if defined(_WIN32)
     GlobalState::g_init_console_cp = GetConsoleCP();
@@ -192,7 +188,7 @@ int main(const int argc, const char* const* const argv)
     set_environment_variable("CLICOLOR_FORCE", {});
 
     Checks::register_global_shutdown_handler([]() {
-        const auto elapsed_us_inner = LockGuardPtr<ElapsedTimer>(GlobalState::timer)->microseconds();
+        const auto elapsed_us_inner = GlobalState::timer.microseconds();
 
         bool debugging = Debug::g_debugging;
 
@@ -210,9 +206,29 @@ int main(const int argc, const char* const* const argv)
 #endif
 
         if (debugging)
-            msg::println(msgVcpkgDebugTimeTaken,
-                         msg::pretty_value = LockGuardPtr<ElapsedTimer>(GlobalState::timer)->to_string(),
-                         msg::value = static_cast<int64_t>(elapsed_us_inner));
+        {
+            msg::write_unlocalized_text_to_stdout(Color::none,
+                                                  Strings::concat("[DEBUG] Time in subprocesses: ",
+                                                                  get_subproccess_stats(),
+                                                                  " us\n",
+                                                                  "[DEBUG] Time in parsing JSON: ",
+                                                                  Json::get_json_parsing_stats(),
+                                                                  " us\n",
+                                                                  "[DEBUG] Time in JSON reader: ",
+                                                                  Json::Reader::get_reader_stats(),
+                                                                  " us\n",
+                                                                  "[DEBUG] Time in filesystem: ",
+                                                                  get_filesystem_stats(),
+                                                                  " us\n",
+                                                                  "[DEBUG] Time in loading ports: ",
+                                                                  Paragraphs::get_load_ports_stats(),
+                                                                  " us\n",
+                                                                  "[DEBUG] Exiting after ",
+                                                                  GlobalState::timer.to_string(),
+                                                                  " (",
+                                                                  static_cast<int64_t>(elapsed_us_inner),
+                                                                  " us)\n"));
+        }
     });
 
     LockGuardPtr<Metrics>(g_metrics)->track_property("version", Commands::Version::version());

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -38,6 +38,8 @@ namespace
 {
     using namespace vcpkg;
 
+    std::atomic<uint64_t> g_us_filesystem_stats(0);
+
     struct IsSlash
     {
         bool operator()(const char c) const noexcept
@@ -1785,6 +1787,7 @@ namespace vcpkg
     {
         virtual std::string read_contents(const Path& file_path, std::error_code& ec) const override
         {
+            StatsTimer t(g_us_filesystem_stats);
             ReadFilePointer file{file_path, ec};
             if (ec)
             {
@@ -1812,6 +1815,7 @@ namespace vcpkg
         }
         virtual std::vector<std::string> read_lines(const Path& file_path, std::error_code& ec) const override
         {
+            StatsTimer t(g_us_filesystem_stats);
             ReadFilePointer file{file_path, ec};
             if (ec)
             {
@@ -2512,6 +2516,7 @@ namespace vcpkg
         }
         virtual bool create_directories(const Path& new_directory, std::error_code& ec) override
         {
+            StatsTimer t(g_us_filesystem_stats);
 #if defined(_WIN32)
             return stdfs::create_directories(to_stdfs_path(new_directory), ec);
 #else // ^^^ _WIN32 // !_WIN32 vvv
@@ -2611,6 +2616,11 @@ namespace vcpkg
 
         virtual void copy_regular_recursive(const Path& source, const Path& destination, std::error_code& ec) override
         {
+            StatsTimer t(g_us_filesystem_stats);
+            copy_regular_recursive_impl(source, destination, ec);
+        }
+        void copy_regular_recursive_impl(const Path& source, const Path& destination, std::error_code& ec)
+        {
 #if defined(_WIN32)
             stdfs::copy(to_stdfs_path(source), to_stdfs_path(destination), stdfs::copy_options::recursive, ec);
 #else  // ^^^ _WIN32 // !_WIN32 vvv
@@ -2641,7 +2651,7 @@ namespace vcpkg
                 }
                 else
                 {
-                    this->copy_regular_recursive(source_entry_name, destination_entry_name, ec);
+                    this->copy_regular_recursive_impl(source_entry_name, destination_entry_name, ec);
                 }
             }
 #endif // ^^^ !_WIN32
@@ -2864,6 +2874,7 @@ namespace vcpkg
         }
         virtual void write_contents(const Path& file_path, const std::string& data, std::error_code& ec) override
         {
+            StatsTimer t(g_us_filesystem_stats);
             auto f = open_for_write(file_path, ec);
             if (!ec)
             {
@@ -3152,6 +3163,8 @@ namespace vcpkg
         message.push_back('\n');
         print2(message);
     }
+
+    uint64_t get_filesystem_stats() { return g_us_filesystem_stats.load(); }
 
 #ifdef _WIN32
     Path win32_fix_path_case(const Path& source)

--- a/src/vcpkg/base/json.cpp
+++ b/src/vcpkg/base/json.cpp
@@ -1056,16 +1056,24 @@ namespace vcpkg::Json
             ++cur;
         }
 
-        // we only check for lowercase in RESERVED since we already remove all
-        // strings with uppercase letters from the basic check
-        if (sv == "prn" || sv == "aux" || sv == "nul" || sv == "con" || sv == "core" || sv == "default")
+        if (sv.size() < 5)
         {
-            return false; // we're a reserved identifier
+            if (sv == "prn" || sv == "aux" || sv == "nul" || sv == "con" || sv == "core")
+            {
+                return false; // we're a reserved identifier
+            }
+            if (sv.size() == 4 && (Strings::starts_with(sv, "lpt") || Strings::starts_with(sv, "com")) &&
+                sv.byte_at_index(3) >= '1' && sv.byte_at_index(3) <= '9')
+            {
+                return false; // we're a reserved identifier
+            }
         }
-        if (sv.size() == 4 && (Strings::starts_with(sv, "lpt") || Strings::starts_with(sv, "com")) &&
-            sv.byte_at_index(3) >= '1' && sv.byte_at_index(3) <= '9')
+        else
         {
-            return false; // we're a reserved identifier
+            if (sv == "default")
+            {
+                return false;
+            }
         }
 
         return true;

--- a/src/vcpkg/base/unicode.cpp
+++ b/src/vcpkg/base/unicode.cpp
@@ -166,20 +166,8 @@ namespace vcpkg::Unicode
         return next_ - count;
     }
 
-    bool Utf8Decoder::is_eof() const noexcept { return current_ == end_of_file; }
-    char32_t Utf8Decoder::operator*() const noexcept
-    {
-        if (is_eof())
-        {
-            Checks::exit_with_message(VCPKG_LINE_INFO, "Dereferenced Utf8Decoder on the end of a string");
-        }
-        return current_;
-    }
-
     void Utf8Decoder::next(std::error_code& ec)
     {
-        ec.clear();
-
         if (is_eof())
         {
             vcpkg::Checks::exit_with_message(VCPKG_LINE_INFO, "Incremented Utf8Decoder at the end of the string");

--- a/src/vcpkg/commands.ci.cpp
+++ b/src/vcpkg/commands.ci.cpp
@@ -673,7 +673,7 @@ namespace vcpkg::Commands::CI
         for (auto&& result : results)
         {
             print2("\nTriplet: ", result.triplet, "\n");
-            print2("Total elapsed time: ", LockGuardPtr<ElapsedTimer>(GlobalState::timer)->to_string(), "\n");
+            print2("Total elapsed time: ", GlobalState::timer.to_string(), "\n");
             result.summary.print();
         }
 

--- a/src/vcpkg/commands.setinstalled.cpp
+++ b/src/vcpkg/commands.setinstalled.cpp
@@ -123,7 +123,7 @@ namespace vcpkg::Commands::SetInstalled
                                               Build::null_build_logs_recorder(),
                                               cmake_vars);
 
-        print2("\nTotal elapsed time: ", LockGuardPtr<ElapsedTimer>(GlobalState::timer)->to_string(), "\n\n");
+        print2("\nTotal elapsed time: ", GlobalState::timer.to_string(), "\n\n");
 
         std::set<std::string> printed_usages;
         for (auto&& ur_spec : user_requested_specs)

--- a/src/vcpkg/commands.upgrade.cpp
+++ b/src/vcpkg/commands.upgrade.cpp
@@ -207,7 +207,7 @@ namespace vcpkg::Commands::Upgrade
                                                                  Build::null_build_logs_recorder(),
                                                                  var_provider);
 
-        print2("\nTotal elapsed time: ", LockGuardPtr<ElapsedTimer>(GlobalState::timer)->to_string(), "\n\n");
+        print2("\nTotal elapsed time: ", GlobalState::timer.to_string(), "\n\n");
 
         if (keep_going == KeepGoing::YES)
         {

--- a/src/vcpkg/configuration.cpp
+++ b/src/vcpkg/configuration.cpp
@@ -318,20 +318,16 @@ namespace
             obj.insert(el.first.to_string(), el.second);
         }
 
-        if (auto default_registry = config.registry_set.default_registry())
+        if (!config.registry_set.is_default_builtin_registry())
         {
-            auto&& serialized = default_registry->serialize();
-
-            // The `baseline` field can only be an empty string when the original
-            // vcpkg-configuration doesn't override `default-registry`
-            if (!serialized.get("baseline")->string().empty())
+            if (auto default_registry = config.registry_set.default_registry())
             {
-                obj.insert(ConfigurationDeserializer::DEFAULT_REGISTRY, serialized);
+                obj.insert(ConfigurationDeserializer::DEFAULT_REGISTRY, default_registry->serialize());
             }
-        }
-        else
-        {
-            obj.insert(ConfigurationDeserializer::DEFAULT_REGISTRY, Json::Value::null(nullptr));
+            else
+            {
+                obj.insert(ConfigurationDeserializer::DEFAULT_REGISTRY, Json::Value::null(nullptr));
+            }
         }
 
         auto reg_view = config.registry_set.registries();

--- a/src/vcpkg/globalstate.cpp
+++ b/src/vcpkg/globalstate.cpp
@@ -4,7 +4,7 @@
 
 namespace vcpkg
 {
-    LockGuarded<ElapsedTimer> GlobalState::timer;
+    ElapsedTimer GlobalState::timer;
     LockGuarded<std::string> GlobalState::g_surveydate;
 
     std::atomic<int> GlobalState::g_init_console_cp(0);

--- a/src/vcpkg/install.cpp
+++ b/src/vcpkg/install.cpp
@@ -1077,7 +1077,7 @@ namespace vcpkg::Install
                                                Build::null_build_logs_recorder(),
                                                var_provider);
 
-        print2("\nTotal elapsed time: ", LockGuardPtr<ElapsedTimer>(GlobalState::timer)->to_string(), "\n\n");
+        print2("\nTotal elapsed time: ", GlobalState::timer.to_string(), "\n\n");
 
         if (keep_going == KeepGoing::YES)
         {

--- a/src/vcpkg/paragraphs.cpp
+++ b/src/vcpkg/paragraphs.cpp
@@ -272,12 +272,11 @@ namespace vcpkg::Paragraphs
                fs.exists(maybe_directory / "vcpkg.json", IgnoreErrors{});
     }
 
-    static ParseExpected<SourceControlFile> try_load_manifest_object(
-        StringView origin,
-        const ExpectedT<std::pair<vcpkg::Json::Value, vcpkg::Json::JsonStyle>, std::unique_ptr<Parse::IParseError>>&
-            res)
+    static ParseExpected<SourceControlFile> try_load_manifest_text(const std::string& text, StringView origin)
     {
-        auto error_info = std::make_unique<ParseControlErrorInfo>();
+        auto res = Json::parse(text);
+
+        std::string error;
         if (auto val = res.get())
         {
             if (val->first.is_object())
@@ -285,35 +284,16 @@ namespace vcpkg::Paragraphs
                 return SourceControlFile::parse_manifest_object(origin, val->first.object());
             }
 
-            error_info->error = "Manifest files must have a top-level object";
+            error = "Manifest files must have a top-level object";
         }
         else
         {
-            error_info->error = res.error()->format();
+            error = res.error()->format();
         }
-
-        error_info->name = origin.to_string();
-        return error_info;
-    }
-
-    static ParseExpected<SourceControlFile> try_load_manifest_text(const std::string& text, StringView origin)
-    {
-        auto res = Json::parse(text);
-        return try_load_manifest_object(origin, res);
-    }
-
-    static ParseExpected<SourceControlFile> try_load_manifest(const Filesystem& fs,
-                                                              const std::string& port_name,
-                                                              const Path& manifest_path,
-                                                              std::error_code& ec)
-    {
-        (void)port_name;
-
         auto error_info = std::make_unique<ParseControlErrorInfo>();
-        auto res = Json::parse_file(fs, manifest_path, ec);
-        if (ec) return error_info;
-
-        return try_load_manifest_object(manifest_path, res);
+        error_info->name = origin.to_string();
+        error_info->error = std::move(error);
+        return error_info;
     }
 
     ParseExpected<SourceControlFile> try_load_port_text(const std::string& text, StringView origin, bool is_manifest)
@@ -343,16 +323,11 @@ namespace vcpkg::Paragraphs
         const auto manifest_path = port_directory / "vcpkg.json";
         const auto control_path = port_directory / "CONTROL";
         const auto port_name = port_directory.filename().to_string();
-        if (fs.exists(manifest_path, IgnoreErrors{}))
+        std::error_code ec;
+        auto manifest_contents = fs.read_contents(manifest_path, ec);
+        if (ec)
         {
-            vcpkg::Checks::check_exit(VCPKG_LINE_INFO,
-                                      !fs.exists(control_path, IgnoreErrors{}),
-                                      "Found both manifest and CONTROL file in port %s; please rename one or the other",
-                                      port_directory);
-
-            std::error_code ec;
-            auto res = try_load_manifest(fs, port_name, manifest_path, ec);
-            if (ec)
+            if (fs.exists(manifest_path, IgnoreErrors{}))
             {
                 auto error_info = std::make_unique<ParseControlErrorInfo>();
                 error_info->name = port_name;
@@ -360,8 +335,15 @@ namespace vcpkg::Paragraphs
                     Strings::format("Failed to load manifest file for port: %s\n", manifest_path, ec.message());
                 return error_info;
             }
+        }
+        else
+        {
+            vcpkg::Checks::check_exit(VCPKG_LINE_INFO,
+                                      !fs.exists(control_path, IgnoreErrors{}),
+                                      "Found both manifest and CONTROL file in port %s; please rename one or the other",
+                                      port_directory);
 
-            return res;
+            return try_load_manifest_text(manifest_contents, manifest_path);
         }
 
         if (fs.exists(control_path, IgnoreErrors{}))

--- a/src/vcpkg/paragraphs.cpp
+++ b/src/vcpkg/paragraphs.cpp
@@ -455,16 +455,12 @@ namespace vcpkg::Paragraphs
                 continue;
             }
 
-            auto port_entry = impl->get_port_entry(paths, port_name);
-            auto baseline_version = impl->get_baseline_version(paths, port_name);
-            if (port_entry && baseline_version)
+            if (auto p = impl->get_path_to_baseline_version(paths, port_name))
             {
-                auto port_path =
-                    port_entry->get_path_to_version(paths, *baseline_version.get()).value_or_exit(VCPKG_LINE_INFO);
-                auto maybe_spgh = try_load_port(fs, port_path);
+                auto maybe_spgh = try_load_port(fs, *p.get());
                 if (const auto spgh = maybe_spgh.get())
                 {
-                    ret.paragraphs.push_back({std::move(*spgh), std::move(port_path)});
+                    ret.paragraphs.push_back({std::move(*spgh), std::move(*p.get())});
                 }
                 else
                 {
@@ -476,7 +472,6 @@ namespace vcpkg::Paragraphs
                 // the registry that owns the name of this port does not actually contain the port
                 // this can happen if R1 contains the port definition for <abc>, but doesn't
                 // declare it owns <abc>.
-                continue;
             }
         }
 

--- a/src/vcpkg/paragraphs.cpp
+++ b/src/vcpkg/paragraphs.cpp
@@ -14,6 +14,8 @@
 using namespace vcpkg::Parse;
 using namespace vcpkg;
 
+static std::atomic<uint64_t> g_load_ports_stats(0);
+
 namespace vcpkg::Parse
 {
     static Optional<std::pair<std::string, TextRowCol>> remove_field(Paragraph* fields, const std::string& fieldname)
@@ -316,6 +318,8 @@ namespace vcpkg::Paragraphs
 
     ParseExpected<SourceControlFile> try_load_port_text(const std::string& text, StringView origin, bool is_manifest)
     {
+        StatsTimer timer(g_load_ports_stats);
+
         if (is_manifest)
         {
             return try_load_manifest_text(text, origin);
@@ -334,6 +338,8 @@ namespace vcpkg::Paragraphs
 
     ParseExpected<SourceControlFile> try_load_port(const Filesystem& fs, const Path& port_directory)
     {
+        StatsTimer timer(g_load_ports_stats);
+
         const auto manifest_path = port_directory / "vcpkg.json";
         const auto control_path = port_directory / "CONTROL";
         const auto port_name = port_directory.filename().to_string();
@@ -387,6 +393,8 @@ namespace vcpkg::Paragraphs
 
     ExpectedS<BinaryControlFile> try_load_cached_package(const VcpkgPaths& paths, const PackageSpec& spec)
     {
+        StatsTimer timer(g_load_ports_stats);
+
         ExpectedS<std::vector<Paragraph>> pghs =
             get_paragraphs(paths.get_filesystem(), paths.package_dir(spec) / "CONTROL");
 
@@ -527,4 +535,6 @@ namespace vcpkg::Paragraphs
         load_results_print_error(ret);
         return std::move(ret.paragraphs);
     }
+
+    uint64_t get_load_ports_stats() { return g_load_ports_stats.load(); }
 }

--- a/src/vcpkg/portfileprovider.cpp
+++ b/src/vcpkg/portfileprovider.cpp
@@ -11,8 +11,6 @@
 #include <vcpkg/vcpkgpaths.h>
 #include <vcpkg/versiondeserializers.h>
 
-#include <regex>
-
 using namespace vcpkg;
 using namespace Versions;
 

--- a/src/vcpkg/registries.cpp
+++ b/src/vcpkg/registries.cpp
@@ -252,10 +252,7 @@ namespace
     {
         static constexpr StringLiteral s_kind = "builtin-git";
 
-        BuiltinGitRegistry(std::string&& baseline) : m_baseline_identifier(std::move(baseline))
-        {
-            Checks::check_exit(VCPKG_LINE_INFO, !m_baseline_identifier.empty());
-        }
+        BuiltinGitRegistry(std::string&& baseline) : m_baseline_identifier(std::move(baseline)) { }
 
         StringLiteral kind() const override { return s_kind; }
 
@@ -276,6 +273,7 @@ namespace
         const GitRegistry& get_git_reg() const
         {
             return *m_git_registry.get([this]() {
+                Checks::check_exit(VCPKG_LINE_INFO, !m_baseline_identifier.empty());
                 return std::make_unique<GitRegistry>(
                     "https://github.com/Microsoft/vcpkg", "HEAD", std::string(m_baseline_identifier));
             });

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -1259,6 +1259,10 @@ namespace vcpkg
     }
 
     const Configuration& VcpkgPaths::get_configuration() const { return m_pimpl->m_config; }
+    void VcpkgPaths::set_builtin_baseline(const std::string& baseline) const
+    {
+        m_pimpl->m_config.registry_set.set_default_builtin_registry_baseline(baseline);
+    }
     const Downloads::DownloadManager& VcpkgPaths::get_download_manager() const { return m_pimpl->m_download_manager; }
 
     const Toolset& VcpkgPaths::get_toolset(const Build::PreBuildInfo& prebuildinfo) const


### PR DESCRIPTION
Results: `vcpkg search zlib` is 30x faster in my Linux docker container. The biggest sources of improvement were:
1. Eliminate uses of `std::regex`
2. Avoid loading and parsing the manifests multiple times
3. Optimize low level utf8 reader

I've also left in basic performance counters to enable future performance tracking and improvement.

Before perf work:
```
$ time vcpkg search zlib --debug
...
[DEBUG] Time in subprocesses: 0 us
[DEBUG] Time in parsing JSON: 89751 us
[DEBUG] Time in JSON reader: 743202 us
[DEBUG] Time in filesystem: 12453 us
[DEBUG] Time in loading ports: 862885 us
[DEBUG] Exiting after 876.1 ms (876052 us)

real    0m0.878s
user    0m0.848s
sys     0m0.030s
```
After perf work:
```
$ time vcpkg search zlib --debug
...
[DEBUG] Time in subprocesses: 0 us
[DEBUG] Time in parsing JSON: 8732 us
[DEBUG] Time in JSON reader: 6051 us
[DEBUG] Time in filesystem: 4993 us
[DEBUG] Time in loading ports: 23459 us
[DEBUG] Exiting after 28.84 ms (28809 us)

real    0m0.031s
user    0m0.017s
sys     0m0.009s
```

More numbers from Windows (Surface Book 3): 4.5x faster

From hot without perf improvements:
```
[DEBUG] Time in parsing JSON: 189672 us
[DEBUG] Time in JSON reader: 294580 us
[DEBUG] Time in filesystem: 813409 us
[DEBUG] Time in loading ports: 1731497 us
[DEBUG] Exiting after 1.898 s (1837987 us)
```

From cold with perf improvements:
```
[DEBUG] Time in parsing JSON: 46451 us
[DEBUG] Time in JSON reader: 44898 us
[DEBUG] Time in filesystem: 9744531 us
[DEBUG] Time in loading ports: 9921944 us
[DEBUG] Exiting after 10.08 s (9947811 us)
```

hot with perf improvements:
```
[DEBUG] Time in parsing JSON: 30963 us
[DEBUG] Time in JSON reader: 21867 us
[DEBUG] Time in filesystem: 300172 us
[DEBUG] Time in loading ports: 401880 us
[DEBUG] Exiting after 418.1 ms (416803 us)
```