### PR TITLE
Added missing CheckCXXSourceCompiles include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,7 @@ else()
 endif()
 
 set(CPP_ATOMIC_LIBRARY "")
+include(CheckCXXSourceCompiles)
 if(NOT MSVC)
     # Some platforms require a explicit linkage against libatomic to operate on 64-bit numbers
     set(TEST_SOURCE "


### PR DESCRIPTION
Added missing CheckCXXSourceCompiles include.

Closes https://github.com/microsoft/vcpkg/issues/23842.