### PR TITLE
Fix broken SFINAE in expected, and consistently enable_if_t.

### DIFF
--- a/include/vcpkg/base/cache.h
+++ b/include/vcpkg/base/cache.h
@@ -29,9 +29,9 @@ namespace vcpkg
     {
         template<class KeyIsh,
                  class F,
-                 typename std::enable_if<std::is_constructible<Key, const KeyIsh&>::value &&
-                                             detail::is_callable<Compare&, const Key&, const KeyIsh&>::value,
-                                         int>::type = 0>
+                 std::enable_if_t<std::is_constructible<Key, const KeyIsh&>::value &&
+                                      detail::is_callable<Compare&, const Key&, const KeyIsh&>::value,
+                                  int> = 0>
         const Value& get_lazy(const KeyIsh& k, F&& f) const
         {
             auto it = m_cache.lower_bound(k);

--- a/include/vcpkg/base/expected.h
+++ b/include/vcpkg/base/expected.h
@@ -134,13 +134,13 @@ namespace vcpkg
         // Constructors are intentionally implicit
 
         ExpectedT(const S& s, ExpectedRightTag = {}) : m_s(s) { }
-        template<class = std::enable_if<!std::is_reference<S>::value>>
+        template<std::enable_if_t<!std::is_reference<S>::value, int> = 0>
         ExpectedT(S&& s, ExpectedRightTag = {}) : m_s(std::move(s))
         {
         }
 
         ExpectedT(const T& t, ExpectedLeftTag = {}) : m_t(t) { }
-        template<class = std::enable_if<!std::is_reference<T>::value>>
+        template<std::enable_if_t<!std::is_reference<S>::value, int> = 0>
         ExpectedT(T&& t, ExpectedLeftTag = {}) : m_t(std::move(t))
         {
         }


### PR DESCRIPTION
ExpectedT tried to use enable_if but forgot the ::type, so no SFINAE was applied.