### PR TITLE
[archives] Fix typo

### DIFF
--- a/src/vcpkg/archives.cpp
+++ b/src/vcpkg/archives.cpp
@@ -259,7 +259,7 @@ namespace vcpkg
         const auto code =
             cmd_execute(Command{cmake_tool}.string_arg("-E").string_arg("tar").string_arg("xzf").string_arg(archive),
                         WorkingDirectory{to_path});
-        Checks::check_exit(VCPKG_LINE_INFO, code == 0, "tar failed while extracting %s", archive);
+        Checks::check_exit(VCPKG_LINE_INFO, code == 0, "CMake failed while extracting %s", archive);
     }
 
     void extract_archive(Filesystem& fs, const ToolCache& tools, const Path& archive, const Path& to_path)


### PR DESCRIPTION
Error message in `extract_tar_cmake` was copied over from `extract_tar` without changing the name of the tool from `tar` to `CMake`