### PR TITLE
Lock VCPKG_BASE_VERSION in the first job for use in subsequent jobs.

### DIFF
--- a/azure-pipelines/signing.yml
+++ b/azure-pipelines/signing.yml
@@ -19,12 +19,6 @@ parameters:
   default:
 
 variables:
-  - ${{ if eq(parameters.VcpkgBaseVersionOverride, '') }}:
-    - name: VCPKG_BASE_VERSION
-      value: $[format('{0:yyyy}-{0:MM}-{0:dd}', pipeline.startTime)]
-  - ${{ if ne(parameters.VcpkgBaseVersionOverride, '') }}:
-    - name: VCPKG_BASE_VERSION
-      value: ${{parameters.VcpkgBaseVersionOverride}}
   - name: TeamName
     value: vcpkg
   - group: vcpkg-dependency-source-blobs
@@ -47,15 +41,34 @@ variables:
 jobs:
   - job: arch_independent
     displayName: 'Build and Sign Arch-Independent Scripts and vcpkg-ce'
+    # The first job records VCPKG_INITIAL_BASE_VERSION as VCPKG_BASE_VERSION so that all subsequent stages agree
+    # on the value; AzureDevOps appears to repeat evaluation of variables such that crossing UTC's day start
+    # would make subsequent pipeline stages use a different day producing a broken build.
+    # Note that pipeline.startTime seems to refer to the start of the *job*, not the overall pipeline run.
+    variables:
+    - ${{ if eq(parameters.VcpkgBaseVersionOverride, '') }}:
+      - name: VCPKG_INITIAL_BASE_VERSION
+        value: $[format('{0:yyyy}-{0:MM}-{0:dd}', pipeline.startTime)]
+    - ${{ if ne(parameters.VcpkgBaseVersionOverride, '') }}:
+      - name: VCPKG_INITIAL_BASE_VERSION
+        value: ${{parameters.VcpkgBaseVersionOverride}}
     pool:
       name: 'VSEngSS-MicroBuild2022-1ES'
     steps:
+    - task: Powershell@2
+      displayName: 'Lock VCPKG_BASE_VERSION'
+      name: versions
+      inputs:
+        pwsh: true
+        targetType: 'inline'
+        script: |
+          Write-Host "##vso[task.setvariable variable=VCPKG_BASE_VERSION;isOutput=true]$env:VCPKG_INITIAL_BASE_VERSION"
     - task: Powershell@2
       displayName: 'Lock Installer Scripts Versions'
       inputs:
         pwsh: true
         filePath: vcpkg-init/lock-versions.ps1
-        arguments: '-Destination "$(Build.BinariesDirectory)" -VcpkgBaseVersion $(VCPKG_BASE_VERSION)'
+        arguments: '-Destination "$(Build.BinariesDirectory)" -VcpkgBaseVersion $(VCPKG_INITIAL_BASE_VERSION)'
     # Build and test vcpkg-ce
     - task: PowerShell@2
       displayName: 'Download vcpkg-ce sources'
@@ -174,6 +187,7 @@ jobs:
     variables:
       VCPKG_STANDALONE_BUNDLE_SHA: $[ dependencies.arch_independent.outputs['shas.VCPKG_STANDALONE_BUNDLE_SHA'] ]
       VCPKG_CE_SHA: $[ dependencies.arch_independent.outputs['shas.VCPKG_CE_SHA'] ]
+      VCPKG_BASE_VERSION: $[ dependencies.arch_independent.outputs['versions.VCPKG_BASE_VERSION'] ]
     steps:
     - task: CmdLine@2
       displayName: "Download fmt library"
@@ -207,6 +221,7 @@ jobs:
     variables:
       VCPKG_STANDALONE_BUNDLE_SHA: $[ dependencies.arch_independent.outputs['shas.VCPKG_STANDALONE_BUNDLE_SHA'] ]
       VCPKG_CE_SHA: $[ dependencies.arch_independent.outputs['shas.VCPKG_CE_SHA'] ]
+      VCPKG_BASE_VERSION: $[ dependencies.arch_independent.outputs['versions.VCPKG_BASE_VERSION'] ]
     steps:
     - task: CmdLine@2
       displayName: "Download fmt library"
@@ -241,6 +256,7 @@ jobs:
     variables:
       VCPKG_STANDALONE_BUNDLE_SHA: $[ dependencies.arch_independent.outputs['shas.VCPKG_STANDALONE_BUNDLE_SHA'] ]
       VCPKG_CE_SHA: $[ dependencies.arch_independent.outputs['shas.VCPKG_CE_SHA'] ]
+      VCPKG_BASE_VERSION: $[ dependencies.arch_independent.outputs['versions.VCPKG_BASE_VERSION'] ]
     steps:
     - task: CmdLine@2
       displayName: "Download fmt library"
@@ -280,6 +296,7 @@ jobs:
     variables:
       VCPKG_STANDALONE_BUNDLE_SHA: $[ dependencies.arch_independent.outputs['shas.VCPKG_STANDALONE_BUNDLE_SHA'] ]
       VCPKG_CE_SHA: $[ dependencies.arch_independent.outputs['shas.VCPKG_CE_SHA'] ]
+      VCPKG_BASE_VERSION: $[ dependencies.arch_independent.outputs['versions.VCPKG_BASE_VERSION'] ]
     steps:
     - task: PowerShell@2
       displayName: "Download fmt library"


### PR DESCRIPTION
The "2022-02-01" release is broken because the CE build thought the date was 2022-01-31, while the vcpkg.exe build thought it was 2022-02-01. See https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build/results?buildId=5694458&view=results

The pipeline.startTime variable appears to be reevaluated each time a job starts, and refers to the *job* start time, not the overall pipeline start time, so when a build crosses 4PM pacific time it produced broken output.

This change gets the first arch_independent stage to write the value it used, and this is fed into the remaining stages.