### PR TITLE
Change guid_marker in download_files_inner to be unique

### DIFF
--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -349,7 +349,7 @@ namespace vcpkg
         for (auto i : {100, 1000, 10000, 0})
         {
             size_t start_size = out->size();
-            static constexpr StringLiteral guid_marker = "8a1db05f-a65d-419b-aa72-037fb4d0672e";
+            static constexpr StringLiteral guid_marker = "5ec47b8e-6776-4d70-b9b3-ac2a57bc0a1c";
 
             Command cmd;
             cmd.string_arg("curl")


### PR DESCRIPTION
As far as I can tell, these are used as a combination of simple
disambiguation for the different curl callsites and a normalized
output prefix to be stripped later.

However, two functions, `url_heads_inner` and `download_files_inner`
ended up with the same guid, so I generated a new one for the
latter, so that they are unique again.