### PR TITLE
[AWS] Stat file before downloading it when doing binary cache lookup.

### DIFF
--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -1258,6 +1258,11 @@ namespace
 
         bool download_file(StringView object, const Path& archive) const override
         {
+            if (!stat(object))
+            {
+                return false;
+            }
+
             auto cmd = command().string_arg("s3").string_arg("cp").string_arg(object).string_arg(archive);
             if (m_no_sign_request)
             {


### PR DESCRIPTION
Currently when downloading file while doing binary caching lookup fails with an error because there is a cache miss, msbuild interprets this as an error and fails the build step. Also, this adds a fatal error message in the log that is usually not ok because cache miss is a normal and expected situation.

This PR adds a stat operation before actual file download on cache lookup to eliminate fatal error and prettify log a little.

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>