### PR TITLE
Files::get_regular_files_recursive_proximate

### DIFF
--- a/include/vcpkg/base/files.h
+++ b/include/vcpkg/base/files.h
@@ -237,8 +237,9 @@ namespace vcpkg
         virtual std::vector<Path> get_regular_files_recursive(const Path& dir, std::error_code& ec) const = 0;
         std::vector<Path> get_regular_files_recursive(const Path& dir, LineInfo li) const;
 
-        virtual std::vector<Path> get_regular_files_recursive_proximate(const Path& dir, std::error_code& ec) const = 0;
-        std::vector<Path> get_regular_files_recursive_proximate(const Path& dir, LineInfo li) const;
+        virtual std::vector<Path> get_regular_files_recursive_lexically_proximate(const Path& dir,
+                                                                                  std::error_code& ec) const = 0;
+        std::vector<Path> get_regular_files_recursive_lexically_proximate(const Path& dir, LineInfo li) const;
 
         virtual std::vector<Path> get_regular_files_non_recursive(const Path& dir, std::error_code& ec) const = 0;
         std::vector<Path> get_regular_files_non_recursive(const Path& dir, LineInfo li) const;

--- a/include/vcpkg/base/files.h
+++ b/include/vcpkg/base/files.h
@@ -237,6 +237,9 @@ namespace vcpkg
         virtual std::vector<Path> get_regular_files_recursive(const Path& dir, std::error_code& ec) const = 0;
         std::vector<Path> get_regular_files_recursive(const Path& dir, LineInfo li) const;
 
+        virtual std::vector<Path> get_regular_files_recursive_proximate(const Path& dir, std::error_code& ec) const = 0;
+        std::vector<Path> get_regular_files_recursive_proximate(const Path& dir, LineInfo li) const;
+
         virtual std::vector<Path> get_regular_files_non_recursive(const Path& dir, std::error_code& ec) const = 0;
         std::vector<Path> get_regular_files_non_recursive(const Path& dir, LineInfo li) const;
 

--- a/src/vcpkg-test/files.cpp
+++ b/src/vcpkg-test/files.cpp
@@ -749,7 +749,7 @@ TEST_CASE ("get_regular_files_recursive_proximate_symlinks", "[files]")
 {
     do_filesystem_enumeration_test(
         [](Filesystem& fs, const Path& root) {
-            return fs.get_regular_files_recursive_proximate(root, VCPKG_LINE_INFO);
+            return fs.get_regular_files_recursive_lexically_proximate(root, VCPKG_LINE_INFO);
         },
         [](const Path&) {
             Path somedir{"some-directory"};

--- a/src/vcpkg-test/files.cpp
+++ b/src/vcpkg-test/files.cpp
@@ -167,6 +167,7 @@ namespace
     template<class Enumerator, class ExpectedGenerator>
     void do_filesystem_enumeration_test(Enumerator&& enumerator, ExpectedGenerator&& generate_expected)
     {
+        // Note: not seeded with random data, so this will always produce the same sequence of names
         urbg_t urbg;
 
         auto& fs = setup();
@@ -186,6 +187,8 @@ namespace
         const auto target_inside_directory = target_directory / "some-inner-directory";
         const auto target_inside_directory_symlink = target_directory / "symlink-to-some-inner-directory";
 
+        fs.remove_all(temp_dir, VCPKG_LINE_INFO);
+
         fs.create_directory(temp_dir, VCPKG_LINE_INFO);
         fs.create_directory(target_root, VCPKG_LINE_INFO);
         fs.create_directory(target_directory, VCPKG_LINE_INFO);
@@ -198,6 +201,7 @@ namespace
         fs.create_symlink(target_file, target_symlink, ec);
         if (ec)
         {
+            INFO(ec.message());
             REQUIRE(is_valid_symlink_failure(ec));
         }
         else
@@ -737,6 +741,23 @@ TEST_CASE ("get_files_recursive_symlinks", "[files]")
                 root / "some-directory" / "symlink-to-some-inner-directory",
                 root / "symlink-to-file.txt",
                 root / "symlink-to-some-directory",
+            };
+        });
+}
+
+TEST_CASE ("get_regular_files_recursive_proximate_symlinks", "[files]")
+{
+    do_filesystem_enumeration_test(
+        [](Filesystem& fs, const Path& root) {
+            return fs.get_regular_files_recursive_proximate(root, VCPKG_LINE_INFO);
+        },
+        [](const Path&) {
+            Path somedir{"some-directory"};
+            return std::vector<Path>{
+                "file.txt",
+                somedir / "file2.txt",
+                somedir / "symlink-to-file2.txt",
+                "symlink-to-file.txt",
             };
         });
 }

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -825,8 +825,8 @@ namespace
             if (!S_ISDIR(s.st_mode))
             {
                 // if it isn't still a directory something is racy
-                ec = std::make_error_code(std::errc::device_or_resource_busy);
                 mark_recursive_error(base, ec, failure_point);
+                ec = std::make_error_code(std::errc::device_or_resource_busy);
                 return;
             }
 
@@ -1410,6 +1410,18 @@ namespace vcpkg
     {
         std::error_code ec;
         auto maybe_directories = this->get_regular_files_recursive(dir, ec);
+        if (ec)
+        {
+            exit_filesystem_call_error(li, ec, __func__, {dir});
+        }
+
+        return maybe_directories;
+    }
+
+    std::vector<Path> Filesystem::get_regular_files_recursive_proximate(const Path& dir, LineInfo li) const
+    {
+        std::error_code ec;
+        auto maybe_directories = this->get_regular_files_recursive_proximate(dir, ec);
         if (ec)
         {
             exit_filesystem_call_error(li, ec, __func__, {dir});
@@ -2064,6 +2076,21 @@ namespace vcpkg
         {
             return get_regular_files_impl<stdfs::directory_iterator>(dir, ec);
         }
+
+        virtual std::vector<Path> get_regular_files_recursive_proximate(const Path& dir,
+                                                                        std::error_code& ec) const override
+        {
+            auto ret = this->get_regular_files_recursive(dir, ec);
+            if (!ec)
+            {
+                const auto base = to_stdfs_path(dir);
+                for (auto& p : ret)
+                {
+                    p = from_stdfs_path(to_stdfs_path(p).lexically_proximate(base));
+                }
+            }
+            return ret;
+        }
 #else  // ^^^ _WIN32 // !_WIN32 vvv
         static void insert_if_stat_matches(std::vector<Path>& result,
                                            const Path& full,
@@ -2097,8 +2124,18 @@ namespace vcpkg
             result.push_back(full);
         }
 
+        struct PushPopPath
+        {
+            PushPopPath(Path& parent, StringView appendee) : p(parent) { p /= appendee; }
+            ~PushPopPath() { p.make_parent_path(); }
+
+        private:
+            Path& p;
+        };
+
         static void get_files_recursive_impl(std::vector<Path>& result,
                                              const Path& base,
+                                             Path& out_base,
                                              std::error_code& ec,
                                              bool want_directories,
                                              bool want_regular_files,
@@ -2133,6 +2170,7 @@ namespace vcpkg
                     }
 
                     const auto full = base / entry->d_name;
+                    PushPopPath pushpop_outbase(out_base, entry->d_name);
                     const auto entry_dtype = get_d_type(entry);
                     struct stat s;
                     struct stat ls;
@@ -2142,11 +2180,11 @@ namespace vcpkg
                             if (want_directories)
                             {
                                 // push results before recursion to get outer entries first
-                                result.push_back(full);
+                                result.push_back(out_base);
                             }
 
                             get_files_recursive_impl(
-                                result, full, ec, want_directories, want_regular_files, want_other);
+                                result, full, out_base, ec, want_directories, want_regular_files, want_other);
                             if (ec)
                             {
                                 return;
@@ -2156,7 +2194,7 @@ namespace vcpkg
                         case PosixDType::Regular:
                             if (want_regular_files)
                             {
-                                result.push_back(full);
+                                result.push_back(out_base);
                             }
 
                             break;
@@ -2167,7 +2205,7 @@ namespace vcpkg
                         case PosixDType::BlockDevice:
                             if (want_other)
                             {
-                                result.push_back(full);
+                                result.push_back(out_base);
                             }
 
                             break;
@@ -2194,7 +2232,7 @@ namespace vcpkg
                                 if (want_directories && want_regular_files && want_other)
                                 {
                                     // skip extra stat syscall since we want everything
-                                    result.push_back(full);
+                                    result.push_back(out_base);
                                 }
                                 else
                                 {
@@ -2214,21 +2252,21 @@ namespace vcpkg
                                     }
 
                                     insert_if_stat_matches(
-                                        result, full, &s, want_directories, want_regular_files, want_other);
+                                        result, out_base, &s, want_directories, want_regular_files, want_other);
                                 }
                             }
                             else
                             {
                                 // push results before recursion to get outer entries first
                                 insert_if_stat_matches(
-                                    result, full, &ls, want_directories, want_regular_files, want_other);
+                                    result, out_base, &ls, want_directories, want_regular_files, want_other);
                             }
 
                             // recursion check doesn't follow symlinks:
                             if (S_ISDIR(ls.st_mode))
                             {
                                 get_files_recursive_impl(
-                                    result, full, ec, want_directories, want_regular_files, want_other);
+                                    result, full, out_base, ec, want_directories, want_regular_files, want_other);
                             }
                             break;
                     }
@@ -2284,7 +2322,8 @@ namespace vcpkg
         virtual std::vector<Path> get_files_recursive(const Path& dir, std::error_code& ec) const override
         {
             std::vector<Path> result;
-            get_files_recursive_impl(result, dir, ec, true, true, true);
+            Path out_base = dir;
+            get_files_recursive_impl(result, dir, out_base, ec, true, true, true);
             return result;
         }
 
@@ -2298,7 +2337,8 @@ namespace vcpkg
         virtual std::vector<Path> get_directories_recursive(const Path& dir, std::error_code& ec) const override
         {
             std::vector<Path> result;
-            get_files_recursive_impl(result, dir, ec, true, false, false);
+            Path out_base = dir;
+            get_files_recursive_impl(result, dir, out_base, ec, true, false, false);
 
             return result;
         }
@@ -2327,7 +2367,17 @@ namespace vcpkg
         virtual std::vector<Path> get_regular_files_recursive(const Path& dir, std::error_code& ec) const override
         {
             std::vector<Path> result;
-            get_files_recursive_impl(result, dir, ec, false, true, false);
+            Path out_base = dir;
+            get_files_recursive_impl(result, dir, out_base, ec, false, true, false);
+            return result;
+        }
+
+        virtual std::vector<Path> get_regular_files_recursive_proximate(const Path& dir,
+                                                                        std::error_code& ec) const override
+        {
+            std::vector<Path> result;
+            Path out_base;
+            get_files_recursive_impl(result, dir, out_base, ec, false, true, false);
             return result;
         }
 

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -1418,10 +1418,10 @@ namespace vcpkg
         return maybe_directories;
     }
 
-    std::vector<Path> Filesystem::get_regular_files_recursive_proximate(const Path& dir, LineInfo li) const
+    std::vector<Path> Filesystem::get_regular_files_recursive_lexically_proximate(const Path& dir, LineInfo li) const
     {
         std::error_code ec;
-        auto maybe_directories = this->get_regular_files_recursive_proximate(dir, ec);
+        auto maybe_directories = this->get_regular_files_recursive_lexically_proximate(dir, ec);
         if (ec)
         {
             exit_filesystem_call_error(li, ec, __func__, {dir});
@@ -2077,8 +2077,8 @@ namespace vcpkg
             return get_regular_files_impl<stdfs::directory_iterator>(dir, ec);
         }
 
-        virtual std::vector<Path> get_regular_files_recursive_proximate(const Path& dir,
-                                                                        std::error_code& ec) const override
+        virtual std::vector<Path> get_regular_files_recursive_lexically_proximate(const Path& dir,
+                                                                                  std::error_code& ec) const override
         {
             auto ret = this->get_regular_files_recursive(dir, ec);
             if (!ec)
@@ -2372,8 +2372,8 @@ namespace vcpkg
             return result;
         }
 
-        virtual std::vector<Path> get_regular_files_recursive_proximate(const Path& dir,
-                                                                        std::error_code& ec) const override
+        virtual std::vector<Path> get_regular_files_recursive_lexically_proximate(const Path& dir,
+                                                                                  std::error_code& ec) const override
         {
             std::vector<Path> result;
             Path out_base;

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -825,8 +825,8 @@ namespace
             if (!S_ISDIR(s.st_mode))
             {
                 // if it isn't still a directory something is racy
-                mark_recursive_error(base, ec, failure_point);
                 ec = std::make_error_code(std::errc::device_or_resource_busy);
+                failure_point = base;
                 return;
             }
 
@@ -2124,10 +2124,10 @@ namespace vcpkg
             result.push_back(full);
         }
 
-        struct PushPopPath
+        struct PushPopPathElement
         {
-            PushPopPath(Path& parent, StringView appendee) : p(parent) { p /= appendee; }
-            ~PushPopPath() { p.make_parent_path(); }
+            PushPopPathElement(Path& parent, StringView appendee) : p(parent) { p /= appendee; }
+            ~PushPopPathElement() { p.make_parent_path(); }
 
         private:
             Path& p;
@@ -2170,7 +2170,7 @@ namespace vcpkg
                     }
 
                     const auto full = base / entry->d_name;
-                    PushPopPath pushpop_outbase(out_base, entry->d_name);
+                    PushPopPathElement pushpop_outbase(out_base, entry->d_name);
                     const auto entry_dtype = get_d_type(entry);
                     struct stat s;
                     struct stat ls;


### PR DESCRIPTION
This PR implements `Files::get_regular_files_recursive_proximate`, which returns a list of all regular files from a subdirectory without that base path prepended. The result is the same as if you called
```
// pseudocode
files = Files::get_regular_files_recursive(dir);
for (auto& file : files) {
    file = file.lexically_proximate(dir);
}
```
However it generates the desired contents directly instead of "subtracting" after the fact on Linux.

This is needed for #296 