### PR TITLE
Use explicit curl executable

### DIFF
--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -14,6 +14,8 @@
 namespace vcpkg
 {
 #if defined(_WIN32)
+    constexpr char curlCommand[] = "curl.exe";
+    
     struct WinHttpHandleDeleter
     {
         void operator()(HINTERNET h) const { WinHttpCloseHandle(h); }
@@ -171,6 +173,8 @@ namespace vcpkg
 
         std::unique_ptr<void, WinHttpHandleDeleter> m_hConnect;
     };
+#else
+    constexpr char curlCommand[] = "curl";
 #endif
 
     ExpectedS<details::SplitURIView> details::split_uri_view(StringView uri)
@@ -265,7 +269,7 @@ namespace vcpkg
         static constexpr StringLiteral guid_marker = "8a1db05f-a65d-419b-aa72-037fb4d0672e";
 
         Command cmd;
-        cmd.string_arg("curl.exe")
+        cmd.string_arg(curlCommand)
             .string_arg("--head")
             .string_arg("--location")
             .string_arg("-w")
@@ -321,7 +325,7 @@ namespace vcpkg
             static constexpr StringLiteral guid_marker = "8a1db05f-a65d-419b-aa72-037fb4d0672e";
 
             Command cmd;
-            cmd.string_arg("curl.exe")
+            cmd.string_arg(curlCommand)
                 .string_arg("--location")
                 .string_arg("-w")
                 .string_arg(Strings::concat(guid_marker, " %{http_code}\\n"));
@@ -383,7 +387,7 @@ namespace vcpkg
         {
             // HTTP headers are ignored for FTP clients
             Command cmd;
-            cmd.string_arg("curl.exe");
+            cmd.string_arg(curlCommand);
             cmd.string_arg(url);
             cmd.string_arg("-T").path_arg(file);
             auto res = cmd_execute_and_capture_output(cmd);
@@ -396,7 +400,7 @@ namespace vcpkg
             return 0;
         }
         Command cmd;
-        cmd.string_arg("curl.exe").string_arg("-X").string_arg("PUT");
+        cmd.string_arg(curlCommand).string_arg("-X").string_arg("PUT");
         for (auto&& header : headers)
         {
             cmd.string_arg("-H").string_arg(header);
@@ -549,7 +553,7 @@ namespace vcpkg
         }
 #endif
         Command cmd;
-        cmd.string_arg("curl.exe")
+        cmd.string_arg(curlCommand)
             .string_arg("--fail")
             .string_arg("-L")
             .string_arg(url)

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -265,7 +265,7 @@ namespace vcpkg
         static constexpr StringLiteral guid_marker = "8a1db05f-a65d-419b-aa72-037fb4d0672e";
 
         Command cmd;
-        cmd.string_arg("curl")
+        cmd.string_arg("curl.exe")
             .string_arg("--head")
             .string_arg("--location")
             .string_arg("-w")
@@ -321,7 +321,7 @@ namespace vcpkg
             static constexpr StringLiteral guid_marker = "8a1db05f-a65d-419b-aa72-037fb4d0672e";
 
             Command cmd;
-            cmd.string_arg("curl")
+            cmd.string_arg("curl.exe")
                 .string_arg("--location")
                 .string_arg("-w")
                 .string_arg(Strings::concat(guid_marker, " %{http_code}\\n"));
@@ -383,7 +383,7 @@ namespace vcpkg
         {
             // HTTP headers are ignored for FTP clients
             Command cmd;
-            cmd.string_arg("curl");
+            cmd.string_arg("curl.exe");
             cmd.string_arg(url);
             cmd.string_arg("-T").path_arg(file);
             auto res = cmd_execute_and_capture_output(cmd);
@@ -396,7 +396,7 @@ namespace vcpkg
             return 0;
         }
         Command cmd;
-        cmd.string_arg("curl").string_arg("-X").string_arg("PUT");
+        cmd.string_arg("curl.exe").string_arg("-X").string_arg("PUT");
         for (auto&& header : headers)
         {
             cmd.string_arg("-H").string_arg(header);
@@ -549,7 +549,7 @@ namespace vcpkg
         }
 #endif
         Command cmd;
-        cmd.string_arg("curl")
+        cmd.string_arg("curl.exe")
             .string_arg("--fail")
             .string_arg("-L")
             .string_arg(url)


### PR DESCRIPTION
This PR specifies `curl.exe` explicitly so that it doesn't get replaced by Powershell's `curl` alias.

The issue arose for me when using `vcpkg` binary-caching feature in a Windows container:

```
[DEBUG] CreateProcessW(curl -X PUT -w "\n9a1db05f-a65d-419b-aa72-037fb4d0672e%{http_code}" "https://datadogagent.blob.core.windows.net/vcpkg/0404814fbe3d58c3030a86d0decf265f0a09fe7f.zip?<secret>" -T "C:\vcpkg\buildtrees\zlib\x64-windows-static.zip" -H "x-ms-version: 2020-04-08" -H "x-ms-blob-type: BlockBlob")
[DEBUG] cmd_execute_and_stream_data() returned 2 after     4983 us
curl failed to execute with exit code: 2
Failed to upload to https://datadogagent.blob.core.windows.net/vcpkg/0404814fbe3d58c3030a86d0decf265f0a09fe7f.zip?<secret>: 0
Uploaded binaries to 0 HTTP remotes.
```

I can confirm that by exec'ing `Powershell` in the container:
```
PS C:\mnt> curl --version
curl : The remote name could not be resolved: '--version'
At line:1 char:1
+ curl --version
+ ~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (System.Net.HttpWebRequest:HttpWebRequest) [Invoke-WebRequest], WebException
    + FullyQualifiedErrorId : WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand
```

I tried to remove the `curl` alias with the following code, which works in the current Powershell session and any new Powershell session I create, but doesn't seem to affect `vcpkg`:

```
New-Item $profile -force -itemtype file
"remove-item alias:curl" | Out-File $profile
. $profile
while (Test-Path Alias:curl) {Remove-Item Alias:curl}
New-Alias -Name curl -Value curl.exe
```