### PR TITLE
Fix CI crash by ensuring the "core" feature is installed for all ports.

### DIFF
--- a/include/vcpkg/packagespec.h
+++ b/include/vcpkg/packagespec.h
@@ -27,8 +27,6 @@ namespace vcpkg
         PackageSpec() = default;
         PackageSpec(std::string name, Triplet triplet) : m_name(std::move(name)), m_triplet(triplet) { }
 
-        static std::vector<PackageSpec> to_package_specs(const std::vector<std::string>& ports, Triplet triplet);
-
         const std::string& name() const;
 
         Triplet triplet() const;

--- a/src/vcpkg/packagespec.cpp
+++ b/src/vcpkg/packagespec.cpp
@@ -28,13 +28,6 @@ namespace vcpkg
         }
     }
 
-    std::vector<PackageSpec> PackageSpec::to_package_specs(const std::vector<std::string>& ports, Triplet triplet)
-    {
-        return Util::fmap(ports, [&](const std::string& spec_as_string) -> PackageSpec {
-            return {spec_as_string, triplet};
-        });
-    }
-
     const std::string& PackageSpec::name() const { return this->m_name; }
 
     Triplet PackageSpec::triplet() const { return this->m_triplet; }


### PR DESCRIPTION
This is an attempt to fix the crash/regression in the "ci" command caused by https://github.com/microsoft/vcpkg-tool/pull/298

I'm pretty sure this is not a correct fix but it at least makes the ci command seem to match the last known good commit.
