### PR TITLE
[ci] Change triplet to be processed the same way as how other commands get their triplet.

### DIFF
--- a/azure-pipelines/end-to-end-tests-dir/ci.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/ci.ps1
@@ -1,13 +1,13 @@
 . $PSScriptRoot/../end-to-end-tests-prelude.ps1
 
 # Not a number
-Run-Vcpkg ci $Triplet --x-skipped-cascade-count=fish
+Run-Vcpkg ci --triplet=$Triplet --x-skipped-cascade-count=fish
 Throw-IfNotFailed
 
 # Negative
-Run-Vcpkg ci $Triplet --x-skipped-cascade-count=-1
+Run-Vcpkg ci --triplet=$Triplet --x-skipped-cascade-count=-1
 Throw-IfNotFailed
 
 # Clearly not the correct answer
-Run-Vcpkg ci $Triplet --x-skipped-cascade-count=1000
+Run-Vcpkg ci --triplet=$Triplet --x-skipped-cascade-count=1000
 Throw-IfNotFailed

--- a/src/vcpkg/commands.ci.cpp
+++ b/src/vcpkg/commands.ci.cpp
@@ -115,9 +115,9 @@ namespace vcpkg::Commands::CI
     }};
 
     const CommandStructure COMMAND_STRUCTURE = {
-        create_example_string("ci x64-windows"),
-        1,
-        1,
+        create_example_string("ci --triplet=x64-windows"),
+        0,
+        0,
         {CI_SWITCHES, CI_SETTINGS},
         nullptr,
     };
@@ -475,7 +475,10 @@ namespace vcpkg::Commands::CI
         return result;
     }
 
-    void perform_and_exit(const VcpkgCmdArguments& args, const VcpkgPaths& paths, Triplet, Triplet host_triplet)
+    void perform_and_exit(const VcpkgCmdArguments& args,
+                          const VcpkgPaths& paths,
+                          Triplet target_triplet,
+                          Triplet host_triplet)
     {
         vcpkg::print2(Color::warning,
                       "'vcpkg ci' is an internal command which will change incompatibly or be removed at any time.\n");
@@ -484,7 +487,6 @@ namespace vcpkg::Commands::CI
         const auto& settings = options.settings;
 
         BinaryCache binary_cache{args, paths};
-        Triplet target_triplet = Triplet::from_canonical_name(std::string(args.command_arguments[0]));
         ExclusionPredicate is_excluded{
             parse_exclusions(settings, OPTION_EXCLUDE),
             parse_exclusions(settings, OPTION_HOST_EXCLUDE),


### PR DESCRIPTION
Processing triplet from command-arguments is a historical artifact from back when the ci command supported multiple triplets at once.