### PR TITLE
[arm64ec] Add more arm64ec support in validation checks.

### DIFF
--- a/include/vcpkg/base/system.h
+++ b/include/vcpkg/base/system.h
@@ -30,6 +30,7 @@ namespace vcpkg
         X64,
         ARM,
         ARM64,
+        ARM64EC,
         S390X,
         PPC64LE,
     };

--- a/src/vcpkg/base/system.cpp
+++ b/src/vcpkg/base/system.cpp
@@ -48,6 +48,7 @@ namespace vcpkg
         if (Strings::case_insensitive_ascii_equals(arch, "amd64")) return CPUArchitecture::X64;
         if (Strings::case_insensitive_ascii_equals(arch, "arm")) return CPUArchitecture::ARM;
         if (Strings::case_insensitive_ascii_equals(arch, "arm64")) return CPUArchitecture::ARM64;
+        if (Strings::case_insensitive_ascii_equals(arch, "arm64ec")) return CPUArchitecture::ARM64EC;
         if (Strings::case_insensitive_ascii_equals(arch, "s390x")) return CPUArchitecture::S390X;
         if (Strings::case_insensitive_ascii_equals(arch, "ppc64le")) return CPUArchitecture::PPC64LE;
         return nullopt;
@@ -61,6 +62,7 @@ namespace vcpkg
             case CPUArchitecture::X64: return "x64";
             case CPUArchitecture::ARM: return "arm";
             case CPUArchitecture::ARM64: return "arm64";
+            case CPUArchitecture::ARM64EC: return "arm64ec";
             case CPUArchitecture::S390X: return "s390x";
             case CPUArchitecture::PPC64LE: return "ppc64le";
             default: Checks::exit_with_message(VCPKG_LINE_INFO, "unexpected vcpkg::CPUArchitecture");

--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -335,8 +335,14 @@ namespace vcpkg::Build
         Checks::check_maybe_upgrade(
             VCPKG_LINE_INFO, maybe_target_arch.has_value(), "Invalid architecture string: %s", target_architecture);
         auto target_arch = maybe_target_arch.value_or_exit(VCPKG_LINE_INFO);
-        auto host_architectures = get_supported_host_architectures();
+        // Ask for an arm64 compiler when targeting arm64ec; arm64ec is selected with a different flag on the compiler
+        // command line.
+        if (target_arch == CPUArchitecture::ARM64EC)
+        {
+            target_arch = CPUArchitecture::ARM64;
+        }
 
+        auto host_architectures = get_supported_host_architectures();
         for (auto&& host : host_architectures)
         {
             const auto it = Util::find_if(toolset.supported_architectures, [&](const ToolsetArchOption& opt) {

--- a/src/vcpkg/triplet.cpp
+++ b/src/vcpkg/triplet.cpp
@@ -60,6 +60,10 @@ namespace vcpkg
         {
             return CPUArchitecture::ARM64;
         }
+        if (Strings::starts_with(this->canonical_name(), "arm64ec-"))
+        {
+            return CPUArchitecture::ARM64EC;
+        }
         if (Strings::starts_with(this->canonical_name(), "s390x-"))
         {
             return CPUArchitecture::S390X;


### PR DESCRIPTION
* Add arm64ec to the CPUArchitecture enum.
* When invoking vcvarsall, translate arm64ec to arm64 because the toolchain for these is the same.
* Teach "guess_architecture" that arm64ec is a good guess.