### PR TITLE
Output error text if cmake failed during triplet var detection

### DIFF
--- a/locales/messages.en.json
+++ b/locales/messages.en.json
@@ -66,6 +66,7 @@
   "CiBaselineRegressionHeader": "REGRESSIONS:",
   "CiBaselineUnexpectedPass": "PASSING, REMOVE FROM FAIL LIST: {spec} ({path}).",
   "CmakeTargetsExcluded": "note: {count} additional targets are not displayed.",
+  "CommandFailed": "command:\n{command_line}\nfailed with the following results:\n{list}\n",
   "CouldNotDeduceNugetIdAndVersion": "Could not deduce nuget id and version from filename: {path}",
   "CurlReportedUnexpectedResults": "curl has reported unexpected results to vcpkg and vcpkg cannot continue.\nPlease review the following text for sensitive information and open an issue on the Microsoft/vcpkg GitHub to help fix this problem!\ncmd: {command_line}\n=== curl output ===\n{actual}\n=== end curl output ===\n",
   "DownloadedSources": "Downloaded sources for {spec}",

--- a/src/vcpkg/cmakevars.cpp
+++ b/src/vcpkg/cmakevars.cpp
@@ -264,7 +264,11 @@ endfunction()
             [&](StringView sv) { lines.emplace_back(sv.begin(), sv.end()); },
             default_working_directory);
 
-        Checks::check_exit(VCPKG_LINE_INFO, exit_code == 0, exit_code == 0 ? "" : Strings::join("\n", lines));
+        Checks::check_exit(VCPKG_LINE_INFO,
+                           exit_code == 0,
+                           "Run command: \"%s\" failed with the following results:\n%s\n",
+                           cmd_launch_cmake.command_line(),
+                           Strings::join("\n", lines));
 
         const auto end = lines.cend();
 


### PR DESCRIPTION
When `VCPKG_FORCE_SYSTEM_BINARIES` is set and cmake is not installed, the install command will stop and no specific information is printed:
```pwsh
PS F:\vcpkg> .\vcpkg.exe install ctemplate
Computing installation plan...

PS F:\vcpkg>
```
Output with `--debug`:
```pwsh
PS F:\vcpkg> .\vcpkg.exe install ctemplate --debug
[DEBUG] Feature flag 'binarycaching' unset
[DEBUG] Feature flag 'manifests' unset
[DEBUG] Feature flag 'compilertracking' unset
[DEBUG] Feature flag 'registries' unset
[DEBUG] Feature flag 'versions' unset
[DEBUG] Failed to open: F:\vcpkg\vcpkg-bundle.json
[DEBUG] Bundle config: readonly=0, usegitregistry=0, embeddedsha=nullopt
[DEBUG] Using builtin-ports: F:\vcpkg\ports
[DEBUG] Using installed-root: F:\vcpkg\installed
[DEBUG] Using buildtrees-root: F:\vcpkg\buildtrees
[DEBUG] Using packages-root: F:\vcpkg\packages
[DEBUG] Using scripts-root: F:\vcpkg\scripts
[DEBUG] Using vcpkg-root: F:\vcpkg
[DEBUG] Using scripts-root: F:\vcpkg\scripts
[DEBUG] Using builtin-registry: F:\vcpkg\versions
[DEBUG] Using downloads-root: F:\vcpkg\downloads
[DEBUG] Default binary cache path is: C:\Users\usr\AppData\Local\vcpkg\archives
Computing installation plan...
[DEBUG] CreateProcessW(cmake -DVCPKG_ROOT_DIR=F:/vcpkg -DPACKAGES_DIR=F:/vcpkg/packages -DBUILDTREES_DIR=F:/vcpkg/buildtrees -D_VCPKG_INSTALLED_DIR=F:/vcpkg/installed -DDOWNLOADS=F:/vcpkg/downloads -DVCPKG_MANIFEST_INSTALL=OFF -P "F:\vcpkg\buildtrees\0.vcpkg_dep_info.cmake")
[DEBUG] 2156: cmd_execute_and_stream_data() returned 2 after     3427 us

[DEBUG] D:\a\_work\1\s\src\vcpkg\cmakevars.cpp(267):
[DEBUG] Time in subprocesses: 3427 us
[DEBUG] Time in parsing JSON: 50160 us
[DEBUG] Time in JSON reader: 28941 us
[DEBUG] Time in filesystem: 15995594 us
[DEBUG] Time in loading ports: 16095057 us
[DEBUG] Exiting after 16.36 s (16243766 us)
```

Fixed results:
```pwsh
PS F:\vcpkg> .\vcpkg.exe install ctemplate
Computing installation plan...
command:
cmake -DVCPKG_ROOT_DIR=F:/vcpkg -DPACKAGES_DIR=F:/vcpkg/packages -DBUILDTREES_DIR=F:/vcpkg/buildtrees -D_VCPKG_INSTALLED_DIR=F:/vcpkg/installed -DDOWNLOADS=F:/vcpkg/downloads -DVCPKG_MANIFEST_INSTALL=OFF -P "F:\vcpkg\buildtrees\0.vcpkg_dep_info.cmake"
failed with the following results:


PS F:\vcpkg>
```