### PR TITLE
Provide better debug information about Visual Studio instances

### DIFF
--- a/include/pch.h
+++ b/include/pch.h
@@ -2,9 +2,12 @@
 
 #include <vcpkg/base/system_headers.h>
 
+#if defined(_MSC_VER)
+// pch.h only is used for performance with MSVC
 #include <vcpkg/base/files.h>
 #include <vcpkg/base/format.h>
 #include <vcpkg/base/pragmas.h>
+#endif
 
 #if defined(_WIN32)
 #include <process.h>

--- a/include/vcpkg/base/expected.h
+++ b/include/vcpkg/base/expected.h
@@ -1,8 +1,9 @@
 #pragma once
 
+#include <vcpkg/base/fwd/messages.h>
+
 #include <vcpkg/base/checks.h>
 #include <vcpkg/base/lineinfo.h>
-#include <vcpkg/base/messages.h>
 #include <vcpkg/base/stringliteral.h>
 
 #include <system_error>

--- a/include/vcpkg/base/files.h
+++ b/include/vcpkg/base/files.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vcpkg/base/fwd/format.h>
+
 #include <vcpkg/base/checks.h>
 #include <vcpkg/base/pragmas.h>
 #include <vcpkg/base/stringview.h>
@@ -386,20 +388,4 @@ namespace vcpkg
     };
 }
 
-namespace fmt
-{
-    template<>
-    struct formatter<vcpkg::Path>
-    {
-        constexpr auto parse(format_parse_context& ctx) -> decltype(ctx.begin())
-        {
-            return vcpkg::basic_format_parse_impl(ctx);
-        }
-        template<class FormatContext>
-        auto format(const vcpkg::Path& path, FormatContext& ctx) -> decltype(ctx.out())
-        {
-            return format_to(ctx.out(), "{}", path.native());
-        }
-    };
-
-}
+VCPKG_FORMAT_AS(vcpkg::Path, vcpkg::StringView);

--- a/include/vcpkg/base/format.h
+++ b/include/vcpkg/base/format.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vcpkg/base/fwd/format.h>
+
 #include <vcpkg/base/lineinfo.h>
 #include <vcpkg/base/pragmas.h>
 #include <vcpkg/base/stringview.h>
@@ -31,45 +33,27 @@ namespace vcpkg
 
 namespace fmt
 {
-    template<>
-    struct formatter<vcpkg::LineInfo>
+    template<class Char>
+    struct formatter<vcpkg::LineInfo, Char>
     {
-        constexpr auto parse(format_parse_context& ctx) -> decltype(ctx.begin())
+        constexpr auto parse(format_parse_context& ctx) const -> decltype(ctx.begin())
         {
             return vcpkg::basic_format_parse_impl(ctx);
         }
         template<class FormatContext>
-        auto format(const vcpkg::LineInfo& li, FormatContext& ctx) -> decltype(ctx.out())
+        auto format(const vcpkg::LineInfo& li, FormatContext& ctx) const -> decltype(ctx.out())
         {
             return format_to(ctx.out(), "{}({})", li.file_name, li.line_number);
         }
     };
 
-    template<>
-    struct formatter<vcpkg::StringView> : formatter<string_view>
+    template<class Char>
+    struct formatter<vcpkg::StringView, Char> : formatter<string_view, Char>
     {
-        // parse is inherited from formatter<string_view>.
         template<class FormatContext>
-        auto format(vcpkg::StringView sv, FormatContext& ctx)
+        auto format(vcpkg::StringView sv, FormatContext& ctx) const -> decltype(ctx.out())
         {
-            return formatter<string_view>::format(string_view(sv.data(), sv.size()), ctx);
-        }
-    };
-
-    // Other types can take advantage of this specialization without depending on format.h by:
-    // 1. Supporting `vcpkg::StringView(t)`
-    // 2. Define `static constexpr bool fmt_via_StringView = true;`
-    template<class T, class = std::enable_if_t<T::fmt_via_StringView>>
-    using fmt_via_StringView = T;
-
-    template<class T>
-    struct formatter<fmt_via_StringView<T>> : formatter<vcpkg::StringView>
-    {
-        // parse is inherited from formatter<string_view>.
-        template<class FormatContext>
-        auto format(const T& t, FormatContext& ctx)
-        {
-            return formatter<vcpkg::StringView>::format(vcpkg::StringView(t), ctx);
+            return formatter<string_view, Char>::format(string_view(sv.data(), sv.size()), ctx);
         }
     };
 }

--- a/include/vcpkg/base/fwd/format.h
+++ b/include/vcpkg/base/fwd/format.h
@@ -1,0 +1,21 @@
+#pragma once
+
+namespace fmt
+{
+    inline namespace v8
+    {
+        template<typename T, typename Char, typename Enable>
+        struct formatter;
+    }
+}
+
+#define VCPKG_FORMAT_AS(Type, Base)                                                                                    \
+    template<typename Char>                                                                                            \
+    struct fmt::formatter<Type, Char, void> : fmt::formatter<Base, Char, void>                                         \
+    {                                                                                                                  \
+        template<typename FormatContext>                                                                               \
+        auto format(Type const& val, FormatContext& ctx) const -> decltype(ctx.out())                                  \
+        {                                                                                                              \
+            return fmt::formatter<Base, Char, void>::format(static_cast<Base>(val), ctx);                              \
+        }                                                                                                              \
+    }

--- a/include/vcpkg/base/fwd/messages.h
+++ b/include/vcpkg/base/fwd/messages.h
@@ -1,0 +1,31 @@
+#pragma once
+
+namespace vcpkg
+{
+#if defined(_WIN32)
+    enum class Color : unsigned short
+    {
+        none = 0,
+        success = 0x0A, // FOREGROUND_GREEN | FOREGROUND_INTENSITY
+        error = 0xC,    // FOREGROUND_RED | FOREGROUND_INTENSITY
+        warning = 0xE,  // FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_INTENSITY
+    };
+#else
+    enum class Color : char
+    {
+        none = 0,
+        success = '2', // [with 9] bright green
+        error = '1',   // [with 9] bright red
+        warning = '3', // [with 9] bright yellow
+    };
+#endif
+
+    struct StringView;
+}
+
+namespace vcpkg::msg
+{
+    struct LocalizedString;
+
+    void write_unlocalized_text_to_stdout(Color c, vcpkg::StringView sv);
+}

--- a/include/vcpkg/base/messages.h
+++ b/include/vcpkg/base/messages.h
@@ -85,10 +85,20 @@ namespace vcpkg::msg
             return res;
         }
 
-        LocalizedString& append(const LocalizedString& s);
+        LocalizedString& append(const LocalizedString& s)
+        {
+            m_data.append(s.m_data);
+            return *this;
+        }
+        LocalizedString& appendnl()
+        {
+            m_data.push_back('\n');
+            return *this;
+        }
 
     private:
         std::string m_data;
+
         // to avoid lock-in on LocalizedString, these are free functions
         // this allows us to convert to `std::string` in the future without changing All The Code
         friend LocalizedString& append_newline(LocalizedString&);
@@ -162,9 +172,13 @@ namespace vcpkg::msg
 
     DECLARE_MSG_ARG(email);
     DECLARE_MSG_ARG(error);
-    DECLARE_MSG_ARG(version);
-    DECLARE_MSG_ARG(value);
+    DECLARE_MSG_ARG(path);
     DECLARE_MSG_ARG(pretty_value);
+    DECLARE_MSG_ARG(triplet);
+    DECLARE_MSG_ARG(url);
+    DECLARE_MSG_ARG(value);
+    DECLARE_MSG_ARG(version);
+    DECLARE_MSG_ARG(list);
 #undef DECLARE_MSG_ARG
 
 // These are `...` instead of
@@ -182,6 +196,8 @@ namespace vcpkg::msg
 #define DECLARE_AND_REGISTER_MESSAGE(NAME, ARGS, COMMENT, ...)                                                         \
     DECLARE_MESSAGE(NAME, ARGS, COMMENT, __VA_ARGS__);                                                                 \
     REGISTER_MESSAGE(NAME)
+
+    DECLARE_MESSAGE(SeeURL, (msg::url), "", "See {url} for more information.");
 }
 
 namespace fmt

--- a/include/vcpkg/base/messages.h
+++ b/include/vcpkg/base/messages.h
@@ -2,33 +2,13 @@
 
 #include <vcpkg/base/fwd/files.h>
 #include <vcpkg/base/fwd/json.h>
+#include <vcpkg/base/fwd/messages.h>
 
 #include <vcpkg/base/format.h>
 #include <vcpkg/base/lineinfo.h>
 #include <vcpkg/base/stringliteral.h>
 
 #include <string>
-
-namespace vcpkg
-{
-#if defined(_WIN32)
-    enum class Color : unsigned short
-    {
-        none = 0,
-        success = 0x0A, // FOREGROUND_GREEN | FOREGROUND_INTENSITY
-        error = 0xC,    // FOREGROUND_RED | FOREGROUND_INTENSITY
-        warning = 0xE,  // FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_INTENSITY
-    };
-#else
-    enum class Color : char
-    {
-        none = 0,
-        success = '2', // [with 9] bright green
-        error = '1',   // [with 9] bright red
-        warning = '3', // [with 9] bright yellow
-    };
-#endif
-}
 
 namespace vcpkg::msg
 {
@@ -117,8 +97,6 @@ namespace vcpkg::msg
             return lhs.data() < rhs.data();
         }
     };
-
-    void write_unlocalized_text_to_stdout(Color c, StringView sv);
 
     template<class Message, class... Tags, class... Ts>
     LocalizedString format(Message, detail::MessageArgument<Tags, Ts>... args)

--- a/include/vcpkg/base/messages.h
+++ b/include/vcpkg/base/messages.h
@@ -189,7 +189,7 @@ namespace vcpkg::msg
         static ::vcpkg::StringLiteral localization_comment() { return COMMENT; };                                      \
         static ::vcpkg::StringLiteral default_format_string() noexcept { return __VA_ARGS__; }                         \
         static const ::size_t index;                                                                                   \
-    } msg##NAME = {}
+    } msg##NAME VCPKG_UNUSED = {}
 #define REGISTER_MESSAGE(NAME)                                                                                         \
     const ::size_t NAME##_msg_t ::index = ::vcpkg::msg::detail::startup_register_message(                              \
         NAME##_msg_t::name(), NAME##_msg_t::default_format_string(), NAME##_msg_t::localization_comment())

--- a/include/vcpkg/base/pragmas.h
+++ b/include/vcpkg/base/pragmas.h
@@ -33,13 +33,16 @@
 #define VCPKG_MSVC_WARNING(...)
 #define VCPKG_GCC_DIAGNOSTIC(...)
 #define VCPKG_CLANG_DIAGNOSTIC(DIAGNOSTIC) Z_VCPKG_PRAGMA(clang diagnostic DIAGNOSTIC)
+#define VCPKG_UNUSED [[maybe_unused]]
 #elif defined(_MSC_VER)
 #define VCPKG_MSVC_WARNING(...) Z_VCPKG_PRAGMA(warning(__VA_ARGS__))
 #define VCPKG_GCC_DIAGNOSTIC(...)
 #define VCPKG_CLANG_DIAGNOSTIC(...)
+#define VCPKG_UNUSED [[maybe_unused]]
 #else
 // gcc
 #define VCPKG_MSVC_WARNING(...)
 #define VCPKG_GCC_DIAGNOSTIC(DIAGNOSTIC) Z_VCPKG_PRAGMA(gcc diagnostic DIAGNOSTIC)
 #define VCPKG_CLANG_DIAGNOSTIC(DIAGNOSTIC)
+#define VCPKG_UNUSED __attribute__((unused))
 #endif

--- a/include/vcpkg/base/stringliteral.h
+++ b/include/vcpkg/base/stringliteral.h
@@ -17,16 +17,4 @@ namespace vcpkg
     };
 }
 
-namespace fmt
-{
-    template<>
-    struct formatter<vcpkg::StringLiteral> : formatter<vcpkg::ZStringView>
-    {
-        template<class FormatContext>
-        auto format(const vcpkg::StringLiteral& s, FormatContext& ctx) -> decltype(ctx.out())
-        {
-            return formatter<vcpkg::StringView>::format(s, ctx);
-        }
-    };
-
-}
+VCPKG_FORMAT_AS(vcpkg::StringLiteral, vcpkg::StringView);

--- a/include/vcpkg/base/strings.h
+++ b/include/vcpkg/base/strings.h
@@ -2,7 +2,6 @@
 
 #include <vcpkg/base/cstringview.h>
 #include <vcpkg/base/lineinfo.h>
-#include <vcpkg/base/messages.h>
 #include <vcpkg/base/optional.h>
 #include <vcpkg/base/pragmas.h>
 #include <vcpkg/base/stringliteral.h>

--- a/include/vcpkg/base/stringview.h
+++ b/include/vcpkg/base/stringview.h
@@ -2,8 +2,6 @@
 
 #include <vcpkg/base/fwd/stringview.h>
 
-#include <vcpkg/base/format.h>
-
 #include <stddef.h>
 #include <string.h>
 
@@ -56,19 +54,4 @@ namespace vcpkg
     bool operator>(StringView lhs, StringView rhs) noexcept;
     bool operator<=(StringView lhs, StringView rhs) noexcept;
     bool operator>=(StringView lhs, StringView rhs) noexcept;
-}
-
-namespace fmt
-{
-    template<>
-    struct formatter<vcpkg::StringView> : formatter<string_view>
-    {
-        // parse is inherited from formatter<string_view>.
-        template<class FormatContext>
-        auto format(vcpkg::StringView sv, FormatContext& ctx)
-        {
-            return formatter<string_view>::format(string_view(sv.data(), sv.size()), ctx);
-        }
-    };
-
 }

--- a/include/vcpkg/base/system.debug.h
+++ b/include/vcpkg/base/system.debug.h
@@ -1,8 +1,9 @@
 #pragma once
 
+#include <vcpkg/base/fwd/messages.h>
+
 #include <vcpkg/base/chrono.h>
 #include <vcpkg/base/lineinfo.h>
-#include <vcpkg/base/messages.h>
 #include <vcpkg/base/strings.h>
 
 #include <atomic>

--- a/include/vcpkg/base/system.print.h
+++ b/include/vcpkg/base/system.print.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <vcpkg/base/messages.h>
+#include <vcpkg/base/fwd/messages.h>
+
 #include <vcpkg/base/strings.h>
 #include <vcpkg/base/view.h>
 

--- a/include/vcpkg/base/zstringview.h
+++ b/include/vcpkg/base/zstringview.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vcpkg/base/fwd/format.h>
+
 #include <vcpkg/base/stringview.h>
 
 #include <algorithm>
@@ -51,16 +53,4 @@ namespace vcpkg
     inline bool operator==(ZStringView l, const char* r) { return strcmp(l.c_str(), r) == 0; }
 }
 
-namespace fmt
-{
-    template<>
-    struct formatter<vcpkg::ZStringView> : formatter<vcpkg::StringView>
-    {
-        template<class FormatContext>
-        auto format(const vcpkg::ZStringView& s, FormatContext& ctx) -> decltype(ctx.out())
-        {
-            return formatter<vcpkg::StringView>::format(s, ctx);
-        }
-    };
-
-}
+VCPKG_FORMAT_AS(vcpkg::ZStringView, vcpkg::StringView);

--- a/include/vcpkg/build.h
+++ b/include/vcpkg/build.h
@@ -242,7 +242,7 @@ namespace vcpkg::Build
         const VcpkgPaths& m_paths;
     };
 
-    vcpkg::Command make_build_env_cmd(const PreBuildInfo& pre_build_info, const Toolset& toolset, const VcpkgPaths&);
+    vcpkg::Command make_build_env_cmd(const PreBuildInfo& pre_build_info, const Toolset& toolset);
 
     struct ExtendedBuildResult
     {

--- a/include/vcpkg/sourceparagraph.h
+++ b/include/vcpkg/sourceparagraph.h
@@ -5,7 +5,6 @@
 #include <vcpkg/fwd/vcpkgcmdarguments.h>
 
 #include <vcpkg/base/expected.h>
-#include <vcpkg/base/messages.h>
 #include <vcpkg/base/span.h>
 #include <vcpkg/base/system.h>
 

--- a/include/vcpkg/triplet.h
+++ b/include/vcpkg/triplet.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vcpkg/base/fwd/format.h>
+
 #include <vcpkg/fwd/vcpkgcmdarguments.h>
 
 #include <vcpkg/base/optional.h>
@@ -25,12 +27,10 @@ namespace vcpkg
         size_t hash_code() const;
         Optional<CPUArchitecture> guess_architecture() const noexcept;
 
-        bool operator==(Triplet other) const { return this->m_instance == other.m_instance; }
-        bool operator<(Triplet other) const { return canonical_name() < other.canonical_name(); }
-
         operator StringView() const { return canonical_name(); }
 
-        static constexpr bool fmt_via_StringView = true;
+        bool operator==(Triplet other) const { return this->m_instance == other.m_instance; }
+        bool operator<(Triplet other) const { return canonical_name() < other.canonical_name(); }
 
     private:
         static const TripletInstance DEFAULT_INSTANCE;
@@ -45,6 +45,8 @@ namespace vcpkg
     Triplet default_triplet(const VcpkgCmdArguments& args);
     Triplet default_host_triplet(const VcpkgCmdArguments& args);
 }
+
+VCPKG_FORMAT_AS(vcpkg::Triplet, vcpkg::StringView);
 
 namespace std
 {

--- a/include/vcpkg/triplet.h
+++ b/include/vcpkg/triplet.h
@@ -3,6 +3,7 @@
 #include <vcpkg/fwd/vcpkgcmdarguments.h>
 
 #include <vcpkg/base/optional.h>
+#include <vcpkg/base/stringview.h>
 #include <vcpkg/base/system.h>
 
 #include <string>
@@ -26,6 +27,10 @@ namespace vcpkg
 
         bool operator==(Triplet other) const { return this->m_instance == other.m_instance; }
         bool operator<(Triplet other) const { return canonical_name() < other.canonical_name(); }
+
+        operator StringView() const { return canonical_name(); }
+
+        static constexpr bool fmt_via_StringView = true;
 
     private:
         static const TripletInstance DEFAULT_INSTANCE;

--- a/include/vcpkg/vcpkgpaths.h
+++ b/include/vcpkg/vcpkgpaths.h
@@ -160,8 +160,6 @@ namespace vcpkg
         // Retrieve a toolset matching the requirements in prebuildinfo
         const Toolset& get_toolset(const Build::PreBuildInfo& prebuildinfo) const;
 
-        View<Toolset> get_all_toolsets() const;
-
         Filesystem& get_filesystem() const;
 
         const Environment& get_action_env(const Build::AbiInfo& abi_info) const;

--- a/include/vcpkg/visualstudio.h
+++ b/include/vcpkg/visualstudio.h
@@ -1,14 +1,28 @@
 #pragma once
 
-#if defined(_WIN32)
-
 #include <vcpkg/vcpkgpaths.h>
+
+namespace vcpkg
+{
+    struct ToolsetsInformation
+    {
+        std::vector<Toolset> toolsets;
+
+#if defined(_WIN32)
+        std::vector<Path> paths_examined;
+        std::vector<Toolset> excluded_toolsets;
+        msg::LocalizedString get_localized_debug_info() const;
+#endif
+    };
+}
+
+#if defined(_WIN32)
 
 namespace vcpkg::VisualStudio
 {
     std::vector<std::string> get_visual_studio_instances(const VcpkgPaths& paths);
 
-    std::vector<Toolset> find_toolset_instances_preferred_first(const VcpkgPaths& paths);
+    ToolsetsInformation find_toolset_instances_preferred_first(const VcpkgPaths& paths);
 }
 
 #endif

--- a/src/vcpkg.cpp
+++ b/src/vcpkg.cpp
@@ -2,6 +2,7 @@
 
 #include <vcpkg/base/chrono.h>
 #include <vcpkg/base/files.h>
+#include <vcpkg/base/messages.h>
 #include <vcpkg/base/pragmas.h>
 #include <vcpkg/base/strings.h>
 #include <vcpkg/base/system.debug.h>

--- a/src/vcpkg/base/messages.cpp
+++ b/src/vcpkg/base/messages.cpp
@@ -6,6 +6,8 @@ namespace vcpkg::msg
 {
     DECLARE_AND_REGISTER_MESSAGE(NoLocalizationForMessages, (), "", "No localization for the following messages:");
 
+    REGISTER_MESSAGE(SeeURL);
+
     // basic implementation - the write_unlocalized_text_to_stdout
 #if defined(_WIN32)
     static bool is_console(HANDLE h)

--- a/src/vcpkg/base/system.print.cpp
+++ b/src/vcpkg/base/system.print.cpp
@@ -1,3 +1,4 @@
+#include <vcpkg/base/messages.h>
 #include <vcpkg/base/system.print.h>
 #include <vcpkg/base/util.h>
 
@@ -7,24 +8,6 @@ namespace vcpkg
     {
         void print(StringView message) { fwrite(message.data(), 1, message.size(), stdout); }
 
-        void print(const Color c, StringView message)
-        {
-#if defined(_WIN32)
-            const HANDLE console_handle = GetStdHandle(STD_OUTPUT_HANDLE);
-
-            CONSOLE_SCREEN_BUFFER_INFO console_screen_buffer_info{};
-            GetConsoleScreenBufferInfo(console_handle, &console_screen_buffer_info);
-            const auto original_color = console_screen_buffer_info.wAttributes;
-
-            SetConsoleTextAttribute(console_handle, static_cast<WORD>(c) | (original_color & 0xF0));
-            print2(message);
-            SetConsoleTextAttribute(console_handle, original_color);
-#else
-            // TODO: add color handling code
-            // it should probably use VT-220 codes
-            (void)c;
-            print2(message);
-#endif
-        }
+        void print(const Color c, StringView message) { msg::write_unlocalized_text_to_stdout(c, message); }
     }
 }

--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -2,6 +2,7 @@
 #include <vcpkg/base/checks.h>
 #include <vcpkg/base/chrono.h>
 #include <vcpkg/base/hash.h>
+#include <vcpkg/base/messages.h>
 #include <vcpkg/base/optional.h>
 #include <vcpkg/base/stringliteral.h>
 #include <vcpkg/base/system.debug.h>

--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -299,23 +299,36 @@ namespace vcpkg::Build
         static const std::string LIBRARY_LINKAGE = "LibraryLinkage";
     }
 
+    DECLARE_AND_REGISTER_MESSAGE(
+        UnsupportedToolchain,
+        (msg::triplet, msg::value, msg::path, msg::list),
+        "",
+        "Error: in triplet {triplet}: Unable to find a valid toolchain combination.\n    The requested target "
+        "architecture was {value}\n    "
+        "The selected Visual Studio instance is at {path}\n    The available toolchain combinations are {list}\n");
+
+    DECLARE_AND_REGISTER_MESSAGE(UnsupportedSystemName,
+                                 (msg::value),
+                                 "",
+                                 "Error: Could not map VCPKG_CMAKE_SYSTEM_NAME '{value}' to a vcvarsall platform. "
+                                 "Supported system names are '', 'Windows' and 'WindowsStore'.");
+
+#if defined(_WIN32)
     static CStringView to_vcvarsall_target(const std::string& cmake_system_name)
     {
         if (cmake_system_name.empty()) return "";
         if (cmake_system_name == "Windows") return "";
         if (cmake_system_name == "WindowsStore") return "store";
 
-        Checks::exit_maybe_upgrade(VCPKG_LINE_INFO,
-                                   "Error: Could not map VCPKG_CMAKE_SYSTEM_NAME '%s' to a vcvarsall platform. "
-                                   "Supported systems are '', 'Windows' and 'WindowsStore'.",
-                                   cmake_system_name);
+        msg::println(Color::error, msgUnsupportedSystemName, msg::value = cmake_system_name);
+
+        Checks::exit_maybe_upgrade(VCPKG_LINE_INFO);
     }
 
     static CStringView to_vcvarsall_toolchain(const std::string& target_architecture,
                                               const Toolset& toolset,
-                                              View<Toolset> all_toolsets)
+                                              Triplet triplet)
     {
-#if defined(_WIN32)
         auto maybe_target_arch = to_cpu_architecture(target_architecture);
         Checks::check_maybe_upgrade(
             VCPKG_LINE_INFO, maybe_target_arch.has_value(), "Invalid architecture string: %s", target_architecture);
@@ -330,36 +343,27 @@ namespace vcpkg::Build
             if (it != toolset.supported_architectures.end()) return it->name;
         }
 
-        print2("Error: Unsupported toolchain combination.\n");
-        print2("Target was ",
-               target_architecture,
-               " but the chosen Visual Studio instance supports:\n    ",
-               Strings::join(
-                   ", ", toolset.supported_architectures, [](const ToolsetArchOption& t) { return t.name.c_str(); }),
-               "\nVcpkg selected ",
-               toolset.visual_studio_root_path,
-               " as the Visual Studio instance.\nDetected instances:\n",
-               Strings::join("",
-                             all_toolsets,
-                             [](const Toolset& t) { return Strings::concat("    ", t.visual_studio_root_path, '\n'); }),
-               "\nSee "
-               "https://github.com/microsoft/vcpkg/blob/master/docs/users/triplets.md#VCPKG_VISUAL_STUDIO_PATH "
-               "for more information.\n");
+        const auto toolset_list = Strings::join(
+            ", ", toolset.supported_architectures, [](const ToolsetArchOption& t) { return t.name.c_str(); });
+
+        msg::println(msgUnsupportedToolchain,
+                     msg::triplet = triplet,
+                     msg::value = target_architecture,
+                     msg::path = toolset.visual_studio_root_path,
+                     msg::list = toolset_list);
+        msg::println(
+            msg::msgSeeURL,
+            msg::url = StringLiteral(
+                "https://github.com/microsoft/vcpkg/blob/master/docs/users/triplets.md#VCPKG_VISUAL_STUDIO_PATH"));
         Checks::exit_maybe_upgrade(VCPKG_LINE_INFO);
-#else
-        (void)target_architecture;
-        (void)toolset;
-        (void)all_toolsets;
-        Checks::exit_with_message(VCPKG_LINE_INFO,
-                                  "Error: vcvars-based toolchains are only usable on Windows platforms.");
-#endif
     }
+#endif
 
 #if defined(_WIN32)
     const Environment& EnvCache::get_action_env(const VcpkgPaths& paths, const AbiInfo& abi_info)
     {
         auto build_env_cmd =
-            make_build_env_cmd(*abi_info.pre_build_info, abi_info.toolset.value_or_exit(VCPKG_LINE_INFO), paths);
+            make_build_env_cmd(*abi_info.pre_build_info, abi_info.toolset.value_or_exit(VCPKG_LINE_INFO));
 
         const auto& base_env = envs.get_lazy(abi_info.pre_build_info->passthrough_env_vars, [&]() -> EnvMapEntry {
             std::unordered_map<std::string, std::string> env;
@@ -561,11 +565,16 @@ namespace vcpkg::Build
         }
     }
 
-    vcpkg::Command make_build_env_cmd(const PreBuildInfo& pre_build_info,
-                                      const Toolset& toolset,
-                                      const VcpkgPaths& paths)
+    vcpkg::Command make_build_env_cmd(const PreBuildInfo& pre_build_info, const Toolset& toolset)
     {
         if (!pre_build_info.using_vcvars()) return {};
+
+#if !defined(WIN32)
+        // pre_build_info.using_vcvars() should always be false on non-Win32 hosts.
+        // If it was true, we should have failed earlier while selecting a Toolset
+        (void)toolset;
+        Checks::unreachable(VCPKG_LINE_INFO);
+#else
 
         const char* tonull = " >nul";
         if (Debug::g_debugging)
@@ -573,7 +582,7 @@ namespace vcpkg::Build
             tonull = "";
         }
 
-        const auto arch = to_vcvarsall_toolchain(pre_build_info.target_architecture, toolset, paths.get_all_toolsets());
+        const auto arch = to_vcvarsall_toolchain(pre_build_info.target_architecture, toolset, pre_build_info.triplet);
         const auto target = to_vcvarsall_target(pre_build_info.cmake_system_name);
 
         return vcpkg::Command{"cmd"}.string_arg("/c").raw_arg(
@@ -583,6 +592,7 @@ namespace vcpkg::Build
                             arch,
                             target,
                             tonull));
+#endif
     }
 
     static std::unique_ptr<BinaryControlFile> create_binary_control_file(
@@ -950,11 +960,8 @@ namespace vcpkg::Build
         auto find_itr = action.feature_dependencies.find("core");
         Checks::check_exit(VCPKG_LINE_INFO, find_itr != action.feature_dependencies.end());
 
-        std::unique_ptr<BinaryControlFile> bcf = create_binary_control_file(*scfl.source_control_file->core_paragraph,
-                                                                            triplet,
-                                                                            build_info,
-                                                                            action.public_abi(),
-                                                                            std::move(find_itr->second));
+        std::unique_ptr<BinaryControlFile> bcf = create_binary_control_file(
+            *scfl.source_control_file->core_paragraph, triplet, build_info, action.public_abi(), find_itr->second);
 
         if (error_count != 0 && action.build_options.backcompat_features == BackcompatFeatures::PROHIBIT)
         {
@@ -971,7 +978,7 @@ namespace vcpkg::Build
                     Checks::check_exit(VCPKG_LINE_INFO, find_itr != action.feature_dependencies.end());
 
                     bcf->features.emplace_back(
-                        *scfl.source_control_file->core_paragraph, *f_pgh, triplet, std::move(find_itr->second));
+                        *scfl.source_control_file->core_paragraph, *f_pgh, triplet, find_itr->second);
                 }
             }
         }

--- a/src/vcpkg/commands.env.cpp
+++ b/src/vcpkg/commands.env.cpp
@@ -51,7 +51,7 @@ namespace vcpkg::Commands::Env
         const Build::PreBuildInfo pre_build_info(
             paths, triplet, var_provider.get_generic_triplet_vars(triplet).value_or_exit(VCPKG_LINE_INFO));
         const Toolset& toolset = paths.get_toolset(pre_build_info);
-        auto build_env_cmd = Build::make_build_env_cmd(pre_build_info, toolset, paths);
+        auto build_env_cmd = Build::make_build_env_cmd(pre_build_info, toolset);
 
         std::unordered_map<std::string, std::string> extra_env = {};
         const bool add_bin = Util::Sets::contains(options.switches, OPTION_BIN);

--- a/src/vcpkg/install.cpp
+++ b/src/vcpkg/install.cpp
@@ -1033,7 +1033,7 @@ namespace vcpkg::Install
                                "warning: vcpkg appears to be in a Visual Studio prompt targeting ",
                                vs_prompt_view,
                                " but is installing packages for ",
-                               common_triplet.to_string(),
+                               common_triplet,
                                ". Consider using --triplet ",
                                vs_prompt_view,
                                "-windows or --triplet ",

--- a/src/vcpkg/registries.cpp
+++ b/src/vcpkg/registries.cpp
@@ -1,6 +1,7 @@
 #include <vcpkg/base/delayed_init.h>
 #include <vcpkg/base/json.h>
 #include <vcpkg/base/jsonreader.h>
+#include <vcpkg/base/messages.h>
 #include <vcpkg/base/system.debug.h>
 #include <vcpkg/base/system.print.h>
 

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -1291,9 +1291,8 @@ namespace vcpkg
 #if defined(_WIN32)
     static const ToolsetsInformation& get_all_toolsets(details::VcpkgPathsImpl& impl, const VcpkgPaths& paths)
     {
-        return impl.toolsets.get_lazy([&paths]() -> ToolsetsInformation {
-            return VisualStudio::find_toolset_instances_preferred_first(paths);
-        });
+        return impl.toolsets.get_lazy(
+            [&paths]() -> ToolsetsInformation { return VisualStudio::find_toolset_instances_preferred_first(paths); });
     }
 
     static bool toolset_matches_full_version(const Toolset& t, StringView fv)

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -246,7 +246,7 @@ namespace vcpkg
             }
 
             Lazy<std::vector<VcpkgPaths::TripletFile>> available_triplets;
-            Lazy<std::vector<Toolset>> toolsets;
+            Lazy<ToolsetsInformation> toolsets;
             Lazy<std::map<std::string, std::string>> cmake_script_hashes;
             Lazy<std::string> ports_cmake_hash;
 
@@ -1261,6 +1261,55 @@ namespace vcpkg
     const Configuration& VcpkgPaths::get_configuration() const { return m_pimpl->m_config; }
     const Downloads::DownloadManager& VcpkgPaths::get_download_manager() const { return m_pimpl->m_download_manager; }
 
+    DECLARE_AND_REGISTER_MESSAGE(ErrorVcvarsUnsupported,
+                                 (msg::triplet),
+                                 "",
+                                 "Error: in triplet {triplet}: Use of Visual Studio's Developer Prompt is unsupported "
+                                 "on non-Windows hosts.\nDefine 'VCPKG_CMAKE_SYSTEM_NAME' or "
+                                 "'VCPKG_CHAINLOAD_TOOLCHAIN_FILE' in the triplet file.");
+
+    static const ToolsetsInformation& get_all_toolsets(details::VcpkgPathsImpl& impl, const VcpkgPaths& paths)
+    {
+        return impl.toolsets.get_lazy([&paths]() -> ToolsetsInformation {
+#if defined(_WIN32)
+            return VisualStudio::find_toolset_instances_preferred_first(paths);
+#else
+            return {};
+#endif
+        });
+    }
+
+    DECLARE_AND_REGISTER_MESSAGE(ErrorNoVSInstance,
+                                 (msg::triplet),
+                                 "",
+                                 "Error: in triplet {triplet}: Unable to find a valid Visual Studio instance");
+
+    DECLARE_AND_REGISTER_MESSAGE(ErrorNoVSInstanceVersion,
+                                 (msg::version),
+                                 "Printed after ErrorNoVSInstance on a separate line",
+                                 "    with toolset version {version}");
+
+    DECLARE_AND_REGISTER_MESSAGE(ErrorNoVSInstanceFullVersion,
+                                 (msg::version),
+                                 "Printed after ErrorNoVSInstance on a separate line",
+                                 "    with toolset version prefix {version}");
+
+    DECLARE_AND_REGISTER_MESSAGE(ErrorNoVSInstanceAt,
+                                 (msg::path),
+                                 "Printed after ErrorNoVSInstance on a separate line",
+                                 "     at \"{path}\"");
+
+    static bool toolset_matches_full_version(const Toolset& t, StringView fv)
+    {
+        // User specification can be a prefix. Example:
+        // fv = "14.25", t.full_version = "14.25.28610"
+        if (!Strings::starts_with(t.full_version, fv))
+        {
+            return false;
+        }
+        return fv.size() == t.full_version.size() || t.full_version[fv.size()] == '.';
+    }
+
     const Toolset& VcpkgPaths::get_toolset(const Build::PreBuildInfo& prebuildinfo) const
     {
         if (!prebuildinfo.using_vcvars())
@@ -1278,12 +1327,13 @@ namespace vcpkg
             return external_toolset;
         }
 
-#if !defined(_WIN32)
-        Checks::exit_maybe_upgrade(VCPKG_LINE_INFO, "Cannot build windows triplets from non-windows.");
+#if !defined(WIN32)
+        msg::println(Color::error, msgErrorVcvarsUnsupported, msg::triplet = prebuildinfo.triplet);
+        Checks::exit_fail(VCPKG_LINE_INFO);
 #else
-        View<Toolset> vs_toolsets = get_all_toolsets();
+        const auto& toolsets_info = get_all_toolsets(*m_pimpl, *this);
+        View<Toolset> vs_toolsets = toolsets_info.toolsets;
 
-        std::vector<const Toolset*> candidates = Util::fmap(vs_toolsets, [](auto&& x) { return &x; });
         const auto tsv = prebuildinfo.platform_toolset.get();
         const auto tsvf = prebuildinfo.platform_toolset_version.get();
         auto vsp = prebuildinfo.visual_studio_path.get();
@@ -1292,49 +1342,30 @@ namespace vcpkg
             vsp = &m_pimpl->default_vs_path;
         }
 
-        std::string error_message = "Could not find any Visual Studio instance";
-
-        if (vsp)
+        auto candidate = Util::find_if(vs_toolsets, [&](const Toolset& t) {
+            return (!tsv || *tsv == t.version) && (!vsp || *vsp == t.visual_studio_root_path) &&
+                   (!tsvf || toolset_matches_full_version(t, *tsvf));
+        });
+        if (candidate == vs_toolsets.end())
         {
-            Util::erase_remove_if(candidates, [&](const Toolset* t) { return *vsp != t->visual_studio_root_path; });
-            error_message += " at " + (*vsp).native();
+            msg::println(Color::error, msgErrorNoVSInstance, msg::triplet = prebuildinfo.triplet);
+            if (vsp)
+            {
+                msg::println(Color::error, msgErrorNoVSInstanceAt, msg::path = *vsp);
+            }
+            if (tsv)
+            {
+                msg::println(Color::error, msgErrorNoVSInstanceVersion, msg::version = *tsv);
+            }
+            if (tsvf)
+            {
+                msg::println(Color::error, msgErrorNoVSInstanceFullVersion, msg::version = *tsvf);
+            }
+
+            msg::print(Color::error, toolsets_info.get_localized_debug_info());
+            Checks::exit_fail(VCPKG_LINE_INFO);
         }
-
-        if (tsv)
-        {
-            Util::erase_remove_if(candidates, [&](const Toolset* t) { return *tsv != t->version; });
-            error_message += " with " + *tsv + " toolset";
-        }
-
-        if (tsvf)
-        {
-            Util::erase_remove_if(candidates, [&](const Toolset* t) {
-                const auto requested_version = *tsvf;
-                if (requested_version == t->full_version)
-                {
-                    return false;
-                }
-                // Check if requested version is part of the full version, ie "14.25" should match "14.25.28610"
-                return !(requested_version.size() < t->full_version.size() &&
-                         t->full_version[requested_version.size()] == '.' &&
-                         t->full_version.substr(0, tsvf->size()) == requested_version);
-            });
-            error_message += " for toolset version " + *tsvf;
-        }
-
-        Checks::check_exit(VCPKG_LINE_INFO, !candidates.empty(), error_message + ".");
-
-        return *candidates.front();
-#endif
-    }
-
-    View<Toolset> VcpkgPaths::get_all_toolsets() const
-    {
-#if defined(_WIN32)
-        return m_pimpl->toolsets.get_lazy(
-            [this]() { return VisualStudio::find_toolset_instances_preferred_first(*this); });
-#else
-        return {};
+        return *candidate;
 #endif
     }
 

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -1268,17 +1268,6 @@ namespace vcpkg
                                  "on non-Windows hosts.\nDefine 'VCPKG_CMAKE_SYSTEM_NAME' or "
                                  "'VCPKG_CHAINLOAD_TOOLCHAIN_FILE' in the triplet file.");
 
-    static const ToolsetsInformation& get_all_toolsets(details::VcpkgPathsImpl& impl, const VcpkgPaths& paths)
-    {
-        return impl.toolsets.get_lazy([&paths]() -> ToolsetsInformation {
-#if defined(_WIN32)
-            return VisualStudio::find_toolset_instances_preferred_first(paths);
-#else
-            return {};
-#endif
-        });
-    }
-
     DECLARE_AND_REGISTER_MESSAGE(ErrorNoVSInstance,
                                  (msg::triplet),
                                  "",
@@ -1299,6 +1288,14 @@ namespace vcpkg
                                  "Printed after ErrorNoVSInstance on a separate line",
                                  "     at \"{path}\"");
 
+#if defined(_WIN32)
+    static const ToolsetsInformation& get_all_toolsets(details::VcpkgPathsImpl& impl, const VcpkgPaths& paths)
+    {
+        return impl.toolsets.get_lazy([&paths]() -> ToolsetsInformation {
+            return VisualStudio::find_toolset_instances_preferred_first(paths);
+        });
+    }
+
     static bool toolset_matches_full_version(const Toolset& t, StringView fv)
     {
         // User specification can be a prefix. Example:
@@ -1309,6 +1306,7 @@ namespace vcpkg
         }
         return fv.size() == t.full_version.size() || t.full_version[fv.size()] == '.';
     }
+#endif
 
     const Toolset& VcpkgPaths::get_toolset(const Build::PreBuildInfo& prebuildinfo) const
     {

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -3,6 +3,7 @@
 #include <vcpkg/base/files.h>
 #include <vcpkg/base/hash.h>
 #include <vcpkg/base/jsonreader.h>
+#include <vcpkg/base/messages.h>
 #include <vcpkg/base/system.debug.h>
 #include <vcpkg/base/system.print.h>
 #include <vcpkg/base/system.process.h>


### PR DESCRIPTION
This PR localizes information displayed about the Visual Studio instances on the machine and provides more context about why vcpkg was unable to locate an instance that matches the user's request.

As drive by's, this PR also:

1. Moves `StringView` to be more fundamental than `format`
2. Makes `Triplet` fmt-serializable by introducing a SFINAE specialization for string-like types. This specialization avoids needing the full boilerplate of defining an entire separate specialization for types that can be trivially converted to `StringView`s.
