### PR TITLE
Add 'embeddedsha' to record tested baseline for bundle

### DIFF
--- a/include/vcpkg/vcpkgpaths.h
+++ b/include/vcpkg/vcpkgpaths.h
@@ -115,7 +115,11 @@ namespace vcpkg
         Path community_triplets;
         Path scripts;
         Path prefab;
+
+    private:
         Path builtin_ports;
+
+    public:
         Path builtin_registry_versions;
 
         Path tools;
@@ -133,10 +137,8 @@ namespace vcpkg
         // Git manipulation in the vcpkg directory
         ExpectedS<std::string> get_current_git_sha() const;
         std::string get_current_git_sha_baseline_message() const;
-        ExpectedS<Path> git_checkout_baseline(StringView commit_sha) const;
         ExpectedS<Path> git_checkout_port(StringView port_name, StringView git_tree, const Path& dot_git_dir) const;
         ExpectedS<std::string> git_show(const std::string& treeish, const Path& dot_git_dir) const;
-        ExpectedS<std::string> git_describe_head() const;
 
         const Downloads::DownloadManager& get_download_manager() const;
 

--- a/include/vcpkg/vcpkgpaths.h
+++ b/include/vcpkg/vcpkgpaths.h
@@ -129,6 +129,8 @@ namespace vcpkg
 
         Path ports_cmake;
 
+        std::string get_toolver_diagnostics() const;
+
         const Path& get_tool_exe(const std::string& tool) const;
         const std::string& get_tool_version(const std::string& tool) const;
 

--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -1334,19 +1334,15 @@ namespace vcpkg::Build
         {
             Strings::append(package, " -> ", scfl->to_versiont());
         }
-        auto description = paths.get_current_git_sha();
         return Strings::format("Please ensure you're using the latest portfiles with `git pull` and `%s update`, then\n"
                                "submit an issue at https://github.com/Microsoft/vcpkg/issues including:\n"
                                "  package: %s\n"
-                               "  vcpkg version: %s\n"
-                               "  vcpkg-tool version: %s\n"
+                               "%s"
                                "\n"
                                "Additionally, attach any relevant sections from the log files above.",
                                vcpkg_update_cmd,
                                package,
-                               description.has_value() ? description.value_or_exit(VCPKG_LINE_INFO)
-                                                       : "Failed to get HEAD: " + description.error(),
-                               Commands::Version::version());
+                               paths.get_toolver_diagnostics());
     }
 
     static BuildInfo inner_create_buildinfo(Parse::Paragraph pgh)

--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -1334,7 +1334,7 @@ namespace vcpkg::Build
         {
             Strings::append(package, " -> ", scfl->to_versiont());
         }
-        auto description = paths.git_describe_head();
+        auto description = paths.get_current_git_sha();
         return Strings::format("Please ensure you're using the latest portfiles with `git pull` and `%s update`, then\n"
                                "submit an issue at https://github.com/Microsoft/vcpkg/issues including:\n"
                                "  package: %s\n"


### PR DESCRIPTION
The primary change in this PR is very small: Add `$bundle.embeddedsha` to enable read-only vcpkg to provide useful error messages around baselines.

While investigating the general problem, I discovered several other functions that were generally 'unsafe' (they depend upon `root / ".git"`), but in the single context they're used are safe. I therefore refactored things to move those functions closer to their contexts and out of the public `VcpkgPaths::` interface. 