### PR TITLE
Fix add artifact regression "you can only add one artifact at a time"

### DIFF
--- a/locales/messages.en.json
+++ b/locales/messages.en.json
@@ -1,6 +1,5 @@
 {
   "AddArtifactOnlyOne": "'{command_line}' can only add one artifact at a time.",
-  "AddFailedToWriteManifest": "Failed to write manifest file {path}: {error}",
   "AddFirstArgument": "The first argument to '{command_line}' must be 'artifact' or 'port'.\n",
   "AddPortRequiresManifest": "'{command_line}' requires an active manifest file.",
   "AddPortSucceded": "Succeeded in adding ports to vcpkg.json file.",

--- a/locales/messages.json
+++ b/locales/messages.json
@@ -1,8 +1,6 @@
 {
   "AddArtifactOnlyOne": "'{command_line}' can only add one artifact at a time.",
   "_AddArtifactOnlyOne.comment": "example of {command_line} is 'vcpkg install zlib'.\n",
-  "AddFailedToWriteManifest": "Failed to write manifest file {path}: {error}",
-  "_AddFailedToWriteManifest.comment": "example of {error} is 'no such file or directory'\nexample of {path} is '/foo/bar'.\n",
   "AddFirstArgument": "The first argument to '{command_line}' must be 'artifact' or 'port'.\n",
   "_AddFirstArgument.comment": "example of {command_line} is 'vcpkg install zlib'.\n",
   "AddPortRequiresManifest": "'{command_line}' requires an active manifest file.",


### PR DESCRIPTION
https://github.com/microsoft/vcpkg-tool/pull/301/ broke add artifact by flipping the sense of check_exit: it is "ensure that this is true" not "fail when this is true".

Drivebys: `add port` was also broken because it would try to add a port named "port".

60: Fix the flipped sense.
78: Replace fmap with a for loop starting at 1 to skip the selector.
80: Use Expected::value_or_exit which was equivalent to the previous behavior of printing the message followed by exit_fail.
84: Similarly combine printing msgAddTripletExpressionNotAllowed and exit_failure into msg_exit_with_message.
126: Similarly, write_contents' default behavior of exiting and printing the path in question with VCPKG_LINE_INFO was equivalent to checking error_code