### PR TITLE
Improve printed filesystem error message

### DIFF
--- a/include/vcpkg/base/basic_checks.h
+++ b/include/vcpkg/base/basic_checks.h
@@ -25,6 +25,9 @@ namespace vcpkg::Checks
     // Display an error message to the user and exit the tool.
     [[noreturn]] void exit_with_message(const LineInfo& line_info, StringView error_message);
 
+    // Display an error message and the line to the user and exit the tool.
+    [[noreturn]] void exit_with_message_and_line(const LineInfo& line_info, StringView error_message);
+
     // If expression is false, call exit_fail.
     void check_exit(const LineInfo& line_info, bool expression);
 

--- a/src/vcpkg/base/checks.cpp
+++ b/src/vcpkg/base/checks.cpp
@@ -66,6 +66,13 @@ namespace vcpkg
         exit_fail(line_info);
     }
 
+    [[noreturn]] void Checks::exit_with_message_and_line(const LineInfo& line_info, StringView error_message)
+    {
+        print2(Color::error,
+               Strings::format("%s(%d): %s\n", line_info.file_name, line_info.line_number, error_message));
+        exit_fail(line_info);
+    }
+
     void Checks::check_exit(const LineInfo& line_info, bool expression)
     {
         if (!expression)

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -72,8 +72,7 @@ namespace
                                                  std::initializer_list<StringView> args)
     {
         auto arguments = args.size() == 0 ? "()" : "(\"" + Strings::join("\", \"", args.begin(), args.end()) + "\")";
-        Checks::exit_with_message(
-            li, Strings::concat(li.file_name, "(", li.line_number, "): ", call_name, arguments, ": ", ec.message()));
+        Checks::exit_with_message_and_line(li, Strings::concat(call_name, arguments, ": ", ec.message()));
     }
 
 #if defined(_WIN32)

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -71,8 +71,9 @@ namespace
                                                  StringView call_name,
                                                  std::initializer_list<StringView> args)
     {
+        auto arguments = args.size() == 0 ? "()" : "(\"" + Strings::join("\", \"", args.begin(), args.end()) + "\")";
         Checks::exit_with_message(
-            li, Strings::concat(call_name, "(", Strings::join(", ", args.begin(), args.end()), "): ", ec.message()));
+            li, Strings::concat(li.file_name, "(", li.line_number, "): ", call_name, arguments, ": ", ec.message()));
     }
 
 #if defined(_WIN32)


### PR DESCRIPTION
For example before vcpkg failed with:
```
read_contents(): No such file or directory
```
Now vcpkg prints:
```
/Users/leanderSchulten/git_projekte/vcpkg-tool/src/vcpkg/build.cpp(1349): read_contents(""): No such file or directory
```