### PR TITLE
Fixes azure blob binary caching by not sending put headers for get requests and by sending headers only once

### DIFF
--- a/include/vcpkg/base/downloads.h
+++ b/include/vcpkg/base/downloads.h
@@ -33,7 +33,8 @@ namespace vcpkg
     View<std::string> azure_blob_headers();
 
     std::vector<int> download_files(Filesystem& fs,
-                                    View<std::tuple<std::string, View<std::string>, Path>> url_header_path_tuples);
+                                    View<std::pair<std::string, Path>> url_pairs,
+                                    View<std::string> headers);
     ExpectedS<int> put_file(const Filesystem&, StringView url, View<std::string> headers, const Path& file);
     std::vector<int> url_heads(View<std::string> urls, View<std::string> headers, View<std::string> secrets);
     std::string replace_secrets(std::string input, View<std::string> secrets);

--- a/include/vcpkg/binarycaching.h
+++ b/include/vcpkg/binarycaching.h
@@ -72,7 +72,8 @@ namespace vcpkg
     struct UrlTemplate
     {
         std::string url_template;
-        std::vector<std::string> headers;
+        std::vector<std::string> headers_for_put;
+        std::vector<std::string> headers_for_get;
 
         LocalizedString valid();
         std::string instantiate_variables(const Dependencies::InstallPlanAction& action) const;

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -354,7 +354,8 @@ namespace vcpkg
     }
 
     static void download_files_inner(Filesystem&,
-                                     View<std::tuple<std::string, View<std::string>, Path>> url_header_path_tuples,
+                                     View<std::pair<std::string, Path>> url_pairs,
+                                     View<std::string> headers,
                                      std::vector<int>* out)
     {
         for (auto i : {100, 1000, 10000, 0})
@@ -368,13 +369,13 @@ namespace vcpkg
                 .string_arg("--location")
                 .string_arg("-w")
                 .string_arg(Strings::concat(guid_marker, " %{http_code}\\n"));
-            for (auto&& url : url_header_path_tuples)
+            for (StringView header : headers)
             {
-                cmd.string_arg(std::get<0>(url)).string_arg("-o").string_arg(std::get<2>(url));
-                for (StringView header : std::get<1>(url))
-                {
-                    cmd.string_arg("-H").string_arg(header);
-                }
+                cmd.string_arg("-H").string_arg(header);
+            }
+            for (auto&& url : url_pairs)
+            {
+                cmd.string_arg(url.first).string_arg("-o").string_arg(url.second);
             }
             auto res = cmd_execute_and_stream_lines(cmd, [out](StringView line) {
                            if (Strings::starts_with(line, guid_marker))
@@ -384,13 +385,13 @@ namespace vcpkg
                        }).value_or_exit(VCPKG_LINE_INFO);
             Checks::check_exit(VCPKG_LINE_INFO, res == 0, "Error: curl failed to execute with exit code: %d", res);
 
-            if (start_size + url_header_path_tuples.size() > out->size())
+            if (start_size + url_pairs.size() > out->size())
             {
                 // curl stopped before finishing all downloads; retry after some time
                 msg::println_warning(msgUnexpectedErrorDuringBulkDownload);
                 std::this_thread::sleep_for(std::chrono::milliseconds(i));
-                url_header_path_tuples = View<std::tuple<std::string, View<std::string>, Path>>{
-                    url_header_path_tuples.begin() + out->size() - start_size, url_header_path_tuples.end()};
+                url_pairs =
+                    View<std::pair<std::string, Path>>{url_pairs.begin() + out->size() - start_size, url_pairs.end()};
             }
             else
             {
@@ -399,27 +400,27 @@ namespace vcpkg
         }
     }
     std::vector<int> download_files(Filesystem& fs,
-                                    View<std::tuple<std::string, View<std::string>, Path>> url_header_path_tuples)
+                                    View<std::pair<std::string, Path>> url_pairs,
+                                    View<std::string> headers)
     {
         static constexpr size_t batch_size = 50;
 
         std::vector<int> ret;
 
         size_t i = 0;
-        for (; i + batch_size <= url_header_path_tuples.size(); i += batch_size)
+        for (; i + batch_size <= url_pairs.size(); i += batch_size)
         {
-            download_files_inner(fs, {url_header_path_tuples.data() + i, batch_size}, &ret);
+            download_files_inner(fs, {url_pairs.data() + i, batch_size}, headers, &ret);
         }
-        if (i != url_header_path_tuples.size())
-            download_files_inner(fs, {url_header_path_tuples.begin() + i, url_header_path_tuples.end()}, &ret);
+        if (i != url_pairs.size()) download_files_inner(fs, {url_pairs.begin() + i, url_pairs.end()}, headers, &ret);
 
         Checks::check_exit(
             VCPKG_LINE_INFO,
-            ret.size() == url_header_path_tuples.size(),
+            ret.size() == url_pairs.size(),
             "Error: curl returned a different number of response codes than were expected for the request (",
             ret.size(),
             " vs expected ",
-            url_header_path_tuples.size(),
+            url_pairs.size(),
             ")");
         return ret;
     }


### PR DESCRIPTION

Fixes https://github.com/microsoft/vcpkg-tool/pull/558#issuecomment-1158239080

There were actually two issues: 
1. Headers are send twice
2. azure blob headers meant for put requests are also send in get requests (I didn't know that and thought it would be ok to also send them in get requests)