### PR TITLE
Warn on classic mode build failure if version constraints weren't met

### DIFF
--- a/azure-pipelines/e2e_ports/overlays/classic-versions-a/portfile.cmake
+++ b/azure-pipelines/e2e_ports/overlays/classic-versions-a/portfile.cmake
@@ -1,0 +1,1 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/azure-pipelines/e2e_ports/overlays/classic-versions-a/vcpkg.json
+++ b/azure-pipelines/e2e_ports/overlays/classic-versions-a/vcpkg.json
@@ -1,0 +1,4 @@
+{
+    "name": "classic-versions-a",
+    "version": "1"
+}

--- a/azure-pipelines/e2e_ports/overlays/classic-versions-b/portfile.cmake
+++ b/azure-pipelines/e2e_ports/overlays/classic-versions-b/portfile.cmake
@@ -1,0 +1,1 @@
+message(FATAL_ERROR "FATAL_ERROR")

--- a/azure-pipelines/e2e_ports/overlays/classic-versions-b/vcpkg.json
+++ b/azure-pipelines/e2e_ports/overlays/classic-versions-b/vcpkg.json
@@ -1,0 +1,10 @@
+{
+    "name": "classic-versions-b",
+    "version": "1",
+    "dependencies": [
+        {
+            "name": "classic-versions-a",
+            "version>=": "2"
+        }
+    ]
+}

--- a/azure-pipelines/end-to-end-tests-dir/classic-versions.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/classic-versions.ps1
@@ -1,0 +1,10 @@
+. $PSScriptRoot/../end-to-end-tests-prelude.ps1
+
+# Not a number
+$out = Run-Vcpkg @commonArgs install classic-versions-b | Out-String
+Throw-IfNotFailed
+if ($out -notmatch ".*warning:.*dependency classic-versions-a.*at least version 2.*is currently 1.*")
+{
+    $out
+    throw "Expected to fail and print warning about mismatched versions"
+}

--- a/include/vcpkg/binaryparagraph.h
+++ b/include/vcpkg/binaryparagraph.h
@@ -32,6 +32,8 @@ namespace vcpkg
 
         bool is_feature() const { return !feature.empty(); }
 
+        Version get_version() const { return {version, port_version}; }
+
         PackageSpec spec;
         std::string version;
         int port_version = 0;

--- a/include/vcpkg/dependencies.h
+++ b/include/vcpkg/dependencies.h
@@ -67,7 +67,8 @@ namespace vcpkg::Dependencies
                           const SourceControlFileAndLocation& scfl,
                           const RequestType& request_type,
                           Triplet host_triplet,
-                          std::map<std::string, std::vector<FeatureSpec>>&& dependencies);
+                          std::map<std::string, std::vector<FeatureSpec>>&& dependencies,
+                          std::vector<LocalizedString>&& build_failure_messages);
 
         std::string displayname() const;
         const std::string& public_abi() const;
@@ -86,6 +87,7 @@ namespace vcpkg::Dependencies
 
         std::map<std::string, std::vector<FeatureSpec>> feature_dependencies;
         std::vector<PackageSpec> package_dependencies;
+        std::vector<LocalizedString> build_failure_messages;
         InternalFeatureSet feature_list;
         Triplet host_triplet;
 

--- a/include/vcpkg/versions.h
+++ b/include/vcpkg/versions.h
@@ -133,6 +133,11 @@ namespace vcpkg
 
     VerComp compare(const DateVersion& a, const DateVersion& b);
 
+    // Try parsing with all version schemas and return 'unk' if none match
+    VerComp compare_any(const Version& a, const Version& b);
+
+    VerComp compare_versions(VersionScheme sa, const Version& a, VersionScheme sb, const Version& b);
+
     enum class VersionConstraintKind
     {
         None,
@@ -158,3 +163,4 @@ namespace vcpkg
 }
 
 VCPKG_FORMAT_WITH_TO_STRING(vcpkg::VersionSpec);
+VCPKG_FORMAT_WITH_TO_STRING(vcpkg::Version);

--- a/locales/messages.en.json
+++ b/locales/messages.en.json
@@ -121,6 +121,7 @@
   "VcpkgInvalidCommand": "invalid command: {command_name}",
   "VcpkgSendMetricsButDisabled": "Warning: passed --sendmetrics, but metrics are disabled.",
   "VersionCommandHeader": "vcpkg package management program version {version}\n\nSee LICENSE.txt for license information.",
+  "VersionConstraintViolated": "dependency {spec} was expected to be at least version {expected_version}, but is currently {actual_version}.",
   "VersionInvalidDate": "`{version}` is not a valid date version. Dates must follow the format YYYY-MM-DD and disambiguators must be dot-separated positive integer values without leading zeroes.",
   "VersionInvalidRelaxed": "`{version}` is not a valid relaxed version (semver with arbitrary numeric element count).",
   "VersionInvalidSemver": "`{version}` is not a valid semantic version, consult <https://semver.org>.",

--- a/locales/messages.json
+++ b/locales/messages.json
@@ -202,6 +202,8 @@
   "VcpkgSendMetricsButDisabled": "Warning: passed --sendmetrics, but metrics are disabled.",
   "VersionCommandHeader": "vcpkg package management program version {version}\n\nSee LICENSE.txt for license information.",
   "_VersionCommandHeader.comment": "example of {version} is '1.3.8'.\n",
+  "VersionConstraintViolated": "dependency {spec} was expected to be at least version {expected_version}, but is currently {actual_version}.",
+  "_VersionConstraintViolated.comment": "example of {spec} is 'zlib:x64-windows'.\nexample of {expected_version} is '1.3.8'.\nexample of {actual_version} is '1.3.8'.\n",
   "VersionInvalidDate": "`{version}` is not a valid date version. Dates must follow the format YYYY-MM-DD and disambiguators must be dot-separated positive integer values without leading zeroes.",
   "_VersionInvalidDate.comment": "example of {version} is '1.3.8'.\n",
   "VersionInvalidRelaxed": "`{version}` is not a valid relaxed version (semver with arbitrary numeric element count).",

--- a/src/vcpkg-test/binarycaching.cpp
+++ b/src/vcpkg-test/binarycaching.cpp
@@ -260,7 +260,8 @@ Build-Depends: bzip
                                         scfl,
                                         Dependencies::RequestType::USER_REQUESTED,
                                         Test::ARM_UWP,
-                                        {{"a", {}}, {"b", {}}});
+                                        {{"a", {}}, {"b", {}}},
+                                        {});
 
     ipa.abi_info = Build::AbiInfo{};
     ipa.abi_info.get()->package_abi = "packageabi";
@@ -390,7 +391,8 @@ Description:
                               scfl,
                               Dependencies::RequestType::USER_REQUESTED,
                               Test::ARM_UWP,
-                              std::map<std::string, std::vector<FeatureSpec>>{});
+                              std::map<std::string, std::vector<FeatureSpec>>{},
+                              std::vector<LocalizedString>{});
     Dependencies::InstallPlanAction& ipa_without_abi = install_plan.back();
 
     // test that the binary cache does the right thing. See also CHECKs etc. in KnowNothingBinaryProvider

--- a/src/vcpkg-test/dependencies.cpp
+++ b/src/vcpkg-test/dependencies.cpp
@@ -817,6 +817,17 @@ TEST_CASE ("version sort date", "[versionplan]")
     CHECK(versions[8].original_string == "2021-01-01.10");
 }
 
+TEST_CASE ("version compare string", "[versionplan]")
+{
+    const Version a_0("a", 0);
+    const Version a_1("a", 1);
+    const Version b_1("b", 1);
+    CHECK(VerComp::lt == compare_versions(VersionScheme::String, a_0, VersionScheme::String, a_1));
+    CHECK(VerComp::eq == compare_versions(VersionScheme::String, a_0, VersionScheme::String, a_0));
+    CHECK(VerComp::gt == compare_versions(VersionScheme::String, a_1, VersionScheme::String, a_0));
+    CHECK(VerComp::unk == compare_versions(VersionScheme::String, a_1, VersionScheme::String, b_1));
+}
+
 TEST_CASE ("version install simple semver", "[versionplan]")
 {
     MockBaselineProvider bp;

--- a/src/vcpkg-test/dependencies.cpp
+++ b/src/vcpkg-test/dependencies.cpp
@@ -828,6 +828,34 @@ TEST_CASE ("version compare string", "[versionplan]")
     CHECK(VerComp::unk == compare_versions(VersionScheme::String, a_1, VersionScheme::String, b_1));
 }
 
+TEST_CASE ("version compare_any", "[versionplan]")
+{
+    const Version a_0("a", 0);
+    const Version a_1("a", 1);
+    const Version b_1("b", 1);
+    CHECK(VerComp::lt == compare_any(a_0, a_1));
+    CHECK(VerComp::gt == compare_any(a_1, a_0));
+    CHECK(VerComp::eq == compare_any(a_0, a_0));
+    CHECK(VerComp::unk == compare_any(a_1, b_1));
+
+    const Version v_0_0("0", 0);
+    const Version v_1_0("1", 0);
+    const Version v_1_1_1("1.1", 1);
+    CHECK(VerComp::lt == compare_any(v_0_0, v_1_0));
+    CHECK(VerComp::gt == compare_any(v_1_1_1, v_1_0));
+    CHECK(VerComp::eq == compare_any(v_0_0, v_0_0));
+
+    const Version date_0("2021-04-05", 0);
+    const Version date_1("2022-02-01", 0);
+    CHECK(VerComp::eq == compare_any(date_0, date_0));
+    CHECK(VerComp::lt == compare_any(date_0, date_1));
+
+    CHECK(VerComp::unk == compare_any(date_0, a_0));
+    // Note: dates are valid relaxed dotversions, so these are valid comparisons
+    CHECK(VerComp::gt == compare_any(date_0, v_0_0));
+    CHECK(VerComp::gt == compare_any(date_0, v_1_1_1));
+}
+
 TEST_CASE ("version install simple semver", "[versionplan]")
 {
     MockBaselineProvider bp;

--- a/src/vcpkg-test/spdx.cpp
+++ b/src/vcpkg-test/spdx.cpp
@@ -23,7 +23,7 @@ TEST_CASE ("spdx maximum serialization", "[spdx]")
     cpgh.raw_version = "1.0";
     cpgh.version_scheme = VersionScheme::Relaxed;
 
-    InstallPlanAction ipa(spec, scfl, RequestType::USER_REQUESTED, Test::X86_WINDOWS, {});
+    InstallPlanAction ipa(spec, scfl, RequestType::USER_REQUESTED, Test::X86_WINDOWS, {}, {});
     auto& abi = *(ipa.abi_info = Build::AbiInfo{}).get();
     abi.package_abi = "ABIHASH";
 
@@ -178,7 +178,7 @@ TEST_CASE ("spdx minimum serialization", "[spdx]")
     cpgh.raw_version = "1.0";
     cpgh.version_scheme = VersionScheme::String;
 
-    InstallPlanAction ipa(spec, scfl, RequestType::USER_REQUESTED, Test::X86_WINDOWS, {});
+    InstallPlanAction ipa(spec, scfl, RequestType::USER_REQUESTED, Test::X86_WINDOWS, {}, {});
     auto& abi = *(ipa.abi_info = Build::AbiInfo{}).get();
     abi.package_abi = "deadbeef";
 
@@ -307,7 +307,7 @@ TEST_CASE ("spdx concat resources", "[spdx]")
     cpgh.raw_version = "1.0";
     cpgh.version_scheme = VersionScheme::String;
 
-    InstallPlanAction ipa(spec, scfl, RequestType::USER_REQUESTED, Test::X86_WINDOWS, {});
+    InstallPlanAction ipa(spec, scfl, RequestType::USER_REQUESTED, Test::X86_WINDOWS, {}, {});
     auto& abi = *(ipa.abi_info = Build::AbiInfo{}).get();
     abi.package_abi = "deadbeef";
 

--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -232,7 +232,16 @@ namespace vcpkg::Build
 
         if (result.code != BuildResult::SUCCEEDED)
         {
-            print2(Color::error, Build::create_error_message(result, spec), '\n');
+            LocalizedString warnings;
+            for (auto&& msg : action->build_failure_messages)
+            {
+                warnings.append(msg).appendnl();
+            }
+            if (!warnings.data().empty())
+            {
+                msg::print(Color::warning, warnings);
+            }
+            msg::println(Color::error, Build::create_error_message(result, spec));
             print2(Build::create_user_troubleshooting_message(*action, paths), '\n');
             return 1;
         }

--- a/src/vcpkg/install.cpp
+++ b/src/vcpkg/install.cpp
@@ -392,6 +392,15 @@ namespace vcpkg::Install
 
                 if (result.code != Build::BuildResult::SUCCEEDED)
                 {
+                    LocalizedString warnings;
+                    for (auto&& msg : action.build_failure_messages)
+                    {
+                        warnings.append(msg).appendnl();
+                    }
+                    if (!warnings.data().empty())
+                    {
+                        msg::print(Color::warning, warnings);
+                    }
                     msg::println(Color::error, Build::create_error_message(result, action.spec));
                     return result;
                 }

--- a/src/vcpkg/versions.cpp
+++ b/src/vcpkg/versions.cpp
@@ -396,7 +396,7 @@ namespace vcpkg
     {
         if (sa == VersionScheme::String && sb == VersionScheme::String)
         {
-            return int_to_vercomp(a.text().compare(b.text()));
+            return a.text() == b.text() ? VerComp::eq : VerComp::unk;
         }
 
         if (sa == VersionScheme::Date && sb == VersionScheme::Date)

--- a/src/vcpkg/versions.cpp
+++ b/src/vcpkg/versions.cpp
@@ -392,6 +392,44 @@ namespace vcpkg
         return VerComp::eq;
     }
 
+    static VerComp compare_version_texts(VersionScheme sa, const Version& a, VersionScheme sb, const Version& b)
+    {
+        if (sa == VersionScheme::String && sb == VersionScheme::String)
+        {
+            return int_to_vercomp(a.text().compare(b.text()));
+        }
+
+        if (sa == VersionScheme::Date && sb == VersionScheme::Date)
+        {
+            return compare(DateVersion::try_parse(a.text()).value_or_exit(VCPKG_LINE_INFO),
+                           DateVersion::try_parse(b.text()).value_or_exit(VCPKG_LINE_INFO));
+        }
+
+        if ((sa == VersionScheme::Semver || sa == VersionScheme::Relaxed) &&
+            (sb == VersionScheme::Semver || sb == VersionScheme::Relaxed))
+        {
+            return compare(DotVersion::try_parse(a.text(), sa).value_or_exit(VCPKG_LINE_INFO),
+                           DotVersion::try_parse(b.text(), sb).value_or_exit(VCPKG_LINE_INFO));
+        }
+
+        return VerComp::unk;
+    }
+
+    static VerComp integer_vercomp(int a, int b)
+    {
+        if (a == b) return VerComp::eq;
+        return a < b ? VerComp::lt : VerComp::gt;
+    }
+    static inline VerComp portversion_vercomp(VerComp base, int a, int b)
+    {
+        return base == VerComp::eq ? integer_vercomp(a, b) : base;
+    }
+
+    VerComp compare_versions(VersionScheme sa, const Version& a, VersionScheme sb, const Version& b)
+    {
+        return portversion_vercomp(compare_version_texts(sa, a, sb, b), a.port_version(), b.port_version());
+    }
+
     VerComp compare(const DateVersion& a, const DateVersion& b)
     {
         if (auto x = strcmp(a.version_string.c_str(), b.version_string.c_str()))
@@ -400,6 +438,34 @@ namespace vcpkg
         }
 
         return static_cast<VerComp>(Util::range_lexcomp(a.identifiers, b.identifiers, uint64_comp));
+    }
+
+    VerComp compare_any(const Version& a, const Version& b)
+    {
+        if (a.text() == b.text())
+        {
+            return integer_vercomp(a.port_version(), b.port_version());
+        }
+        auto date_a = DateVersion::try_parse(a.text());
+        if (auto p_date_a = date_a.get())
+        {
+            auto date_b = DateVersion::try_parse(b.text());
+            if (auto p_date_b = date_b.get())
+            {
+                return portversion_vercomp(compare(*p_date_a, *p_date_b), a.port_version(), b.port_version());
+            }
+        }
+
+        auto dot_a = DotVersion::try_parse_relaxed(a.text());
+        if (auto p_dot_a = dot_a.get())
+        {
+            auto dot_b = DotVersion::try_parse_relaxed(b.text());
+            if (auto p_dot_b = dot_b.get())
+            {
+                return portversion_vercomp(compare(*p_dot_a, *p_dot_b), a.port_version(), b.port_version());
+            }
+        }
+        return VerComp::unk;
     }
 
     StringView normalize_external_version_zeros(StringView sv)


### PR DESCRIPTION
This PR adds tracking for version constraints in classic mode so that they can be displayed to the user in case of a build failure. While it is by design that classic mode does not force users to rebuild dependencies that are out-of-date, knowing the version constraints is a big help for debugging.

The output could be rough in certain circumstances; it will display every non-identical broken constraint and won't deduplicate 'similar' ones. For example, if the immediate dependencies list contains 3 references to `curl` with constraints `>= 2`, `>= 2`, and `>= 3`, on build failure this would display two messages (one for `>= 2` and one for `>= 3`). This more complex deduplication is challenging to prove correct because we don't have schema information for installed packages. That said, it seems reasonably pathologic to have multiple non-identical constraints in the same package manifest.

Finally, this only displays for `install` commands -- it does not display for any other command (e.g. `build`, `ci`, `x-set-installed`).

Diff from e2e test:
```diff
 [end-to-end-tests.ps1] [1/1] Running suite /workspaces/vcpkg-tool/azure-pipelines/end-to-end-tests-dir/classic-versions.ps1
 /workspaces/vcpkg-tool-build/vcpkg --triplet x64-linux --x-buildtrees-root=/workspaces/vcpkg-tool/testing/testing/buildtrees --x-install-root=/workspaces/vcpkg-tool/testing/testing/installed --x-packages-root=/workspaces/vcpkg-tool/testing/testing/packages --overlay-ports=/workspaces/vcpkg-tool/azure-pipelines/e2e_ports/overlays --overlay-triplets=/workspaces/vcpkg-tool/azure-pipelines/e2e_ports/triplets install classic-versions-b
 Computing installation plan...
 found constraint violation: warning: dependency classic-versions-a:x64-linux was expected to be at least version 2, but is currently 1.
 The following packages will be built and installed:
   * classic-versions-a[core]:x64-linux -> 1 -- /workspaces/vcpkg-tool/azure-pipelines/e2e_ports/overlays/classic-versions-a
     classic-versions-b[core]:x64-linux -> 1 -- /workspaces/vcpkg-tool/azure-pipelines/e2e_ports/overlays/classic-versions-b
 Additional packages (*) will be modified to complete this operation.
 Detecting compiler hash for triplet x64-linux...
 Restored 1 packages from /workspaces/.cache/vcpkg in 1.506 ms. Use --debug to see more details.
 Installing classic-versions-a:x64-linux... (1/2)...
 Elapsed time to handle classic-versions-a:x64-linux: 547.1 us
 Installing classic-versions-b:x64-linux... (2/2)...
 Building classic-versions-b[core]:x64-linux...
 -- Installing port from location: /workspaces/vcpkg-tool/azure-pipelines/e2e_ports/overlays/classic-versions-b
 CMake Error at /workspaces/vcpkg-tool/azure-pipelines/e2e_ports/overlays/classic-versions-b/portfile.cmake:1 (message):
   FATAL_ERROR
 Call Stack (most recent call first):
   scripts/ports.cmake:145 (include)
 
 
+warning: dependency classic-versions-a:x64-linux was expected to be at least version 2, but is currently 1.
 error: building classic-versions-b:x64-linux failed with: BUILD_FAILED
 Please ensure you're using the latest portfiles with `git pull` and `./vcpkg update`.
 Then check for known issues at:
   https://github.com/microsoft/vcpkg/issues?q=is%3Aissue+is%3Aopen+in%3Atitle+classic-versions-b
 You can submit a new issue at:
   https://github.com/microsoft/vcpkg/issues/new?template=report-package-build-failure.md&title=[classic-versions-b]+Build+error
 including:
   package: classic-versions-b[core]:x64-linux -> 1
     vcpkg-tool version: 2999-12-31-unknownhash-debug
     vcpkg-scripts version: 9e46bb072 2022-03-02 (5 weeks ago)
 
 Additionally, attach any relevant sections from the log files above.
```

While implementing this, I identified a regression introduced in #322 where `VersionScheme::String`'s were being compared lexographically. I've reverted this to the intended behavior (either `eq` or `unk`) and added tests covering this case.