### PR TITLE
Run msiexec with start /wait

### DIFF
--- a/src/vcpkg/archives.cpp
+++ b/src/vcpkg/archives.cpp
@@ -62,6 +62,9 @@ namespace
             const auto code_and_output = cmd_execute_and_capture_output(
                 Command{"cmd"}
                     .string_arg("/c")
+                    .string_arg("start")
+                    .string_arg("/wait")
+                    .string_arg("(no title)")
                     .string_arg("msiexec")
                     // "/a" is administrative mode, which unpacks without modifying the system
                     .string_arg("/a")


### PR DESCRIPTION
A potential fix for 
- https://github.com/microsoft/vcpkg/issues/19490 
- https://github.com/microsoft/vcpkg/issues/23284

Cf. https://github.com/microsoft/vcpkg/issues/19490#issuecomment-1053580397, https://devblogs.microsoft.com/setup/waiting-for-msiexec-exe-to-finish/