### PR TITLE
Adds missing include for WIFEXITED on FreeBSD

### DIFF
--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -17,6 +17,7 @@
 
 #if defined(__FreeBSD__)
 #include <sys/sysctl.h>
+#include <sys/wait.h>
 #endif
 
 #if defined(_WIN32)


### PR DESCRIPTION
Fixes compilation issues on FreeBSD 13.0 using Clang11

```cpp
/root/vcpkg-tool/src/vcpkg/base/system.process.cpp:836:13: error: use of undeclared identifier 'WIFEXITED'
        if (WIFEXITED(exit_code))
            ^
/root/vcpkg-tool/src/vcpkg/base/system.process.cpp:838:25: error: use of undeclared identifier 'WEXITSTATUS'
            exit_code = WEXITSTATUS(exit_code);
                        ^
/root/vcpkg-tool/src/vcpkg/base/system.process.cpp:840:18: error: use of undeclared identifier 'WIFSIGNALED'
        else if (WIFSIGNALED(exit_code))
                 ^
/root/vcpkg-tool/src/vcpkg/base/system.process.cpp:842:25: error: use of undeclared identifier 'WTERMSIG'
            exit_code = WTERMSIG(exit_code);
                        ^
/root/vcpkg-tool/src/vcpkg/base/system.process.cpp:844:18: error: use of undeclared identifier 'WIFSTOPPED'
        else if (WIFSTOPPED(exit_code))
                 ^
/root/vcpkg-tool/src/vcpkg/base/system.process.cpp:846:25: error: use of undeclared identifier 'WSTOPSIG'
            exit_code = WSTOPSIG(exit_code);

```