### PR TITLE
Remove VcpkgPaths from RegistrySet interfaces

### DIFF
--- a/include/vcpkg/configuration.h
+++ b/include/vcpkg/configuration.h
@@ -35,7 +35,7 @@ namespace vcpkg
         Json::Object serialize() const;
         void validate_as_active();
 
-        std::unique_ptr<RegistrySet> instantiate_registry_set(const Path& config_dir) const;
+        std::unique_ptr<RegistrySet> instantiate_registry_set(const VcpkgPaths& paths, const Path& config_dir) const;
 
         static View<StringView> known_fields();
     };

--- a/include/vcpkg/install.h
+++ b/include/vcpkg/install.h
@@ -72,8 +72,6 @@ namespace vcpkg::Install
         SUCCESS,
     };
 
-    std::vector<std::string> get_all_port_names(const VcpkgPaths& paths);
-
     void install_package_and_write_listfile(const VcpkgPaths& paths, const PackageSpec& spec, const InstallDir& dirs);
 
     void install_files_and_write_listfile(Filesystem& fs,

--- a/include/vcpkg/paragraphs.h
+++ b/include/vcpkg/paragraphs.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <vcpkg/fwd/registries.h>
 #include <vcpkg/fwd/vcpkgpaths.h>
 
 #include <vcpkg/base/expected.h>
@@ -54,8 +55,9 @@ namespace vcpkg::Paragraphs
         const std::string& operator()(const SourceControlFile& scf) const { return scf.core_paragraph->name; }
     } get_name_of_control_file;
 
-    LoadResults try_load_all_registry_ports(const VcpkgPaths& paths);
+    LoadResults try_load_all_registry_ports(const Filesystem& fs, const RegistrySet& registries);
 
-    std::vector<SourceControlFileAndLocation> load_all_registry_ports(const VcpkgPaths& paths);
+    std::vector<SourceControlFileAndLocation> load_all_registry_ports(const Filesystem& fs,
+                                                                      const RegistrySet& registries);
     std::vector<SourceControlFileAndLocation> load_overlay_ports(const Filesystem& fs, const Path& dir);
 }

--- a/include/vcpkg/portfileprovider.h
+++ b/include/vcpkg/portfileprovider.h
@@ -56,8 +56,6 @@ namespace vcpkg::PortFileProvider
     struct PathsPortFileProvider : PortFileProvider
     {
         explicit PathsPortFileProvider(const vcpkg::VcpkgPaths& paths, const std::vector<std::string>& overlay_ports);
-        PathsPortFileProvider(const PathsPortFileProvider&) = delete;
-        PathsPortFileProvider& operator=(const PathsPortFileProvider&) = delete;
         ExpectedS<const SourceControlFileAndLocation&> get_control_file(const std::string& src_name) const override;
         std::vector<const SourceControlFileAndLocation*> load_all_control_files() const override;
 

--- a/include/vcpkg/registries.h
+++ b/include/vcpkg/registries.h
@@ -53,7 +53,7 @@ namespace vcpkg
     {
         virtual View<VersionT> get_port_versions() const = 0;
 
-        virtual ExpectedS<Path> get_path_to_version(const VcpkgPaths& paths, const VersionT& version) const = 0;
+        virtual ExpectedS<Path> get_path_to_version(const VersionT& version) const = 0;
 
         virtual ~RegistryEntry() = default;
     };
@@ -63,15 +63,15 @@ namespace vcpkg
         virtual StringLiteral kind() const = 0;
 
         // returns nullptr if the port doesn't exist
-        virtual std::unique_ptr<RegistryEntry> get_port_entry(const VcpkgPaths& paths, StringView port_name) const = 0;
+        virtual std::unique_ptr<RegistryEntry> get_port_entry(StringView port_name) const = 0;
 
         // appends the names of the ports to the out parameter
         // may result in duplicated port names; make sure to Util::sort_unique_erase at the end
-        virtual void get_all_port_names(std::vector<std::string>& port_names, const VcpkgPaths& paths) const = 0;
+        virtual void get_all_port_names(std::vector<std::string>& port_names) const = 0;
 
-        virtual Optional<VersionT> get_baseline_version(const VcpkgPaths& paths, StringView port_name) const = 0;
+        virtual Optional<VersionT> get_baseline_version(StringView port_name) const = 0;
 
-        virtual Optional<Path> get_path_to_baseline_version(const VcpkgPaths& paths, StringView port_name) const;
+        virtual Optional<Path> get_path_to_baseline_version(StringView port_name) const;
 
         virtual ~RegistryImplementation() = default;
     };
@@ -110,7 +110,7 @@ namespace vcpkg
         // finds the correct registry for the port name
         // Returns the null pointer if there is no registry set up for that name
         const RegistryImplementation* registry_for_port(StringView port_name) const;
-        Optional<VersionT> baseline_for_port(const VcpkgPaths& paths, StringView port_name) const;
+        Optional<VersionT> baseline_for_port(StringView port_name) const;
 
         View<Registry> registries() const { return registries_; }
 
@@ -128,13 +128,15 @@ namespace vcpkg
         std::vector<Registry> registries_;
     };
 
-    std::unique_ptr<RegistryImplementation> make_builtin_registry();
-    std::unique_ptr<RegistryImplementation> make_builtin_registry(std::string baseline);
-    std::unique_ptr<RegistryImplementation> make_git_registry(std::string repo,
+    std::unique_ptr<RegistryImplementation> make_builtin_registry(const VcpkgPaths& paths);
+    std::unique_ptr<RegistryImplementation> make_builtin_registry(const VcpkgPaths& paths, std::string baseline);
+    std::unique_ptr<RegistryImplementation> make_git_registry(const VcpkgPaths& paths,
+                                                              std::string repo,
                                                               std::string reference,
                                                               std::string baseline);
-    std::unique_ptr<RegistryImplementation> make_filesystem_registry(Path path, std::string baseline);
-    std::unique_ptr<RegistryImplementation> make_artifact_registry(std::string name, std::string location);
+    std::unique_ptr<RegistryImplementation> make_filesystem_registry(const Filesystem& fs,
+                                                                     Path path,
+                                                                     std::string baseline);
 
     ExpectedS<std::vector<std::pair<SchemedVersion, std::string>>> get_builtin_versions(const VcpkgPaths& paths,
                                                                                         StringView port_name);

--- a/src/vcpkg-test/configmetadata.cpp
+++ b/src/vcpkg-test/configmetadata.cpp
@@ -272,7 +272,6 @@ TEST_CASE ("config ce metadata only", "[ce-metadata]")
 
     auto config = parse_test_configuration(raw_config);
     REQUIRE(!config.registries.size());
-    REQUIRE(config.instantiate_registry_set({})->is_default_builtin_registry());
 
     REQUIRE(!config.extra_info.is_empty());
     REQUIRE(config.extra_info.size() == 1);

--- a/src/vcpkg-test/registries.cpp
+++ b/src/vcpkg-test/registries.cpp
@@ -13,11 +13,11 @@ namespace
     {
         StringLiteral kind() const override { return "test"; }
 
-        std::unique_ptr<RegistryEntry> get_port_entry(const VcpkgPaths&, StringView) const override { return nullptr; }
+        std::unique_ptr<RegistryEntry> get_port_entry(StringView) const override { return nullptr; }
 
-        void get_all_port_names(std::vector<std::string>&, const VcpkgPaths&) const override { }
+        void get_all_port_names(std::vector<std::string>&) const override { }
 
-        Optional<VersionT> get_baseline_version(const VcpkgPaths&, StringView) const override { return nullopt; }
+        Optional<VersionT> get_baseline_version(StringView) const override { return nullopt; }
 
         int number;
 

--- a/src/vcpkg/commands.edit.cpp
+++ b/src/vcpkg/commands.edit.cpp
@@ -87,7 +87,8 @@ namespace vcpkg::Commands::Edit
 
     static std::vector<std::string> valid_arguments(const VcpkgPaths& paths)
     {
-        auto sources_and_errors = Paragraphs::try_load_all_registry_ports(paths);
+        auto sources_and_errors =
+            Paragraphs::try_load_all_registry_ports(paths.get_filesystem(), paths.get_registry_set());
 
         return Util::fmap(sources_and_errors.paragraphs, Paragraphs::get_name_of_control_file);
     }

--- a/src/vcpkg/install.cpp
+++ b/src/vcpkg/install.cpp
@@ -579,11 +579,23 @@ namespace vcpkg::Install
         {OPTION_MANIFEST_FEATURE, "A feature from the manifest to install."},
     }};
 
-    std::vector<std::string> get_all_port_names(const VcpkgPaths& paths)
+    static std::vector<std::string> get_all_port_names(const VcpkgPaths& paths)
     {
-        auto sources_and_errors = Paragraphs::try_load_all_registry_ports(paths);
+        const auto& registries = paths.get_registry_set();
 
-        return Util::fmap(sources_and_errors.paragraphs, Paragraphs::get_name_of_control_file);
+        std::vector<std::string> ret;
+        for (const auto& registry : registries.registries())
+        {
+            const auto packages = registry.packages();
+            ret.insert(ret.end(), packages.begin(), packages.end());
+        }
+        if (auto registry = registries.default_registry())
+        {
+            registry->get_all_port_names(ret);
+        }
+
+        Util::sort_unique_erase(ret);
+        return ret;
     }
 
     const CommandStructure COMMAND_STRUCTURE = {

--- a/src/vcpkg/paragraphs.cpp
+++ b/src/vcpkg/paragraphs.cpp
@@ -405,14 +405,11 @@ namespace vcpkg::Paragraphs
         return pghs.error();
     }
 
-    LoadResults try_load_all_registry_ports(const VcpkgPaths& paths)
+    LoadResults try_load_all_registry_ports(const Filesystem& fs, const RegistrySet& registries)
     {
         LoadResults ret;
-        const auto& fs = paths.get_filesystem();
 
         std::vector<std::string> ports;
-
-        const auto& registries = paths.get_registry_set();
 
         for (const auto& registry : registries.registries())
         {
@@ -421,7 +418,7 @@ namespace vcpkg::Paragraphs
         }
         if (auto registry = registries.default_registry())
         {
-            registry->get_all_port_names(ports, paths);
+            registry->get_all_port_names(ports);
         }
 
         Util::sort_unique_erase(ports);
@@ -437,7 +434,7 @@ namespace vcpkg::Paragraphs
                 continue;
             }
 
-            if (auto p = impl->get_path_to_baseline_version(paths, port_name))
+            if (auto p = impl->get_path_to_baseline_version(port_name))
             {
                 auto maybe_spgh = try_load_port(fs, *p.get());
                 if (const auto spgh = maybe_spgh.get())
@@ -479,9 +476,10 @@ namespace vcpkg::Paragraphs
         }
     }
 
-    std::vector<SourceControlFileAndLocation> load_all_registry_ports(const VcpkgPaths& paths)
+    std::vector<SourceControlFileAndLocation> load_all_registry_ports(const Filesystem& fs,
+                                                                      const RegistrySet& registries)
     {
-        auto results = try_load_all_registry_ports(paths);
+        auto results = try_load_all_registry_ports(fs, registries);
         load_results_print_error(results);
         return std::move(results.paragraphs);
     }

--- a/src/vcpkg/portfileprovider.cpp
+++ b/src/vcpkg/portfileprovider.cpp
@@ -23,7 +23,7 @@ namespace
         OverlayRegistryEntry(Path&& p, VersionT&& v) : root(p), version(v) { }
 
         View<VersionT> get_port_versions() const override { return {&version, 1}; }
-        ExpectedS<Path> get_path_to_version(const VcpkgPaths&, const VersionT& v) const override
+        ExpectedS<Path> get_path_to_version(const VersionT& v) const override
         {
             if (v == version)
             {
@@ -107,20 +107,23 @@ namespace vcpkg::PortFileProvider
                 }
                 else
                 {
-                    auto version = paths.get_registry_set().baseline_for_port(paths, port_name);
+                    auto version = paths.get_registry_set().baseline_for_port(port_name);
                     m_baseline_cache.emplace(port_name.to_string(), version);
                     return version;
                 }
             }
 
         private:
-            const VcpkgPaths& paths; // TODO: remove this data member
+            const VcpkgPaths& paths;
             mutable std::map<std::string, Optional<VersionT>, std::less<>> m_baseline_cache;
         };
 
         struct VersionedPortfileProviderImpl : IVersionedPortfileProvider
         {
-            VersionedPortfileProviderImpl(const VcpkgPaths& paths_) : paths(paths_) { }
+            VersionedPortfileProviderImpl(const Filesystem& fs, const RegistrySet& rset)
+                : m_fs(fs), m_registry_set(rset)
+            {
+            }
             VersionedPortfileProviderImpl(const VersionedPortfileProviderImpl&) = delete;
             VersionedPortfileProviderImpl& operator=(const VersionedPortfileProviderImpl&) = delete;
 
@@ -129,9 +132,9 @@ namespace vcpkg::PortFileProvider
                 auto entry_it = m_entry_cache.find(name);
                 if (entry_it == m_entry_cache.end())
                 {
-                    if (auto reg = paths.get_registry_set().registry_for_port(name))
+                    if (auto reg = m_registry_set.registry_for_port(name))
                     {
-                        if (auto entry = reg->get_port_entry(paths, name))
+                        if (auto entry = reg->get_port_entry(name))
                         {
                             entry_it = m_entry_cache.emplace(name.to_string(), std::move(entry)).first;
                         }
@@ -166,10 +169,10 @@ namespace vcpkg::PortFileProvider
                 const auto& maybe_ent = entry(version_spec.port_name);
                 if (auto ent = maybe_ent.get())
                 {
-                    auto maybe_path = ent->get()->get_path_to_version(paths, version_spec.version);
+                    auto maybe_path = ent->get()->get_path_to_version(version_spec.version);
                     if (auto path = maybe_path.get())
                     {
-                        auto maybe_control_file = Paragraphs::try_load_port(paths.get_filesystem(), *path);
+                        auto maybe_control_file = Paragraphs::try_load_port(m_fs, *path);
                         if (auto scf = maybe_control_file.get())
                         {
                             if (scf->get()->core_paragraph->name == version_spec.port_name)
@@ -219,7 +222,7 @@ namespace vcpkg::PortFileProvider
             virtual void load_all_control_files(
                 std::map<std::string, const SourceControlFileAndLocation*>& out) const override
             {
-                auto all_ports = Paragraphs::load_all_registry_ports(paths);
+                auto all_ports = Paragraphs::load_all_registry_ports(m_fs, m_registry_set);
                 for (auto&& scfl : all_ports)
                 {
                     auto port_name = scfl.source_control_file->core_paragraph->name;
@@ -234,7 +237,8 @@ namespace vcpkg::PortFileProvider
             }
 
         private:
-            const VcpkgPaths& paths; // TODO: remove this data member
+            const Filesystem& m_fs;
+            const RegistrySet& m_registry_set;
             mutable std::
                 unordered_map<VersionSpec, ExpectedS<std::unique_ptr<SourceControlFileAndLocation>>, VersionSpecHasher>
                     m_control_cache;
@@ -382,7 +386,7 @@ namespace vcpkg::PortFileProvider
 
     std::unique_ptr<IVersionedPortfileProvider> make_versioned_portfile_provider(const vcpkg::VcpkgPaths& paths)
     {
-        return std::make_unique<VersionedPortfileProviderImpl>(paths);
+        return std::make_unique<VersionedPortfileProviderImpl>(paths.get_filesystem(), paths.get_registry_set());
     }
 
     std::unique_ptr<IOverlayProvider> make_overlay_provider(const vcpkg::VcpkgPaths& paths,

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -463,6 +463,10 @@ namespace vcpkg
         Checks::check_exit(VCPKG_LINE_INFO, !root.empty(), "Error: Could not detect vcpkg-root.");
         Debug::print("Using vcpkg-root: ", root, '\n');
 
+        builtin_ports = process_output_directory(filesystem, args.builtin_ports_root_dir.get(), root / "ports");
+        builtin_registry_versions =
+            process_output_directory(filesystem, args.builtin_registry_versions_dir.get(), root / "versions");
+
         load_bundle_file(filesystem, root, *m_pimpl);
 
         const auto vcpkg_root_file = root / ".vcpkg-root";
@@ -531,7 +535,7 @@ namespace vcpkg
                                                        m_pimpl->m_config_dir,
                                                        *this);
 
-            m_pimpl->m_registry_set = m_pimpl->m_config.instantiate_registry_set(m_pimpl->m_config_dir);
+            m_pimpl->m_registry_set = m_pimpl->m_config.instantiate_registry_set(*this, m_pimpl->m_config_dir);
         }
 
         // metrics from configuration
@@ -576,10 +580,6 @@ namespace vcpkg
             downloads = root / "downloads";
         }
         downloads = filesystem.almost_canonical(downloads, VCPKG_LINE_INFO);
-
-        builtin_ports = process_output_directory(filesystem, args.builtin_ports_root_dir.get(), root / "ports");
-        builtin_registry_versions =
-            process_output_directory(filesystem, args.builtin_registry_versions_dir.get(), root / "versions");
 
         m_pimpl->m_download_manager = Downloads::DownloadManager{
             parse_download_configuration(args.asset_sources_template()).value_or_exit(VCPKG_LINE_INFO)};


### PR DESCRIPTION
This follows up #275 by removing `VcpkgPaths` from the `RegistrySet` interfaces, enabling many functions to take a `RegistrySet` instead of a whole `VcpkgPaths`.