### PR TITLE
fix: ignore . and .. when copy regular recursive.

### DIFF
--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -2699,7 +2699,7 @@ namespace vcpkg
                 {
                     this->copy_file(source_entry_name, destination_entry_name, CopyOptions::none, ec);
                 }
-                else
+                else if (!is_dot_or_dot_dot(entry->d_name))
                 {
                     this->copy_regular_recursive_impl(source_entry_name, destination_entry_name, ec);
                 }


### PR DESCRIPTION
`copy_regular_recursive_impl` didn't ignore . and ..