### PR TITLE
Support media queries binary logical operator syntax in platform expressions

### DIFF
--- a/src/vcpkg-test/platform-expression.cpp
+++ b/src/vcpkg-test/platform-expression.cpp
@@ -421,6 +421,17 @@ TEST_CASE ("platform-expressions without whitespace", "[platform-expression]")
     CHECK_FALSE(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "Linux"}, {"VCPKG_TARGET_ARCHITECTURE", "arm64"}}));
 }
 
+TEST_CASE ("ambiguities without whitespace", "[platform-expression]")
+{
+    // Operator keywords ("and","not") require a break to separate them from identifiers
+    // In these cases, strings containing an operator keyword parse as an identifier, not as a unary/binary expression
+    auto m_expr = parse_expr("!windowsandandroid");
+    CHECK(m_expr);
+
+    m_expr = parse_expr("notwindows");
+    CHECK(m_expr);
+}
+
 TEST_CASE ("invalid logic expression, unexpected character", "[platform-expression]")
 {
     auto m_expr = parse_expr("windows arm");

--- a/src/vcpkg-test/platform-expression.cpp
+++ b/src/vcpkg-test/platform-expression.cpp
@@ -253,6 +253,47 @@ TEST_CASE ("platform-expression-mixed-with-parens", "[platform-expression]")
     CHECK(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "WindowsStore"}, {"VCPKG_TARGET_ARCHITECTURE", "arm64"}}));
 }
 
+TEST_CASE ("platform-expression-low-precedence-or", "[platform-expression]")
+{
+    auto m_expr = parse_expr("(x64 & windows) , (linux & arm)");
+    REQUIRE(m_expr);
+    auto& expr = *m_expr.get();
+
+    CHECK_FALSE(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", ""}}));
+    CHECK_FALSE(expr.evaluate({{"VCPKG_TARGET_ARCHITECTURE", ""}}));
+    CHECK(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", ""}, {"VCPKG_TARGET_ARCHITECTURE", "x64"}}));
+    CHECK_FALSE(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", ""}, {"VCPKG_TARGET_ARCHITECTURE", "arm"}}));
+    CHECK_FALSE(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", ""}, {"VCPKG_TARGET_ARCHITECTURE", "x86"}}));
+    CHECK(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "WindowsStore"}, {"VCPKG_TARGET_ARCHITECTURE", "x64"}}));
+    CHECK_FALSE(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "WindowsStore"}, {"VCPKG_TARGET_ARCHITECTURE", "arm"}}));
+    CHECK_FALSE(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "WindowsStore"}, {"VCPKG_TARGET_ARCHITECTURE", "arm64"}}));
+    CHECK(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "Linux"}, {"VCPKG_TARGET_ARCHITECTURE", "arm"}}));
+    CHECK(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "Linux"}, {"VCPKG_TARGET_ARCHITECTURE", "arm64"}}));
+    CHECK_FALSE(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "Linux"}, {"VCPKG_TARGET_ARCHITECTURE", "x64"}}));
+    CHECK_FALSE(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "Linux"}, {"VCPKG_TARGET_ARCHITECTURE", "x86"}}));
+    CHECK_FALSE(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "Darwin"}, {"VCPKG_TARGET_ARCHITECTURE", "x64"}}));
+    CHECK_FALSE(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "Darwin"}, {"VCPKG_TARGET_ARCHITECTURE", "arm64"}}));
+
+    m_expr = parse_expr("x64 & windows , linux & arm");
+    REQUIRE(m_expr);
+    expr = *m_expr.get();
+
+    CHECK_FALSE(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", ""}}));
+    CHECK_FALSE(expr.evaluate({{"VCPKG_TARGET_ARCHITECTURE", ""}}));
+    CHECK(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", ""}, {"VCPKG_TARGET_ARCHITECTURE", "x64"}}));
+    CHECK_FALSE(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", ""}, {"VCPKG_TARGET_ARCHITECTURE", "arm"}}));
+    CHECK_FALSE(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", ""}, {"VCPKG_TARGET_ARCHITECTURE", "x86"}}));
+    CHECK(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "WindowsStore"}, {"VCPKG_TARGET_ARCHITECTURE", "x64"}}));
+    CHECK_FALSE(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "WindowsStore"}, {"VCPKG_TARGET_ARCHITECTURE", "arm"}}));
+    CHECK_FALSE(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "WindowsStore"}, {"VCPKG_TARGET_ARCHITECTURE", "arm64"}}));
+    CHECK(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "Linux"}, {"VCPKG_TARGET_ARCHITECTURE", "arm"}}));
+    CHECK(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "Linux"}, {"VCPKG_TARGET_ARCHITECTURE", "arm64"}}));
+    CHECK_FALSE(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "Linux"}, {"VCPKG_TARGET_ARCHITECTURE", "x64"}}));
+    CHECK_FALSE(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "Linux"}, {"VCPKG_TARGET_ARCHITECTURE", "x86"}}));
+    CHECK_FALSE(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "Darwin"}, {"VCPKG_TARGET_ARCHITECTURE", "x64"}}));
+    CHECK_FALSE(expr.evaluate({{"VCPKG_CMAKE_SYSTEM_NAME", "Darwin"}, {"VCPKG_TARGET_ARCHITECTURE", "arm64"}}));
+}
+
 TEST_CASE ("weird platform-expressions whitespace", "[platform-expression]")
 {
     auto m_expr = parse_expr(" ! \t  windows \n| arm \r");

--- a/src/vcpkg-test/platform-expression.cpp
+++ b/src/vcpkg-test/platform-expression.cpp
@@ -427,11 +427,21 @@ TEST_CASE ("invalid logic expression, unexpected character", "[platform-expressi
     CHECK_FALSE(m_expr);
 }
 
-TEST_CASE ("unexpected character in logic expression", "[platform-expression]")
+TEST_CASE ("invalid logic expression, use '|' instead of 'or'", "[platform-expression]")
+{
+    auto m_expr = parse_expr("windows or arm");
+    CHECK_FALSE(m_expr);
+}
+
+TEST_CASE ("unexpected character or identifier in logic expression", "[platform-expression]")
 {
     auto m_expr = parse_expr("windows aND arm");
     CHECK_FALSE(m_expr);
     m_expr = parse_expr("windows a&d arm");
+    CHECK_FALSE(m_expr);
+    m_expr = parse_expr("windows oR arm");
+    CHECK_FALSE(m_expr);
+    m_expr = parse_expr("windows o|r arm");
     CHECK_FALSE(m_expr);
 }
 

--- a/src/vcpkg-test/platform-expression.cpp
+++ b/src/vcpkg-test/platform-expression.cpp
@@ -386,7 +386,6 @@ TEST_CASE ("mixing & and | is not allowed", "[platform-expression]")
     CHECK_FALSE(m_expr);
 }
 
-
 TEST_CASE ("invalid expression, no binary operator", "[platform-expression]")
 {
     auto m_expr = parse_expr("windows linux");

--- a/src/vcpkg/platform-expression.cpp
+++ b/src/vcpkg/platform-expression.cpp
@@ -174,7 +174,7 @@ namespace vcpkg::PlatformExpression
                     case ExprKind::op_empty: return result;
 
                     default:
-                        // TODO: op_identifier and op_invalid both indicate a syntax error, which should have
+                        // op_identifier and op_invalid both indicate a syntax error, which should have
                         // already been flagged by expr_operator.
                         return result;
                 }
@@ -222,7 +222,6 @@ namespace vcpkg::PlatformExpression
                         // { ",", optional-whitespace, platform-expression-not }
                         // "," is a near-synonym of "|", with the differences that it can be combined with "&"/"and",
                         // but has lower precedence
-                        // TODO: handle precedence
                         next();
                         return ExprKind::op_low_precedence_or;
                     }

--- a/src/vcpkg/platform-expression.cpp
+++ b/src/vcpkg/platform-expression.cpp
@@ -230,20 +230,15 @@ namespace vcpkg::PlatformExpression
                         // { "and", optional-whitespace, platform-expression-not }
                         // "and" is a synonym of "&"
                         std::string name = match_zero_or_more(is_identifier_char).to_string();
-                        if (!name.empty() && (name == "and"))
+                        Checks::check_exit(VCPKG_LINE_INFO, !name.empty());
+
+                        if (name == "and")
                         {
                             return ExprKind::op_and;
                         }
 
                         // Invalid alphanumeric strings or strings other than "and" are errors.
-                        if (name.empty())
-                        {
-                            add_error("unexpected character in logic expression");
-                        }
-                        else
-                        {
-                            add_error("unexpected identifier in logic expression");
-                        }
+                        add_error("unexpected character or identifier in logic expression");
                         return ExprKind::op_invalid;
                     }
                     default:

--- a/src/vcpkg/platform-expression.cpp
+++ b/src/vcpkg/platform-expression.cpp
@@ -315,9 +315,9 @@ namespace vcpkg::PlatformExpression
                     // "not"
                     if (name == "not")
                     {
-                        // optional-whitespace,
+                        // required-whitespace, platform-expression-simple
+                        // optional-whitespace, platform-expression-grouped
                         skip_whitespace();
-                        // platform-expression-simple
                         return std::make_unique<ExprImpl>(ExprKind::op_not, expr_simple());
                     }
 
@@ -344,11 +344,13 @@ namespace vcpkg::PlatformExpression
             //
             // platform-expression-and =
             // | platform-expression-not, { "&", optional-whitespace, platform-expression-not }
-            // | platform-expression-binary-keyword-first-operand, { "and", platform-expression-binary-keyword-second-operand } ;
+            // | platform-expression-binary-keyword-first-operand, { "and",
+            // platform-expression-binary-keyword-second-operand } ;
             //
             // platform-expression-or =
             // | platform-expression-not, { "|", optional-whitespace, platform-expression-not }
-            // | platform-expression-binary-keyword-first-operand, { "or", platform-expression-binary-keyword-second-operand } (* to allow for future extension *) ;
+            // | platform-expression-binary-keyword-first-operand, { "or",
+            // platform-expression-binary-keyword-second-operand } (* to allow for future extension *) ;
             //
             // Processing of the operator was already taken care of by the caller: continue
             // with the next platform-expression-not or platform-expression-binary-keyword-second-operand.

--- a/src/vcpkg/platform-expression.cpp
+++ b/src/vcpkg/platform-expression.cpp
@@ -167,7 +167,7 @@ namespace vcpkg::PlatformExpression
                     case ExprKind::op_low_precedence_or:
                         // { ",", optional-whitespace, platform-expression-not }
                         // "," is a near-synonym of "|", with the difference that it can be combined with "&", but has
-                        // lower precedence Precedence is handled in expr_binary().
+                        // lower precedence (which is handled in expr_binary()).
                         return expr_binary<ExprKind::op_low_precedence_or, ExprKind::op_invalid>(
                             std::make_unique<ExprImpl>(oper, std::move(result)));
 

--- a/src/vcpkg/platform-expression.cpp
+++ b/src/vcpkg/platform-expression.cpp
@@ -215,6 +215,7 @@ namespace vcpkg::PlatformExpression
                         return ExprKind::op_list;
                     }
                     case 'a':
+                    case 'o':
                     {
                         // { "and", optional-whitespace, platform-expression-not }
                         // "and" is a synonym of "&"
@@ -224,6 +225,11 @@ namespace vcpkg::PlatformExpression
                         if (name == "and")
                         {
                             return ExprKind::op_and;
+                        }
+                        else if (name == "or")
+                        {
+                            add_error("invalid logic expression, use '|' instead of 'or'");
+                            return ExprKind::op_invalid;
                         }
 
                         // Invalid alphanumeric strings or strings other than "and" are errors.


### PR DESCRIPTION
This change implements support in platform expressions for binary logical operators (and, or) as defined by [Media Queries](https://www.w3.org/TR/css3-mediaqueries/#syntax).

We are extending current platform expressions as follows:
* for logical-and, 'and' is a synonym for '&'
* for logical-or, ',' is accepted, but has lower precedence than logical-and
  * currently using both '&' and '|' in the same expression is disallowed unless parens are used to identify evaluation precedence; that constraint is preserved, but '&', 'and', and ',' can be freely mixed in a platform expression without the need for parens

The existing platform expression parser:
* does a left-to-right linear scan of the expression string
* assumes that logical operators are individual chars ('!', '&', '|')
* consumption/processing of binary logical operators is split between multiple methods (expr(), expr_binary()) and tightly couple with assumptions about valid syntax
* does not create a binary expression tree
  * instead expr_binary() gathers consecutive instances of the same operation into the expression node (e.g., "A & B & C" yields <op_and, vector<A,B,C>>)
* expr_binary() support backwards compatibility for chained vcpkg operators '&' and '|' (e.g., '&&&') 
* expr_binary() also detects the error case of mixing '&' and '|'
* operator precedence is supported only explicitly (using parens, e.g., '(A & B) | C')

To support the media queries syntax, the following changes have been made:
* moved all processing of logical-operators to a new function expr_operator()
  * removed the assumption that a logical operator is represented by an individual char (e.g., 'and')
  * added parsing support for 'and' and ','
* added support for implicit operator precedence (the low-precedence or-operator ',')

Implementation details:
* Added 16 unit tests for platform expressions, covering both existing and new syntax
* Extended ExprKind to support low_precedence_or, empty and invalid operators to represent a more complete set of parse states after scanning for an expected operator
* Added expr_operator() to extract the next operator from the input string. This is a destructive operation as it removes the chars parsed from the input text.
  * backwards compatible support for chained vcpkg operators '&' and '|' moved here from expr_binary()
  * expr_operator adds support for parsing non-single-char operators (e.g., "and")
    * note: 'and' is odd in that it's multiple chars and looks like an identifier, so it required special handling
* Updated inaccurate error messages
* Updated expr_binary() to template on ExprKind instead of char to support new operators and restrictions 
  * chained vcpkg operator handling moved to expr_operator()
  * process ',' as 'platform_expression , platform_expression' to handle precedence order (as opposed to '|', which is 
    implemented as 'plaform_expression_not | platform_expression_not'
  * consecutive instance gathering is supported for 'and' and ','