### PR TITLE
Add --create-dirs to curl call in download_files_inner

### DIFF
--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -353,6 +353,7 @@ namespace vcpkg
 
             Command cmd;
             cmd.string_arg("curl")
+                .string_arg("--create-dirs")
                 .string_arg("--location")
                 .string_arg("-w")
                 .string_arg(Strings::concat(guid_marker, " %{http_code}\\n"));


### PR DESCRIPTION
Without this option, curl does not create intermediate directories
and thus trying to retrieve binary cache from az blob storage
fails if the `buildtrees` and its various subdirectories for ports
are not already present.

The alternative is for vcpkg to create the intermediate dirs
explicitly, but we already use the option in `try_download_file`,
so there is no reason not to use it here as well.

-----

Tests: not sure how to add tests for this, if you have any ideas
I don't mind adding them.
