### PR TITLE
files: Add missing include on windows

### DIFF
--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -30,6 +30,8 @@
 #include <thread>
 
 #if defined(_WIN32)
+#include <share.h>
+
 #include <filesystem>
 namespace stdfs = std::filesystem;
 #endif // _WIN32


### PR DESCRIPTION
Needed for mingw

According to https://docs.microsoft.com/en-us/cpp/c-runtime-library/sharing-constants?view=msvc-170