### PR TITLE
Retry popen on 127 osx

### DIFF
--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -809,52 +809,38 @@ namespace vcpkg
         }
 
         Debug::print(thread_id, ": popen(", actual_cmd_line, ")\n");
-        int exit_code;
-        for (int i = 1; i <= 2; ++i)
+        // Flush stdout before launching external process
+        fflush(stdout);
+
+        const auto pipe = popen(actual_cmd_line.c_str(), "r");
+        if (pipe == nullptr)
         {
-            // Flush stdout before launching external process
-            fflush(stdout);
+            return 1;
+        }
+        char buf[1024];
+        // Use fgets because fread will block until the entire buffer is filled.
+        while (fgets(buf, 1024, pipe))
+        {
+            data_cb(StringView{buf, strlen(buf)});
+        }
 
-            const auto pipe = popen(actual_cmd_line.c_str(), "r");
-            if (pipe == nullptr)
-            {
-                return 1;
-            }
-            [[maybe_unused]] bool got_output = false;
-            char buf[1024];
-            // Use fgets because fread will block until the entire buffer is filled.
-            while (fgets(buf, 1024, pipe))
-            {
-                data_cb(StringView{buf, strlen(buf)});
-                got_output = true;
-            }
+        if (!feof(pipe))
+        {
+            return 1;
+        }
 
-            if (!feof(pipe))
-            {
-                return 1;
-            }
-
-            exit_code = pclose(pipe);
-            if (WIFEXITED(exit_code))
-            {
-                exit_code = WEXITSTATUS(exit_code);
-            }
-            else if (WIFSIGNALED(exit_code))
-            {
-                exit_code = WTERMSIG(exit_code);
-            }
-            else if (WIFSTOPPED(exit_code))
-            {
-                exit_code = WSTOPSIG(exit_code);
-            }
-#ifdef __APPLE__
-            if (exit_code == 127 && !got_output)
-            {
-                Debug::print(thread_id, ": pclose returned 127, try again \n");
-                continue;
-            }
-#endif
-            break;
+        auto exit_code = pclose(pipe);
+        if (WIFEXITED(exit_code))
+        {
+            exit_code = WEXITSTATUS(exit_code);
+        }
+        else if (WIFSIGNALED(exit_code))
+        {
+            exit_code = WTERMSIG(exit_code);
+        }
+        else if (WIFSTOPPED(exit_code))
+        {
+            exit_code = WSTOPSIG(exit_code);
         }
 #endif
         const auto elapsed = timer.us_64();

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -184,6 +184,24 @@ namespace
         return cmd;
     }
 
+    static std::vector<ExitCodeAndOutput> decompress_in_parallel(View<Command> jobs)
+    {
+        auto results = cmd_execute_and_capture_output_parallel(jobs, get_clean_environment());
+#ifdef __APPLE__
+        int i = 0;
+        for (auto& result : results)
+        {
+            if (result.exit_code == 127 && result.output.empty())
+            {
+                Debug::print(jobs[i].command_line(), ": pclose returned 127, try again \n");
+                result = cmd_execute_and_capture_output(jobs[i], get_clean_environment());
+            }
+            ++i;
+        }
+#endif
+        return results;
+    }
+
     // Compress the source directory into the destination file.
     static void compress_directory(const VcpkgPaths& paths, const Path& source, const Path& destination)
     {
@@ -294,7 +312,7 @@ namespace
                 }
             }
 
-            auto job_results = cmd_execute_and_capture_output_parallel(jobs, get_clean_environment());
+            auto job_results = decompress_in_parallel(jobs);
 
             for (size_t j = 0; j < jobs.size(); ++j)
             {
@@ -498,7 +516,7 @@ namespace
                             paths, paths.package_dir(actions[url_indices[i]].spec), url_paths[i].second));
                     }
                 }
-                auto job_results = cmd_execute_and_capture_output_parallel(jobs, get_clean_environment());
+                auto job_results = decompress_in_parallel(jobs);
                 for (size_t j = 0; j < jobs.size(); ++j)
                 {
                     const auto i = action_idxs[j];
@@ -1033,7 +1051,7 @@ namespace
                     idxs.push_back(idx);
                 }
 
-                const auto job_results = cmd_execute_and_capture_output_parallel(jobs, get_clean_environment());
+                const auto job_results = decompress_in_parallel(jobs);
 
                 for (size_t j = 0; j < jobs.size(); ++j)
                 {


### PR DESCRIPTION
Close https://github.com/microsoft/vcpkg/issues/21905 bullet point 1.  

Code 127 normally means `command not found`, but that does not really makes sense here. Sometimes (not often) `unzip` returns 127 and sometimes not, when you retry it the return code is 0. I have no idea what the problem could be, but this implements a workaround by retrying the command once on mac when the return code is 127.  