### PR TITLE
[depend-info] Add x-tree to the usage message

### DIFF
--- a/src/vcpkg/commands.dependinfo.cpp
+++ b/src/vcpkg/commands.dependinfo.cpp
@@ -103,7 +103,7 @@ namespace vcpkg::Commands::DependInfo
             {{OPTION_MAX_RECURSE, "Set max recursion depth, a value of -1 indicates no limit"},
              {OPTION_SORT,
               "Set sort order for the list of dependencies, accepted values are: lexicographical, topological "
-              "(default), "
+              "(default), x-tree, "
               "reverse"}}};
 
         enum SortMode


### PR DESCRIPTION
In PR #74, we added an addtional option `x-tree` to command `depend-info` sub option `--sort` but lack of the usage message.
Add it now.