### PR TITLE
Fix CI crash due to missing package ABIs

### DIFF
--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -1449,6 +1449,18 @@ namespace vcpkg
                                                          View<Dependencies::InstallPlanAction> actions)
     {
         auto cache_status = build_cache_status_vector(actions, m_status);
+
+        for (size_t i = 0; i < actions.size(); ++i)
+        {
+            if (cache_status[i] == nullptr)
+            {
+                Checks::exit_with_message(
+                    VCPKG_LINE_INFO,
+                    "Error: package %s did not have an abi during ci. This is an internal error.\n",
+                    actions[i].spec);
+            }
+        }
+
         for (auto&& provider : m_providers)
         {
             provider->precheck(paths, actions, cache_status);

--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -1113,7 +1113,10 @@ namespace vcpkg::Build
         abi_tag_entries.emplace_back("ports.cmake", paths.get_ports_cmake_hash().to_string());
         abi_tag_entries.emplace_back("post_build_checks", "2");
         std::vector<std::string> sorted_feature_list = action.feature_list;
-        Util::sort(sorted_feature_list);
+        // Renormalize feature list: remove "default" (since it's a virtual feature) and add "core" to ensure non-empty
+        Util::erase_remove_if(sorted_feature_list, [](const std::string& s) { return s == "default"; });
+        sorted_feature_list.push_back("core");
+        Util::sort_unique_erase(sorted_feature_list);
         abi_tag_entries.emplace_back("features", Strings::join(";", sorted_feature_list));
 
         Util::sort(abi_tag_entries);


### PR DESCRIPTION
PR #298 introduced a regression during ABI calculation for packages
that do not have features. It removed the implicit entry "core"
from `InstallPlanAction::feature_list`, which meant that packages
without features would end up with an empty ABI tag for their
features list.

We consider an empty ABI tag to indicate that
a value could not be calculated and therefore that the package
cannot be cached (no ABI). This then resulted in a crash during CI
which assumes that all packages have ABIs.