### PR TITLE
Block features containing _ in their names.

### DIFF
--- a/include/vcpkg/base/parse.h
+++ b/include/vcpkg/base/parse.h
@@ -84,6 +84,10 @@ namespace vcpkg::Parse
         static constexpr bool is_alphanum(char32_t ch) { return is_icase_alpha(ch) || is_ascii_digit(ch); }
         static constexpr bool is_alphadash(char32_t ch) { return is_icase_alpha(ch) || ch == '-'; }
         static constexpr bool is_alphanumdash(char32_t ch) { return is_alphanum(ch) || ch == '-'; }
+        static constexpr bool is_package_name_char(char32_t ch)
+        {
+            return is_lower_alpha(ch) || is_ascii_digit(ch) || ch == '-';
+        }
 
         static constexpr bool is_hex_digit(char32_t ch)
         {

--- a/src/vcpkg/packagespec.cpp
+++ b/src/vcpkg/packagespec.cpp
@@ -99,19 +99,6 @@ namespace vcpkg
         return PackageSpec{name, t};
     }
 
-    static bool is_package_name_char(char32_t ch)
-    {
-        return Parse::ParserBase::is_lower_alpha(ch) || Parse::ParserBase::is_ascii_digit(ch) || ch == '-';
-    }
-
-    static bool is_feature_name_char(char32_t ch)
-    {
-        // TODO: we do not intend underscores to be valid, however there is currently a feature using them
-        // (libwebp[vwebp_sdl]).
-        // TODO: we need to rename this feature, then remove underscores from this list.
-        return is_package_name_char(ch) || ch == '_';
-    }
-
     ExpectedS<ParsedQualifiedSpecifier> parse_qualified_specifier(StringView input)
     {
         auto parser = Parse::ParserBase(input, "<unknown>");
@@ -124,7 +111,7 @@ namespace vcpkg
     Optional<std::string> parse_feature_name(Parse::ParserBase& parser)
     {
         using Parse::ParserBase;
-        auto ret = parser.match_zero_or_more(is_feature_name_char).to_string();
+        auto ret = parser.match_zero_or_more(ParserBase::is_package_name_char).to_string();
         auto ch = parser.cur();
 
         // ignores the feature name vwebp_sdl as a back-compat thing
@@ -151,7 +138,7 @@ namespace vcpkg
     Optional<std::string> parse_package_name(Parse::ParserBase& parser)
     {
         using Parse::ParserBase;
-        auto ret = parser.match_zero_or_more(is_package_name_char).to_string();
+        auto ret = parser.match_zero_or_more(ParserBase::is_package_name_char).to_string();
         auto ch = parser.cur();
         if (ParserBase::is_upper_alpha(ch) || ch == '_')
         {
@@ -221,7 +208,7 @@ namespace vcpkg
         if (ch == ':')
         {
             parser.next();
-            ret.triplet = parser.match_zero_or_more(is_package_name_char).to_string();
+            ret.triplet = parser.match_zero_or_more(ParserBase::is_package_name_char).to_string();
             if (ret.triplet.get()->empty())
             {
                 parser.add_error("expected triplet name (must be lowercase, digits, '-')");


### PR DESCRIPTION
In https://github.com/microsoft/vcpkg-tool/pull/345#discussion_r831389137 Nicole indicated that the workaround here to support features with _ in their names is no longer relevant because the feature in question was already renamed before versioning.

Since this is a change in the usable surface of the tool I extracted the change into its own more targeted PR.