### PR TITLE
Fix interleaving issue between `print2(...)` and `print2(Color,...)`

### DIFF
--- a/src/vcpkg/base/system.print.cpp
+++ b/src/vcpkg/base/system.print.cpp
@@ -6,7 +6,7 @@ namespace vcpkg
 {
     namespace details
     {
-        void print(StringView message) { fwrite(message.data(), 1, message.size(), stdout); }
+        void print(StringView message) { msg::write_unlocalized_text_to_stdout(Color::none, message); }
 
         void print(const Color c, StringView message) { msg::write_unlocalized_text_to_stdout(c, message); }
     }


### PR DESCRIPTION
In a previous PR I changed `print2(Color)` to go through `msg::`, however I didn't change `print(...)` to also use the new printing mechanism. This resulted in strangely interleaved output on Windows since `msg::` doesn't go through the CRT.