### PR TITLE
[cgmanifest] correct CommitHashes for catch2 and fmt

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -5,7 +5,7 @@
         "Type": "git",
         "git": {
           "RepositoryUrl": "https://github.com/catchorg/Catch2",
-          "CommitHash": "2f631bb8087a0355d2b23a75a28d936ce237659d"
+          "CommitHash": "c4e3767e265808590986d5db6ca1b5532a7f3d13"
         }
       },
       "DevelopmentDependency": true,
@@ -16,7 +16,7 @@
         "Type": "git",
         "git": {
           "RepositoryUrl": "https://github.com/fmtlib/fmt",
-          "CommitHash": "d141cdbeb0fb422a3fb7173b285fd38e0d1772dc"
+          "CommitHash": "b6f4ceaed0a0a24ccf575fab6c56dd50ccf6f1a9"
         }
       },
       "DevelopmentDependency": false,


### PR DESCRIPTION
We are using outdated commit hashes for each of these dependencies in our cgmanifest.json;
this is an internal legal thing.