### PR TITLE
Fix the cmake's output for vcpkg_get_dep_info()

### DIFF
--- a/src/vcpkg.cpp
+++ b/src/vcpkg.cpp
@@ -187,7 +187,13 @@ int main(const int argc, const char* const* const argv)
 #endif
     set_environment_variable("VCPKG_COMMAND", get_exe_path_of_current_process().generic_u8string());
     
-    // See http://bixense.com/clicolors
+    // Prevent child processes (ex. cmake) from producing "colorized"
+    // output (which may include ANSI escape codes), since it would
+    // complicate parsing the output.
+    //
+    // See http://bixense.com/clicolors for the semantics associated with
+    // the CLICOLOR and CLICOLOR_FORCE env variables
+    //
     set_environment_variable("CLICOLOR_FORCE", {});
     set_environment_variable("CLICOLOR", "0");
 

--- a/src/vcpkg.cpp
+++ b/src/vcpkg.cpp
@@ -186,7 +186,7 @@ int main(const int argc, const char* const* const argv)
     }
 #endif
     set_environment_variable("VCPKG_COMMAND", get_exe_path_of_current_process().generic_u8string());
-    
+
     // Prevent child processes (ex. cmake) from producing "colorized"
     // output (which may include ANSI escape codes), since it would
     // complicate parsing the output.

--- a/src/vcpkg.cpp
+++ b/src/vcpkg.cpp
@@ -186,6 +186,8 @@ int main(const int argc, const char* const* const argv)
     }
 #endif
     set_environment_variable("VCPKG_COMMAND", get_exe_path_of_current_process().generic_u8string());
+    
+    // See http://bixense.com/clicolors
     set_environment_variable("CLICOLOR_FORCE", {});
     set_environment_variable("CLICOLOR", "0");
 

--- a/src/vcpkg.cpp
+++ b/src/vcpkg.cpp
@@ -187,6 +187,7 @@ int main(const int argc, const char* const* const argv)
 #endif
     set_environment_variable("VCPKG_COMMAND", get_exe_path_of_current_process().generic_u8string());
     set_environment_variable("CLICOLOR_FORCE", {});
+    set_environment_variable("CLICOLOR", "0");
 
     Checks::register_global_shutdown_handler([]() {
         const auto elapsed_us_inner = GlobalState::timer.microseconds();


### PR DESCRIPTION
Set `CLICOLOR=0` to force cmake to output "plain" text (without ANSI escape codes)
(see [Terminal.c](https://github.com/Kitware/CMake/blob/29c80aec94b3607f3aae82170f0b3d0804de2aea/Source/kwsys/Terminal.c#L176-L182))

On Linux (and likely on other non-Windows platforms), CMake may "colorize" the output depending on the terminal type. This creates problems when `vcpkg` attempts to parse the output from CMake ([ex](https://github.com/microsoft/vcpkg-tool/blob/1b7edfa7196228006613d96657492e78d3e22043/src/vcpkg/cmakevars.cpp#L260-L264))

This PR would fix https://github.com/microsoft/vcpkg/issues/20430