### PR TITLE
Reduce msiexec round 2

### DIFF
--- a/include/vcpkg/archives.h
+++ b/include/vcpkg/archives.h
@@ -16,6 +16,12 @@ namespace vcpkg
     // Extract `archive` to `to_path`, deleting `to_path` first.
     void extract_archive(const VcpkgPaths& paths, const Path& archive, const Path& to_path);
 
+#ifdef _WIN32
+    // Extract `archive` to `to_path`, deleting `to_path` first. `archive` must be a zip file.
+    // This function will use potentially less performant tools that are reliably available on any machine.
+    void win32_extract_bootstrap_zip(const VcpkgPaths& paths, const Path& archive, const Path& to_path);
+#endif
+
     // Compress the source directory into the destination file.
     int compress_directory_to_zip(const VcpkgPaths& paths, const Path& source, const Path& destination);
 

--- a/include/vcpkg/tools.h
+++ b/include/vcpkg/tools.h
@@ -29,6 +29,8 @@ namespace vcpkg
         static const std::string IFW_INSTALLER_BASE = "ifw_installerbase";
         static const std::string IFW_BINARYCREATOR = "ifw_binarycreator";
         static const std::string IFW_REPOGEN = "ifw_repogen";
+        // This duplicate of 7zip uses msiexec to unpack, which is a fallback for Windows 7.
+        static const std::string SEVEN_ZIP_MSI = "7zip_msi";
     }
 
     struct ToolCache

--- a/src/vcpkg/archives.cpp
+++ b/src/vcpkg/archives.cpp
@@ -190,7 +190,7 @@ namespace vcpkg
         fs.remove_all(to_path_partial, VCPKG_LINE_INFO);
         fs.create_directories(to_path_partial, VCPKG_LINE_INFO);
         const auto tar_path = get_system32().value_or_exit(VCPKG_LINE_INFO) / "tar.exe";
-        if (paths.get_filesystem().exists(tar_path, IgnoreErrors{}))
+        if (fs.exists(tar_path, IgnoreErrors{}))
         {
             // On Windows 10, tar.exe is in the box.
 

--- a/src/vcpkg/archives.cpp
+++ b/src/vcpkg/archives.cpp
@@ -104,12 +104,11 @@ namespace
         }
     }
 
-    void win32_extract_with_seven_zip(const VcpkgPaths& paths, const Path& archive, const Path& to_path)
+    void win32_extract_with_seven_zip(const Path& seven_zip, const Path& archive, const Path& to_path)
     {
         static bool recursion_limiter_sevenzip = false;
         Checks::check_exit(VCPKG_LINE_INFO, !recursion_limiter_sevenzip);
         recursion_limiter_sevenzip = true;
-        const auto seven_zip = paths.get_tool_exe(Tools::SEVEN_ZIP);
         const auto code_and_output = cmd_execute_and_capture_output(Command{seven_zip}
                                                                         .string_arg("x")
                                                                         .path_arg(archive)
@@ -136,25 +135,14 @@ namespace
         {
             win32_extract_msi(archive, to_path);
         }
-        else if (Strings::case_insensitive_ascii_equals(ext, ".zip"))
-        {
-            const auto tar_path = get_system32().value_or_exit(VCPKG_LINE_INFO) / "tar.exe";
-            if (paths.get_filesystem().exists(tar_path, IgnoreErrors{}))
-            {
-                extract_tar(tar_path, archive, to_path);
-            }
-            else
-            {
-                win32_extract_with_seven_zip(paths, archive, to_path);
-            }
-        }
-        else if (Strings::case_insensitive_ascii_equals(ext, ".7z"))
+        else if (Strings::case_insensitive_ascii_equals(ext, ".zip") ||
+                 Strings::case_insensitive_ascii_equals(ext, ".7z"))
         {
             extract_tar_cmake(paths.get_tool_exe(Tools::CMAKE), archive, to_path);
         }
         else if (Strings::case_insensitive_ascii_equals(ext, ".exe"))
         {
-            win32_extract_with_seven_zip(paths, archive, to_path);
+            win32_extract_with_seven_zip(paths.get_tool_exe(Tools::SEVEN_ZIP), archive, to_path);
         }
 #else
         if (ext == ".zip")
@@ -191,6 +179,37 @@ namespace
 
 namespace vcpkg
 {
+
+#ifdef _WIN32
+    void win32_extract_bootstrap_zip(const VcpkgPaths& paths, const Path& archive, const Path& to_path)
+    {
+        Filesystem& fs = paths.get_filesystem();
+        fs.remove_all(to_path, VCPKG_LINE_INFO);
+        Path to_path_partial = to_path + ".partial." + std::to_string(GetCurrentProcessId());
+
+        fs.remove_all(to_path_partial, VCPKG_LINE_INFO);
+        fs.create_directories(to_path_partial, VCPKG_LINE_INFO);
+        const auto tar_path = get_system32().value_or_exit(VCPKG_LINE_INFO) / "tar.exe";
+        if (paths.get_filesystem().exists(tar_path, IgnoreErrors{}))
+        {
+            // On Windows 10, tar.exe is in the box.
+
+            // Example:
+            // tar unpacks cmake unpacks 7zip unpacks git
+            extract_tar(tar_path, archive, to_path_partial);
+        }
+        else
+        {
+            // On Windows <10, we attempt to use msiexec to unpack 7zip.
+
+            // Example:
+            // msiexec unpacks 7zip_msi unpacks cmake unpacks 7zip unpacks git
+            win32_extract_with_seven_zip(paths.get_tool_exe(Tools::SEVEN_ZIP_MSI), archive, to_path_partial);
+        }
+        fs.rename_with_retry(to_path_partial, to_path, VCPKG_LINE_INFO);
+    }
+#endif
+
     void extract_tar(const Path& tar_tool, const Path& archive, const Path& to_path)
     {
         const auto code = cmd_execute(Command{tar_tool}.string_arg("xzf").path_arg(archive), WorkingDirectory{to_path});

--- a/src/vcpkg/tools.cpp
+++ b/src/vcpkg/tools.cpp
@@ -207,7 +207,7 @@ namespace vcpkg
         if (tool_data.is_archive)
         {
             print2("Extracting ", tool_name, "...\n");
-#ifdef _WIN32
+#if defined(_WIN32)
             if (tool_name == "cmake")
             {
                 // We use cmake as the core extractor on Windows, so we need to perform a special dance when
@@ -215,12 +215,11 @@ namespace vcpkg
                 win32_extract_bootstrap_zip(paths, tool_data.download_path, tool_data.tool_dir_path);
             }
             else
+#endif // ^^^ _WIN32
             {
                 extract_archive(paths, tool_data.download_path, tool_data.tool_dir_path);
             }
-#else
-            extract_archive(paths, tool_data.download_path, tool_data.tool_dir_path);
-#endif
+
         }
         else
         {

--- a/src/vcpkg/tools.cpp
+++ b/src/vcpkg/tools.cpp
@@ -219,7 +219,6 @@ namespace vcpkg
             {
                 extract_archive(paths, tool_data.download_path, tool_data.tool_dir_path);
             }
-
         }
         else
         {

--- a/src/vcpkg/tools.cpp
+++ b/src/vcpkg/tools.cpp
@@ -207,7 +207,20 @@ namespace vcpkg
         if (tool_data.is_archive)
         {
             print2("Extracting ", tool_name, "...\n");
+#ifdef _WIN32
+            if (tool_name == "cmake")
+            {
+                // We use cmake as the core extractor on Windows, so we need to perform a special dance when
+                // extracting it.
+                win32_extract_bootstrap_zip(paths, tool_data.download_path, tool_data.tool_dir_path);
+            }
+            else
+            {
+                extract_archive(paths, tool_data.download_path, tool_data.tool_dir_path);
+            }
+#else
             extract_archive(paths, tool_data.download_path, tool_data.tool_dir_path);
+#endif
         }
         else
         {


### PR DESCRIPTION
Following up from https://github.com/microsoft/vcpkg-tool/pull/407#issuecomment-1058798498 and the continued issues with msiexec, this PR implements a stopgap solution until we can ship unzip functionality directly in the vcpkg binary.

The approach in this PR is:
1. Make the primary `7zip` tool come from the `.7z` archive
2. Move the existing msi-based acquisition to `7zip_msi`
3. Use `cmake` to extract `.7z` files
4. Special case extracting `cmake` to use the first of:
    a. C:\Windows\System32\tar.exe
    b. `7zip_msi`

This means that Windows 10 users should not run msiexec at all as part of the core operation of vcpkg. Windows 7 users will either need to install a recent version of CMake _or_ we will use msiexec. 7zip is 100% fetchable without msiexec once we have cmake, so we can still use it for archive creation or any other existing purpose.

### Windows 10 fetching git (no msiexec!)
```
PS C:\src\vcpkg> vcpkg fetch git2 --debug
A suitable version of git2 was not found (required v2.32.0). Downloading portable git2 v2.32.0...
Extracting git2...
A suitable version of 7zip was not found (required v20.0.0). Downloading portable 7zip v20.0.0...
Extracting 7zip...
A suitable version of cmake was not found (required v3.21.1). Downloading portable cmake v3.21.1...
Extracting cmake...
[DEBUG] CreateProcessW("C:\WINDOWS\System32\tar.exe" xzf "C:\src\vcpkg\downloads\cmake-3.21.1-windows-i386.zip")
[DEBUG] cmd_execute() returned 0 after 4824385 us
[DEBUG] CreateProcessW("C:\src\vcpkg\downloads\tools\cmake-3.21.1-windows\cmake-3.21.1-windows-i386\bin\cmake.exe" --version)
[DEBUG] ReadFile() finished with GetLastError(): 109
[DEBUG] 19464: cmd_execute_and_stream_data() returned 0 after   440565 us
[DEBUG] CreateProcessW("C:\src\vcpkg\downloads\tools\cmake-3.21.1-windows\cmake-3.21.1-windows-i386\bin\cmake.exe" -E tar xzf "C:\src\vcpkg\downloads\7z2107-extra.7z")
[DEBUG] cmd_execute() returned 0 after 330059 us
[DEBUG] CreateProcessW("C:\src\vcpkg\downloads\tools\7zip-20.00-windows\7za.exe" x "C:\src\vcpkg\downloads\PortableGit-2.32.0.2-32-bit.7z.exe" "-oC:\src\vcpkg\downloads\tools\git2-2.32.0.2-windows.partial.19464" -y)
[DEBUG] ReadFile() finished with GetLastError(): 109
[DEBUG] 19464: cmd_execute_and_stream_data() returned 0 after 11572140 us
C:\src\vcpkg\downloads\tools\git2-2.32.0.2-windows\mingw32\bin\git.exe
```

### Windows 10 fetching 7zip (no msiexec!)
```
PS C:\src\vcpkg-tool> vcpkg fetch 7zip --debug
A suitable version of 7zip was not found (required v20.0.0). Downloading portable 7zip v20.0.0...
Extracting 7zip...
A suitable version of cmake was not found (required v3.21.1). Downloading portable cmake v3.21.1...
Extracting cmake...
[DEBUG] CreateProcessW("C:\WINDOWS\System32\tar.exe" xzf "C:\src\vcpkg\downloads\cmake-3.21.1-windows-i386.zip")
[DEBUG] cmd_execute() returned 0 after 5089887 us
[DEBUG] CreateProcessW("C:\src\vcpkg\downloads\tools\cmake-3.21.1-windows\cmake-3.21.1-windows-i386\bin\cmake.exe" --version)
[DEBUG] ReadFile() finished with GetLastError(): 109
[DEBUG] 17520: cmd_execute_and_stream_data() returned 0 after   394882 us
[DEBUG] CreateProcessW("C:\src\vcpkg\downloads\tools\cmake-3.21.1-windows\cmake-3.21.1-windows-i386\bin\cmake.exe" -E tar xzf "C:\src\vcpkg\downloads\7z2107-extra.7z")
[DEBUG] cmd_execute() returned 0 after 345513 us
C:\src\vcpkg\downloads\tools\7zip-20.00-windows\7za.exe
```

### Windows 7 (simulated by failing to find `tar.exe`) fetching git
```
PS C:\src\vcpkg> vcpkg fetch git2 --debug
A suitable version of git2 was not found (required v2.32.0). Downloading portable git2 v2.32.0...
Extracting git2...
A suitable version of 7zip was not found (required v20.0.0). Downloading portable 7zip v20.0.0...
Extracting 7zip...
A suitable version of cmake was not found (required v3.21.1). Downloading portable cmake v3.21.1...
Extracting cmake...
A suitable version of 7zip_msi was not found (required v19.0.0). Downloading portable 7zip_msi v19.0.0...
Extracting 7zip_msi...
[DEBUG] CreateProcessW(cmd /c start /wait "(no title)" msiexec /a "C:\src\vcpkg\downloads\7z2107-x64.msi" /qn TARGETDIR="C:\src\vcpkg\downloads\tools\7zip_msi-19.00-windows.partial.22228")
[DEBUG] ReadFile() finished with GetLastError(): 109
[DEBUG] 22228: cmd_execute_and_stream_data() returned 0 after   644626 us
[DEBUG] CreateProcessW("C:\src\vcpkg\downloads\tools\7zip_msi-19.00-windows\Files\7-Zip\7z.exe" x "C:\src\vcpkg\downloads\cmake-3.21.1-windows-i386.zip" "-oC:\src\vcpkg\downloads\tools\cmake-3.21.1-windows.partial.22228" -y)
[DEBUG] ReadFile() finished with GetLastError(): 109
[DEBUG] 22228: cmd_execute_and_stream_data() returned 0 after  8446566 us
[DEBUG] CreateProcessW("C:\src\vcpkg\downloads\tools\cmake-3.21.1-windows\cmake-3.21.1-windows-i386\bin\cmake.exe" --version)
[DEBUG] ReadFile() finished with GetLastError(): 109
[DEBUG] 22228: cmd_execute_and_stream_data() returned 0 after   413431 us
[DEBUG] CreateProcessW("C:\src\vcpkg\downloads\tools\cmake-3.21.1-windows\cmake-3.21.1-windows-i386\bin\cmake.exe" -E tar xzf "C:\src\vcpkg\downloads\7z2107-extra.7z")
[DEBUG] cmd_execute() returned 0 after 321748 us
[DEBUG] CreateProcessW("C:\src\vcpkg\downloads\tools\7zip-20.00-windows\7za.exe" x "C:\src\vcpkg\downloads\PortableGit-2.32.0.2-32-bit.7z.exe" "-oC:\src\vcpkg\downloads\tools\git2-2.32.0.2-windows.partial.22228" -y)
[DEBUG] ReadFile() finished with GetLastError(): 109
[DEBUG] 22228: cmd_execute_and_stream_data() returned 0 after 10881353 us
C:\src\vcpkg\downloads\tools\git2-2.32.0.2-windows\mingw32\bin\git.exe
```


To test this, make the following edits to `scripts/vcpkgTools.xml`:
```diff
@@ -112,12 +112,19 @@
         <sha512>1f3e593270d7c2a4e271fdb49c637a2de462351310ef66bba298d30f6ca23365ec6aecf2e57799a00c873267cd3f92060ecac03eb291d42903d0e0869cd17c73</sha512>
         <archiveName>QtInstallerFramework-win-x86.zip</archiveName>
     </tool>
-    <tool name="7zip" os="windows">
-        <version>19.00</version>
+    <tool name="7zip_msi" os="windows">
+        <version>20.00</version>
         <exeRelativePath>Files\7-Zip\7z.exe</exeRelativePath>
-        <url>https://www.7-zip.org/a/7z1900-x64.msi</url>
-        <sha512>7837a8677a01eed9c3309923f7084bc864063ba214ee169882c5b04a7a8b198ed052c15e981860d9d7952c98f459a4fab87a72fd78e7d0303004dcb86f4324c8</sha512>
-        <archiveName>7z1900-x64.msi</archiveName>
+        <url>https://www.7-zip.org/a/7z2107-x64.msi</url>
+        <sha512>d55b44f1255d1b0e629719383a600a7e83dc6378d470096337b886ce24684d26bcc2b04f9cea39ad888179edce23ad2bd0e8e1863ddc40106c176adece8c012d</sha512>
+        <archiveName>7z2107-x64.msi</archiveName>
+    </tool>
+    <tool name="7zip" os="windows">
+        <version>20.00</version>
+        <exeRelativePath>7za.exe</exeRelativePath>
+        <url>https://www.7-zip.org/a/7z2107-extra.7z</url>
+        <sha512>648d894940bcc29951752d7a8fd18c770ee8d4fd944e17f1a52588e51ca8f58375ba48514538f2e1387786fd812bb86f75fd6bdd0892685cdcafb2989942c848</sha512>
+        <archiveName>7z2107-extra.7z</archiveName>
     </tool>
     <tool name="aria2" os="windows">
         <version>1.35.0</version>
```