### PR TITLE
Fix crash-on-shutdown around all "CE" powered commands

### DIFF
--- a/include/vcpkg/base/hash.h
+++ b/include/vcpkg/base/hash.h
@@ -31,5 +31,6 @@ namespace vcpkg::Hash
 
     std::string get_bytes_hash(const void* first, const void* last, Algorithm algo);
     std::string get_string_hash(StringView s, Algorithm algo);
+    std::string get_string_sha256(StringView s);
     ExpectedL<std::string> get_file_hash(const Filesystem& fs, const Path& target, Algorithm algo);
 }

--- a/src/vcpkg/base/hash.cpp
+++ b/src/vcpkg/base/hash.cpp
@@ -558,6 +558,8 @@ namespace vcpkg::Hash
         return get_bytes_hash(sv.data(), sv.data() + sv.size(), algo);
     }
 
+    std::string get_string_sha256(StringView s) { return get_string_hash(s, Hash::Algorithm::Sha256); }
+
     ExpectedL<std::string> get_file_hash(const Filesystem& fs, const Path& path, Algorithm algo)
     {
         std::error_code ec;

--- a/src/vcpkg/commands.find.cpp
+++ b/src/vcpkg/commands.find.cpp
@@ -226,27 +226,31 @@ namespace vcpkg::Commands
                 print2(Color::warning, "--x-json has no effect on find artifact\n");
             }
 
-            auto metrics = LockGuardPtr<Metrics>(g_metrics);
-            metrics->track_property("command_context", "artifact");
-            if (filter.has_value())
+            auto args_hash = Hash::get_string_hash(filter.value_or_exit(VCPKG_LINE_INFO), Hash::Algorithm::Sha256);
             {
-                metrics->track_property(
-                    "command_args",
-                    Hash::get_string_hash(filter.value_or_exit(VCPKG_LINE_INFO), Hash::Algorithm::Sha256));
-            }
+                auto metrics = LockGuardPtr<Metrics>(g_metrics);
+                metrics->track_property("command_context", "artifact");
+                if (filter.has_value())
+                {
+                    metrics->track_property("command_args", args_hash);
+                }
+            } // unlock metrics
+
             perform_find_artifact_and_exit(paths, filter);
         }
 
         if (selector == "port")
         {
-            auto metrics = LockGuardPtr<Metrics>(g_metrics);
-            metrics->track_property("command_context", "port");
-            if (filter.has_value())
+            auto filter_hash = Hash::get_string_hash(filter.value_or_exit(VCPKG_LINE_INFO), Hash::Algorithm::Sha256);
             {
-                metrics->track_property(
-                    "command_args",
-                    Hash::get_string_hash(filter.value_or_exit(VCPKG_LINE_INFO), Hash::Algorithm::Sha256));
+                auto metrics = LockGuardPtr<Metrics>(g_metrics);
+                metrics->track_property("command_context", "port");
+                if (filter.has_value())
+                {
+                    metrics->track_property("command_args", filter_hash);
+                }
             }
+
             perform_find_port_and_exit(paths, full_description, enable_json, filter, args.overlay_ports);
         }
 

--- a/src/vcpkg/commands.find.cpp
+++ b/src/vcpkg/commands.find.cpp
@@ -226,7 +226,7 @@ namespace vcpkg::Commands
                 print2(Color::warning, "--x-json has no effect on find artifact\n");
             }
 
-            Optional<std::string> filter_hash = filter.then(Hash::get_string_sha256);
+            Optional<std::string> filter_hash = filter.map(Hash::get_string_sha256);
             auto args_hash = Hash::get_string_hash(filter.value_or_exit(VCPKG_LINE_INFO), Hash::Algorithm::Sha256);
             {
                 auto metrics = LockGuardPtr<Metrics>(g_metrics);
@@ -242,7 +242,7 @@ namespace vcpkg::Commands
 
         if (selector == "port")
         {
-            Optional<std::string> filter_hash = filter.then(Hash::get_string_sha256);
+            Optional<std::string> filter_hash = filter.map(Hash::get_string_sha256);
             {
                 auto metrics = LockGuardPtr<Metrics>(g_metrics);
                 metrics->track_property("command_context", "port");

--- a/src/vcpkg/commands.find.cpp
+++ b/src/vcpkg/commands.find.cpp
@@ -226,13 +226,14 @@ namespace vcpkg::Commands
                 print2(Color::warning, "--x-json has no effect on find artifact\n");
             }
 
+            Optional<std::string> filter_hash = filter.then(Hash::get_string_sha256);
             auto args_hash = Hash::get_string_hash(filter.value_or_exit(VCPKG_LINE_INFO), Hash::Algorithm::Sha256);
             {
                 auto metrics = LockGuardPtr<Metrics>(g_metrics);
                 metrics->track_property("command_context", "artifact");
-                if (filter.has_value())
+                if (auto p_filter_hash = filter_hash.get())
                 {
-                    metrics->track_property("command_args", args_hash);
+                    metrics->track_property("command_args", *p_filter_hash);
                 }
             } // unlock metrics
 
@@ -241,15 +242,15 @@ namespace vcpkg::Commands
 
         if (selector == "port")
         {
-            auto filter_hash = Hash::get_string_hash(filter.value_or_exit(VCPKG_LINE_INFO), Hash::Algorithm::Sha256);
+            Optional<std::string> filter_hash = filter.then(Hash::get_string_sha256);
             {
                 auto metrics = LockGuardPtr<Metrics>(g_metrics);
                 metrics->track_property("command_context", "port");
-                if (filter.has_value())
+                if (auto p_filter_hash = filter_hash.get())
                 {
-                    metrics->track_property("command_args", filter_hash);
+                    metrics->track_property("command_args", *p_filter_hash);
                 }
-            }
+            } // unlock metrics
 
             perform_find_port_and_exit(paths, full_description, enable_json, filter, args.overlay_ports);
         }


### PR DESCRIPTION
introduced in https://github.com/microsoft/vcpkg-tool/commit/0840ffdf10c20c23fc5b9a048e1d7f896e3e76b1

These commands called into CE bits, and exit_with_code, while holding the lock. This causes an immediate crash on shutdown because the lock is reentered. This change ensures that a minimal amount of code runs while holding the lock.