### PR TITLE
Add ARM64EC to the MachineType enumeration

### DIFF
--- a/include/vcpkg/base/cofffilereader.h
+++ b/include/vcpkg/base/cofffilereader.h
@@ -15,7 +15,7 @@ namespace vcpkg
         AMD64 = 0x8664,    // x64
         ARM = 0x1c0,       // ARM little endian
         ARM64 = 0xaa64,    // ARM64 little endian
-        ARM64EC = 0xa641,  // ARM64 "emulator compatible"
+        ARM64EC = 0xa641,  // ARM64 "emulation compatible"
         ARMNT = 0x1c4,     // ARM Thumb-2 little endian
         EBC = 0xebc,       // EFI byte code
         I386 = 0x14c,      // Intel 386 or later processors and compatible processors

--- a/include/vcpkg/base/cofffilereader.h
+++ b/include/vcpkg/base/cofffilereader.h
@@ -15,6 +15,7 @@ namespace vcpkg
         AMD64 = 0x8664,    // x64
         ARM = 0x1c0,       // ARM little endian
         ARM64 = 0xaa64,    // ARM64 little endian
+        ARM64EC = 0xa641,  // ARM64 "emulator compatible"
         ARMNT = 0x1c4,     // ARM Thumb-2 little endian
         EBC = 0xebc,       // EFI byte code
         I386 = 0x14c,      // Intel 386 or later processors and compatible processors

--- a/src/vcpkg/base/cofffilereader.cpp
+++ b/src/vcpkg/base/cofffilereader.cpp
@@ -211,6 +211,7 @@ namespace vcpkg
             case MachineType::AMD64:
             case MachineType::ARM:
             case MachineType::ARM64:
+            case MachineType::ARM64EC:
             case MachineType::ARMNT:
             case MachineType::EBC:
             case MachineType::I386:

--- a/src/vcpkg/postbuildlint.cpp
+++ b/src/vcpkg/postbuildlint.cpp
@@ -496,6 +496,7 @@ namespace vcpkg::PostBuildLint
             case MachineType::ARM:
             case MachineType::ARMNT: return "arm";
             case MachineType::ARM64: return "arm64";
+            case MachineType::ARM64EC: return "arm64ec";
             default: return "Machine Type Code = " + std::to_string(static_cast<uint16_t>(machine_type));
         }
     }


### PR DESCRIPTION
This (hopefully) allows ARM64 Emulation Compatible binaries to pass post-build lint.

https://blogs.windows.com/windowsdeveloper/2021/06/28/announcing-arm64ec-building-native-and-interoperable-apps-for-windows-11-on-arm/
