### PR TITLE
[format] remove disable 6385

### DIFF
--- a/include/vcpkg/base/format.h
+++ b/include/vcpkg/base/format.h
@@ -7,14 +7,10 @@
 #include <vcpkg/base/stringview.h>
 
 VCPKG_MSVC_WARNING(push)
-// notes:
+// note:
 // C6239 is not a useful warning for external code; it is
 //   (<non-zero constant> && <expression>) always evaluates to the result of <expression>.
-// C6385 is a useful warning, but it's incorrect in this case; it thinks that (on line 1238),
-//   const char* top = data::digits[exp / 100];
-// accesses outside the bounds of data::digits; however, `exp < 10000 => exp / 100 < 100`,
-// and thus the access is safe.
-VCPKG_MSVC_WARNING(disable : 6239 6385)
+VCPKG_MSVC_WARNING(disable : 6239)
 #include <fmt/format.h>
 VCPKG_MSVC_WARNING(pop)
 


### PR DESCRIPTION
Some old code did `const char* top = data::digits[exp / 100]`;
in that case, `exp < 10000 => exp / 100 < 100`, and thus that was not _actually_ broken,
but the warning still fired so it had to be disabled.
However, in new code they now do:

`const char* top = digits2(to_unsigned(exp / 100))`,
and thus this warning is no longer hit.

Since this is a useful warning, we don't want to disable it,
and thus we are re-enabling it.