### PR TITLE
Revert start /wait for msiexec and change nulls to ? in UTF-8 mode.

### DIFF
--- a/src/vcpkg/archives.cpp
+++ b/src/vcpkg/archives.cpp
@@ -68,9 +68,6 @@ namespace
             const auto code_and_output = cmd_execute_and_capture_output(
                 Command{"cmd"}
                     .string_arg("/c")
-                    .string_arg("start")
-                    .string_arg("/wait")
-                    .string_arg("(no title)")
                     .string_arg("msiexec")
                     // "/a" is administrative mode, which unpacks without modifying the system
                     .string_arg("/a")

--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -602,6 +602,7 @@ namespace vcpkg
             {
                 while (ReadFile(child_stdout, static_cast<void*>(buf), buffer_size, &bytes_read, nullptr))
                 {
+                    std::replace(buf, buf + bytes_read, '\0', '?');
                     f(StringView{buf, static_cast<size_t>(bytes_read)});
                 }
             }


### PR DESCRIPTION
https://github.com/microsoft/vcpkg/pull/23367 was a failure because we still end up trying to download portable git; however as some combination of changes in attempt to debug we drop all msiexec output on the floor now.

This reverts change to add start /wait, replaces nulls with ?s.