### PR TITLE
Clarify VcpkgPaths initialization order and const-ify

### DIFF
--- a/include/vcpkg/vcpkgpaths.h
+++ b/include/vcpkg/vcpkgpaths.h
@@ -102,25 +102,21 @@ namespace vcpkg
         const Path original_cwd;
         const Path root;
 
-        Path manifest_root_dir;
-        Path downloads;
-        Path triplets;
-        Path community_triplets;
-        Path scripts;
-        Path prefab;
-
     private:
-        Path builtin_ports;
+        const std::unique_ptr<details::VcpkgPathsImpl> m_pimpl;
 
     public:
-        Path builtin_registry_versions;
-
-        Path tools;
-        Path buildsystems;
-        Path buildsystems_msbuild_targets;
-        Path buildsystems_msbuild_props;
-
-        Path ports_cmake;
+        const Path builtin_registry_versions;
+        const Path scripts;
+        const Path prefab;
+        const Path buildsystems;
+        const Path buildsystems_msbuild_targets;
+        const Path buildsystems_msbuild_props;
+        const Path downloads;
+        const Path tools;
+        const Path ports_cmake;
+        const Path triplets;
+        const Path community_triplets;
 
         std::string get_toolver_diagnostics() const;
 
@@ -169,15 +165,8 @@ namespace vcpkg
 
         // the directory of the builtin ports
         // this should be used only for helper commands, not core commands like `install`.
-        Path builtin_ports_directory() const { return this->builtin_ports; }
+        const Path& builtin_ports_directory() const;
 
         bool use_git_default_registry() const;
-
-    private:
-        Optional<Path> maybe_get_tmp_path(const std::string* arg_path,
-                                          StringLiteral root_subpath,
-                                          StringLiteral readonly_subpath,
-                                          LineInfo li) const;
-        std::unique_ptr<details::VcpkgPathsImpl> m_pimpl;
     };
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -2,6 +2,7 @@
   "ErrorIndividualPackagesUnsupported": "Error: In manifest mode, `vcpkg install` does not support individual package arguments.\nTo install additional packages, edit vcpkg.json and then run `vcpkg install` without any package arguments.",
   "ErrorInvalidClassicModeOption": "Error: The option {value} is not supported in classic mode and no manifest was found.",
   "ErrorInvalidManifestModeOption": "Error: The option {value} is not supported in manifest mode.",
+  "ErrorMissingVcpkgRoot": "Error: Could not detect vcpkg-root. If you are trying to use a copy of vcpkg that you've built, you must define the VCPKG_ROOT environment variable to point to a cloned copy of {url}.",
   "ErrorNoVSInstance": "Error: in triplet {triplet}: Unable to find a valid Visual Studio instance",
   "ErrorNoVSInstanceAt": "     at \"{path}\"",
   "_ErrorNoVSInstanceAt.comment": "Printed after ErrorNoVSInstance on a separate line",

--- a/src/vcpkg/install.cpp
+++ b/src/vcpkg/install.cpp
@@ -850,7 +850,7 @@ namespace vcpkg::Install
             }
             if (failure)
             {
-                msg::println(msgUsingManifestAt, msg::path = paths.manifest_root_dir / "vcpkg.json");
+                msg::println(msgUsingManifestAt, msg::path = paths.get_manifest_path().value_or_exit(VCPKG_LINE_INFO));
                 print2("\n");
                 print_usage(MANIFEST_COMMAND_STRUCTURE);
                 Checks::exit_fail(VCPKG_LINE_INFO);

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -1386,9 +1386,9 @@ namespace vcpkg
         const auto tsv = prebuildinfo.platform_toolset.get();
         const auto tsvf = prebuildinfo.platform_toolset_version.get();
         auto vsp = prebuildinfo.visual_studio_path.get();
-        if (!vsp && !m_pimpl->default_vs_path.empty())
+        if (!vsp && !m_pimpl->m_default_vs_path.empty())
         {
-            vsp = &m_pimpl->default_vs_path;
+            vsp = &m_pimpl->m_default_vs_path;
         }
 
         auto candidate = Util::find_if(vs_toolsets, [&](const Toolset& t) {

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -263,59 +263,258 @@ namespace vcpkg
             }
         }
 
-        struct VcpkgPathsImpl
+        struct BundleSettings
         {
-            VcpkgPathsImpl(Filesystem& fs, FeatureFlagSettings ff_settings, RequireExactVersions abiToolsHandling)
-                : fs_ptr(&fs)
-                , m_tool_cache(get_tool_cache(abiToolsHandling))
-                , m_env_cache(ff_settings.compiler_tracking)
-                , m_ff_settings(ff_settings)
-            {
-                const auto& cache_root = default_registries_cache_path().value_or_exit(VCPKG_LINE_INFO);
-                registries_work_tree_dir = cache_root / "git";
-                registries_dot_git_dir = registries_work_tree_dir / ".git";
-                registries_git_trees = cache_root / "git-trees";
-            }
+            bool m_readonly = false;
+            bool m_usegitregistry = false;
+            Optional<std::string> m_embedded_git_sha;
+        };
 
+        static details::BundleSettings load_bundle_file(const Filesystem& fs, const Path& root)
+        {
+            details::BundleSettings ret;
+            const auto vcpkg_bundle_file = root / "vcpkg-bundle.json";
+            std::error_code ec;
+            auto bundle_file = fs.read_contents(vcpkg_bundle_file, ec);
+            if (!ec)
+            {
+                auto maybe_bundle_doc = Json::parse(bundle_file, bundle_file);
+                if (auto bundle_doc = maybe_bundle_doc.get())
+                {
+                    const auto& first_object = bundle_doc->first.object();
+                    if (auto v = first_object.get("readonly"))
+                    {
+                        ret.m_readonly = v->boolean();
+                    }
+
+                    if (auto v = first_object.get("usegitregistry"))
+                    {
+                        ret.m_usegitregistry = v->boolean();
+                    }
+
+                    if (auto v = first_object.get("embeddedsha"))
+                    {
+                        ret.m_embedded_git_sha = v->string().to_string();
+                    }
+                }
+                else
+                {
+                    print2(Color::error, "Error: Invalid bundle definition.\n", maybe_bundle_doc.error()->format());
+                    Checks::exit_fail(VCPKG_LINE_INFO);
+                }
+            }
+            return ret;
+        }
+
+        static Optional<Path> maybe_get_tmp_path(const Filesystem& fs,
+                                                 const details::BundleSettings& bundle,
+                                                 const Optional<InstalledPaths>& installed,
+                                                 const Path& root,
+                                                 const std::string* arg_path,
+                                                 StringLiteral root_subpath,
+                                                 StringLiteral readonly_subpath,
+                                                 LineInfo li)
+        {
+            if (arg_path)
+            {
+                return fs.almost_canonical(*arg_path, li);
+            }
+            else if (bundle.m_readonly)
+            {
+                if (auto i = installed.get())
+                {
+                    return fs.almost_canonical(i->vcpkg_dir() / readonly_subpath, li);
+                }
+                else
+                {
+                    return nullopt;
+                }
+            }
+            else
+            {
+                return fs.almost_canonical(root / root_subpath, li);
+            }
+        }
+
+        static Path compute_manifest_dir(const Filesystem& fs, const VcpkgCmdArguments& args, const Path& original_cwd)
+        {
+            if (args.manifests_enabled())
+            {
+                if (args.manifest_root_dir)
+                {
+                    return fs.almost_canonical(*args.manifest_root_dir, VCPKG_LINE_INFO);
+                }
+                else
+                {
+                    return fs.find_file_recursively_up(original_cwd, "vcpkg.json", VCPKG_LINE_INFO);
+                }
+            }
+            return {};
+        }
+
+        // This structure holds members for VcpkgPathsImpl that don't require explicit initialization/destruction
+        struct VcpkgPathsImplStage0
+        {
             Lazy<std::vector<VcpkgPaths::TripletFile>> available_triplets;
             Lazy<ToolsetsInformation> toolsets;
             Lazy<std::map<std::string, std::string>> cmake_script_hashes;
             Lazy<std::string> ports_cmake_hash;
-
-            Filesystem* fs_ptr;
-
-            Path default_vs_path;
-            std::vector<Path> triplets_dirs;
-
-            std::unique_ptr<ToolCache> m_tool_cache;
             Cache<Triplet, Path> m_triplets_cache;
+            Optional<LockFile> m_installed_lock;
+        };
+
+        // This structure holds members that
+        // 1. Do not have any inter-member dependencies
+        // 2. Are const (and therefore initialized in the initializer list)
+        struct VcpkgPathsImplStage1 : VcpkgPathsImplStage0
+        {
+            VcpkgPathsImplStage1(Filesystem& fs,
+                                 const VcpkgCmdArguments& args,
+                                 const Path& root,
+                                 const Path& original_cwd)
+                : m_fs(fs)
+                , m_ff_settings(args.feature_flag_settings())
+                , m_cache_root(default_registries_cache_path().value_or_exit(VCPKG_LINE_INFO))
+                , m_manifest_dir(compute_manifest_dir(fs, args, original_cwd))
+                , m_bundle(load_bundle_file(fs, root))
+                , m_tool_cache(get_tool_cache(args.exact_abi_tools_versions.value_or(false) ? RequireExactVersions::YES
+                                                                                            : RequireExactVersions::NO))
+                , m_download_manager(
+                      parse_download_configuration(args.asset_sources_template()).value_or_exit(VCPKG_LINE_INFO))
+                , m_builtin_ports(process_output_directory(fs, args.builtin_ports_root_dir.get(), root / "ports"))
+                , m_default_vs_path(args.default_visual_studio_path
+                                        ? fs.almost_canonical(*args.default_visual_studio_path, VCPKG_LINE_INFO)
+                                        : Path{})
+            {
+                Debug::print("Bundle config: readonly=",
+                             m_bundle.m_readonly,
+                             ", usegitregistry=",
+                             m_bundle.m_usegitregistry,
+                             ", embeddedsha=",
+                             m_bundle.m_embedded_git_sha.value_or("nullopt"),
+                             "\n");
+
+                Debug::print("Using builtin-ports: ", m_builtin_ports, '\n');
+            }
+
+            Filesystem& m_fs;
+            const FeatureFlagSettings m_ff_settings;
+            const Path m_cache_root;
+            const Path m_manifest_dir;
+            const BundleSettings m_bundle;
+            const std::unique_ptr<ToolCache> m_tool_cache;
+            const DownloadManager m_download_manager;
+            const Path m_builtin_ports;
+            const Path m_default_vs_path;
+        };
+
+        static Optional<InstalledPaths> compute_installed(Filesystem& fs,
+                                                          const VcpkgCmdArguments& args,
+                                                          const Path& root,
+                                                          const Path& manifest_dir,
+                                                          const BundleSettings& bundle)
+        {
+            if (manifest_dir.empty())
+            {
+                if (!bundle.m_readonly)
+                {
+                    return InstalledPaths{
+                        process_output_directory(fs, args.install_root_dir.get(), root / "installed")};
+                }
+            }
+            else
+            {
+                return InstalledPaths{
+                    process_output_directory(fs, args.install_root_dir.get(), manifest_dir / "vcpkg_installed")};
+            }
+            return nullopt;
+        }
+
+        struct VcpkgPathsImpl : VcpkgPathsImplStage1
+        {
+            VcpkgPathsImpl(Filesystem& fs, const VcpkgCmdArguments& args, const Path& root, const Path& original_cwd)
+                : VcpkgPathsImplStage1(fs, args, root, original_cwd)
+                , m_config_dir(m_manifest_dir.empty() ? root : m_manifest_dir)
+                , m_manifest_path(m_manifest_dir.empty() ? Path{} : m_manifest_dir / "vcpkg.json")
+                , m_registries_work_tree_dir(m_cache_root / "git")
+                , m_registries_dot_git_dir(m_cache_root / "git" / ".git")
+                , m_registries_git_trees(m_cache_root / "git-trees")
+                , m_installed(compute_installed(fs, args, root, m_manifest_dir, m_bundle))
+                , buildtrees(maybe_get_tmp_path(fs,
+                                                m_bundle,
+                                                m_installed,
+                                                root,
+                                                args.buildtrees_root_dir.get(),
+                                                "buildtrees",
+                                                "blds",
+                                                VCPKG_LINE_INFO))
+                , packages(maybe_get_tmp_path(fs,
+                                              m_bundle,
+                                              m_installed,
+                                              root,
+                                              args.packages_root_dir.get(),
+                                              "packages",
+                                              "pkgs",
+                                              VCPKG_LINE_INFO))
+                , m_env_cache(m_ff_settings.compiler_tracking)
+                , triplets_dirs(Util::fmap(args.overlay_triplets, [&fs](const std::string& p) {
+                    return fs.almost_canonical(p, VCPKG_LINE_INFO);
+                }))
+            {
+                if (auto i = m_installed.get())
+                {
+                    Debug::print("Using installed-root: ", i->root(), '\n');
+                }
+                Debug::print("Using buildtrees-root: ", buildtrees.value_or("nullopt"), '\n');
+                Debug::print("Using packages-root: ", packages.value_or("nullopt"), '\n');
+
+                if (!m_manifest_dir.empty())
+                {
+                    Debug::print("Using manifest-root: ", m_manifest_dir, '\n');
+
+                    std::error_code ec;
+                    const auto vcpkg_root_file = root / ".vcpkg-root";
+                    if (args.wait_for_lock.value_or(false))
+                    {
+                        file_lock_handle = fs.take_exclusive_file_lock(vcpkg_root_file, ec);
+                    }
+                    else
+                    {
+                        file_lock_handle = fs.try_take_exclusive_file_lock(vcpkg_root_file, ec);
+                    }
+
+                    if (ec)
+                    {
+                        bool is_already_locked = ec == std::errc::device_or_resource_busy;
+                        bool allow_errors = args.ignore_lock_failures.value_or(false);
+                        if (is_already_locked || !allow_errors)
+                        {
+                            vcpkg::printf(Color::error, "Failed to take the filesystem lock on %s:\n", vcpkg_root_file);
+                            vcpkg::printf(Color::error, "    %s\n", ec.message());
+                            Checks::exit_fail(VCPKG_LINE_INFO);
+                        }
+                    }
+
+                    m_manifest_doc = load_manifest(fs, m_manifest_dir);
+                }
+            }
+
+            const Path m_config_dir;
+            const Path m_manifest_path;
+            const Path m_registries_work_tree_dir;
+            const Path m_registries_dot_git_dir;
+            const Path m_registries_git_trees;
+            const Optional<InstalledPaths> m_installed;
+            const Optional<Path> buildtrees;
+            const Optional<Path> packages;
             Build::EnvCache m_env_cache;
+            std::vector<Path> triplets_dirs;
 
             std::unique_ptr<IExclusiveFileLock> file_lock_handle;
 
             Optional<std::pair<Json::Object, Json::JsonStyle>> m_manifest_doc;
-            Path m_manifest_path;
-            Path m_config_dir;
             Configuration m_config;
             std::unique_ptr<RegistrySet> m_registry_set;
-
-            DownloadManager m_download_manager;
-
-            FeatureFlagSettings m_ff_settings;
-
-            Optional<InstalledPaths> installed;
-            Optional<Path> buildtrees;
-            Optional<Path> packages;
-
-            Path registries_work_tree_dir;
-            Path registries_dot_git_dir;
-            Path registries_git_trees;
-
-            bool m_readonly = false;
-            bool m_usegitregistry = false;
-            Optional<std::string> m_embedded_git_sha;
-
-            Optional<LockFile> m_installed_lock;
         };
     }
 
@@ -327,7 +526,7 @@ namespace vcpkg
 
     const InstalledPaths& VcpkgPaths::installed() const
     {
-        if (auto i = m_pimpl->installed.get())
+        if (auto i = m_pimpl->m_installed.get())
         {
             return *i;
         }
@@ -354,95 +553,46 @@ namespace vcpkg
         msg::println(Color::error, msgVcpkgDisallowedClassicMode);
         Checks::exit_fail(VCPKG_LINE_INFO);
     }
+    const Path& VcpkgPaths::builtin_ports_directory() const { return m_pimpl->m_builtin_ports; }
 
-    const Optional<InstalledPaths>& VcpkgPaths::maybe_installed() const { return m_pimpl->installed; }
+    const Optional<InstalledPaths>& VcpkgPaths::maybe_installed() const { return m_pimpl->m_installed; }
     const Optional<Path>& VcpkgPaths::maybe_buildtrees() const { return m_pimpl->buildtrees; }
     const Optional<Path>& VcpkgPaths::maybe_packages() const { return m_pimpl->packages; }
 
-    Optional<Path> VcpkgPaths::maybe_get_tmp_path(const std::string* arg_path,
-                                                  StringLiteral root_subpath,
-                                                  StringLiteral readonly_subpath,
-                                                  LineInfo li) const
+    DECLARE_AND_REGISTER_MESSAGE(
+        ErrorMissingVcpkgRoot,
+        (msg::url),
+        "",
+        "Error: Could not detect vcpkg-root. If you are trying to use a copy of vcpkg that you've built, you must "
+        "define the VCPKG_ROOT environment variable to point to a cloned copy of {url}.");
+
+    // Guaranteed to return non-empty
+    static Path determine_root(const Filesystem& fs, const Path& original_cwd, const VcpkgCmdArguments& args)
     {
-        if (arg_path)
+        Path ret;
+        if (args.vcpkg_root_dir)
         {
-            return get_filesystem().almost_canonical(*arg_path, li);
-        }
-        else if (m_pimpl->m_readonly)
-        {
-            if (auto i = m_pimpl->installed.get())
-            {
-                return get_filesystem().almost_canonical(i->vcpkg_dir() / readonly_subpath, li);
-            }
-            else
-            {
-                return nullopt;
-            }
+            ret = fs.almost_canonical(*args.vcpkg_root_dir, VCPKG_LINE_INFO);
         }
         else
         {
-            return get_filesystem().almost_canonical(root / root_subpath, li);
+            ret = fs.find_file_recursively_up(original_cwd, ".vcpkg-root", VCPKG_LINE_INFO);
+            if (ret.empty())
+            {
+                ret =
+                    fs.find_file_recursively_up(fs.almost_canonical(get_exe_path_of_current_process(), VCPKG_LINE_INFO),
+                                                ".vcpkg-root",
+                                                VCPKG_LINE_INFO);
+            }
         }
-    }
 
-    static Path determine_root(const Filesystem& fs, const Path& original_cwd, const VcpkgCmdArguments& args)
-    {
-        if (args.vcpkg_root_dir)
-        {
-            return fs.almost_canonical(*args.vcpkg_root_dir, VCPKG_LINE_INFO);
-        }
-
-        auto ret = fs.find_file_recursively_up(original_cwd, ".vcpkg-root", VCPKG_LINE_INFO);
         if (ret.empty())
         {
-            return fs.find_file_recursively_up(fs.almost_canonical(get_exe_path_of_current_process(), VCPKG_LINE_INFO),
-                                               ".vcpkg-root",
-                                               VCPKG_LINE_INFO);
+            msg::println(Color::error, msgErrorMissingVcpkgRoot, msg::url = "https://github.com/Microsoft/vcpkg");
+            Checks::exit_fail(VCPKG_LINE_INFO);
         }
 
         return ret;
-    }
-
-    static void load_bundle_file(const Filesystem& fs, const Path& root, details::VcpkgPathsImpl& impl)
-    {
-        const auto vcpkg_bundle_file = root / "vcpkg-bundle.json";
-        std::error_code ec;
-        auto bundle_file = fs.read_contents(vcpkg_bundle_file, ec);
-        if (!ec)
-        {
-            auto maybe_bundle_doc = Json::parse(bundle_file, bundle_file);
-            if (auto bundle_doc = maybe_bundle_doc.get())
-            {
-                const auto& first_object = bundle_doc->first.object();
-                if (auto v = first_object.get("readonly"))
-                {
-                    impl.m_readonly = v->boolean();
-                }
-
-                if (auto v = first_object.get("usegitregistry"))
-                {
-                    impl.m_usegitregistry = v->boolean();
-                }
-
-                if (auto v = first_object.get("embeddedsha"))
-                {
-                    impl.m_embedded_git_sha = v->string().to_string();
-                }
-            }
-            else
-            {
-                print2(Color::error, "Error: Invalid bundle definition.\n", maybe_bundle_doc.error()->format());
-                Checks::exit_fail(VCPKG_LINE_INFO);
-            }
-        }
-
-        Debug::print("Bundle config: readonly=",
-                     impl.m_readonly,
-                     ", usegitregistry=",
-                     impl.m_usegitregistry,
-                     ", embeddedsha=",
-                     impl.m_embedded_git_sha.value_or("nullopt"),
-                     "\n");
     }
 
     static Path preferred_current_path(const Filesystem& fs)
@@ -454,85 +604,59 @@ namespace vcpkg
 #endif
     }
 
-    VcpkgPaths::VcpkgPaths(Filesystem& filesystem, const VcpkgCmdArguments& args)
-        : original_cwd(preferred_current_path(filesystem))
-        , root(determine_root(filesystem, original_cwd, args))
-        , m_pimpl(std::make_unique<details::VcpkgPathsImpl>(
-              filesystem,
-              args.feature_flag_settings(),
-              Util::Enum::to_enum<RequireExactVersions>(args.exact_abi_tools_versions.value_or(false))))
+    static Path compute_downloads_root(const Filesystem& fs,
+                                       const VcpkgCmdArguments& args,
+                                       const Path& root,
+                                       const details::BundleSettings& bundle)
     {
-        Checks::check_exit(VCPKG_LINE_INFO, !root.empty(), "Error: Could not detect vcpkg-root.");
-        Debug::print("Using vcpkg-root: ", root, '\n');
-
-        builtin_ports = process_output_directory(filesystem, args.builtin_ports_root_dir.get(), root / "ports");
-        builtin_registry_versions =
-            process_output_directory(filesystem, args.builtin_registry_versions_dir.get(), root / "versions");
-
-        load_bundle_file(filesystem, root, *m_pimpl);
-
-        const auto vcpkg_root_file = root / ".vcpkg-root";
-        std::error_code ec;
-        if (args.manifests_enabled())
+        Path ret;
+        if (args.downloads_root_dir)
         {
-            if (args.manifest_root_dir)
-            {
-                manifest_root_dir = filesystem.almost_canonical(*args.manifest_root_dir, VCPKG_LINE_INFO);
-            }
-            else
-            {
-                manifest_root_dir = filesystem.find_file_recursively_up(original_cwd, "vcpkg.json", VCPKG_LINE_INFO);
-            }
+            ret = *args.downloads_root_dir;
         }
-
-        if (manifest_root_dir.empty())
+        else if (bundle.m_readonly)
         {
-            m_pimpl->m_config_dir = root;
-            if (!m_pimpl->m_readonly)
-            {
-                m_pimpl->installed.emplace(
-                    process_output_directory(filesystem, args.install_root_dir.get(), root / "installed"));
-            }
+            ret = get_platform_cache_home().value_or_exit(VCPKG_LINE_INFO) / "vcpkg" / "downloads";
         }
         else
         {
-            Debug::print("Using manifest-root: ", manifest_root_dir, '\n');
-
-            m_pimpl->m_config_dir = manifest_root_dir;
-            m_pimpl->installed.emplace(process_output_directory(
-                filesystem, args.install_root_dir.get(), manifest_root_dir / "vcpkg_installed"));
-
-            if (args.wait_for_lock.value_or(false))
-            {
-                m_pimpl->file_lock_handle = filesystem.take_exclusive_file_lock(vcpkg_root_file, ec);
-            }
-            else
-            {
-                m_pimpl->file_lock_handle = filesystem.try_take_exclusive_file_lock(vcpkg_root_file, ec);
-            }
-
-            if (ec)
-            {
-                bool is_already_locked = ec == std::errc::device_or_resource_busy;
-                bool allow_errors = args.ignore_lock_failures.value_or(false);
-                if (is_already_locked || !allow_errors)
-                {
-                    vcpkg::printf(Color::error, "Failed to take the filesystem lock on %s:\n", vcpkg_root_file);
-                    vcpkg::printf(Color::error, "    %s\n", ec.message());
-                    Checks::exit_fail(VCPKG_LINE_INFO);
-                }
-            }
-
-            m_pimpl->m_manifest_doc = load_manifest(filesystem, manifest_root_dir);
-            m_pimpl->m_manifest_path = manifest_root_dir / "vcpkg.json";
+            ret = root / "downloads";
         }
+        return fs.almost_canonical(ret, VCPKG_LINE_INFO);
+    }
+
+    VcpkgPaths::VcpkgPaths(Filesystem& filesystem, const VcpkgCmdArguments& args)
+        : original_cwd(preferred_current_path(filesystem))
+        , root(determine_root(filesystem, original_cwd, args))
+        // this is used during the initialization of the below public members
+        , m_pimpl(std::make_unique<details::VcpkgPathsImpl>(filesystem, args, root, original_cwd))
+        , builtin_registry_versions(
+              process_output_directory(filesystem, args.builtin_registry_versions_dir.get(), root / "versions"))
+        , scripts(process_input_directory(filesystem, root, args.scripts_root_dir.get(), "scripts", VCPKG_LINE_INFO))
+        , prefab(root / "prefab")
+        , buildsystems(scripts / "buildsystems")
+        , buildsystems_msbuild_targets(buildsystems / "msbuild" / "vcpkg.targets")
+        , buildsystems_msbuild_props(buildsystems / "msbuild" / "vcpkg.props")
+        , downloads(compute_downloads_root(filesystem, args, root, m_pimpl->m_bundle))
+        , tools(downloads / "tools")
+        , ports_cmake(filesystem.almost_canonical(scripts / "ports.cmake", VCPKG_LINE_INFO))
+        , triplets(filesystem.almost_canonical(root / "triplets", VCPKG_LINE_INFO))
+        , community_triplets(filesystem.almost_canonical(triplets / "community", VCPKG_LINE_INFO))
+    {
+        Debug::print("Using vcpkg-root: ", root, '\n');
+        Debug::print("Using scripts-root: ", scripts, '\n');
+        Debug::print("Using builtin-registry: ", builtin_registry_versions, '\n');
+        Debug::print("Using downloads-root: ", downloads, '\n');
+
+        m_pimpl->triplets_dirs.emplace_back(triplets);
+        m_pimpl->triplets_dirs.emplace_back(community_triplets);
 
         {
             auto maybe_manifest_config = config_from_manifest(m_pimpl->m_manifest_path, m_pimpl->m_manifest_doc);
             auto maybe_config_json = config_from_json(m_pimpl->m_config_dir / "vcpkg-configuration.json", filesystem);
 
             m_pimpl->m_config = merge_validate_configs(std::move(maybe_manifest_config),
-                                                       manifest_root_dir,
+                                                       m_pimpl->m_manifest_dir,
                                                        std::move(maybe_config_json),
                                                        m_pimpl->m_config_dir,
                                                        *this);
@@ -565,62 +689,6 @@ namespace vcpkg
                 metrics->track_property("registries-kinds-used", Strings::join(",", registry_kinds));
             }
         }
-
-        m_pimpl->buildtrees = maybe_get_tmp_path(args.buildtrees_root_dir.get(), "buildtrees", "blds", VCPKG_LINE_INFO);
-        m_pimpl->packages = maybe_get_tmp_path(args.packages_root_dir.get(), "packages", "pkgs", VCPKG_LINE_INFO);
-
-        if (args.downloads_root_dir)
-        {
-            downloads = *args.downloads_root_dir;
-        }
-        else if (m_pimpl->m_readonly)
-        {
-            downloads = get_platform_cache_home().value_or_exit(VCPKG_LINE_INFO) / "vcpkg" / "downloads";
-        }
-        else
-        {
-            downloads = root / "downloads";
-        }
-        downloads = filesystem.almost_canonical(downloads, VCPKG_LINE_INFO);
-
-        m_pimpl->m_download_manager =
-            DownloadManager{parse_download_configuration(args.asset_sources_template()).value_or_exit(VCPKG_LINE_INFO)};
-        scripts = process_input_directory(filesystem, root, args.scripts_root_dir.get(), "scripts", VCPKG_LINE_INFO);
-        prefab = root / "prefab";
-
-        Debug::print("Using downloads-root: ", downloads, '\n');
-        Debug::print("Using scripts-root: ", scripts, '\n');
-        Debug::print("Using builtin-ports: ", builtin_ports, '\n');
-        Debug::print("Using builtin-registry: ", builtin_registry_versions, '\n');
-        if (auto i = m_pimpl->installed.get())
-        {
-            Debug::print("Using installed-root: ", i->root(), '\n');
-        }
-        Debug::print("Using packages-root: ", m_pimpl->packages.value_or("nullopt"), '\n');
-        Debug::print("Using buildtrees-root: ", m_pimpl->buildtrees.value_or("nullopt"), '\n');
-
-        if (args.default_visual_studio_path)
-        {
-            m_pimpl->default_vs_path = filesystem.almost_canonical(*args.default_visual_studio_path, VCPKG_LINE_INFO);
-        }
-
-        triplets = filesystem.almost_canonical(root / "triplets", VCPKG_LINE_INFO);
-        community_triplets = filesystem.almost_canonical(triplets / "community", VCPKG_LINE_INFO);
-
-        tools = downloads / "tools";
-        buildsystems = scripts / "buildsystems";
-        const auto msbuildDirectory = buildsystems / "msbuild";
-        buildsystems_msbuild_targets = msbuildDirectory / "vcpkg.targets";
-        buildsystems_msbuild_props = msbuildDirectory / "vcpkg.props";
-
-        ports_cmake = filesystem.almost_canonical(scripts / "ports.cmake", VCPKG_LINE_INFO);
-
-        for (auto&& overlay_triplets_dir : args.overlay_triplets)
-        {
-            m_pimpl->triplets_dirs.emplace_back(filesystem.almost_canonical(overlay_triplets_dir, VCPKG_LINE_INFO));
-        }
-        m_pimpl->triplets_dirs.emplace_back(triplets);
-        m_pimpl->triplets_dirs.emplace_back(community_triplets);
     }
 
     Path VcpkgPaths::package_dir(const PackageSpec& spec) const { return this->packages() / spec.dir(); }
@@ -847,7 +915,7 @@ namespace vcpkg
 
     ExpectedS<std::string> VcpkgPaths::get_current_git_sha() const
     {
-        if (auto sha = m_pimpl->m_embedded_git_sha.get())
+        if (auto sha = m_pimpl->m_bundle.m_embedded_git_sha.get())
         {
             return {*sha, expected_left_tag};
         }
@@ -867,7 +935,7 @@ namespace vcpkg
     {
         std::string ret;
         Strings::append(ret, "    vcpkg-tool version: ", Commands::Version::version(), "\n");
-        if (m_pimpl->m_readonly)
+        if (m_pimpl->m_bundle.m_readonly)
         {
             Strings::append(ret, "    vcpkg-readonly: true\n");
             const auto sha = get_current_git_sha();
@@ -1044,9 +1112,9 @@ namespace vcpkg
     {
         auto& fs = get_filesystem();
 
-        auto work_tree = m_pimpl->registries_work_tree_dir;
+        const auto& work_tree = m_pimpl->m_registries_work_tree_dir;
         fs.create_directories(work_tree, VCPKG_LINE_INFO);
-        auto dot_git_dir = m_pimpl->registries_dot_git_dir;
+        const auto& dot_git_dir = m_pimpl->m_registries_dot_git_dir;
 
         Command init_registries_git_dir = git_cmd_builder(dot_git_dir, work_tree).string_arg("init");
         auto init_output = cmd_execute_and_capture_output(init_registries_git_dir);
@@ -1090,14 +1158,14 @@ namespace vcpkg
     {
         auto& fs = get_filesystem();
 
-        auto work_tree = m_pimpl->registries_work_tree_dir;
+        const auto& work_tree = m_pimpl->m_registries_work_tree_dir;
         fs.create_directories(work_tree, VCPKG_LINE_INFO);
 
         auto lock_file = work_tree / ".vcpkg-lock";
 
         auto guard = fs.take_exclusive_file_lock(lock_file, IgnoreErrors{});
 
-        auto dot_git_dir = m_pimpl->registries_dot_git_dir;
+        const auto& dot_git_dir = m_pimpl->m_registries_dot_git_dir;
 
         Command init_registries_git_dir = git_cmd_builder(dot_git_dir, work_tree).string_arg("init");
         auto init_output = cmd_execute_and_capture_output(init_registries_git_dir);
@@ -1127,7 +1195,7 @@ namespace vcpkg
     ExpectedS<std::string> VcpkgPaths::git_show_from_remote_registry(StringView hash, const Path& relative_path) const
     {
         auto revision = Strings::format("%s:%s", hash, relative_path.generic_u8string());
-        Command git_show = git_cmd_builder(m_pimpl->registries_dot_git_dir, m_pimpl->registries_work_tree_dir)
+        Command git_show = git_cmd_builder(m_pimpl->m_registries_dot_git_dir, m_pimpl->m_registries_work_tree_dir)
                                .string_arg("show")
                                .string_arg(revision);
 
@@ -1142,7 +1210,7 @@ namespace vcpkg
                                                                                    const Path& relative_path) const
     {
         auto revision = Strings::format("%s:%s", hash, relative_path.generic_u8string());
-        Command git_rev_parse = git_cmd_builder(m_pimpl->registries_dot_git_dir, m_pimpl->registries_work_tree_dir)
+        Command git_rev_parse = git_cmd_builder(m_pimpl->m_registries_dot_git_dir, m_pimpl->m_registries_work_tree_dir)
                                     .string_arg("rev-parse")
                                     .string_arg(revision);
 
@@ -1156,9 +1224,9 @@ namespace vcpkg
     ExpectedS<Path> VcpkgPaths::git_checkout_object_from_remote_registry(StringView object) const
     {
         auto& fs = get_filesystem();
-        fs.create_directories(m_pimpl->registries_git_trees, VCPKG_LINE_INFO);
+        fs.create_directories(m_pimpl->m_registries_git_trees, VCPKG_LINE_INFO);
 
-        auto git_tree_final = m_pimpl->registries_git_trees / object;
+        auto git_tree_final = m_pimpl->m_registries_git_trees / object;
         if (fs.exists(git_tree_final, IgnoreErrors{}))
         {
             return git_tree_final;
@@ -1171,8 +1239,8 @@ namespace vcpkg
         fs.remove_all(git_tree_temp, VCPKG_LINE_INFO);
         fs.create_directory(git_tree_temp, VCPKG_LINE_INFO);
 
-        auto dot_git_dir = m_pimpl->registries_dot_git_dir;
-        Command git_archive = git_cmd_builder(dot_git_dir, m_pimpl->registries_work_tree_dir)
+        const auto& dot_git_dir = m_pimpl->m_registries_dot_git_dir;
+        Command git_archive = git_cmd_builder(dot_git_dir, m_pimpl->m_registries_work_tree_dir)
                                   .string_arg("archive")
                                   .string_arg("--format")
                                   .string_arg("tar")
@@ -1365,9 +1433,9 @@ namespace vcpkg
         return m_pimpl->m_env_cache.get_compiler_info(*this, abi_info);
     }
 
-    Filesystem& VcpkgPaths::get_filesystem() const { return *m_pimpl->fs_ptr; }
+    Filesystem& VcpkgPaths::get_filesystem() const { return m_pimpl->m_fs; }
 
-    bool VcpkgPaths::use_git_default_registry() const { return m_pimpl->m_usegitregistry; }
+    bool VcpkgPaths::use_git_default_registry() const { return m_pimpl->m_bundle.m_usegitregistry; }
 
     const FeatureFlagSettings& VcpkgPaths::get_feature_flags() const { return m_pimpl->m_ff_settings; }
 


### PR DESCRIPTION
Currently there are regressions around vcpkg paths initialization order. Failures during manifest manipulation want to use git to give the user better error messages, but that requires accessing the ToolCache, which fundementally depends on VcpkgPaths.

The fundamental error here is that `.scripts` was being initialized later. I've taken a "correct-by-construction" approach to preventing this entire class of errors by:
1. Making as many of the members `const` as possible. This ensures they can't be "late initialized" in the wrong order.
2. As a consequence of (1), performing as much initialization in the initializer list as reasonable. GCC warns if the initializer list ordering does not match the member order, so it is easy to optically inspect and ensure there aren't incorrect data dependencies upon uninitialized members.
3. Breaking up VcpkgPathsImpl into stages for different categories of data, reducing the scope available for each constructor. These stages are explained in the code comments.

For example, if the user has an empty `"builtin-baseline":`, they currently are greeted with:
```
$ vcpkg install
read_contents(vcpkgTools.xml): No such file or directory
```
After this PR, the desired functionality is restored:
```
$ vcpkg install
Error: the top-level builtin-baseline () was not a valid commit sha: expected 40 lowercase hexadecimal characters.
You can use the current commit as a baseline, which is:
    "builtin-baseline": "9f04533f307a8560cc1cc5c1fdee0d88d6d7d818"

Note: Updating vcpkg by rerunning bootstrap-vcpkg may resolve this failure.
```