### PR TITLE
Add "vcpkg fetch python3_with_venv" which is a venv-enabled python.

### DIFF
--- a/include/vcpkg/tools.h
+++ b/include/vcpkg/tools.h
@@ -34,6 +34,7 @@ namespace vcpkg
         // This duplicate of 7zip uses msiexec to unpack, which is a fallback for Windows 7.
         static constexpr StringLiteral SEVEN_ZIP_MSI = "7zip_msi";
         static constexpr StringLiteral PYTHON3 = "python3";
+        static constexpr StringLiteral PYTHON3_WITH_VENV = "python3_with_venv";
     }
 
     struct ToolCache


### PR DESCRIPTION
Add Python3WithVEnvProvider which is python with venv/pip support.

`expresif` artifacts, and a few ports that want to talk to `pip` need a `venv`-enabled copy of Python. `venv` is typically a separate apt package, so we don't want to change the behavior of the existing "python" tool name / behavior. This adds `python_with_venv` which is python with `pip` and `venv`.

To test on Windows, cherry pick https://github.com/BillyONeal/vcpkg/commit/d0525e0f8ede44a6407ddfad0e8217a237d3cae7 into your vcpkg-root.