### PR TITLE
re-enable disabled warnings which are no longer relevant

### DIFF
--- a/include/vcpkg/base/jsonreader.h
+++ b/include/vcpkg/base/jsonreader.h
@@ -206,9 +206,6 @@ namespace vcpkg::Json
         StatsTimer m_stat_timer;
     };
 
-    VCPKG_MSVC_WARNING(push)
-    VCPKG_MSVC_WARNING(disable : 4505)
-
     template<class Type>
     Optional<Type> IDeserializer<Type>::visit(Reader& r, const Value& value)
     {
@@ -273,8 +270,6 @@ namespace vcpkg::Json
     {
         return nullopt;
     }
-
-    VCPKG_MSVC_WARNING(pop)
 
     struct StringDeserializer final : IDeserializer<std::string>
     {

--- a/include/vcpkg/base/optional.h
+++ b/include/vcpkg/base/optional.h
@@ -26,7 +26,6 @@ namespace vcpkg
         template<class T, bool B = std::is_copy_constructible<T>::value>
         struct OptionalStorage
         {
-            VCPKG_MSVC_WARNING(suppress : 26495)
             constexpr OptionalStorage() noexcept : m_is_present(false), m_inactive() { }
             constexpr OptionalStorage(const T& t) : m_is_present(true), m_t(t) { }
             constexpr OptionalStorage(T&& t) : m_is_present(true), m_t(std::move(t)) { }
@@ -54,13 +53,11 @@ namespace vcpkg
                 if (m_is_present) m_t.~T();
             }
 
-            VCPKG_MSVC_WARNING(suppress : 26495)
             OptionalStorage(const OptionalStorage& o) : m_is_present(o.m_is_present), m_inactive()
             {
                 if (m_is_present) new (&m_t) T(o.m_t);
             }
 
-            VCPKG_MSVC_WARNING(suppress : 26495)
             OptionalStorage(OptionalStorage&& o) noexcept : m_is_present(o.m_is_present), m_inactive()
             {
                 if (m_is_present)
@@ -144,7 +141,6 @@ namespace vcpkg
         template<class T>
         struct OptionalStorage<T, false>
         {
-            VCPKG_MSVC_WARNING(suppress : 26495)
             constexpr OptionalStorage() noexcept : m_is_present(false), m_inactive() { }
             constexpr OptionalStorage(T&& t) : m_is_present(true), m_t(std::move(t)) { }
 
@@ -153,7 +149,6 @@ namespace vcpkg
                 if (m_is_present) m_t.~T();
             }
 
-            VCPKG_MSVC_WARNING(suppress : 26495)
             OptionalStorage(OptionalStorage&& o) noexcept : m_is_present(o.m_is_present), m_inactive()
             {
                 if (m_is_present)

--- a/include/vcpkg/base/pragmas.h
+++ b/include/vcpkg/base/pragmas.h
@@ -1,15 +1,5 @@
 #pragma once
 
-#if defined(_MSC_VER) && _MSC_VER < 1911
-// [[nodiscard]] is not recognized before VS 2017 version 15.3
-#pragma warning(disable : 5030)
-#endif
-
-#if defined(_MSC_VER) && _MSC_VER < 1910
-// https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4800?view=vs-2019
-#pragma warning(disable : 4800)
-#endif
-
 #if defined(__GNUC__) && __GNUC__ < 7
 // [[nodiscard]] is not recognized before GCC version 7
 #pragma GCC diagnostic ignored "-Wattributes"

--- a/include/vcpkg/base/system_headers.h
+++ b/include/vcpkg/base/system_headers.h
@@ -10,8 +10,8 @@
 #define WIN32_LEAN_AND_MEAN
 #endif
 
-#include <windows.h>
 #include <Shlobj.h>
+#include <windows.h>
 
 #else // ^^^^ Windows / Unix vvvv
 

--- a/include/vcpkg/base/system_headers.h
+++ b/include/vcpkg/base/system_headers.h
@@ -10,10 +10,7 @@
 #define WIN32_LEAN_AND_MEAN
 #endif
 
-#pragma warning(suppress : 4768)
 #include <windows.h>
-
-#pragma warning(suppress : 4768)
 #include <Shlobj.h>
 
 #else // ^^^^ Windows / Unix vvvv

--- a/src/vcpkg-test/manifests.cpp
+++ b/src/vcpkg-test/manifests.cpp
@@ -11,10 +11,6 @@
 
 #include <vcpkg-test/util.h>
 
-#if defined(_MSC_VER)
-#pragma warning(disable : 6237)
-#endif
-
 using namespace vcpkg;
 using namespace vcpkg::Paragraphs;
 using namespace vcpkg::Test;

--- a/src/vcpkg-test/strings.cpp
+++ b/src/vcpkg-test/strings.cpp
@@ -10,10 +10,6 @@
 #include <utility>
 #include <vector>
 
-#if defined(_MSC_VER)
-#pragma warning(disable : 6237)
-#endif
-
 TEST_CASE ("b32 encoding", "[strings]")
 {
     using u64 = uint64_t;

--- a/src/vcpkg-test/system.cpp
+++ b/src/vcpkg-test/system.cpp
@@ -11,10 +11,6 @@
 
 #include <string>
 
-#if defined(_MSC_VER)
-#pragma warning(disable : 6237)
-#endif
-
 using vcpkg::CPUArchitecture;
 using vcpkg::get_environment_variable;
 using vcpkg::guess_visual_studio_prompt_target_architecture;

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -383,7 +383,7 @@ namespace
         // bug in MSVC considers h_file uninitialized:
         // https://developercommunity.visualstudio.com/t/Spurious-warning-C6001-Using-uninitial/1299941
         VCPKG_MSVC_WARNING(push)
-        VCPKG_MSVC_WARNING(disable: 6001)
+        VCPKG_MSVC_WARNING(disable : 6001)
         ~FileHandle()
         {
             if (h_file != INVALID_HANDLE_VALUE)

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -380,6 +380,10 @@ namespace
             }
         }
 
+        // bug in MSVC considers h_file uninitialized:
+        // https://developercommunity.visualstudio.com/t/Spurious-warning-C6001-Using-uninitial/1299941
+        VCPKG_MSVC_WARNING(push)
+        VCPKG_MSVC_WARNING(disable: 6001)
         ~FileHandle()
         {
             if (h_file != INVALID_HANDLE_VALUE)
@@ -387,6 +391,7 @@ namespace
                 Checks::check_exit(VCPKG_LINE_INFO, ::CloseHandle(h_file));
             }
         }
+        VCPKG_MSVC_WARNING(pop)
     };
 
     struct RemoveAllErrorInfo

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -380,11 +380,6 @@ namespace
             }
         }
 
-        // https://developercommunity.visualstudio.com/t/Spurious-warning-C6001-Using-uninitial/1299941
-#if defined(_MSC_VER)
-#pragma warning(push)
-#pragma warning(disable : 6001)
-#endif // ^^^ _MSC_VER
         ~FileHandle()
         {
             if (h_file != INVALID_HANDLE_VALUE)
@@ -392,9 +387,6 @@ namespace
                 Checks::check_exit(VCPKG_LINE_INFO, ::CloseHandle(h_file));
             }
         }
-#if defined(_MSC_VER)
-#pragma warning(pop)
-#endif // ^^^ _MSC_VER
     };
 
     struct RemoveAllErrorInfo

--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -549,6 +549,10 @@ namespace vcpkg
         }
 
         auto environment_block = env.m_env_data;
+
+        // Leaking process information handle 'process_info.proc_info.hProcess'
+        // /analyze can't tell that we transferred ownership here
+        VCPKG_MSVC_WARNING(suppress: 6335)
         bool succeeded = TRUE == CreateProcessW(nullptr,
                                                 Strings::to_utf16(cmd_line).data(),
                                                 nullptr,

--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -548,10 +548,7 @@ namespace vcpkg
                 Strings::to_utf16(get_real_filesystem().absolute(wd.working_directory, VCPKG_LINE_INFO));
         }
 
-        VCPKG_MSVC_WARNING(suppress : 6335) // Leaking process information handle 'process_info.proc_info.hProcess'
-                                            // /analyze can't tell that we transferred ownership here
         auto environment_block = env.m_env_data;
-#pragma warning(suppress : 6335) // Leaking process information handle 'process_info.proc_info.hProcess'
         bool succeeded = TRUE == CreateProcessW(nullptr,
                                                 Strings::to_utf16(cmd_line).data(),
                                                 nullptr,

--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -552,7 +552,7 @@ namespace vcpkg
 
         // Leaking process information handle 'process_info.proc_info.hProcess'
         // /analyze can't tell that we transferred ownership here
-        VCPKG_MSVC_WARNING(suppress: 6335)
+        VCPKG_MSVC_WARNING(suppress : 6335)
         bool succeeded = TRUE == CreateProcessW(nullptr,
                                                 Strings::to_utf16(cmd_line).data(),
                                                 nullptr,

--- a/src/vcpkg/export.cpp
+++ b/src/vcpkg/export.cpp
@@ -458,12 +458,6 @@ namespace vcpkg::Export
             }
         };
 
-#if defined(_MSC_VER) && _MSC_VER <= 1900
-// there's a bug in VS 2015 that causes a bunch of "unreferenced local variable" warnings
-#pragma warning(push)
-#pragma warning(disable : 4189)
-#endif
-
         options_implies(OPTION_NUGET,
                         ret.nuget,
                         {
@@ -499,9 +493,6 @@ namespace vcpkg::Export
                             {OPTION_CHOCOLATEY_VERSION_SUFFIX, ret.chocolatey_options.maybe_version_suffix},
                         });
 
-#if defined(_MSC_VER) && _MSC_VER <= 1900
-#pragma warning(pop)
-#endif
         return ret;
     }
 


### PR DESCRIPTION
try to find all the warnings that are still an issue in modern VS

Also, standardize on `VCPKG_MSVC_WARNING`