### PR TITLE
Fix crash when detecting binary cache

### DIFF
--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -1457,8 +1457,9 @@ namespace vcpkg
         std::vector<CacheAvailability> results{actions.size()};
         for (size_t idx = 0; idx < results.size(); ++idx)
         {
-            results[idx] = cache_status[idx]->get_available_provider() ? CacheAvailability::available
-                                                                       : CacheAvailability::unavailable;
+            if (cache_status[idx])
+                results[idx] = cache_status[idx]->get_available_provider() ? CacheAvailability::available
+                                                                           : CacheAvailability::unavailable;
         }
 
         return results;


### PR DESCRIPTION
https://github.com/microsoft/vcpkg-tool/blob/abe9562a24a2e8fff13af310ef7d6164202350fa/src/vcpkg/binarycaching.cpp#L1451-L1455
https://github.com/microsoft/vcpkg-tool/blob/abe9562a24a2e8fff13af310ef7d6164202350fa/src/vcpkg/binarycaching.cpp#L1416-L1429

`m_status` maybe empty so `cache_status[idx]` maybe a nullptr.