### PR TITLE
Updated StringView and link list for vcpkglib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,11 +180,11 @@ set(CPP_ATOMIC_LIBRARY "")
 if(NOT MSVC)
     # Some platforms require a explicit linkage against libatomic to operate on 64-bit numbers
     set(TEST_SOURCE "
-#include <cstdint>
+#include <stdint.h>
 #include <atomic>
 std::atomic<uintptr_t> x;
 std::atomic<uintmax_t> y;
-int main(int, char**) {
+int main() {
     return x + y;
 }
 ")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,7 +183,7 @@ target_link_libraries(vcpkglib
         fmt::fmt
     PRIVATE
         Threads::Threads
-        atomic
+        $<$<NOT:$<AND:$<BOOL:${MSVC}>,$<BOOL:${APPLE}>>>:atomic>
 )
 
 if(MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,31 @@ else()
     )
 endif()
 
+set(CPP_ATOMIC_LIBRARY "")
+if(NOT MSVC)
+    # Some platforms require a explicit linkage against libatomic
+    # Using clang with libstdc++ requires explicitly linking against libatomic
+    set(TEST_SOURCE "
+#include <atomic>
+int main(int argc, char** argv) {
+    struct Test { int val; };
+    std::atomic<Test> s;
+    return static_cast<int>(s.is_lock_free());
+}")
+    check_cxx_source_compiles("${TEST_SOURCE}" CPP_ATOMIC_BUILTIN)
+    if(NOT CPP_ATOMIC_BUILTIN)
+        list(APPEND CMAKE_REQUIRED_LIBRARIES atomic)
+        set(CPP_ATOMIC_LIBRARY atomic)
+        check_cxx_source_compiles("${TEST_SOURCE}" CPP_ATOMIC_WITH_LIBATOMIC)
+        if (NOT CPP_ATOMIC_WITH_LIBATOMIC)
+            message(
+                FATAL_ERROR "unable to link C++ std::atomic code: you may need \
+                to install GNU libatomic"
+            )
+        endif()
+    endif()
+endif()
+
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 target_link_libraries(vcpkglib
@@ -183,7 +208,7 @@ target_link_libraries(vcpkglib
         fmt::fmt
     PRIVATE
         Threads::Threads
-        $<$<NOT:$<OR:$<BOOL:${MSVC}>,$<BOOL:${APPLE}>>>:atomic>
+        ${CPP_ATOMIC_LIBRARY}
 )
 
 if(MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,7 +183,7 @@ target_link_libraries(vcpkglib
         fmt::fmt
     PRIVATE
         Threads::Threads
-        $<$<NOT:$<AND:$<BOOL:${MSVC}>,$<BOOL:${APPLE}>>>:atomic>
+        $<$<NOT:$<OR:$<BOOL:${MSVC}>,$<BOOL:${APPLE}>>>:atomic>
 )
 
 if(MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,6 +183,7 @@ target_link_libraries(vcpkglib
         fmt::fmt
     PRIVATE
         Threads::Threads
+        atomic
 )
 
 if(MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,15 +178,16 @@ endif()
 
 set(CPP_ATOMIC_LIBRARY "")
 if(NOT MSVC)
-    # Some platforms require a explicit linkage against libatomic
-    # Using clang with libstdc++ requires explicitly linking against libatomic
+    # Some platforms require a explicit linkage against libatomic to operate on 64-bit numbers
     set(TEST_SOURCE "
+#include <cstdint>
 #include <atomic>
-int main(int argc, char** argv) {
-    struct Test { int val; };
-    std::atomic<Test> s;
-    return static_cast<int>(s.is_lock_free());
-}")
+std::atomic<uintptr_t> x;
+std::atomic<uintmax_t> y;
+int main(int, char**) {
+    return x + y;
+}
+")
     check_cxx_source_compiles("${TEST_SOURCE}" CPP_ATOMIC_BUILTIN)
     if(NOT CPP_ATOMIC_BUILTIN)
         list(APPEND CMAKE_REQUIRED_LIBRARIES atomic)

--- a/include/vcpkg/base/stringliteral.h
+++ b/include/vcpkg/base/stringliteral.h
@@ -17,4 +17,4 @@ namespace vcpkg
     };
 }
 
-VCPKG_FORMAT_AS(vcpkg::StringLiteral, vcpkg::StringView);
+VCPKG_FORMAT_AS(vcpkg::StringLiteral, vcpkg::ZStringView);

--- a/include/vcpkg/base/stringview.h
+++ b/include/vcpkg/base/stringview.h
@@ -12,9 +12,6 @@
 namespace vcpkg
 {
 
-    // Forward declaration needed for StringView(T&) constructor
-    struct ZStringView;
-
     struct StringView
     {
         constexpr StringView() = default;
@@ -29,10 +26,6 @@ namespace vcpkg
         StringView(const char* ptr) noexcept : m_ptr(ptr), m_size(strlen(ptr)) { }
         constexpr StringView(const char* ptr, size_t size) noexcept : m_ptr(ptr), m_size(size) { }
         constexpr StringView(const char* b, const char* e) noexcept : m_ptr(b), m_size(static_cast<size_t>(e - b)) { }
-
-        template<typename T,
-                 typename std::enable_if<std::is_base_of<ZStringView, T>::value, bool>::type...>
-        constexpr StringView(const T& t) noexcept : m_ptr(t.begin()), m_size(t.size()) { }
 
         constexpr const char* begin() const noexcept { return m_ptr; }
         constexpr const char* end() const noexcept { return m_ptr + m_size; }

--- a/include/vcpkg/base/stringview.h
+++ b/include/vcpkg/base/stringview.h
@@ -11,6 +11,10 @@
 
 namespace vcpkg
 {
+
+    // Forward declaration needed for StringView(T&) constructor
+    struct ZStringView;
+
     struct StringView
     {
         constexpr StringView() = default;
@@ -25,6 +29,10 @@ namespace vcpkg
         StringView(const char* ptr) noexcept : m_ptr(ptr), m_size(strlen(ptr)) { }
         constexpr StringView(const char* ptr, size_t size) noexcept : m_ptr(ptr), m_size(size) { }
         constexpr StringView(const char* b, const char* e) noexcept : m_ptr(b), m_size(static_cast<size_t>(e - b)) { }
+
+        template<typename T,
+                 typename std::enable_if<std::is_base_of<ZStringView, T>::value, bool>::type...>
+        constexpr StringView(const T& t) noexcept : m_ptr(t.begin()), m_size(t.size()) { }
 
         constexpr const char* begin() const noexcept { return m_ptr; }
         constexpr const char* end() const noexcept { return m_ptr + m_size; }

--- a/src/vcpkg/base/messages.cpp
+++ b/src/vcpkg/base/messages.cpp
@@ -167,7 +167,7 @@ namespace vcpkg::msg
         m.localized_strings.resize(m.names.size());
         m.initialized = true;
 
-        std::set<StringView, std::less<>> names_set(m.names.begin(), m.names.end());
+        std::set<StringLiteral, std::less<>> names_set(m.names.begin(), m.names.end());
         if (names_set.size() < m.names.size())
         {
             // This will not trigger on any correct code path, so it's fine to use a naive O(n^2)


### PR DESCRIPTION
These changes address 2 issues that have blocked compilation on Raspberry Pi OS since Oct 29, 2021.

The first fix is found in StringView. With gcc 8.3, compilation failed due to ambiguous resolution of constructor overloads. This fix adds a new constructor for any type based on ZStringView. The template constructor allows the compilation to avoid a circular dependency that would be seen if the constructor was specifically written to use the ZStringView type. This addresses https://github.com/microsoft/vcpkg/issues/21142.

The second fix is the next issue that surfaces once the ambiguous issue is resolved. The fix is simply adding the atomic library to the link list for vcpkglb. This addresses https://github.com/microsoft/vcpkg/issues/22843.

The combo of these two fixes allows compilation to complete on the target ARM (32-bit) platform - Raspberry Pi OS with gcc 8.3.

I have tested these changes on the target platform, specifically tested on a RPi 3B+.  I have also tested the fix against x86_64 platform using Alpine, Debian, and Arch distros (gcc versions 10.3, 10.2, 11.2, respectively). On the x86_64 platform, I have also confirmed compilation with clang works as well (versions 12.0, 11.0, 13.0, respectively). I have not tested compilation on macOS or any ARM64 system.

Note, this is my first submission to vcpkg-tool. Please let me know if anything needs to be adjusted. I would love to have these fixes picked up so that we can resume using vcpkg on RPi once again.