### PR TITLE
[x-generate-default-message-map] allow writing to a file directly

### DIFF
--- a/azure-pipelines/pipelines.yml
+++ b/azure-pipelines/pipelines.yml
@@ -118,7 +118,7 @@ jobs:
       displayName: 'Generate the Messages File'
       inputs:
         script: |
-          build.x86.debug\vcpkg.exe x-generate-default-message-map >locales/en.json
+          build.x86.debug\vcpkg.exe x-generate-default-message-map locales/en.json
     - task: Powershell@2
       displayName: 'Create Diff'
       inputs:

--- a/src/vcpkg/commands.generate-message-map.cpp
+++ b/src/vcpkg/commands.generate-message-map.cpp
@@ -6,8 +6,19 @@
 namespace vcpkg::Commands
 {
     using namespace msg;
-    void GenerateDefaultMessageMapCommand::perform_and_exit(const VcpkgCmdArguments&, Filesystem&) const
+
+    const CommandStructure COMMAND_STRUCTURE = {
+        create_example_string(R"###(x-generate-default-message-map locales/messages.json)###"),
+        0,
+        1,
+        {{}, {}, {}},
+        nullptr,
+    };
+
+    void GenerateDefaultMessageMapCommand::perform_and_exit(const VcpkgCmdArguments& args, Filesystem& fs) const
     {
+        auto parsed_args = args.parse_arguments(COMMAND_STRUCTURE);
+
         // in order to implement sorting, we create a vector of messages before converting into a JSON object
         struct Message
         {
@@ -39,7 +50,17 @@ namespace vcpkg::Commands
                 obj.insert(fmt::format("_{}.comment", msg.name), Json::Value::string(std::move(msg.comment)));
             }
         }
-        msg::write_unlocalized_text_to_stdout(Color::none, Json::stringify(obj, {}));
+
+        auto stringified = Json::stringify(obj, {});
+        if (args.command_arguments.size() == 0)
+        {
+            msg::write_unlocalized_text_to_stdout(Color::none, stringified);
+        }
+        else
+        {
+            Path filepath = fs.current_path(VCPKG_LINE_INFO) / args.command_arguments[0];
+            fs.write_contents(filepath, stringified, VCPKG_LINE_INFO);
+        }
         Checks::exit_success(VCPKG_LINE_INFO);
     }
 }


### PR DESCRIPTION
this prevents PowerShell from adding CRLFs when doing a `>`

cc @BillyONeal 