### PR TITLE
Hotfix #21604 race condition on .vcpkg-lock

### DIFF
--- a/azure-pipelines/end-to-end-tests-dir/bundles.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/bundles.ps1
@@ -40,9 +40,10 @@ foreach ($k in $b.keys) {
 Refresh-TestRoot
 
 New-Item -ItemType Directory -Force $bundle | Out-Null
+New-Item -ItemType File -Force $bundle/.vcpkg-root | Out-Null
 @{
     readonly = $True
-} | ConvertTo-JSON | out-file -enc ascii $bundle/.vcpkg-root | Out-Null
+} | ConvertTo-JSON | out-file -enc ascii $bundle/vcpkg-bundle.json | Out-Null
 
 $a = Run-Vcpkg z-print-config `
     --vcpkg-root=$bundle `
@@ -72,9 +73,10 @@ Refresh-TestRoot
 
 New-Item -ItemType Directory -Force $manifestdir | Out-Null
 New-Item -ItemType Directory -Force $bundle | Out-Null
+New-Item -ItemType File -Force $bundle/.vcpkg-root | Out-Null
 @{
     readonly = $True
-} | ConvertTo-JSON | out-file -enc ascii $bundle/.vcpkg-root | Out-Null
+} | ConvertTo-JSON | out-file -enc ascii $bundle/vcpkg-bundle.json | Out-Null
 @{
     name = "manifest"
     version = "0"
@@ -112,9 +114,10 @@ $manifestdir = Join-Path $TestingRoot "manifest"
 
 New-Item -ItemType Directory -Force $manifestdir | Out-Null
 New-Item -ItemType Directory -Force $bundle | Out-Null
+New-Item -ItemType File -Force $bundle/.vcpkg-root | Out-Null
 @{
     readonly = $True
-} | ConvertTo-JSON | out-file -enc ascii $bundle/.vcpkg-root | Out-Null
+} | ConvertTo-JSON | out-file -enc ascii $bundle/vcpkg-bundle.json | Out-Null
 @{
     name = "manifest"
     version = "0"
@@ -163,7 +166,7 @@ $CurrentTest = "Testing bundle.usegitregistry"
 @{
     readonly = $True
     usegitregistry = $True
-} | ConvertTo-JSON | out-file -enc ascii $bundle/.vcpkg-root | Out-Null
+} | ConvertTo-JSON | out-file -enc ascii $bundle/vcpkg-bundle.json | Out-Null
 Run-Vcpkg install --dry-run --vcpkg-root=$bundle `
     --x-manifest-root=$manifestdir `
     --overlay-triplets=$env:VCPKG_ROOT/triplets `

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -407,12 +407,12 @@ namespace vcpkg
         }
 
         Debug::print("Bundle config: readonly=",
-                impl.m_readonly,
-                ", usegitregistry=",
-                impl.m_usegitregistry,
-                ", embeddedsha=",
-                impl.m_embedded_git_sha.value_or("nullopt"),
-                "\n");
+                     impl.m_readonly,
+                     ", usegitregistry=",
+                     impl.m_usegitregistry,
+                     ", embeddedsha=",
+                     impl.m_embedded_git_sha.value_or("nullopt"),
+                     "\n");
     }
 
     VcpkgPaths::VcpkgPaths(Filesystem& filesystem, const VcpkgCmdArguments& args)


### PR DESCRIPTION
Due to the new bundle functionality of `.vcpkg-root`, vcpkg now issues read requests for the file during startup. Unfortunately, this conflicts with manifest mode's use of the file as a synchronization mechanism (mutex).

This PR fixes the issue by separating the bundle definition into a different file `vcpkg-bundle.json` which lives alongside `.vcpkg-root`.