### PR TITLE
[VS] allow installations without the english language pack

### DIFF
--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -386,6 +386,9 @@ namespace vcpkg
             new_path += Strings::format(";%s", extra_env.find("PATH")->second);
         env_cstr.append(Strings::to_utf16(new_path));
         env_cstr.push_back(L'\0');
+        // NOTE: we support VS's without the english language pack,
+        // but we still want to default to english just in case your specific
+        // non-standard build system doesn't support non-english
         env_cstr.append(L"VSLANG=1033");
         env_cstr.push_back(L'\0');
         env_cstr.append(L"VSCMD_SKIP_SENDTELEMETRY=1");

--- a/src/vcpkg/visualstudio.cpp
+++ b/src/vcpkg/visualstudio.cpp
@@ -306,13 +306,6 @@ namespace vcpkg::VisualStudio
                                         toolset_version_full.to_string(),
                                         supported_architectures};
 
-                        const auto english_language_pack = dumpbin_dir / "1033";
-                        if (!fs.exists(english_language_pack, IgnoreErrors{}))
-                        {
-                            excluded_toolsets.push_back(std::move(toolset));
-                            continue;
-                        }
-
                         found_toolsets.push_back(std::move(toolset));
                         if (v140_is_available)
                         {
@@ -367,13 +360,6 @@ namespace vcpkg::VisualStudio
                                                  major_version == "14" ? V_140 : V_120,
                                                  major_version,
                                                  supported_architectures};
-
-                        const auto english_language_pack = vs_dumpbin_dir / "1033";
-                        if (!fs.exists(english_language_pack, IgnoreErrors{}))
-                        {
-                            excluded_toolsets.push_back(toolset);
-                            break;
-                        }
 
                         found_toolsets.push_back(toolset);
                     }


### PR DESCRIPTION
See title.

This still requests `VSLANG=1033`, since there may be some minor build systems that don't support non-english language packs; however, we just don't fail when the english language pack isn't installed.