### PR TITLE
Fix crash message, the variable has the name `version`

### DIFF
--- a/src/vcpkg.cpp
+++ b/src/vcpkg.cpp
@@ -49,7 +49,7 @@ Please send an email to:
     {email}
 containing a brief summary of what you were trying to do and the following data blob:
 
-Version={vcpkg_version}
+Version={version}
 EXCEPTION='{error}'
 CMD=)");
     DECLARE_AND_REGISTER_MESSAGE(VcpkgHasCrashedArgument, (msg::value), "{LOCKED}", "{value}|");


### PR DESCRIPTION
Currently vcpkg crashes while displaying the crash message :D 
For example:
```
libc++abi: terminating with uncaught exception of type fmt::v8::format_error: argument not found
[1]    41566 abort      vcpkg install --enforce-port-checks --allow-unsupported
```