### PR TITLE
Fix StringView's array ctor, and align ZStringView.

### DIFF
--- a/include/vcpkg/base/zstringview.h
+++ b/include/vcpkg/base/zstringview.h
@@ -57,12 +57,12 @@ namespace vcpkg
         // Note that only the 1 parameter version of substr is provided to preserve null termination
         ZStringView substr(size_t pos) const;
 
-        friend bool operator==(ZStringView lhs, ZStringView rhs);
-        friend bool operator!=(ZStringView lhs, ZStringView rhs);
-        friend bool operator<(ZStringView lhs, ZStringView rhs);
-        friend bool operator>(ZStringView lhs, ZStringView rhs);
-        friend bool operator<=(ZStringView lhs, ZStringView rhs);
-        friend bool operator>=(ZStringView lhs, ZStringView rhs);
+        friend bool operator==(ZStringView lhs, ZStringView rhs) noexcept;
+        friend bool operator!=(ZStringView lhs, ZStringView rhs) noexcept;
+        friend bool operator<(ZStringView lhs, ZStringView rhs) noexcept;
+        friend bool operator>(ZStringView lhs, ZStringView rhs) noexcept;
+        friend bool operator<=(ZStringView lhs, ZStringView rhs) noexcept;
+        friend bool operator>=(ZStringView lhs, ZStringView rhs) noexcept;
 
         friend std::string operator+(std::string&& l, const ZStringView& r);
 

--- a/include/vcpkg/base/zstringview.h
+++ b/include/vcpkg/base/zstringview.h
@@ -32,8 +32,8 @@ namespace vcpkg
         {
         }
 
-        constexpr const char* begin() const { return m_ptr; }
-        constexpr const char* end() const { return m_ptr + m_size; }
+        constexpr const char* begin() const noexcept { return m_ptr; }
+        constexpr const char* end() const noexcept { return m_ptr + m_size; }
 
         const char& front() const noexcept { return *m_ptr; }
         const char& back() const noexcept { return m_ptr[m_size - 1]; }
@@ -41,21 +41,21 @@ namespace vcpkg
         std::reverse_iterator<const char*> rbegin() const noexcept { return std::make_reverse_iterator(end()); }
         std::reverse_iterator<const char*> rend() const noexcept { return std::make_reverse_iterator(begin()); }
 
-        constexpr const char* data() const { return m_ptr; }
-        constexpr size_t size() const { return m_size; }
-        constexpr bool empty() const { return m_size == 0; }
-        constexpr char operator[](ptrdiff_t off) const { return m_ptr[off]; }
+        constexpr const char* data() const noexcept { return m_ptr; }
+        constexpr size_t size() const noexcept { return m_size; }
+        constexpr bool empty() const noexcept { return m_size == 0; }
+        constexpr char operator[](ptrdiff_t off) const noexcept { return m_ptr[off]; }
 
-        constexpr const char* c_str() const { return m_ptr; }
+        constexpr const char* c_str() const noexcept { return m_ptr; }
 
         std::string to_string() const;
         void to_string(std::string& out) const;
         explicit operator std::string() const { return to_string(); }
 
-        constexpr operator StringView() const { return StringView(m_ptr, m_size); }
+        constexpr operator StringView() const noexcept { return StringView(m_ptr, m_size); }
 
         // Note that only the 1 parameter version of substr is provided to preserve null termination
-        ZStringView substr(size_t pos) const;
+        ZStringView substr(size_t pos) const noexcept;
 
         friend bool operator==(ZStringView lhs, ZStringView rhs) noexcept;
         friend bool operator!=(ZStringView lhs, ZStringView rhs) noexcept;

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -896,7 +896,8 @@ namespace
                 continue;
             }
 
-            vcpkg_remove_all(base / entry->d_name, ec, failure_point, get_d_type(entry));
+            StringView entry_d_name{entry->d_name, strlen(entry->d_name)};
+            vcpkg_remove_all(base / entry_d_name, ec, failure_point, get_d_type(entry));
             if (ec)
             {
                 // removing a contained entity failed; the recursive call will set failure_point
@@ -2183,8 +2184,9 @@ namespace vcpkg
                         continue;
                     }
 
-                    const auto full = base / entry->d_name;
-                    const auto out_full = out_base / entry->d_name;
+                    StringView entry_d_name{entry->d_name, strlen(entry->d_name)};
+                    const auto full = base / entry_d_name;
+                    const auto out_full = out_base / entry_d_name;
                     const auto entry_dtype = get_d_type(entry);
                     struct stat s;
                     struct stat ls;
@@ -2324,7 +2326,7 @@ namespace vcpkg
                         continue;
                     }
 
-                    auto full = base / entry->d_name;
+                    auto full = base / StringView{entry->d_name, strlen(entry->d_name)};
                     if (selector(get_d_type(entry), full))
                     {
                         result.push_back(std::move(full));
@@ -2757,8 +2759,9 @@ namespace vcpkg
             // recent copy_file or copy_regular_recursive on subsequent iterations
             while (!ec && (entry = rd.read(ec)))
             {
-                source_entry_name = source / entry->d_name;
-                destination_entry_name = destination / entry->d_name;
+                StringView entry_d_name{entry->d_name, strlen(entry->d_name)};
+                source_entry_name = source / entry_d_name;
+                destination_entry_name = destination / entry_d_name;
                 if (get_d_type(entry) == PosixDType::Regular)
                 {
                     this->copy_file(source_entry_name, destination_entry_name, CopyOptions::none, ec);

--- a/src/vcpkg/base/stringview.cpp
+++ b/src/vcpkg/base/stringview.cpp
@@ -1,9 +1,8 @@
-#include <vcpkg/base/checks.h>
-#include <vcpkg/base/lineinfo.h>
 #include <vcpkg/base/stringview.h>
 
+#include <string.h>
+
 #include <algorithm>
-#include <cstring>
 
 namespace vcpkg
 {

--- a/src/vcpkg/base/zstringview.cpp
+++ b/src/vcpkg/base/zstringview.cpp
@@ -11,7 +11,7 @@ namespace vcpkg
     std::string ZStringView::to_string() const { return std::string(m_ptr, m_size); }
     void ZStringView::to_string(std::string& s) const { s.append(m_ptr, m_size); }
 
-    ZStringView ZStringView::substr(size_t pos) const
+    ZStringView ZStringView::substr(size_t pos) const noexcept
     {
         if (pos < m_size)
         {

--- a/src/vcpkg/base/zstringview.cpp
+++ b/src/vcpkg/base/zstringview.cpp
@@ -1,0 +1,45 @@
+#include <vcpkg/base/zstringview.h>
+
+#include <string.h>
+
+#include <algorithm>
+
+namespace vcpkg
+{
+    ZStringView::ZStringView(const std::string& s) noexcept : m_ptr(s.data()), m_size(s.size()) { }
+
+    std::string ZStringView::to_string() const { return std::string(m_ptr, m_size); }
+    void ZStringView::to_string(std::string& s) const { s.append(m_ptr, m_size); }
+
+    ZStringView ZStringView::substr(size_t pos) const
+    {
+        if (pos < m_size)
+        {
+            return ZStringView{m_ptr + pos, m_size - pos};
+        }
+
+        return ZStringView{};
+    }
+
+    bool operator==(ZStringView lhs, ZStringView rhs) noexcept
+    {
+        return lhs.size() == rhs.size() && memcmp(lhs.data(), rhs.data(), lhs.size()) == 0;
+    }
+
+    bool operator!=(ZStringView lhs, ZStringView rhs) noexcept { return !(lhs == rhs); }
+
+    bool operator<(ZStringView lhs, ZStringView rhs) noexcept
+    {
+        return std::lexicographical_compare(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
+    }
+
+    bool operator>(ZStringView lhs, ZStringView rhs) noexcept { return rhs < lhs; }
+    bool operator<=(ZStringView lhs, ZStringView rhs) noexcept { return !(rhs < lhs); }
+    bool operator>=(ZStringView lhs, ZStringView rhs) noexcept { return !(lhs < rhs); }
+
+    std::string operator+(std::string&& l, const ZStringView& r)
+    {
+        l.append(r.m_ptr, r.m_size);
+        return std::move(l);
+    }
+}


### PR DESCRIPTION
* Previously, the const char&(arr)[Sz] overloads of StringView and ZStringView were outcompeted by their const char* overloads, so they had no effect. This makes the "const char*" overload a template as well, so that the array version can engage.
* Also aligns / orders StringView and ZStringView functions such that they line up between each other for easier diffing, since functionality provided by one should probably be provided by the other as well.
* Also moves functionality out of the header for ZStringView consistent with StringView.