### PR TITLE
Avoid returning the address of a temporary.

### DIFF
--- a/src/vcpkg/tools.cpp
+++ b/src/vcpkg/tools.cpp
@@ -103,7 +103,7 @@ namespace vcpkg
                            "Expected %s version: [%s], but was [%s]. Please re-run bootstrap-vcpkg.",
                            XML_PATH,
                            XML_VERSION,
-                           match_xml_version[1]);
+                           match_xml_version[1].str());
 
         const std::regex tool_regex{Strings::format(R"###(<tool[\s]+name="%s"[\s]+os="%s">)###", tool, os)};
         std::cmatch match_tool_entry;


### PR DESCRIPTION
Resolves https://github.com/microsoft/vcpkg/issues/24950

This "to_printf_arg" thing needs to die.