### PR TITLE
Fix --only-downloads and --keep-going in manifest mode

### DIFF
--- a/include/vcpkg/commands.setinstalled.h
+++ b/include/vcpkg/commands.setinstalled.h
@@ -2,6 +2,7 @@
 
 #include <vcpkg/cmakevars.h>
 #include <vcpkg/commands.interface.h>
+#include <vcpkg/install.h>
 #include <vcpkg/portfileprovider.h>
 
 namespace vcpkg::Commands::SetInstalled
@@ -15,7 +16,8 @@ namespace vcpkg::Commands::SetInstalled
                              Dependencies::ActionPlan action_plan,
                              DryRun dry_run,
                              const Optional<Path>& pkgsconfig_path,
-                             Triplet host_triplet);
+                             Triplet host_triplet,
+                             const Install::KeepGoing keep_going);
     void perform_and_exit(const VcpkgCmdArguments& args,
                           const VcpkgPaths& paths,
                           Triplet default_triplet,

--- a/src/vcpkg/commands.setinstalled.cpp
+++ b/src/vcpkg/commands.setinstalled.cpp
@@ -16,6 +16,8 @@
 namespace vcpkg::Commands::SetInstalled
 {
     static constexpr StringLiteral OPTION_DRY_RUN = "dry-run";
+    static constexpr StringLiteral OPTION_KEEP_GOING = "keep-going";
+    static constexpr StringLiteral OPTION_ONLY_DOWNLOADS = "only-downloads";
     static constexpr StringLiteral OPTION_WRITE_PACKAGES_CONFIG = "x-write-nuget-packages-config";
 
     static constexpr CommandSwitch INSTALL_SWITCHES[] = {
@@ -43,7 +45,8 @@ namespace vcpkg::Commands::SetInstalled
                              Dependencies::ActionPlan action_plan,
                              DryRun dry_run,
                              const Optional<Path>& maybe_pkgsconfig,
-                             Triplet host_triplet)
+                             Triplet host_triplet,
+                             const Install::KeepGoing keep_going)
     {
         auto& fs = paths.get_filesystem();
 
@@ -118,7 +121,7 @@ namespace vcpkg::Commands::SetInstalled
 
         const auto summary = Install::perform(args,
                                               action_plan,
-                                              Install::KeepGoing::NO,
+                                              keep_going,
                                               paths,
                                               status_db,
                                               binary_cache,
@@ -156,6 +159,10 @@ namespace vcpkg::Commands::SetInstalled
         BinaryCache binary_cache{args, paths};
 
         const bool dry_run = Util::Sets::contains(options.switches, OPTION_DRY_RUN);
+        const bool only_downloads = Util::Sets::contains(options.switches, OPTION_ONLY_DOWNLOADS);
+        const Install::KeepGoing keep_going =
+            Util::Sets::contains(options.switches, OPTION_KEEP_GOING) || only_downloads ? Install::KeepGoing::YES
+                                                                                        : Install::KeepGoing::NO;
 
         PortFileProvider::PathsPortFileProvider provider(paths, args.overlay_ports);
         auto cmake_vars = CMakeVars::make_triplet_cmake_var_provider(paths);
@@ -186,7 +193,8 @@ namespace vcpkg::Commands::SetInstalled
                             std::move(action_plan),
                             dry_run ? DryRun::Yes : DryRun::No,
                             pkgsconfig,
-                            host_triplet);
+                            host_triplet,
+                            keep_going);
     }
 
     void SetInstalledCommand::perform_and_exit(const VcpkgCmdArguments& args,

--- a/src/vcpkg/install.cpp
+++ b/src/vcpkg/install.cpp
@@ -1138,7 +1138,8 @@ namespace vcpkg::Install
                                                         std::move(install_plan),
                                                         dry_run ? Commands::DryRun::Yes : Commands::DryRun::No,
                                                         pkgsconfig,
-                                                        host_triplet);
+                                                        host_triplet,
+                                                        keep_going);
         }
 
         PortFileProvider::PathsPortFileProvider provider(paths, args.overlay_ports);


### PR DESCRIPTION
I tried to run `--only-downloads` in manifest mode with `cmake -DVCPKG_INSTALL_OPTIONS='--only-downloads' ..`. It fails: I found it was because the `keep_going` option was always `Install::KeepGoing::NO` in manifest mode. [A conversation on Discord](https://discord.com/channels/400588936151433218/687365466422902841/977233093649903626) confirmed that this behavior was a bug and not "by design".

This pull request solves this bug.