### PR TITLE
Fix overpowered default-features = false specification in manifest mode

### DIFF
--- a/src/vcpkg/dependencies.cpp
+++ b/src/vcpkg/dependencies.cpp
@@ -1386,7 +1386,7 @@ namespace vcpkg::Dependencies
 
             std::pair<const PackageSpec, PackageNode>& emplace_package(const PackageSpec& spec);
 
-            // the following 5 functions will add stuff recursivly
+            // the following functions will add stuff recursively
             void require_dependency(std::pair<const PackageSpec, PackageNode>& ref,
                                     const Dependency& dep,
                                     const std::string& origin);


### PR DESCRIPTION
Currently, there is a bug in manifest mode where if the top level manifest marks a package as `"default-features": false`, all downstream dependencies upon defaults on that package _will be ignored_. For example,

toplevel -> A, B[core]
A -> B (including defaults)

Expected result: A, B[1,2,3,...]
Current result: A, B[core]

This PR fixes that issue to achieve the expected result.