### PR TITLE
Use System32\tar.exe if present instead of 7zip for zip archives.

### DIFF
--- a/include/vcpkg/archives.h
+++ b/include/vcpkg/archives.h
@@ -11,6 +11,8 @@ namespace vcpkg
 {
     // Extract `archive` to `to_path` using `tar_tool`.
     void extract_tar(const Path& tar_tool, const Path& archive, const Path& to_path);
+    // Extract `archive` to `to_path` using `cmake_tool`. (CMake's built in tar)
+    void extract_tar_cmake(const Path& cmake_tool, const Path& archive, const Path& to_path);
     // Extract `archive` to `to_path`, deleting `to_path` first.
     void extract_archive(const VcpkgPaths& paths, const Path& archive, const Path& to_path);
 

--- a/include/vcpkg/base/system.h
+++ b/include/vcpkg/base/system.h
@@ -18,6 +18,10 @@ namespace vcpkg
 
 #ifdef _WIN32
     const ExpectedS<Path>& get_appdata_local() noexcept;
+
+    const ExpectedS<Path>& get_system_root() noexcept;
+
+    const ExpectedS<Path>& get_system32() noexcept;
 #endif
 
     Optional<std::string> get_registry_string(void* base_hkey, StringView subkey, StringView valuename);

--- a/include/vcpkg/fwd/tools.h
+++ b/include/vcpkg/fwd/tools.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace vcpkg
+{
+    enum class RequireExactVersions
+    {
+        YES,
+        NO,
+    };
+
+    struct ToolCache;
+}

--- a/include/vcpkg/tools.h
+++ b/include/vcpkg/tools.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <vcpkg/fwd/tools.h>
 #include <vcpkg/fwd/vcpkgpaths.h>
 
 #include <vcpkg/base/files.h>
@@ -30,15 +31,9 @@ namespace vcpkg
         static const std::string IFW_REPOGEN = "ifw_repogen";
     }
 
-    enum class RequireExactVersions
-    {
-        YES,
-        NO,
-    };
-
     struct ToolCache
     {
-        virtual ~ToolCache() { }
+        virtual ~ToolCache();
 
         virtual const Path& get_tool_path_from_system(const Filesystem& fs, const std::string& tool) const = 0;
         virtual const Path& get_tool_path(const VcpkgPaths& paths, const std::string& tool) const = 0;

--- a/include/vcpkg/tools.h
+++ b/include/vcpkg/tools.h
@@ -33,7 +33,7 @@ namespace vcpkg
 
     struct ToolCache
     {
-        virtual ~ToolCache();
+        virtual ~ToolCache() = default;
 
         virtual const Path& get_tool_path_from_system(const Filesystem& fs, const std::string& tool) const = 0;
         virtual const Path& get_tool_path(const VcpkgPaths& paths, const std::string& tool) const = 0;

--- a/src/vcpkg/base/system.cpp
+++ b/src/vcpkg/base/system.cpp
@@ -273,6 +273,28 @@ namespace vcpkg
         }();
         return s_home;
     }
+
+    const ExpectedS<Path>& get_system_root() noexcept
+    {
+        static const ExpectedS<Path> s_system_root = []() -> ExpectedS<Path> {
+            auto env = get_environment_variable("SystemRoot");
+            if (const auto p = env.get())
+            {
+                return std::move(*p);
+            }
+            else
+            {
+                return std::string("Expected the SystemRoot environment variable to be always set on Windows.");
+            }
+        }();
+        return s_system_root;
+    }
+
+    const ExpectedS<Path>& get_system32() noexcept
+    {
+        static const ExpectedS<Path> s_system32 = get_system_root().map([](const Path& p) { return p / "system32"; });
+        return s_system32;
+    }
 #else
     static const ExpectedS<Path>& get_xdg_cache_home() noexcept
     {

--- a/src/vcpkg/base/system.cpp
+++ b/src/vcpkg/base/system.cpp
@@ -292,7 +292,7 @@ namespace vcpkg
 
     const ExpectedS<Path>& get_system32() noexcept
     {
-        static const ExpectedS<Path> s_system32 = get_system_root().map([](const Path& p) { return p / "system32"; });
+        static const ExpectedS<Path> s_system32 = get_system_root().map([](const Path& p) { return p / "System32"; });
         return s_system32;
     }
 #else

--- a/src/vcpkg/base/system.cpp
+++ b/src/vcpkg/base/system.cpp
@@ -280,7 +280,7 @@ namespace vcpkg
             auto env = get_environment_variable("SystemRoot");
             if (const auto p = env.get())
             {
-                return std::move(*p);
+                return Path(std::move(*p));
             }
             else
             {

--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -260,9 +260,8 @@ namespace vcpkg
     Environment get_modified_clean_environment(const std::unordered_map<std::string, std::string>& extra_env,
                                                StringView prepend_to_path)
     {
-        static const std::string system_root_env =
-            get_environment_variable("SystemRoot").value_or_exit(VCPKG_LINE_INFO);
-        static const std::string system32_env = system_root_env + R"(\system32)";
+        const std::string& system_root_env = get_system_root().value_or_exit(VCPKG_LINE_INFO).native();
+        const std::string& system32_env = get_system32().value_or_exit(VCPKG_LINE_INFO).native();
         std::string new_path = "PATH=";
         if (!prepend_to_path.empty())
         {

--- a/src/vcpkg/tools.cpp
+++ b/src/vcpkg/tools.cpp
@@ -668,8 +668,6 @@ aws-cli/2.4.4 Python/3.8.8 Windows/10 exe/AMD64 prompt/off
         }
     };
 
-    ToolCache::~ToolCache() = default;
-
     struct ToolCacheImpl final : ToolCache
     {
         RequireExactVersions abiToolVersionHandling;

--- a/src/vcpkg/tools.cpp
+++ b/src/vcpkg/tools.cpp
@@ -668,6 +668,8 @@ aws-cli/2.4.4 Python/3.8.8 Windows/10 exe/AMD64 prompt/off
         }
     };
 
+    ToolCache::~ToolCache() = default;
+
     struct ToolCacheImpl final : ToolCache
     {
         RequireExactVersions abiToolVersionHandling;


### PR DESCRIPTION
This is a more targeted hotfix version of https://github.com/microsoft/vcpkg-tool/pull/404 as there are outstanding code review discussions there. (I do still intend to apply the changes therein but don't want code reviewers to feel like they can't say anything because it's resolving a high priority issue)