### PR TITLE
Fix Linux warnings

### DIFF
--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -219,7 +219,7 @@ namespace vcpkg
         Checks::check_exit(VCPKG_LINE_INFO, ret != nullptr, "Could not determine current executable path.");
         return resolved_path;
 #else /* LINUX */
-        std::array<char, 1024 * 4> buf;
+        std::array<char, 1024 * 4> buf{};
         auto written = readlink("/proc/self/exe", buf.data(), buf.size());
         Checks::check_exit(VCPKG_LINE_INFO, written != -1, "Could not determine current executable path.");
         return Path(buf.data(), buf.data() + written);

--- a/src/vcpkg/commands.civerifyversions.cpp
+++ b/src/vcpkg/commands.civerifyversions.cpp
@@ -90,7 +90,7 @@ namespace vcpkg::Commands::CIVerifyVersions
             for (auto&& version_entry : versions)
             {
                 bool version_ok = false;
-                for (const std::string& control_file : {"CONTROL", "vcpkg.json"})
+                for (StringView control_file : {"CONTROL", "vcpkg.json"})
                 {
                     auto treeish = Strings::concat(version_entry.second, ':', control_file);
                     auto maybe_file = paths.git_show(Strings::concat(treeish), paths.root / ".git");


### PR DESCRIPTION
Fixes these warnings when compiling with GCC 11:
```
[build] /vcpkg/commands.civerifyversions.cpp: In function ‘vcpkg::ExpectedS<std::__cxx11::basic_string<char> > vcpkg::Commands::CIVerifyVersions::verify_version_in_db(const vcpkg::VcpkgPaths&, std::map<std::__cxx11::basic_string<char>, vcpkg::Version, std::less<void> >, vcpkg::StringView, const vcpkg::Path&, const vcpkg::Path&, const string&, bool)’:
[build] /vcpkg/commands.civerifyversions.cpp:93:41: warning: loop variable ‘control_file’ of type ‘const string&’ {aka ‘const std::__cxx11::basic_string<char>&’} binds to a temporary constructed from type ‘const char* const’ [-Wrange-loop-construct]
[build]    93 |                 for (const std::string& control_file : {"CONTROL", "vcpkg.json"})
[build]       |                                         ^~~~~~~~~~~~
[build] /vcpkg/commands.civerifyversions.cpp:93:41: note: use non-reference type ‘const string’ {aka ‘const std::__cxx11::basic_string<char>’} to make the copy explicit or ‘const char* const&’ to prevent copying
[build] /vcpkg/base/system.process.cpp: In function ‘vcpkg::Path vcpkg::get_exe_path_of_current_process()’:
[build] /vcpkg/base/system.process.cpp:223:32: warning: ‘buf’ may be used uninitialized [-Wmaybe-uninitialized]
[build]   223 |         auto written = readlink("/proc/self/exe", buf.data(), buf.size());
[build]       |                        ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[build] In file included from /usr/include/c++/11/tuple:39,
[build]                  from /usr/include/c++/11/functional:54,
[build]                  from /usr/include/c++/11/pstl/glue_algorithm_defs.h:13,
[build]                  from /usr/include/c++/11/algorithm:74,
[build]                  from /vcpkg-tool/include/pch.h:25,
[build]                  from <command-line>:
[build] /usr/include/c++/11/array:176:7: note: by argument 1 of type ‘const std::array<char, 4096>*’ to ‘constexpr std::array<_Tp, _Nm>::size_type std::array<_Tp, _Nm>::size() const [with _Tp = char; long unsigned int _Nm = 4096]’ declared here
[build]   176 |       size() const noexcept { return _Nm; }
[build]       |       ^~~~
[build] /vcpkg/base/system.process.cpp:222:36: note: ‘buf’ declared here
[build]   222 |         std::array<char, 1024 * 4> buf;
[build]       |                                    ^~~
```