### PR TITLE
Fix path separators, create appdata_dst_path and check file operation return value

### DIFF
--- a/src/vcpkg/commands.integrate.cpp
+++ b/src/vcpkg/commands.integrate.cpp
@@ -246,18 +246,8 @@ namespace vcpkg::Commands::Integrate
         {
             std::error_code ec;
             const auto tmp_dir = paths.buildsystems / "tmp";
-            fs.create_directory(paths.buildsystems, ec);
-            if (ec)
-            {
-                print2(Color::error, "Error: Failed to create directory: ", paths.buildsystems, "\n");
-                Checks::exit_fail(VCPKG_LINE_INFO);
-            }
-            fs.create_directory(tmp_dir, ec);
-            if (ec)
-            {
-                print2(Color::error, "Error: Failed to create directory: ", tmp_dir, "\n");
-                Checks::exit_fail(VCPKG_LINE_INFO);
-            }
+            fs.create_directory(paths.buildsystems, VCPKG_LINE_INFO);
+            fs.create_directory(tmp_dir, VCPKG_LINE_INFO);
 
             integrate_install_msbuild14(fs, tmp_dir);
 
@@ -266,15 +256,7 @@ namespace vcpkg::Commands::Integrate
                 appdata_src_path, create_appdata_shortcut(paths.buildsystems_msbuild_targets), VCPKG_LINE_INFO);
             auto appdata_dst_path = get_appdata_targets_path();
 
-            if (!fs.exists(appdata_dst_path, IgnoreErrors{}))
-            {
-                fs.create_directory(appdata_dst_path, ec);
-                if (ec)
-                {
-                    print2(Color::error, "Error: Failed to create directory: ", appdata_dst_path, "", "\n");
-                    Checks::exit_fail(VCPKG_LINE_INFO);
-                }
-            }
+            fs.create_directory(appdata_dst_path, VCPKG_LINE_INFO);
 
             fs.copy_file(appdata_src_path, appdata_dst_path, CopyOptions::overwrite_existing, ec);
             if (ec)

--- a/src/vcpkg/commands.integrate.cpp
+++ b/src/vcpkg/commands.integrate.cpp
@@ -265,7 +265,7 @@ namespace vcpkg::Commands::Integrate
             fs.write_contents(
                 appdata_src_path, create_appdata_shortcut(paths.buildsystems_msbuild_targets), VCPKG_LINE_INFO);
             auto appdata_dst_path = get_appdata_targets_path();
-            
+
             if (!fs.exists(appdata_dst_path, IgnoreErrors{}))
             {
                 fs.create_directory(appdata_dst_path, ec);

--- a/src/vcpkg/commands.integrate.cpp
+++ b/src/vcpkg/commands.integrate.cpp
@@ -155,13 +155,13 @@ namespace vcpkg::Commands::Integrate
 #if defined(_WIN32)
     static Path get_appdata_targets_path()
     {
-        return get_appdata_local().value_or_exit(VCPKG_LINE_INFO) / "vcpkg/vcpkg.user.targets";
+        return get_appdata_local().value_or_exit(VCPKG_LINE_INFO) / "vcpkg\\vcpkg.user.targets";
     }
 #endif
 #if defined(_WIN32)
     static Path get_appdata_props_path()
     {
-        return get_appdata_local().value_or_exit(VCPKG_LINE_INFO) / "vcpkg/vcpkg.user.props";
+        return get_appdata_local().value_or_exit(VCPKG_LINE_INFO) / "vcpkg\\vcpkg.user.props";
     }
 #endif
 

--- a/src/vcpkg/commands.integrate.cpp
+++ b/src/vcpkg/commands.integrate.cpp
@@ -247,7 +247,17 @@ namespace vcpkg::Commands::Integrate
             std::error_code ec;
             const auto tmp_dir = paths.buildsystems / "tmp";
             fs.create_directory(paths.buildsystems, ec);
+            if (ec)
+            {
+                print2(Color::error, "Error: Failed to create directory: ", paths.buildsystems, "\n");
+                Checks::exit_fail(VCPKG_LINE_INFO);
+            }
             fs.create_directory(tmp_dir, ec);
+            if (ec)
+            {
+                print2(Color::error, "Error: Failed to create directory: ", tmp_dir, "\n");
+                Checks::exit_fail(VCPKG_LINE_INFO);
+            }
 
             integrate_install_msbuild14(fs, tmp_dir);
 
@@ -255,6 +265,16 @@ namespace vcpkg::Commands::Integrate
             fs.write_contents(
                 appdata_src_path, create_appdata_shortcut(paths.buildsystems_msbuild_targets), VCPKG_LINE_INFO);
             auto appdata_dst_path = get_appdata_targets_path();
+            
+            if (!fs.exists(appdata_dst_path, IgnoreErrors{}))
+            {
+                fs.create_directory(appdata_dst_path, ec);
+                if (ec)
+                {
+                    print2(Color::error, "Error: Failed to create directory: ", appdata_dst_path, "", "\n");
+                    Checks::exit_fail(VCPKG_LINE_INFO);
+                }
+            }
 
             fs.copy_file(appdata_src_path, appdata_dst_path, CopyOptions::overwrite_existing, ec);
             if (ec)

--- a/src/vcpkg/commands.integrate.cpp
+++ b/src/vcpkg/commands.integrate.cpp
@@ -256,7 +256,7 @@ namespace vcpkg::Commands::Integrate
                 appdata_src_path, create_appdata_shortcut(paths.buildsystems_msbuild_targets), VCPKG_LINE_INFO);
             auto appdata_dst_path = get_appdata_targets_path();
 
-            fs.create_directory(appdata_dst_path, VCPKG_LINE_INFO);
+            fs.create_directory(get_appdata_local().value_or_exit(VCPKG_LINE_INFO), VCPKG_LINE_INFO);
 
             fs.copy_file(appdata_src_path, appdata_dst_path, CopyOptions::overwrite_existing, ec);
             if (ec)

--- a/src/vcpkg/commands.integrate.cpp
+++ b/src/vcpkg/commands.integrate.cpp
@@ -256,7 +256,8 @@ namespace vcpkg::Commands::Integrate
                 appdata_src_path, create_appdata_shortcut(paths.buildsystems_msbuild_targets), VCPKG_LINE_INFO);
             auto appdata_dst_path = get_appdata_targets_path();
 
-            fs.create_directory(get_appdata_local().value_or_exit(VCPKG_LINE_INFO), VCPKG_LINE_INFO);
+            const auto vcpkg_appdata_local = get_appdata_local().value_or_exit(VCPKG_LINE_INFO) / "vcpkg";
+            fs.create_directory(vcpkg_appdata_local, VCPKG_LINE_INFO);
 
             fs.copy_file(appdata_src_path, appdata_dst_path, CopyOptions::overwrite_existing, ec);
             if (ec)


### PR DESCRIPTION
1. Fix path separator: from `/` to `\\` on Windows
2. Create directory _appdata_dst_path_ when it doesn't exist.
3. Check all the filesystem operation and report error when they failed.
```
PS C:\dev\vcpkg\> vcpkg.exe integrate install
Error: Failed to copy file: C:\dev\vcpkg\vcpkg\scripts\buildsystems\tmp\vcpkg.user.targets -> C:\Users\helpdesk\AppData\Local\vcpkg/vcpkg.user.targets
```

Fixse https://github.com/microsoft/vcpkg/issues/22413