### PR TITLE
[#22041] vcpkg install - cmake version check should NOT reject valid response.

### DIFF
--- a/src/vcpkg/tools.cpp
+++ b/src/vcpkg/tools.cpp
@@ -11,6 +11,7 @@
 #include <vcpkg/archives.h>
 #include <vcpkg/tools.h>
 #include <vcpkg/vcpkgpaths.h>
+#include <regex>
 
 namespace vcpkg
 {
@@ -316,8 +317,11 @@ cmake version 3.10.2
 
 CMake suite maintained and supported by Kitware (kitware.com/cmake).
                 */
-            return {Strings::find_exactly_one_enclosed(rc.output, "cmake version ", "\n").to_string(),
-                    expected_left_tag};
+            
+            // There are two expected output formats to handle: "cmake3 version x.x.x" and "cmake version x.x.x"
+            auto simplifiedOutput = std::regex_replace(rc.output, std::regex("cmake3"), "cmake");   
+            return { Strings::find_exactly_one_enclosed(simplifiedOutput, "cmake version ", "\n").to_string(),
+                    expected_left_tag };
         }
     };
 


### PR DESCRIPTION
Proposed fix for:  [#22041](https://github.com/microsoft/vcpkg/issues/22041)

As concisely stated by @BRKVings - There are two types of output:
- cmake3 version x.x.x
- cmake version x.x.x
But the current code can't handle the first case.

This minor annoyance, just turned into a hard-blocker for me. I am proposing a change, which works in a minimal-repro program in Visual Studio 2022. I'm not familiar with your code-base. Could someone please test and promote, or propose an alternative that is inline VCPkg style guidelines?