### PR TITLE
[ci] print out the dependencies that were unmet

### DIFF
--- a/include/vcpkg/build.h
+++ b/include/vcpkg/build.h
@@ -213,7 +213,6 @@ namespace vcpkg::Build
 
     StringLiteral to_string_locale_invariant(const BuildResult build_result);
     LocalizedString to_string(const BuildResult build_result);
-    std::string create_error_message(const BuildResult build_result, const PackageSpec& spec);
     std::string create_user_troubleshooting_message(const Dependencies::InstallPlanAction& action,
                                                     const VcpkgPaths& paths);
 
@@ -263,6 +262,8 @@ namespace vcpkg::Build
         std::vector<FeatureSpec> unmet_dependencies;
         std::unique_ptr<BinaryControlFile> binary_control_file;
     };
+
+    LocalizedString create_error_message(const ExtendedBuildResult& build_result, const PackageSpec& spec);
 
     ExtendedBuildResult build_package(const VcpkgCmdArguments& args,
                                       const VcpkgPaths& paths,

--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -107,6 +107,12 @@ namespace
                                  "Printed after the name of an installed entity to indicate that it was successfully "
                                  "downloaded but no build or install was requested.",
                                  "DOWNLOADED");
+
+    DECLARE_AND_REGISTER_MESSAGE(BuildingPackageFailed,
+        (msg::spec, msg::build_result), "",
+            "building package {spec} failed with: {build_result}");
+    DECLARE_AND_REGISTER_MESSAGE(BuildingPackageFailedDueToMissingDeps,
+        (), "Printed after BuildingPackageFailed, and followed by a list of dependencies that were missing.", "due to the following missing dependencies:");
 }
 
 namespace vcpkg::Build
@@ -1462,10 +1468,21 @@ namespace vcpkg::Build
         }
     }
 
-    std::string create_error_message(const BuildResult build_result, const PackageSpec& spec)
+    LocalizedString create_error_message(const ExtendedBuildResult& build_result, const PackageSpec& spec)
     {
-        return Strings::format(
-            "Error: Building package %s failed with: %s", spec, Build::to_string_locale_invariant(build_result));
+        auto res = msg::format(msg::msgErrorMessage).append(msgBuildingPackageFailed, msg::spec = spec, msg::build_result = to_string_locale_invariant(build_result.code));
+
+        if (build_result.code == BuildResult::CASCADED_DUE_TO_MISSING_DEPENDENCIES)
+        {
+            res.appendnl().append(msgBuildingPackageFailedDueToMissingDeps);
+
+            for (const auto& missing_spec : build_result.unmet_dependencies)
+            {
+                res.appendnl().append_indent().append_raw(missing_spec.to_string());
+            }
+        }
+
+        return res;
     }
 
     std::string create_user_troubleshooting_message(const InstallPlanAction& action, const VcpkgPaths& paths)

--- a/src/vcpkg/install.cpp
+++ b/src/vcpkg/install.cpp
@@ -379,7 +379,7 @@ namespace vcpkg::Install
 
                 if (result.code != Build::BuildResult::SUCCEEDED)
                 {
-                    print2(Color::error, Build::create_error_message(result.code, action.spec), "\n");
+                    msg::println(Color::error, Build::create_error_message(result, action.spec));
                     return result;
                 }
 


### PR DESCRIPTION
This makes the results look like:

```
Computing installation plan...
The following packages will be built and installed:
  * port1[core]:arm64-osx -> 0 -- /Users/nimazzuc/projects/vcpkg-tool/overlays/port1
    port2[core]:arm64-osx -> 0 -- /Users/nimazzuc/projects/vcpkg-tool/overlays/port2
Additional packages (*) will be modified to complete this operation.
Detecting compiler hash for triplet arm64-osx...
Restored 0 packages from /Users/nimazzuc/.cache/vcpkg/archives in 13.08 us. Use --debug to see more details.
Starting package 1/2: port1:arm64-osx
Building package port1[core]:arm64-osx...
-- Using community triplet arm64-osx. This triplet configuration is not guaranteed to succeed.
-- [COMMUNITY] Loading triplet configuration from: /Users/nimazzuc/projects/vcpkg/triplets/community/arm64-osx.cmake
-- Installing port from location: /Users/nimazzuc/projects/vcpkg-tool/overlays/port1
CMake Error at /Users/nimazzuc/projects/vcpkg-tool/overlays/port1/portfile.cmake:1 (message):
  Hi
Call Stack (most recent call first):
  scripts/ports.cmake:145 (include)


error: building package port1:arm64-osx failed with: BUILD_FAILED
Elapsed time for package port1:arm64-osx: 25.72 ms
Starting package 2/2: port2:arm64-osx
Building package port2[core]:arm64-osx...
error: building package port2:arm64-osx failed with: CASCADED_DUE_TO_MISSING_DEPENDENCIES
due to the following missing dependencies:
    port1[core]:arm64-osx
Elapsed time for package port2:arm64-osx: 30.04 us

Total elapsed time: 2.463 s

RESULTS
    port1:arm64-osx: BUILD_FAILED: 25.72 ms
    port2:arm64-osx: CASCADED_DUE_TO_MISSING_DEPENDENCIES: 30.04 us

SUMMARY FOR arm64-osx
    SUCCEEDED: 0
    BUILD_FAILED: 1
    POST_BUILD_CHECKS_FAILED: 0
    FILE_CONFLICTS: 0
    CASCADED_DUE_TO_MISSING_DEPENDENCIES: 1
    EXCLUDED: 0
    CACHE_MISSING: 0
    DOWNLOADED: 0
```