### PR TITLE
Don't complain about CONTROL files or directories in the directory of a consumer manifest.

### DIFF
--- a/include/vcpkg/portfileprovider.h
+++ b/include/vcpkg/portfileprovider.h
@@ -55,7 +55,7 @@ namespace vcpkg::PortFileProvider
 
     struct PathsPortFileProvider : PortFileProvider
     {
-        explicit PathsPortFileProvider(const vcpkg::VcpkgPaths& paths, View<std::string> overlay_ports);
+        explicit PathsPortFileProvider(const vcpkg::VcpkgPaths& paths, std::unique_ptr<IOverlayProvider>&& overlay);
         ExpectedS<const SourceControlFileAndLocation&> get_control_file(const std::string& src_name) const override;
         std::vector<const SourceControlFileAndLocation*> load_all_control_files() const override;
 
@@ -69,4 +69,8 @@ namespace vcpkg::PortFileProvider
     std::unique_ptr<IVersionedPortfileProvider> make_versioned_portfile_provider(const vcpkg::VcpkgPaths& paths);
     std::unique_ptr<IOverlayProvider> make_overlay_provider(const vcpkg::VcpkgPaths& paths,
                                                             View<std::string> overlay_ports);
+    std::unique_ptr<IOverlayProvider> make_manifest_provider(const Path& manifest_path,
+                                                             std::unique_ptr<SourceControlFile>&& manifest_scf);
+    std::unique_ptr<IOverlayProvider> make_combined_overlay_provider(
+        std::vector<std::unique_ptr<IOverlayProvider>>&& providers);
 }

--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -371,7 +371,8 @@ namespace vcpkg::Build
         const FullPackageSpec spec = Input::check_and_get_full_package_spec(
             std::move(first_arg), default_triplet, COMMAND_STRUCTURE.example_text, paths);
 
-        PathsPortFileProvider provider(paths, args.overlay_ports);
+        PortFileProvider::PathsPortFileProvider provider(
+            paths, PortFileProvider::make_overlay_provider(paths, args.overlay_ports));
         return perform_ex(args, spec, host_triplet, provider, binary_cache, Build::null_build_logs_recorder(), paths);
     }
 

--- a/src/vcpkg/commands.buildexternal.cpp
+++ b/src/vcpkg/commands.buildexternal.cpp
@@ -32,7 +32,8 @@ namespace vcpkg::Commands::BuildExternal
         auto overlays = args.overlay_ports;
         overlays.insert(overlays.begin(), args.command_arguments.at(1));
 
-        PortFileProvider::PathsPortFileProvider provider(paths, overlays);
+        PortFileProvider::PathsPortFileProvider provider(paths,
+                                                         PortFileProvider::make_overlay_provider(paths, overlays));
         Build::Command::perform_and_exit_ex(
             args, spec, host_triplet, provider, binary_cache, Build::null_build_logs_recorder(), paths);
     }

--- a/src/vcpkg/commands.check-support.cpp
+++ b/src/vcpkg/commands.check-support.cpp
@@ -111,7 +111,8 @@ namespace vcpkg::Commands
                 std::string(arg), default_triplet, COMMAND_STRUCTURE.example_text, paths);
         });
 
-        PortFileProvider::PathsPortFileProvider provider(paths, args.overlay_ports);
+        PortFileProvider::PathsPortFileProvider provider(
+            paths, PortFileProvider::make_overlay_provider(paths, args.overlay_ports));
         auto cmake_vars = CMakeVars::make_triplet_cmake_var_provider(paths);
 
         // for each spec in the user-requested specs, check all dependencies

--- a/src/vcpkg/commands.ci.cpp
+++ b/src/vcpkg/commands.ci.cpp
@@ -597,7 +597,8 @@ namespace vcpkg::Commands::CI
         const IBuildLogsRecorder& build_logs_recorder =
             build_logs_recorder_storage ? *(build_logs_recorder_storage.get()) : null_build_logs_recorder();
 
-        PortFileProvider::PathsPortFileProvider provider(paths, args.overlay_ports);
+        PortFileProvider::PathsPortFileProvider provider(
+            paths, PortFileProvider::make_overlay_provider(paths, args.overlay_ports));
         auto var_provider_storage = CMakeVars::make_triplet_cmake_var_provider(paths);
         auto& var_provider = *var_provider_storage;
 

--- a/src/vcpkg/commands.dependinfo.cpp
+++ b/src/vcpkg/commands.dependinfo.cpp
@@ -313,7 +313,8 @@ namespace vcpkg::Commands::DependInfo
                 std::string{arg}, default_triplet, COMMAND_STRUCTURE.example_text, paths);
         });
 
-        PathsPortFileProvider provider(paths, args.overlay_ports);
+        PortFileProvider::PathsPortFileProvider provider(
+            paths, PortFileProvider::make_overlay_provider(paths, args.overlay_ports));
         auto var_provider_storage = CMakeVars::make_triplet_cmake_var_provider(paths);
         auto& var_provider = *var_provider_storage;
 

--- a/src/vcpkg/commands.env.cpp
+++ b/src/vcpkg/commands.env.cpp
@@ -44,7 +44,8 @@ namespace vcpkg::Commands::Env
 
         const ParsedArguments options = args.parse_arguments(COMMAND_STRUCTURE);
 
-        PortFileProvider::PathsPortFileProvider provider(paths, args.overlay_ports);
+        PortFileProvider::PathsPortFileProvider provider(
+            paths, PortFileProvider::make_overlay_provider(paths, args.overlay_ports));
         auto var_provider_storage = CMakeVars::make_triplet_cmake_var_provider(paths);
         auto& var_provider = *var_provider_storage;
 

--- a/src/vcpkg/commands.find.cpp
+++ b/src/vcpkg/commands.find.cpp
@@ -15,7 +15,6 @@
 #include <vcpkg/versions.h>
 
 using namespace vcpkg;
-using vcpkg::PortFileProvider::PathsPortFileProvider;
 
 namespace
 {
@@ -116,7 +115,8 @@ namespace vcpkg::Commands
                                     Optional<StringView> filter,
                                     View<std::string> overlay_ports)
     {
-        PathsPortFileProvider provider(paths, overlay_ports);
+        PortFileProvider::PathsPortFileProvider provider(paths,
+                                                         PortFileProvider::make_overlay_provider(paths, overlay_ports));
         auto source_paragraphs =
             Util::fmap(provider.load_all_control_files(),
                        [](auto&& port) -> const SourceControlFile* { return port->source_control_file.get(); });

--- a/src/vcpkg/commands.info.cpp
+++ b/src/vcpkg/commands.info.cpp
@@ -112,7 +112,8 @@ namespace vcpkg::Commands::Info
         {
             Json::Object response;
             Json::Object results;
-            PortFileProvider::PathsPortFileProvider provider(paths, args.overlay_ports);
+            PortFileProvider::PathsPortFileProvider provider(
+                paths, PortFileProvider::make_overlay_provider(paths, args.overlay_ports));
 
             for (auto&& arg : args.command_arguments)
             {

--- a/src/vcpkg/commands.setinstalled.cpp
+++ b/src/vcpkg/commands.setinstalled.cpp
@@ -164,7 +164,8 @@ namespace vcpkg::Commands::SetInstalled
             Util::Sets::contains(options.switches, OPTION_KEEP_GOING) || only_downloads ? Install::KeepGoing::YES
                                                                                         : Install::KeepGoing::NO;
 
-        PortFileProvider::PathsPortFileProvider provider(paths, args.overlay_ports);
+        PortFileProvider::PathsPortFileProvider provider(
+            paths, PortFileProvider::make_overlay_provider(paths, args.overlay_ports));
         auto cmake_vars = CMakeVars::make_triplet_cmake_var_provider(paths);
 
         Optional<Path> pkgsconfig;

--- a/src/vcpkg/commands.upgrade.cpp
+++ b/src/vcpkg/commands.upgrade.cpp
@@ -88,7 +88,8 @@ namespace vcpkg::Commands::Upgrade
         StatusParagraphs status_db = database_load_check(paths.get_filesystem(), paths.installed());
 
         // Load ports from ports dirs
-        PortFileProvider::PathsPortFileProvider provider(paths, args.overlay_ports);
+        PortFileProvider::PathsPortFileProvider provider(
+            paths, PortFileProvider::make_overlay_provider(paths, args.overlay_ports));
         auto var_provider_storage = CMakeVars::make_triplet_cmake_var_provider(paths);
         auto& var_provider = *var_provider_storage;
 

--- a/src/vcpkg/export.cpp
+++ b/src/vcpkg/export.cpp
@@ -614,7 +614,8 @@ With a project open, go to Tools->NuGet Package Manager->Package Manager Console
         const auto opts = handle_export_command_arguments(paths, args, default_triplet, status_db);
 
         // Load ports from ports dirs
-        PortFileProvider::PathsPortFileProvider provider(paths, args.overlay_ports);
+        PortFileProvider::PathsPortFileProvider provider(
+            paths, PortFileProvider::make_overlay_provider(paths, args.overlay_ports));
 
         // create the plan
         std::vector<ExportPlanAction> export_plan = Dependencies::create_export_plan(opts.specs, status_db);

--- a/src/vcpkg/install.cpp
+++ b/src/vcpkg/install.cpp
@@ -1029,9 +1029,9 @@ namespace vcpkg::Install
                 Checks::exit_fail(VCPKG_LINE_INFO);
             }
 
-            auto& manifest_scf = *maybe_manifest_scf.value_or_exit(VCPKG_LINE_INFO);
-
-            if (auto maybe_error = manifest_scf.check_against_feature_flags(
+            auto manifest_scf = std::move(maybe_manifest_scf).value_or_exit(VCPKG_LINE_INFO);
+            const auto& manifest_core = *manifest_scf->core_paragraph;
+            if (auto maybe_error = manifest_scf->check_against_feature_flags(
                     manifest->path, paths.get_feature_flags(), paths.get_registry_set().is_default_builtin_registry()))
             {
                 Checks::exit_with_message(VCPKG_LINE_INFO, maybe_error.value_or_exit(VCPKG_LINE_INFO));
@@ -1051,7 +1051,7 @@ namespace vcpkg::Install
             auto core_it = std::remove(features.begin(), features.end(), "core");
             if (core_it == features.end())
             {
-                const auto& default_features = manifest_scf.core_paragraph->default_features;
+                const auto& default_features = manifest_core.default_features;
                 features.insert(features.end(), default_features.begin(), default_features.end());
             }
             else
@@ -1060,19 +1060,19 @@ namespace vcpkg::Install
             }
             Util::sort_unique_erase(features);
 
-            auto dependencies = manifest_scf.core_paragraph->dependencies;
+            auto dependencies = manifest_core.dependencies;
             for (const auto& feature : features)
             {
                 auto it = Util::find_if(
-                    manifest_scf.feature_paragraphs,
+                    manifest_scf->feature_paragraphs,
                     [&feature](const std::unique_ptr<FeatureParagraph>& fpgh) { return fpgh->name == feature; });
 
-                if (it == manifest_scf.feature_paragraphs.end())
+                if (it == manifest_scf->feature_paragraphs.end())
                 {
                     vcpkg::printf(Color::warning,
                                   "Warning: feature %s was passed, but that is not a feature that %s supports.",
                                   feature,
-                                  manifest_scf.core_paragraph->name);
+                                  manifest_core.name);
                 }
                 else
                 {
@@ -1088,7 +1088,7 @@ namespace vcpkg::Install
                 LockGuardPtr<Metrics>(g_metrics)->track_property("manifest_version_constraint", "defined");
             }
 
-            if (!manifest_scf.core_paragraph->overrides.empty())
+            if (!manifest_core.overrides.empty())
             {
                 LockGuardPtr<Metrics>(g_metrics)->track_property("manifest_overrides", "defined");
             }
@@ -1096,26 +1096,33 @@ namespace vcpkg::Install
             auto verprovider = PortFileProvider::make_versioned_portfile_provider(paths);
             auto baseprovider = PortFileProvider::make_baseline_provider(paths);
 
-            std::vector<std::string> extended_overlay_ports;
-            extended_overlay_ports.reserve(args.overlay_ports.size() + 2);
-            extended_overlay_ports.push_back(manifest->path.parent_path().to_string());
-            Util::Vectors::append(&extended_overlay_ports, args.overlay_ports);
+            std::vector<std::unique_ptr<PortFileProvider::IOverlayProvider>> overlay_providers;
+            if (!args.overlay_ports.empty())
+            {
+                overlay_providers.emplace_back(PortFileProvider::make_overlay_provider(paths, args.overlay_ports));
+            }
+
             if (paths.get_registry_set().is_default_builtin_registry() && !paths.use_git_default_registry())
             {
-                extended_overlay_ports.push_back(paths.builtin_ports_directory().native());
+                overlay_providers.emplace_back(PortFileProvider::make_overlay_provider(
+                    paths, std::vector<std::string>{paths.builtin_ports_directory().native()}));
             }
-            auto oprovider = PortFileProvider::make_overlay_provider(paths, extended_overlay_ports);
-            PackageSpec toplevel{manifest_scf.core_paragraph->name, default_triplet};
+
+            overlay_providers.emplace_back(
+                PortFileProvider::make_manifest_provider(manifest->path, std::move(manifest_scf)));
+            auto oprovider = PortFileProvider::make_combined_overlay_provider(std::move(overlay_providers));
+            PackageSpec toplevel{manifest_core.name, default_triplet};
             auto install_plan = Dependencies::create_versioned_install_plan(*verprovider,
                                                                             *baseprovider,
                                                                             *oprovider,
                                                                             var_provider,
                                                                             dependencies,
-                                                                            manifest_scf.core_paragraph->overrides,
+                                                                            manifest_core.overrides,
                                                                             toplevel,
                                                                             host_triplet,
                                                                             unsupported_port_action)
                                     .value_or_exit(VCPKG_LINE_INFO);
+
             for (const auto& warning : install_plan.warnings)
             {
                 print2(Color::warning, warning, '\n');
@@ -1131,8 +1138,7 @@ namespace vcpkg::Install
             Util::erase_remove_if(install_plan.install_actions,
                                   [&toplevel](auto&& action) { return action.spec == toplevel; });
 
-            PortFileProvider::PathsPortFileProvider provider(paths, extended_overlay_ports);
-
+            PortFileProvider::PathsPortFileProvider provider(paths, std::move(oprovider));
             Commands::SetInstalled::perform_and_exit_ex(args,
                                                         paths,
                                                         provider,
@@ -1145,7 +1151,8 @@ namespace vcpkg::Install
                                                         keep_going);
         }
 
-        PortFileProvider::PathsPortFileProvider provider(paths, args.overlay_ports);
+        PortFileProvider::PathsPortFileProvider provider(
+            paths, PortFileProvider::make_overlay_provider(paths, args.overlay_ports));
 
         const std::vector<FullPackageSpec> specs = Util::fmap(args.command_arguments, [&](auto&& arg) {
             return Input::check_and_get_full_package_spec(

--- a/src/vcpkg/remove.cpp
+++ b/src/vcpkg/remove.cpp
@@ -212,7 +212,8 @@ namespace vcpkg::Remove
             }
 
             // Load ports from ports dirs
-            PortFileProvider::PathsPortFileProvider provider(paths, args.overlay_ports);
+            PortFileProvider::PathsPortFileProvider provider(
+                paths, PortFileProvider::make_overlay_provider(paths, args.overlay_ports));
 
             specs = Util::fmap(Update::find_outdated_packages(provider, status_db),
                                [](auto&& outdated) { return outdated.spec; });

--- a/src/vcpkg/update.cpp
+++ b/src/vcpkg/update.cpp
@@ -68,7 +68,8 @@ namespace vcpkg::Update
 
         const StatusParagraphs status_db = database_load_check(paths.get_filesystem(), paths.installed());
 
-        PortFileProvider::PathsPortFileProvider provider(paths, args.overlay_ports);
+        PortFileProvider::PathsPortFileProvider provider(
+            paths, PortFileProvider::make_overlay_provider(paths, args.overlay_ports));
 
         const auto outdated_packages = SortedVector<OutdatedPackage, decltype(&OutdatedPackage::compare_by_name)>(
             find_outdated_packages(provider, status_db), &OutdatedPackage::compare_by_name);


### PR DESCRIPTION
Today, manifest mode works by effectively injecting the manifest directory as an overlay and letting load_port handle the situation. However, this means that the consuming manifest needs to follow all normal port rules, such as not having a CONTROL file. https://github.com/microsoft/vcpkg-tool/pull/574/ attempts to partially fix this by not failing of the CONTROL found is a directory rather than a file, but we really shouldn't be having opinions about the consuming location at all.

Changes:
* Add ManifestProvider and CombinedProvider which explicitly model the loaded manifest overlay without needing to treat the manifest directory as a port directory
* Fix plumbing in install.cpp to use the same overlay provider at all times.

Competing resolution of https://github.com/microsoft/vcpkg-tool/pull/574 / https://github.com/microsoft/vcpkg/issues/22686