### PR TITLE
Reduce work done in global constructors

### DIFF
--- a/src/vcpkg/base/hash.cpp
+++ b/src/vcpkg/base/hash.cpp
@@ -108,11 +108,10 @@ namespace vcpkg::Hash
 
         struct BCryptHasher : Hasher
         {
-            static const BCRYPT_ALG_HANDLE sha256_alg_handle;
-            static const BCRYPT_ALG_HANDLE sha512_alg_handle;
-
             explicit BCryptHasher(Algorithm algo) noexcept
             {
+                static const BCRYPT_ALG_HANDLE sha256_alg_handle = get_alg_handle(BCRYPT_SHA256_ALGORITHM);
+                static const BCRYPT_ALG_HANDLE sha512_alg_handle = get_alg_handle(BCRYPT_SHA512_ALGORITHM);
                 switch (algo)
                 {
                     case Algorithm::Sha256: alg_handle = sha256_alg_handle; break;
@@ -183,8 +182,6 @@ namespace vcpkg::Hash
             BCRYPT_ALG_HANDLE alg_handle = nullptr;
         };
 
-        const BCRYPT_ALG_HANDLE BCryptHasher::sha256_alg_handle = get_alg_handle(BCRYPT_SHA256_ALGORITHM);
-        const BCRYPT_ALG_HANDLE BCryptHasher::sha512_alg_handle = get_alg_handle(BCRYPT_SHA512_ALGORITHM);
 #else
 
         template<class WordTy>

--- a/src/vcpkg/metrics.cpp
+++ b/src/vcpkg/metrics.cpp
@@ -207,9 +207,9 @@ namespace vcpkg
 
     struct MetricMessage
     {
-        std::string user_id = generate_random_UUID();
+        std::string user_id;
         std::string user_timestamp;
-        std::string timestamp = get_current_date_time_string();
+        std::string timestamp;
 
         Json::Object properties;
         Json::Object measurements;


### PR DESCRIPTION
While doing some performance analysis, two global constructors showed up in the trace.

Changes:

1. Initialize the BCrypt algorithm handles on first use using function statics.
2. There is no need to initialize the `MetricsMessage` with a random id+timestamp -- those are always filled by `Metrics::enable()`.