### PR TITLE
Implement bundle.usegitregistry (continuation of read-only vcpkg)

### DIFF
--- a/azure-pipelines/end-to-end-tests-dir/registries.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/registries.ps1
@@ -1,5 +1,8 @@
 . "$PSScriptRoot/../end-to-end-tests-prelude.ps1"
 
+$env:X_VCPKG_REGISTRIES_CACHE = Join-Path $TestingRoot 'registries'
+New-Item -ItemType Directory -Force $env:X_VCPKG_REGISTRIES_CACHE | Out-Null
+
 $builtinRegistryArgs = $commonArgs + @("--x-builtin-registry-versions-dir=$PSScriptRoot/../e2e_ports/versions")
 
 Run-Vcpkg install @builtinRegistryArgs 'vcpkg-internal-e2e-test-port'
@@ -15,6 +18,7 @@ Throw-IfFailed
 
 Write-Trace "Test git and filesystem registries"
 Refresh-TestRoot
+New-Item -ItemType Directory -Force $env:X_VCPKG_REGISTRIES_CACHE | Out-Null
 $filesystemRegistry = "$TestingRoot/filesystem-registry"
 $gitRegistryUpstream = "$TestingRoot/git-registry-upstream"
 

--- a/azure-pipelines/end-to-end-tests-prelude.ps1
+++ b/azure-pipelines/end-to-end-tests-prelude.ps1
@@ -16,12 +16,10 @@ $commonArgs = @(
     "--overlay-triplets=$PSScriptRoot/e2e_ports/triplets"
 )
 $Script:CurrentTest = 'unassigned'
-$env:X_VCPKG_REGISTRIES_CACHE = Join-Path $TestingRoot 'registries'
 
 function Refresh-TestRoot {
     Remove-Item -Recurse -Force $TestingRoot -ErrorAction SilentlyContinue
     New-Item -ItemType Directory -Force $TestingRoot | Out-Null
-    New-Item -ItemType Directory -Force $env:X_VCPKG_REGISTRIES_CACHE | Out-Null
     New-Item -ItemType Directory -Force $NuGetRoot | Out-Null
 }
 

--- a/azure-pipelines/end-to-end-tests.ps1
+++ b/azure-pipelines/end-to-end-tests.ps1
@@ -71,10 +71,9 @@ $envvars_clear = @(
     "VCPKG_KEEP_ENV_VARS",
     "VCPKG_ROOT",
     "VCPKG_FEATURE_FLAGS",
-    "VCPKG_DISABLE_METRICS",
-    "X_VCPKG_REGISTRIES_CACHE"
+    "VCPKG_DISABLE_METRICS"
 )
-$envvars = $envvars_clear + @("VCPKG_DOWNLOADS")
+$envvars = $envvars_clear + @("VCPKG_DOWNLOADS", "X_VCPKG_REGISTRIES_CACHE")
 
 foreach ($Test in $AllTests)
 {

--- a/include/vcpkg/vcpkgpaths.h
+++ b/include/vcpkg/vcpkgpaths.h
@@ -178,6 +178,8 @@ namespace vcpkg
         // this should be used only for helper commands, not core commands like `install`.
         Path builtin_ports_directory() const { return this->builtin_ports; }
 
+        bool use_git_default_registry() const;
+
     private:
         Optional<Path> maybe_get_tmp_path(const std::string* arg_path,
                                           StringLiteral root_subpath,

--- a/src/vcpkg/install.cpp
+++ b/src/vcpkg/install.cpp
@@ -921,22 +921,6 @@ namespace vcpkg::Install
                 LockGuardPtr<Metrics>(g_metrics)->track_property("manifest_overrides", "defined");
             }
 
-            if (auto p_baseline = manifest_scf.core_paragraph->builtin_baseline.get())
-            {
-                LockGuardPtr<Metrics>(g_metrics)->track_property("manifest_baseline", "defined");
-                if (!is_git_commit_sha(*p_baseline))
-                {
-                    LockGuardPtr<Metrics>(g_metrics)->track_property("versioning-error-baseline", "defined");
-                    Checks::exit_maybe_upgrade(VCPKG_LINE_INFO,
-                                               "Error: the top-level builtin-baseline (%s) was not a valid commit sha: "
-                                               "expected 40 lowercase hexadecimal characters.\n%s\n",
-                                               *p_baseline,
-                                               paths.get_current_git_sha_baseline_message());
-                }
-
-                paths.get_configuration().registry_set.set_default_builtin_registry_baseline(*p_baseline);
-            }
-
             auto verprovider = PortFileProvider::make_versioned_portfile_provider(paths);
             auto baseprovider = PortFileProvider::make_baseline_provider(paths);
 
@@ -944,7 +928,8 @@ namespace vcpkg::Install
             extended_overlay_ports.reserve(args.overlay_ports.size() + 2);
             extended_overlay_ports.push_back(manifest_path.parent_path().to_string());
             Util::Vectors::append(&extended_overlay_ports, args.overlay_ports);
-            if (paths.get_configuration().registry_set.is_default_builtin_registry())
+            if (paths.get_configuration().registry_set.is_default_builtin_registry() &&
+                !paths.use_git_default_registry())
             {
                 extended_overlay_ports.push_back(paths.builtin_ports_directory().native());
             }

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -276,6 +276,7 @@ namespace vcpkg
             Path registries_git_trees;
 
             bool m_readonly = false;
+            bool m_usegitregistry = false;
 
             Optional<LockFile> m_installed_lock;
         };
@@ -386,6 +387,15 @@ namespace vcpkg
                 {
                     m_pimpl->m_readonly = v->boolean();
                 }
+                if (auto v = bundle_doc->first.object().get("usegitregistry"))
+                {
+                    m_pimpl->m_usegitregistry = v->boolean();
+                }
+                Debug::print("Bundle config: readonly=",
+                             m_pimpl->m_readonly,
+                             ", usegitregistry=",
+                             m_pimpl->m_usegitregistry,
+                             "\n");
             }
             else
             {
@@ -472,6 +482,29 @@ namespace vcpkg
             }
         }
         auto config_file = load_configuration(filesystem, args, root, manifest_root_dir, configuration_from_manifest);
+        if (auto manifest = m_pimpl->m_manifest_doc.get())
+        {
+            if (auto p_baseline = manifest->first.get("builtin-baseline"))
+            {
+                LockGuardPtr<Metrics>(g_metrics)->track_property("manifest_baseline", "defined");
+                if (!p_baseline->is_string() || !is_git_commit_sha(p_baseline->string()))
+                {
+                    std::string baseline_in_error;
+                    if (p_baseline->is_string())
+                    {
+                        baseline_in_error = Strings::concat('(', p_baseline->string(), ')');
+                    }
+                    LockGuardPtr<Metrics>(g_metrics)->track_property("versioning-error-baseline", "defined");
+                    Checks::exit_maybe_upgrade(VCPKG_LINE_INFO,
+                                               "Error: the top-level builtin-baseline%s was not a valid commit sha: "
+                                               "expected 40 lowercase hexadecimal characters.\n%s\n",
+                                               baseline_in_error,
+                                               get_current_git_sha_baseline_message());
+                }
+
+                config_file.config.registry_set.set_default_builtin_registry_baseline(p_baseline->string());
+            }
+        }
 
         // metrics from configuration
         {
@@ -1315,6 +1348,8 @@ namespace vcpkg
     }
 
     Filesystem& VcpkgPaths::get_filesystem() const { return *m_pimpl->fs_ptr; }
+
+    bool VcpkgPaths::use_git_default_registry() const { return m_pimpl->m_usegitregistry; }
 
     const FeatureFlagSettings& VcpkgPaths::get_feature_flags() const { return m_pimpl->m_ff_settings; }
 

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -492,7 +492,7 @@ namespace vcpkg
                     std::string baseline_in_error;
                     if (p_baseline->is_string())
                     {
-                        baseline_in_error = Strings::concat('(', p_baseline->string(), ')');
+                        baseline_in_error = Strings::concat(" (", p_baseline->string(), ')');
                     }
                     LockGuardPtr<Metrics>(g_metrics)->track_property("versioning-error-baseline", "defined");
                     Checks::exit_maybe_upgrade(VCPKG_LINE_INFO,


### PR DESCRIPTION
This bundle setting replaces the `BuiltinRegistry` with a `GitRegistry` pointed at `github.com/Microsoft/vcpkg`, enabling functional tool distribution without requiring the entire port history.

Some additional implementation notes:
- I enabled e2e tests outside the registries.ps1 suite to use the user cache -- these e2e tests are not testing the registries code, they are testing other behaviors and shouldn't need to constantly purge and re-download git repos.
- Management of `"builtin-baseline"` has been moved into `load_configuration()`, since it's morally the same as `"vcpkg-configuration"`
- This mode _requires_ a configured baseline even for commands like "search". Future work should address this.