### PR TITLE
Fix crash in `vcpkg search` with `builtin-baseline`

### DIFF
--- a/azure-pipelines/end-to-end-tests-dir/registries.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/registries.ps1
@@ -340,3 +340,31 @@ finally
 {
     Pop-Location
 }
+
+
+# test builtin registry
+Write-Trace "test builtin registry with baseline"
+$manifestDir = "$TestingRoot/manifest"
+
+New-Item -Path $manifestDir -ItemType Directory
+$manifestDir = (Get-Item $manifestDir).FullName
+
+Push-Location $manifestDir
+try
+{
+    $vcpkgJson = @{
+        "name" = "manifest-test";
+        "version-string" = "1.0.0";
+        "builtin-baseline" = "a4b5cde7f504c1bbbbc455f4a6ee60efd9034772";
+    }
+
+    New-Item -Path 'vcpkg.json' -ItemType File `
+        -Value (ConvertTo-Json -Depth 5 -InputObject $vcpkgJson)
+
+    Run-Vcpkg search @builtinRegistryArgs zlib
+    Throw-IfFailed
+}
+finally
+{
+    Pop-Location
+}

--- a/src/vcpkg/registries.cpp
+++ b/src/vcpkg/registries.cpp
@@ -253,7 +253,10 @@ namespace
     {
         static constexpr StringLiteral s_kind = "builtin-git";
 
-        BuiltinGitRegistry(std::string&& baseline) : m_baseline_identifier(std::move(baseline)) { }
+        BuiltinGitRegistry(std::string&& baseline)
+            : m_baseline_identifier(std::move(baseline)), m_files_impl(std::make_unique<BuiltinFilesRegistry>())
+        {
+        }
 
         StringLiteral kind() const override { return s_kind; }
 


### PR DESCRIPTION
`m_files_impl` of the `BuiltinGitRegistry` was never initialized to a `BuiltinFilesRegistry` which results in a crash for several operations (such as search) if in a manifest directory with a builtin-baseline.