### PR TITLE
Read msiexec output as UTF-16.

### DIFF
--- a/include/vcpkg/base/fwd/system.process.h
+++ b/include/vcpkg/base/fwd/system.process.h
@@ -6,4 +6,16 @@ namespace vcpkg
     struct Command;
     struct CommandLess;
     struct ExitCodeAndOutput;
+
+    enum class EchoInDebug
+    {
+        Show,
+        Hide
+    };
+
+    enum class Encoding
+    {
+        Utf8,
+        Utf16
+    };
 }

--- a/include/vcpkg/base/strings.h
+++ b/include/vcpkg/base/strings.h
@@ -125,8 +125,9 @@ namespace vcpkg::Strings
     std::wstring to_utf16(StringView s);
 
     std::string to_utf8(const wchar_t* w);
-    std::string to_utf8(const wchar_t* w, size_t s);
-    inline std::string to_utf8(const std::wstring& ws) { return to_utf8(ws.data(), ws.size()); }
+    std::string to_utf8(const wchar_t* w, size_t size_in_characters);
+    void to_utf8(std::string& output, const wchar_t* w, size_t size_in_characters);
+    std::string to_utf8(const std::wstring& ws);
 #endif
 
     std::string escape_string(std::string&& s, char char_to_escape, char escape_char);

--- a/include/vcpkg/base/system.process.h
+++ b/include/vcpkg/base/system.process.h
@@ -104,71 +104,48 @@ namespace vcpkg
     Environment get_modified_clean_environment(const std::unordered_map<std::string, std::string>& extra_env,
                                                StringView prepend_to_path = {});
 
-    struct InWorkingDirectory
+    struct WorkingDirectory
     {
-        const Path& working_directory;
+        Path working_directory;
     };
 
-    int cmd_execute(const Command& cmd_line, InWorkingDirectory wd, const Environment& env = {});
-    inline int cmd_execute(const Command& cmd_line, const Environment& env = {})
-    {
-        return cmd_execute(cmd_line, InWorkingDirectory{Path()}, env);
-    }
+    extern const WorkingDirectory default_working_directory;
+    extern const Environment default_environment;
 
-    int cmd_execute_clean(const Command& cmd_line, InWorkingDirectory wd);
-    inline int cmd_execute_clean(const Command& cmd_line)
-    {
-        return cmd_execute_clean(cmd_line, InWorkingDirectory{Path()});
-    }
+    int cmd_execute(const Command& cmd_line,
+                    const WorkingDirectory& wd = default_working_directory,
+                    const Environment& env = default_environment);
+    int cmd_execute_clean(const Command& cmd_line, const WorkingDirectory& wd = default_working_directory);
 
 #if defined(_WIN32)
-    Environment cmd_execute_and_capture_environment(const Command& cmd_line, const Environment& env = {});
+    Environment cmd_execute_and_capture_environment(const Command& cmd_line,
+                                                    const Environment& env = default_environment);
 
     void cmd_execute_background(const Command& cmd_line);
 #endif
 
     ExitCodeAndOutput cmd_execute_and_capture_output(const Command& cmd_line,
-                                                     InWorkingDirectory wd,
-                                                     const Environment& env = {},
-                                                     bool tee_in_debug = false);
-    inline ExitCodeAndOutput cmd_execute_and_capture_output(const Command& cmd_line,
-                                                            const Environment& env = {},
-                                                            bool tee_in_debug = false)
-    {
-        return cmd_execute_and_capture_output(cmd_line, InWorkingDirectory{Path()}, env, tee_in_debug);
-    }
+                                                     const WorkingDirectory& wd = default_working_directory,
+                                                     const Environment& env = default_environment,
+                                                     Encoding encoding = Encoding::Utf8,
+                                                     EchoInDebug echo_in_debug = EchoInDebug::Hide);
 
-    std::vector<ExitCodeAndOutput> cmd_execute_and_capture_output_parallel(View<Command> cmd_lines,
-                                                                           InWorkingDirectory wd,
-                                                                           const Environment& env = {});
-
-    inline std::vector<ExitCodeAndOutput> cmd_execute_and_capture_output_parallel(View<Command> cmd_lines,
-                                                                                  const Environment& env = {})
-    {
-        return cmd_execute_and_capture_output_parallel(cmd_lines, InWorkingDirectory{Path()}, env);
-    }
+    std::vector<ExitCodeAndOutput> cmd_execute_and_capture_output_parallel(
+        View<Command> cmd_lines,
+        const WorkingDirectory& wd = default_working_directory,
+        const Environment& env = default_environment);
 
     int cmd_execute_and_stream_lines(const Command& cmd_line,
-                                     InWorkingDirectory wd,
                                      std::function<void(StringView)> per_line_cb,
-                                     const Environment& env = {});
-    inline int cmd_execute_and_stream_lines(const Command& cmd_line,
-                                            std::function<void(StringView)> per_line_cb,
-                                            const Environment& env = {})
-    {
-        return cmd_execute_and_stream_lines(cmd_line, InWorkingDirectory{Path()}, std::move(per_line_cb), env);
-    }
+                                     const WorkingDirectory& wd = default_working_directory,
+                                     const Environment& env = default_environment,
+                                     Encoding encoding = Encoding::Utf8);
 
     int cmd_execute_and_stream_data(const Command& cmd_line,
-                                    InWorkingDirectory wd,
                                     std::function<void(StringView)> data_cb,
-                                    const Environment& env = {});
-    inline int cmd_execute_and_stream_data(const Command& cmd_line,
-                                           std::function<void(StringView)> data_cb,
-                                           const Environment& env = {})
-    {
-        return cmd_execute_and_stream_data(cmd_line, InWorkingDirectory{Path()}, std::move(data_cb), env);
-    }
+                                    const WorkingDirectory& wd = default_working_directory,
+                                    const Environment& env = default_environment,
+                                    Encoding encoding = Encoding::Utf8);
 
     uint64_t get_subproccess_stats();
 

--- a/src/vcpkg/archives.cpp
+++ b/src/vcpkg/archives.cpp
@@ -245,7 +245,7 @@ namespace vcpkg
             if (result.exit_code == 127 && result.output.empty())
             {
                 Debug::print(jobs[i].command_line(), ": pclose returned 127, try again \n");
-                result = cmd_execute_and_capture_output(jobs[i], get_clean_environment());
+                result = cmd_execute_and_capture_output(jobs[i], default_working_directory, get_clean_environment());
             }
             ++i;
         }

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -659,7 +659,11 @@ namespace vcpkg
                                    }
                                }).value_or_exit(VCPKG_LINE_INFO);
 
-                    auto res = cmd_execute_and_capture_output(Command{}.raw_arg(cmd), get_clean_environment(), true);
+                    auto res = cmd_execute_and_capture_output(Command{}.raw_arg(cmd),
+                                                              default_working_directory,
+                                                              get_clean_environment(),
+                                                              Encoding::Utf8,
+                                                              EchoInDebug::Show);
                     if (res.exit_code == 0)
                     {
                         auto maybe_error =

--- a/src/vcpkg/base/strings.cpp
+++ b/src/vcpkg/base/strings.cpp
@@ -143,31 +143,39 @@ std::wstring Strings::to_utf16(StringView s)
 #if defined(_WIN32)
 std::string Strings::to_utf8(const wchar_t* w) { return Strings::to_utf8(w, wcslen(w)); }
 
-std::string Strings::to_utf8(const wchar_t* w, size_t s)
+std::string Strings::to_utf8(const wchar_t* w, size_t size_in_characters)
 {
     std::string output;
-    if (s != 0)
-    {
-        vcpkg::Checks::check_exit(VCPKG_LINE_INFO, s <= INT_MAX);
-        const int size = WideCharToMultiByte(CP_UTF8, 0, w, static_cast<int>(s), nullptr, 0, nullptr, nullptr);
-        if (size <= 0)
-        {
-            unsigned long last_error = ::GetLastError();
-            Checks::exit_with_message(VCPKG_LINE_INFO,
-                                      "Failed to convert to UTF-8. %08lX %s",
-                                      last_error,
-                                      std::system_category().message(static_cast<int>(last_error)));
-        }
-
-        output.resize(size);
-        vcpkg::Checks::check_exit(
-            VCPKG_LINE_INFO,
-            size == WideCharToMultiByte(
-                        CP_UTF8, 0, w, static_cast<int>(s), output.data(), static_cast<int>(size), nullptr, nullptr));
-    }
-
+    to_utf8(output, w, size_in_characters);
     return output;
 }
+
+void Strings::to_utf8(std::string& output, const wchar_t* w, size_t size_in_characters)
+{
+    if (size_in_characters == 0)
+    {
+        output.clear();
+        return;
+    }
+
+    vcpkg::Checks::check_exit(VCPKG_LINE_INFO, size_in_characters <= INT_MAX);
+    const int s_clamped = static_cast<int>(size_in_characters);
+    const int size = WideCharToMultiByte(CP_UTF8, 0, w, s_clamped, nullptr, 0, nullptr, nullptr);
+    if (size <= 0)
+    {
+        unsigned long last_error = ::GetLastError();
+        Checks::exit_with_message(VCPKG_LINE_INFO,
+                                  "Failed to convert to UTF-8. %08lX %s",
+                                  last_error,
+                                  std::system_category().message(static_cast<int>(last_error)));
+    }
+
+    output.resize(size);
+    vcpkg::Checks::check_exit(
+        VCPKG_LINE_INFO, size == WideCharToMultiByte(CP_UTF8, 0, w, s_clamped, output.data(), size, nullptr, nullptr));
+}
+
+std::string Strings::to_utf8(const std::wstring& ws) { return to_utf8(ws.data(), ws.size()); }
 #endif
 
 std::string Strings::escape_string(std::string&& s, char char_to_escape, char escape_char)

--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -805,7 +805,7 @@ namespace vcpkg
     {
         const auto timer = ElapsedTimer::create_started();
 #if defined(_WIN32)
-        const auto thread_id = std::to_string(::GetCurrentThreadId());
+        const auto proc_id = std::to_string(::GetCurrentProcessId());
         using vcpkg::g_ctrl_c_state;
 
         g_ctrl_c_state.transition_to_spawn_process();
@@ -819,7 +819,7 @@ namespace vcpkg
         g_ctrl_c_state.transition_from_spawn_process();
 #else  // ^^^ _WIN32 // !_WIN32 vvv
         Checks::check_exit(VCPKG_LINE_INFO, encoding == Encoding::Utf8);
-        const auto thread_id = std::to_string(::pthread_self());
+        const auto proc_id = std::to_string(::getpid());
         (void)env;
         std::string actual_cmd_line;
         if (wd.working_directory.empty())
@@ -874,7 +874,7 @@ namespace vcpkg
 
         const auto elapsed = timer.us_64();
         g_subprocess_stats += elapsed;
-        Debug::print(thread_id,
+        Debug::print(proc_id,
                      ": cmd_execute_and_stream_data() returned ",
                      exit_code,
                      " after ",

--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -677,8 +677,8 @@ namespace vcpkg
 
         auto process_info =
             windows_create_windowless_process(cmd_line.command_line(),
-                                              WorkingDirectory{},
-                                              {},
+                                              default_working_directory,
+                                              default_environment,
                                               CREATE_NEW_CONSOLE | CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB);
         if (!process_info.get())
         {

--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -836,7 +836,7 @@ namespace vcpkg
                                   .extract();
         }
 
-        Debug::print(thread_id, ": popen(", actual_cmd_line, ")\n");
+        Debug::print(proc_id, ": popen(", actual_cmd_line, ")\n");
         // Flush stdout before launching external process
         fflush(stdout);
 

--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -1,3 +1,5 @@
+#include <vcpkg/base/system_headers.h>
+
 #include <vcpkg/base/checks.h>
 #include <vcpkg/base/chrono.h>
 #include <vcpkg/base/strings.h>
@@ -9,7 +11,6 @@
 
 #include <ctime>
 #include <future>
-#include <sstream>
 
 #if defined(__APPLE__)
 #include <mach-o/dyld.h>
@@ -428,8 +429,11 @@ namespace vcpkg
         return clean_env;
     }
 
+    const WorkingDirectory default_working_directory;
+    const Environment default_environment;
+
     std::vector<ExitCodeAndOutput> cmd_execute_and_capture_output_parallel(View<Command> cmd_lines,
-                                                                           InWorkingDirectory wd,
+                                                                           const WorkingDirectory& wd,
                                                                            const Environment& env)
     {
         if (cmd_lines.size() == 0)
@@ -470,7 +474,7 @@ namespace vcpkg
         return res;
     }
 
-    int cmd_execute_clean(const Command& cmd_line, InWorkingDirectory wd)
+    int cmd_execute_clean(const Command& cmd_line, const WorkingDirectory& wd)
     {
         return cmd_execute(cmd_line, wd, get_clean_environment());
     }
@@ -525,7 +529,7 @@ namespace vcpkg
     /// <param name="maybe_environment">If non-null, an environment block to use for the new process. If null, the
     /// new process will inherit the current environment.</param>
     static ExpectedT<ProcessInfo, unsigned long> windows_create_process(StringView cmd_line,
-                                                                        InWorkingDirectory wd,
+                                                                        const WorkingDirectory& wd,
                                                                         const Environment& env,
                                                                         DWORD dwCreationFlags,
                                                                         STARTUPINFOW& startup_info) noexcept
@@ -567,7 +571,7 @@ namespace vcpkg
     }
 
     static ExpectedT<ProcessInfo, unsigned long> windows_create_windowless_process(StringView cmd_line,
-                                                                                   InWorkingDirectory wd,
+                                                                                   const WorkingDirectory& wd,
                                                                                    const Environment& env,
                                                                                    DWORD dwCreationFlags) noexcept
     {
@@ -587,28 +591,44 @@ namespace vcpkg
         HANDLE child_stdout = 0;
 
         template<class Function>
-        int wait_and_stream_output(Function&& f)
+        int wait_and_stream_output(Function&& f, Encoding encoding)
         {
             CloseHandle(child_stdin);
 
-            unsigned long bytes_read = 0;
-            static constexpr int buffer_size = 1024 * 32;
-            auto buf = std::make_unique<char[]>(buffer_size);
-            while (ReadFile(child_stdout, (void*)buf.get(), buffer_size, &bytes_read, nullptr))
+            DWORD bytes_read = 0;
+            static constexpr DWORD buffer_size = 1024 * 32;
+            char buf[buffer_size];
+            if (encoding == Encoding::Utf8)
             {
-                f(StringView{buf.get(), static_cast<size_t>(bytes_read)});
+                while (ReadFile(child_stdout, static_cast<void*>(buf), buffer_size, &bytes_read, nullptr))
+                {
+                    f(StringView{buf, static_cast<size_t>(bytes_read)});
+                }
+            }
+            else if (encoding == Encoding::Utf16)
+            {
+                // Note: This doesn't handle unpaired surrogates or partial encoding units correctly in order
+                // to be able to reuse Strings::to_utf8 which we believe will be fine 99% of the time.
+                std::string encoded;
+                while (ReadFile(child_stdout, static_cast<void*>(buf), buffer_size, &bytes_read, nullptr))
+                {
+                    Strings::to_utf8(encoded, reinterpret_cast<const wchar_t*>(buf), bytes_read);
+                    f(StringView{encoded});
+                }
+            }
+            else
+            {
+                vcpkg::Checks::unreachable(VCPKG_LINE_INFO);
             }
 
             Debug::print("ReadFile() finished with GetLastError(): ", GetLastError(), '\n');
-
             CloseHandle(child_stdout);
-
             return proc_info.wait();
         }
     };
 
     static ExpectedT<ProcessInfoAndPipes, unsigned long> windows_create_process_redirect(StringView cmd_line,
-                                                                                         InWorkingDirectory wd,
+                                                                                         const WorkingDirectory& wd,
                                                                                          const Environment& env,
                                                                                          DWORD dwCreationFlags) noexcept
     {
@@ -657,7 +677,7 @@ namespace vcpkg
 
         auto process_info =
             windows_create_windowless_process(cmd_line.command_line(),
-                                              InWorkingDirectory{Path()},
+                                              WorkingDirectory{},
                                               {},
                                               CREATE_NEW_CONSOLE | CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB);
         if (!process_info.get())
@@ -675,7 +695,7 @@ namespace vcpkg
         auto actual_cmd_line = cmd_line;
         actual_cmd_line.raw_arg(Strings::concat(" & echo ", magic_string, " & set"));
 
-        auto rc_output = cmd_execute_and_capture_output(actual_cmd_line, env);
+        auto rc_output = cmd_execute_and_capture_output(actual_cmd_line, default_working_directory, env);
         Checks::check_exit(VCPKG_LINE_INFO,
                            rc_output.exit_code == 0,
                            "Run vcvarsall.bat to get Visual Studio env failed with exit code %d",
@@ -713,7 +733,7 @@ namespace vcpkg
     }
 #endif
 
-    int cmd_execute(const Command& cmd_line, InWorkingDirectory wd, const Environment& env)
+    int cmd_execute(const Command& cmd_line, const WorkingDirectory& wd, const Environment& env)
     {
         auto timer = ElapsedTimer::create_started();
 #if defined(_WIN32)
@@ -722,9 +742,13 @@ namespace vcpkg
         auto proc_info = windows_create_windowless_process(cmd_line.command_line(), wd, env, 0);
         auto long_exit_code = [&]() -> unsigned long {
             if (auto p = proc_info.get())
+            {
                 return p->wait();
+            }
             else
+            {
                 return proc_info.error();
+            }
         }();
         if (long_exit_code > INT_MAX) long_exit_code = INT_MAX;
         int exit_code = static_cast<int>(long_exit_code);
@@ -759,43 +783,43 @@ namespace vcpkg
     }
 
     int cmd_execute_and_stream_lines(const Command& cmd_line,
-                                     InWorkingDirectory wd,
                                      std::function<void(StringView)> per_line_cb,
-                                     const Environment& env)
+                                     const WorkingDirectory& wd,
+                                     const Environment& env,
+                                     Encoding encoding)
     {
         Strings::LinesStream lines;
 
         auto rc = cmd_execute_and_stream_data(
-            cmd_line, wd, [&](const StringView sv) { lines.on_data(sv, per_line_cb); }, env);
+            cmd_line, [&](const StringView sv) { lines.on_data(sv, per_line_cb); }, wd, env, encoding);
 
         lines.on_end(per_line_cb);
         return rc;
     }
 
     int cmd_execute_and_stream_data(const Command& cmd_line,
-                                    InWorkingDirectory wd,
                                     std::function<void(StringView)> data_cb,
-                                    const Environment& env)
+                                    const WorkingDirectory& wd,
+                                    const Environment& env,
+                                    Encoding encoding)
     {
         const auto timer = ElapsedTimer::create_started();
-        const auto thread_id = []() {
-            std::ostringstream ss;
-            ss << std::this_thread::get_id();
-            return ss.str();
-        }();
 #if defined(_WIN32)
+        const auto thread_id = std::to_string(::GetCurrentThreadId());
         using vcpkg::g_ctrl_c_state;
 
         g_ctrl_c_state.transition_to_spawn_process();
         auto maybe_proc_info = windows_create_process_redirect(cmd_line.command_line(), wd, env, 0);
         auto exit_code = [&]() -> unsigned long {
             if (auto p = maybe_proc_info.get())
-                return p->wait_and_stream_output(data_cb);
+                return p->wait_and_stream_output(data_cb, encoding);
             else
                 return maybe_proc_info.error();
         }();
         g_ctrl_c_state.transition_from_spawn_process();
-#else
+#else  // ^^^ _WIN32 // !_WIN32 vvv
+        Checks::check_exit(VCPKG_LINE_INFO, encoding == Encoding::Utf8);
+        const auto thread_id = std::to_string(::pthread_self());
         (void)env;
         std::string actual_cmd_line;
         if (wd.working_directory.empty())
@@ -846,7 +870,8 @@ namespace vcpkg
         {
             exit_code = WSTOPSIG(exit_code);
         }
-#endif
+#endif /// ^^^ !_WIN32
+
         const auto elapsed = timer.us_64();
         g_subprocess_stats += elapsed;
         Debug::print(thread_id,
@@ -860,22 +885,24 @@ namespace vcpkg
     }
 
     ExitCodeAndOutput cmd_execute_and_capture_output(const Command& cmd_line,
-                                                     InWorkingDirectory wd,
+                                                     const WorkingDirectory& wd,
                                                      const Environment& env,
-                                                     bool tee_in_debug)
+                                                     Encoding encoding,
+                                                     EchoInDebug echo_in_debug)
     {
         std::string output;
         auto rc = cmd_execute_and_stream_data(
             cmd_line,
-            wd,
             [&](StringView sv) {
                 Strings::append(output, sv);
-                if (tee_in_debug && Debug::g_debugging)
+                if (echo_in_debug == EchoInDebug::Show && Debug::g_debugging)
                 {
                     print2(sv);
                 }
             },
-            env);
+            wd,
+            env,
+            encoding);
         return {rc, std::move(output)};
     }
 

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -1211,7 +1211,8 @@ namespace
                     idxs.push_back(idx);
                 }
 
-                const auto job_results = cmd_execute_and_capture_output_parallel(jobs, get_clean_environment());
+                const auto job_results =
+                    cmd_execute_and_capture_output_parallel(jobs, default_working_directory, get_clean_environment());
 
                 for (size_t j = 0; j < jobs.size(); ++j)
                 {

--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -716,6 +716,7 @@ namespace vcpkg::Build
                                        "Error occurred while writing '%s'",
                                        stdoutlog);
                 },
+                default_working_directory,
                 env);
         } // close out_file
 
@@ -939,6 +940,7 @@ namespace vcpkg::Build
                                        "Error occurred while writing '%s'",
                                        stdoutlog);
                 },
+                default_working_directory,
                 env);
         } // close out_file
 

--- a/src/vcpkg/cmakevars.cpp
+++ b/src/vcpkg/cmakevars.cpp
@@ -260,7 +260,9 @@ endfunction()
 
         std::vector<std::string> lines;
         auto const exit_code = cmd_execute_and_stream_lines(
-            cmd_launch_cmake, [&](StringView sv) { lines.emplace_back(sv.begin(), sv.end()); });
+            cmd_launch_cmake,
+            [&](StringView sv) { lines.emplace_back(sv.begin(), sv.end()); },
+            default_working_directory);
 
         Checks::check_exit(VCPKG_LINE_INFO, exit_code == 0, exit_code == 0 ? "" : Strings::join("\n", lines));
 

--- a/src/vcpkg/commands.env.cpp
+++ b/src/vcpkg/commands.env.cpp
@@ -108,7 +108,7 @@ namespace vcpkg::Commands::Env
 #ifdef _WIN32
         enter_interactive_subprocess();
 #endif
-        auto rc = cmd_execute(cmd, env);
+        auto rc = cmd_execute(cmd, default_working_directory, env);
 #ifdef _WIN32
         exit_interactive_subprocess();
 #endif

--- a/src/vcpkg/commands.integrate.cpp
+++ b/src/vcpkg/commands.integrate.cpp
@@ -368,7 +368,8 @@ CMake projects should use: "-DCMAKE_TOOLCHAIN_FILE=%s"
                             .path_arg(buildsystems_dir)
                             .path_arg(nuspec_file_path);
 
-        const int exit_code = cmd_execute_and_capture_output(cmd_line, get_clean_environment()).exit_code;
+        const int exit_code =
+            cmd_execute_and_capture_output(cmd_line, default_working_directory, get_clean_environment()).exit_code;
 
         const auto nuget_package = buildsystems_dir / Strings::format("%s.%s.nupkg", nuget_id, nupkg_version);
         Checks::check_exit(

--- a/src/vcpkg/commands.portsdiff.cpp
+++ b/src/vcpkg/commands.portsdiff.cpp
@@ -97,8 +97,9 @@ namespace vcpkg::Commands::PortsDiff
                        .string_arg("--")
                        .string_arg(checkout_this_dir)
                        .string_arg(".vcpkg-root");
-        cmd_execute_and_capture_output(cmd, get_clean_environment());
+        cmd_execute_and_capture_output(cmd, default_working_directory, get_clean_environment());
         cmd_execute_and_capture_output(paths.git_cmd_builder(dot_git_dir, temp_checkout_path).string_arg("reset"),
+                                       default_working_directory,
                                        get_clean_environment());
         const auto ports_at_commit = Paragraphs::load_overlay_ports(fs, temp_checkout_path / ports_dir_name);
         std::map<std::string, Version> names_and_versions;

--- a/src/vcpkg/configure-environment.cpp
+++ b/src/vcpkg/configure-environment.cpp
@@ -53,7 +53,7 @@ namespace vcpkg
             cmd_provision.string_arg("--scripts-prepend-node-path=true");
             cmd_provision.string_arg("--silent");
             cmd_provision.path_arg(ce_tarball);
-            const auto provision_status = cmd_execute(cmd_provision, InWorkingDirectory{paths.root}, env);
+            const auto provision_status = cmd_execute(cmd_provision, WorkingDirectory{paths.root}, env);
             fs.remove(ce_tarball, VCPKG_LINE_INFO);
             if (provision_status != 0)
             {
@@ -67,7 +67,7 @@ namespace vcpkg
         cmd_run.path_arg(ce_path);
         cmd_run.forwarded_args(args);
         cmd_run.string_arg("--from-vcpkg");
-        return cmd_execute(cmd_run, InWorkingDirectory{paths.original_cwd});
+        return cmd_execute(cmd_run, WorkingDirectory{paths.original_cwd});
     }
 
     int run_configure_environment_command(const VcpkgPaths& paths, StringView arg0, View<std::string> args)

--- a/src/vcpkg/export.chocolatey.cpp
+++ b/src/vcpkg/export.chocolatey.cpp
@@ -226,7 +226,8 @@ if (Test-Path $installedDir)
                                 .path_arg(nuspec_file_path)
                                 .string_arg("-NoDefaultExcludes");
 
-            const int exit_code = cmd_execute_and_capture_output(cmd_line, get_clean_environment()).exit_code;
+            const int exit_code =
+                cmd_execute_and_capture_output(cmd_line, default_working_directory, get_clean_environment()).exit_code;
             Checks::check_exit(VCPKG_LINE_INFO, exit_code == 0, "Error: NuGet package creation failed");
         }
     }

--- a/src/vcpkg/export.cpp
+++ b/src/vcpkg/export.cpp
@@ -179,7 +179,7 @@ namespace vcpkg::Export
             .path_arg(output_dir)
             .string_arg("-NoDefaultExcludes");
 
-        const auto output = cmd_execute_and_capture_output(cmd, get_clean_environment());
+        const auto output = cmd_execute_and_capture_output(cmd, default_working_directory, get_clean_environment());
         const auto exit_code = output.exit_code;
         if (exit_code != 0)
         {
@@ -243,7 +243,7 @@ namespace vcpkg::Export
             .string_arg("--")
             .path_arg(raw_exported_dir);
 
-        const int exit_code = cmd_execute_clean(cmd, InWorkingDirectory{raw_exported_dir.parent_path()});
+        const int exit_code = cmd_execute_clean(cmd, WorkingDirectory{raw_exported_dir.parent_path()});
         Checks::check_exit(VCPKG_LINE_INFO, exit_code == 0, "Error: %s creation failed", exported_archive_path);
         return exported_archive_path;
     }

--- a/src/vcpkg/export.ifw.cpp
+++ b/src/vcpkg/export.ifw.cpp
@@ -343,7 +343,8 @@ namespace vcpkg::Export::IFW
             auto cmd_line =
                 Command(repogen_exe).string_arg("--packages").path_arg(packages_dir).path_arg(repository_dir);
 
-            const int exit_code = cmd_execute_and_capture_output(cmd_line, get_clean_environment()).exit_code;
+            const int exit_code =
+                cmd_execute_and_capture_output(cmd_line, default_working_directory, get_clean_environment()).exit_code;
             Checks::check_exit(VCPKG_LINE_INFO, exit_code == 0, "Error: IFW repository generating failed");
 
             vcpkg::printf(Color::success, "Generating repository %s... done.\n", repository_dir);
@@ -382,7 +383,8 @@ namespace vcpkg::Export::IFW
                                .path_arg(installer_file);
             }
 
-            const int exit_code = cmd_execute_and_capture_output(cmd_line, get_clean_environment()).exit_code;
+            const int exit_code =
+                cmd_execute_and_capture_output(cmd_line, default_working_directory, get_clean_environment()).exit_code;
             Checks::check_exit(VCPKG_LINE_INFO, exit_code == 0, "Error: IFW installer generating failed");
 
             vcpkg::printf(Color::success, "Generating installer %s... done.\n", installer_file);

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -1091,7 +1091,7 @@ namespace vcpkg
                 destination_tar);
 
         const auto extract_output =
-            cmd_execute_and_capture_output(extract_cmd_builder, InWorkingDirectory{destination_tmp});
+            cmd_execute_and_capture_output(extract_cmd_builder, WorkingDirectory{destination_tmp});
         if (extract_output.exit_code != 0)
         {
             return {Strings::concat(PRELUDE, "Error: Failed to extract port directory\n", extract_output.output),
@@ -1264,7 +1264,7 @@ namespace vcpkg
         auto untar = Command{get_tool_exe(Tools::CMAKE)}.string_arg("-E").string_arg("tar").string_arg("xf").path_arg(
             git_tree_temp_tar);
 
-        auto untar_output = cmd_execute_and_capture_output(untar, InWorkingDirectory{git_tree_temp});
+        auto untar_output = cmd_execute_and_capture_output(untar, WorkingDirectory{git_tree_temp});
         // Attempt to remove temporary files, though non-critical.
         fs.remove(git_tree_temp_tar, IgnoreErrors{});
         if (untar_output.exit_code != 0)


### PR DESCRIPTION
Currently our PR and CI builds in the catalog repo are failing with the message:
````
Extracting 7zip...
msiexec failed while extracting 'D:\downloads\7z1900-x64.msi' with message:
T
##[error]vcpkg ci failed
````

Example: https://dev.azure.com/vcpkg/public/_build/results?buildId=68039&view=logs&j=7922e5c4-0103-5f8f-ad17-45ce9bb98e80&t=491b9f02-7edc-5990-cda1-511e95a3768e

The single character combined with msiexec being a Windows application suggests that it is trying to print UTF-16.

This change adds a new Encoding parameter to our cmd_execute_Xxx functions and passes in UTF-16 for msiexec.