### PR TITLE
Add vcpkg application manifests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,7 +241,7 @@ endif()
 
 # === Target: vcpkg ===
 
-add_executable(vcpkg ${VCPKG_SOURCES})
+add_executable(vcpkg ${VCPKG_SOURCES} "${CMAKE_CURRENT_SOURCE_DIR}/src/vcpkg.manifest")
 target_link_libraries(vcpkg PRIVATE vcpkglib)
 vcpkg_target_add_warning_options(vcpkg)
 if(VCPKG_ADD_SOURCELINK)
@@ -275,6 +275,7 @@ if (BUILD_TESTING)
     add_executable(vcpkg-test
         ${VCPKG_TEST_SOURCES}
         ${VCPKG_TEST_INCLUDES}
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/vcpkg.manifest"
     )
     target_link_libraries(vcpkg-test PRIVATE vcpkglib)
     if(ANDROID)
@@ -292,7 +293,7 @@ endif()
 # === Target: vcpkg-fuzz ===
 
 if(VCPKG_BUILD_FUZZING)
-    add_executable(vcpkg-fuzz ${VCPKG_FUZZ_SOURCES})
+    add_executable(vcpkg-fuzz ${VCPKG_FUZZ_SOURCES} "${CMAKE_CURRENT_SOURCE_DIR}/src/vcpkg.manifest")
     target_link_libraries(vcpkg-fuzz PRIVATE vcpkglib)
     vcpkg_target_add_warning_options(vcpkg-fuzz)
 endif()
@@ -301,7 +302,7 @@ endif()
 # === Target: tls12-download ===
 
 if(VCPKG_BUILD_TLS12_DOWNLOADER)
-    add_executable(tls12-download ${TLS12_DOWNLOAD_SOURCES})
+    add_executable(tls12-download ${TLS12_DOWNLOAD_SOURCES} "${CMAKE_CURRENT_SOURCE_DIR}/src/vcpkg.manifest")
     set_property(TARGET tls12-download PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded")
     set_property(TARGET tls12-download APPEND PROPERTY LINK_OPTIONS "$<IF:$<CONFIG:Debug>,,/ENTRY:entry>")
     target_link_libraries(tls12-download winhttp wintrust shell32)

--- a/src/vcpkg-fuzz/main.cpp
+++ b/src/vcpkg-fuzz/main.cpp
@@ -147,7 +147,7 @@ namespace
             }
         }
 
-        FuzzKind kind;
+        FuzzKind kind = FuzzKind::None;
     };
 
     std::string read_all_of_stdin()

--- a/src/vcpkg.manifest
+++ b/src/vcpkg.manifest
@@ -1,0 +1,23 @@
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+	<compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+		<application>
+			<!--Windows 7 -->
+			<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+			<!--Windows 8 -->
+			<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+			<!--Windows 8.1 -->
+			<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+			<!-- Windows 10 and 11 -->
+			<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+		</application>
+	</compatibility>
+	<asmv3:application>
+		<asmv3:windowsSettings xmlns:ws1="http://schemas.microsoft.com/SMI/2016/WindowsSettings"
+							   xmlns:ws2="http://schemas.microsoft.com/SMI/2019/WindowsSettings"
+							   xmlns:ws3="http://schemas.microsoft.com/SMI/2020/WindowsSettings">
+			<ws1:longPathAware>true</ws1:longPathAware>
+			<ws2:activeCodePage>UTF-8</ws2:activeCodePage>
+			<ws3:heapType>SegmentHeap</ws3:heapType>
+		</asmv3:windowsSettings>
+	</asmv3:application>
+</assembly>


### PR DESCRIPTION
This enables vcpkg to be longPathAware, opts in to current Windows behavior, and the current heap implementation.

Drive by fix for:

```
FAILED: CMakeFiles/vcpkg-fuzz.dir/src/vcpkg-fuzz/main.cpp.o
/usr/bin/c++  -DFMT_LOCALE -DVCPKG_BASE_VERSION=2999-12-31 -DVCPKG_VERSION=unknownhash -I../include -I_deps/fmt-src/include -O3 -DNDEBUG   -Wall -Wextra -Wpedantic -Wno-unknown-pragmas -Wno-missing-field-initializers -Wno-redundant-move -Wmissing-declarations -Werror -std=c++17 -MD -MT CMakeFiles/vcpkg-fuzz.dir/src/vcpkg-fuzz/main.cpp.o -MF CMakeFiles/vcpkg-fuzz.dir/src/vcpkg-fuzz/main.cpp.o.d -o CMakeFiles/vcpkg-fuzz.dir/src/vcpkg-fuzz/main.cpp.o -c ../src/vcpkg-fuzz/main.cpp
../src/vcpkg-fuzz/main.cpp: In function ‘int main(int, char**)’:
../src/vcpkg-fuzz/main.cpp:214:5: error: ‘args’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  214 |     switch (args.kind)
      |     ^~~~~~
cc1plus: all warnings being treated as errors
```