### PR TITLE
Link vcpkg-test to log library on Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,6 +277,9 @@ if (BUILD_TESTING)
         ${VCPKG_TEST_INCLUDES}
     )
     target_link_libraries(vcpkg-test PRIVATE vcpkglib)
+    if(ANDROID)
+        target_link_libraries(vcpkg-test PRIVATE log)
+    endif()
     vcpkg_target_add_warning_options(vcpkg-test)
 
     add_test(NAME default COMMAND vcpkg-test --order rand --rng-seed time)


### PR DESCRIPTION
Fix error: undefined reference to '__android_log_write'.