### PR TITLE
Copy privacy.md from vcpkg repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,5 @@ You can opt-out of telemetry by re-running the bootstrap-vcpkg script with -disa
 passing --disable-metrics to vcpkg on the command line,
 or by setting the VCPKG_DISABLE_METRICS environment variable.
 
-Read more about vcpkg telemetry at docs/about/privacy.md
+Read more about vcpkg telemetry at [docs/about/privacy.md](https://github.com/microsoft/vcpkg/blob/master/docs/about/privacy.md)
+in the main repository


### PR DESCRIPTION
While looking at the documentation on data collection, I noticed that the link to `privacy.md` was broken. This commit copies the file from `vcpkg` repository and fixes the link in `README.md`.