### PR TITLE
Added VCPKG_GENERATOR_TOOLSET to record visual studio version

### DIFF
--- a/include/vcpkg/vcpkgpaths.h
+++ b/include/vcpkg/vcpkgpaths.h
@@ -32,6 +32,7 @@ namespace vcpkg
         std::vector<std::string> vcvarsall_options;
         CStringView version;
         std::vector<ToolsetArchOption> supported_architectures;
+        CStringView vs_version;
     };
 
     namespace Downloads

--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -628,6 +628,7 @@ namespace vcpkg::Build
                                   {"VCPKG_BASE_VERSION", Commands::Version::base_version()},
                                   {"VCPKG_CONCURRENCY", std::to_string(get_concurrency())},
                                   {"VCPKG_PLATFORM_TOOLSET", toolset.version.c_str()},
+                                  {"VCPKG_GENERATOR_TOOLSET", toolset.vs_version.c_str()},
                               });
         if (!get_environment_variable("VCPKG_FORCE_SYSTEM_BINARIES").has_value())
         {

--- a/src/vcpkg/visualstudio.cpp
+++ b/src/vcpkg/visualstudio.cpp
@@ -240,6 +240,14 @@ namespace vcpkg::VisualStudio
                           msvc_subdirectories.end(),
                           [](const Path& left, const Path& right) { return left.filename() > right.filename(); });
 
+                CStringView vs_version;
+                if (major_version == "15")
+                    vs_version = V_141;
+                else if (major_version == "16")
+                    vs_version = V_142;
+                else if (major_version == "17")
+                    vs_version = V_143;
+
                 for (const Path& subdir : msvc_subdirectories)
                 {
                     auto toolset_version_full = subdir.filename();
@@ -281,7 +289,8 @@ namespace vcpkg::VisualStudio
                                         vcvarsall_bat,
                                         {vcvars_option},
                                         toolset_version,
-                                        supported_architectures};
+                                        supported_architectures,
+                                        vs_version};
 
                         const auto english_language_pack = dumpbin_dir / "1033";
                         if (!fs.exists(english_language_pack, IgnoreErrors{}))
@@ -298,7 +307,8 @@ namespace vcpkg::VisualStudio
                                                       vcvarsall_bat,
                                                       {"-vcvars_ver=14.0"},
                                                       V_140,
-                                                      supported_architectures});
+                                                      supported_architectures,
+                                                      V_140});
                         }
 
                         continue;
@@ -341,7 +351,8 @@ namespace vcpkg::VisualStudio
                                                  vcvarsall_bat,
                                                  {},
                                                  major_version == "14" ? V_140 : V_120,
-                                                 supported_architectures};
+                                                 supported_architectures,
+                                                 major_version == "14" ? V_140 : V_120};
 
                         const auto english_language_pack = vs_dumpbin_dir / "1033";
                         if (!fs.exists(english_language_pack, IgnoreErrors{}))


### PR DESCRIPTION
VCPKG_GENERATOR_TOOLSET Will be used to generate the correct vs version of cmake - G
[Fix https://github.com/microsoft/vcpkg/issues/21324](https://github.com/microsoft/vcpkg/issues/21324)
[Fix https://github.com/microsoft/vcpkg/issues/7318](https://github.com/microsoft/vcpkg/issues/7318)