### PR TITLE
[depend-info] Turn errors into warnings when querying dependencies of unsupported triplet

### DIFF
--- a/src/vcpkg/commands.dependinfo.cpp
+++ b/src/vcpkg/commands.dependinfo.cpp
@@ -90,16 +90,14 @@ namespace vcpkg::Commands::DependInfo
         constexpr StringLiteral OPTION_DGML = "dgml";
         constexpr StringLiteral OPTION_SHOW_DEPTH = "show-depth";
         constexpr StringLiteral OPTION_MAX_RECURSE = "max-recurse";
-        constexpr StringLiteral OPTION_ALLOW_UNSUPPORTED_PORT = "allow-unsupported";
         constexpr StringLiteral OPTION_SORT = "sort";
 
         constexpr int NO_RECURSE_LIMIT_VALUE = -1;
 
-        constexpr std::array<CommandSwitch, 4> DEPEND_SWITCHES = {
+        constexpr std::array<CommandSwitch, 3> DEPEND_SWITCHES = {
             {{OPTION_DOT, "Creates graph on basis of dot"},
              {OPTION_DGML, "Creates graph on basis of dgml"},
-             {OPTION_SHOW_DEPTH, "Show recursion depth in output"},
-             {OPTION_ALLOW_UNSUPPORTED_PORT, "Instead of erroring on an unsupported port, continue with a warning."}}};
+             {OPTION_SHOW_DEPTH, "Show recursion depth in output"}}};
 
         constexpr std::array<CommandSetting, 2> DEPEND_SETTINGS = {
             {{OPTION_MAX_RECURSE, "Set max recursion depth, a value of -1 indicates no limit"},
@@ -307,9 +305,6 @@ namespace vcpkg::Commands::DependInfo
         const int max_depth = get_max_depth(options);
         const SortMode sort_mode = get_sort_mode(options);
         const bool show_depth = Util::Sets::contains(options.switches, OPTION_SHOW_DEPTH);
-        const auto unsupported_port_action = Util::Sets::contains(options.switches, OPTION_ALLOW_UNSUPPORTED_PORT)
-                                                 ? Dependencies::UnsupportedPortAction::Warn
-                                                 : Dependencies::UnsupportedPortAction::Error;
 
         const std::vector<FullPackageSpec> specs = Util::fmap(args.command_arguments, [&](auto&& arg) {
             return Input::check_and_get_full_package_spec(
@@ -329,7 +324,11 @@ namespace vcpkg::Commands::DependInfo
         // All actions in the plan should be install actions, as there's no installed packages to remove.
         StatusParagraphs status_db;
         auto action_plan = Dependencies::create_feature_install_plan(
-            provider, var_provider, specs, status_db, {host_triplet, unsupported_port_action});
+            provider, var_provider, specs, status_db, {host_triplet, Dependencies::UnsupportedPortAction::Warn});
+        for (const auto& warning : action_plan.warnings)
+        {
+            print2(Color::warning, warning, '\n');
+        }
         Checks::check_exit(
             VCPKG_LINE_INFO, action_plan.remove_actions.empty(), "Only install actions should exist in the plan");
         std::vector<const InstallPlanAction*> install_actions =

--- a/src/vcpkg/dependencies.cpp
+++ b/src/vcpkg/dependencies.cpp
@@ -881,10 +881,11 @@ namespace vcpkg::Dependencies
                         if (!supports_expression.get()->evaluate(
                                 m_var_provider.get_dep_info_vars(spec.spec()).value_or_exit(VCPKG_LINE_INFO)))
                         {
-                            const auto msg = Strings::format("%s[%s] is only supported on '%s'",
+                            const auto msg = Strings::format("%s[%s] is only supported on '%s'\n%s",
                                                              spec.port(),
                                                              spec.feature(),
-                                                             to_string(*supports_expression.get()));
+                                                             to_string(*supports_expression.get()),
+                                                             "Maybe you should add option '--allow-unsupported'?");
                             if (unsupported_port_action == UnsupportedPortAction::Error)
                             {
                                 Checks::exit_with_message(VCPKG_LINE_INFO, "Error: " + msg);

--- a/src/vcpkg/dependencies.cpp
+++ b/src/vcpkg/dependencies.cpp
@@ -881,11 +881,10 @@ namespace vcpkg::Dependencies
                         if (!supports_expression.get()->evaluate(
                                 m_var_provider.get_dep_info_vars(spec.spec()).value_or_exit(VCPKG_LINE_INFO)))
                         {
-                            const auto msg = Strings::format("%s[%s] is only supported on '%s'\n%s",
+                            const auto msg = Strings::format("%s[%s] is only supported on '%s'",
                                                              spec.port(),
                                                              spec.feature(),
-                                                             to_string(*supports_expression.get()),
-                                                             "Maybe you should add option '--allow-unsupported'?");
+                                                             to_string(*supports_expression.get()));
                             if (unsupported_port_action == UnsupportedPortAction::Error)
                             {
                                 Checks::exit_with_message(VCPKG_LINE_INFO, "Error: " + msg);


### PR DESCRIPTION
In PR https://github.com/microsoft/vcpkg-tool/pull/184, we terminate the command early according to the `supports` field in `CONTROL`/`vcpkg.json`, which affects the command `depend-info`, and it does not support the parameter `--allow-unsupported`.

Now these error messages are always treated as warnings.