### PR TITLE
Move toolchain decision making entirely into the tool

### DIFF
--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -850,7 +850,7 @@ namespace vcpkg::Build
         }
         else if (cmake_system_name == "WindowsStore")
         {
-            // HACK: remove once we have fully shipped a uwp triplet
+            // HACK: remove once we have fully shipped a uwp toolchain
             static bool have_uwp_triplet =
                 m_paths.get_filesystem().exists(m_paths.scripts / "toolchains/uwp.cmake", IgnoreErrors{});
             if (have_uwp_triplet)

--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -758,6 +758,7 @@ namespace vcpkg::Build
             {"_VCPKG_DOWNLOAD_TOOL", to_string(action.build_options.download_tool)},
             {"_VCPKG_EDITABLE", Util::Enum::to_bool(action.build_options.editable) ? "1" : "0"},
             {"_VCPKG_NO_DOWNLOADS", !Util::Enum::to_bool(action.build_options.allow_downloads) ? "1" : "0"},
+            {"VCPKG_CHAINLOAD_TOOLCHAIN_FILE", action.pre_build_info(VCPKG_LINE_INFO).toolchain_file()},
         };
 
         if (action.build_options.download_tool == DownloadTool::ARIA2)
@@ -847,7 +848,21 @@ namespace vcpkg::Build
         {
             return m_paths.scripts / "toolchains/mingw.cmake";
         }
-        else if (cmake_system_name.empty() || cmake_system_name == "Windows" || cmake_system_name == "WindowsStore")
+        else if (cmake_system_name == "WindowsStore")
+        {
+            // HACK: remove once we have fully shipped a uwp triplet
+            static bool have_uwp_triplet =
+                m_paths.get_filesystem().exists(m_paths.scripts / "toolchains/uwp.cmake", IgnoreErrors{});
+            if (have_uwp_triplet)
+            {
+                return m_paths.scripts / "toolchains/uwp.cmake";
+            }
+            else
+            {
+                return m_paths.scripts / "toolchains/windows.cmake";
+            }
+        }
+        else if (cmake_system_name.empty() || cmake_system_name == "Windows")
         {
             return m_paths.scripts / "toolchains/windows.cmake";
         }


### PR DESCRIPTION
This PR is a needed tool change to enable https://github.com/microsoft/vcpkg/pull/22831 and comes with the added benefit of removing duplicate toolchain selection logic across the many helper scripts. With this, ports and helpers may always assume that `VCPKG_CHAINLOAD_TOOLCHAIN_FILE` is defined to the correct toolchain to pull in.

+@neumann-a for review