### PR TITLE
Load overlay ports in the correct order.

### DIFF
--- a/src/vcpkg/portfileprovider.cpp
+++ b/src/vcpkg/portfileprovider.cpp
@@ -345,8 +345,11 @@ namespace vcpkg::PortFileProvider
             virtual void load_all_control_files(
                 std::map<std::string, const SourceControlFileAndLocation*>& out) const override
             {
-                for (auto&& ports_dir : m_overlay_ports)
+                auto first = std::make_reverse_iterator(m_overlay_ports.end());
+                const auto last = std::make_reverse_iterator(m_overlay_ports.begin());
+                for (; first != last; ++first)
                 {
+                    auto&& ports_dir = *first;
                     // Try loading individual port
                     if (Paragraphs::is_port_directory(m_fs, ports_dir))
                     {


### PR DESCRIPTION
In OverlayProviderImpl::load_all_control_files, overlay directories are consulted in consecutive order. Each consulted directory overwrites any overlays that were visited previously. This means that given multiple overlays, the last one wins.

However, in OverlayProviderImpl::load_port, the overlay directories are still consulted in consecutive order, but the first one is chosen. This means that the result will be different than load_all_control_files if multiple overlays contain the same port.

Based on e2e tests, the intent appears to be that the first overlay wins, so we need to do load_all_control_files in reverse order.