### PR TITLE
Add NetBSD support

### DIFF
--- a/src/vcpkg-test/json.cpp
+++ b/src/vcpkg-test/json.cpp
@@ -155,12 +155,12 @@ TEST_CASE ("JSON parse floats", "[json]")
     REQUIRE(res.get()->first.is_number());
     REQUIRE(!res.get()->first.is_integer());
     REQUIRE(res.get()->first.number() == 0.0);
-    REQUIRE(!signbit(res.get()->first.number()));
+    REQUIRE(!std::signbit(res.get()->first.number()));
     res = Json::parse("-0.0");
     REQUIRE(res);
     REQUIRE(res.get()->first.is_number());
     REQUIRE(res.get()->first.number() == 0.0);
-    REQUIRE(signbit(res.get()->first.number()));
+    REQUIRE(std::signbit(res.get()->first.number()));
     res = Json::parse("12345.6789");
     REQUIRE(res);
     REQUIRE(res.get()->first.is_number());

--- a/src/vcpkg/base/json.cpp
+++ b/src/vcpkg/base/json.cpp
@@ -253,7 +253,7 @@ namespace vcpkg::Json
     }
     Value Value::number(double d) noexcept
     {
-        vcpkg::Checks::check_exit(VCPKG_LINE_INFO, isfinite(d));
+        vcpkg::Checks::check_exit(VCPKG_LINE_INFO, std::isfinite(d));
         Value val;
         val.underlying_ = std::make_unique<ValueImpl>(ValueKindConstant<VK::Number>(), d);
         return val;

--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -21,6 +21,10 @@
 #include <sys/wait.h>
 #endif
 
+#if defined(__NetBSD__)
+#include <sys/wait.h>
+#endif
+
 #if defined(_WIN32)
 #pragma comment(lib, "Advapi32")
 #endif


### PR DESCRIPTION
Use `std::signbit` instead of "plain" `signbit`, the latter results in a
compiler error for some reason. Include `sys/wait.h` for `WIFEXITED` and
friends.