### PR TITLE
Fix build failure for clang

### DIFF
--- a/include/vcpkg/base/expected.h
+++ b/include/vcpkg/base/expected.h
@@ -7,6 +7,7 @@
 #include <vcpkg/base/lineinfo.h>
 #include <vcpkg/base/stringliteral.h>
 
+#include <functional>
 #include <system_error>
 #include <type_traits>
 


### PR DESCRIPTION
This fixes a build failure with clang.

```
[ 78%] Building CXX object CMakeFiles/vcpkg-test.dir/src/vcpkg-test/mockcmakevarsprovider.cpp.o
In file included from /home/pi/repos/vcpkg-tool/src/vcpkg-test/mockcmakevarsprovider.cpp:1:
In file included from /home/pi/repos/vcpkg-tool/include/vcpkg-test/mockcmakevarprovider.h:3:
In file included from /home/pi/repos/vcpkg-tool/include/vcpkg/cmakevars.h:10:
In file included from /home/pi/repos/vcpkg-tool/include/vcpkg/packagespec.h:3:
/home/pi/repos/vcpkg-tool/include/vcpkg/base/expected.h:208:29: error: no member named 'invoke' in namespace 'std'; did you mean '__invoke'?
                return std::invoke(f, *m_t.get(), static_cast<Args&&>(args)...);
                       ~~~~~^~~~~~
                            __invoke
/usr/bin/../lib/gcc/arm-linux-gnueabihf/8/../../../../include/c++/8/bits/invoke.h:89:5: note: '__invoke' declared here
    __invoke(_Callable&& __fn, _Args&&... __args)
    ^
In file included from /home/pi/repos/vcpkg-tool/src/vcpkg-test/mockcmakevarsprovider.cpp:1:
In file included from /home/pi/repos/vcpkg-tool/include/vcpkg-test/mockcmakevarprovider.h:3:
In file included from /home/pi/repos/vcpkg-tool/include/vcpkg/cmakevars.h:10:
In file included from /home/pi/repos/vcpkg-tool/include/vcpkg/packagespec.h:3:
/home/pi/repos/vcpkg-tool/include/vcpkg/base/expected.h:221:29: error: no member named 'invoke' in namespace 'std'; did you mean '__invoke'?
                return std::invoke(f, std::move(*m_t.get()), static_cast<Args&&>(args)...);
                       ~~~~~^~~~~~
                            __invoke
/usr/bin/../lib/gcc/arm-linux-gnueabihf/8/../../../../include/c++/8/bits/invoke.h:89:5: note: '__invoke' declared here
    __invoke(_Callable&& __fn, _Args&&... __args)
    ^
```

`std::invoke` needs header `<functional>` to be included.