### PR TITLE
Fix unneccessary warning about unified builds on MacOS (#25295)

### DIFF
--- a/include/vcpkg/build.h
+++ b/include/vcpkg/build.h
@@ -248,7 +248,7 @@ namespace vcpkg
         Triplet triplet;
         bool load_vcvars_env = false;
         bool disable_compiler_tracking = false;
-        std::string target_architecture;
+        std::vector<std::string> target_architectures;
         std::string cmake_system_name;
         std::string cmake_system_version;
         Optional<std::string> platform_toolset;

--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -311,7 +311,7 @@ namespace vcpkg
                                               Triplet triplet)
     {
         Checks::check_maybe_upgrade(VCPKG_LINE_INFO,
-                                    target_architectures.size() > 1,
+                                    target_architectures.size() == 1,
                                     "Only expected one architecture, got: %s",
                                     Strings::join(";", target_architectures));
         auto maybe_target_arch = to_cpu_architecture(target_architectures[0]);

--- a/src/vcpkg/export.prefab.cpp
+++ b/src/vcpkg/export.prefab.cpp
@@ -277,8 +277,12 @@ namespace vcpkg::Export::Prefab
                 auto triplet_build_info = build_info_from_triplet(paths, provider, triplet);
                 if (is_supported(*triplet_build_info))
                 {
+                    Checks::check_maybe_upgrade(VCPKG_LINE_INFO,
+                                                triplet_build_info->target_architectures.size() > 1,
+                                                "Only expected one architecture, got: %s",
+                                                Strings::join(";", triplet_build_info->target_architectures));
                     auto cpu_architecture =
-                        to_cpu_architecture(triplet_build_info->target_architecture).value_or_exit(VCPKG_LINE_INFO);
+                        to_cpu_architecture(triplet_build_info->target_architectures[0]).value_or_exit(VCPKG_LINE_INFO);
                     auto required_arch = required_archs.find(cpu_architecture);
                     if (required_arch != required_archs.end())
                     {

--- a/src/vcpkg/export.prefab.cpp
+++ b/src/vcpkg/export.prefab.cpp
@@ -278,7 +278,7 @@ namespace vcpkg::Export::Prefab
                 if (is_supported(*triplet_build_info))
                 {
                     Checks::check_maybe_upgrade(VCPKG_LINE_INFO,
-                                                triplet_build_info->target_architectures.size() > 1,
+                                                triplet_build_info->target_architectures.size() == 1,
                                                 "Only expected one architecture, got: %s",
                                                 Strings::join(";", triplet_build_info->target_architectures));
                     auto cpu_architecture =

--- a/src/vcpkg/postbuildlint.cpp
+++ b/src/vcpkg/postbuildlint.cpp
@@ -601,6 +601,7 @@ namespace vcpkg::PostBuildLint
                     if (!Util::Vectors::contains(machine_types, expected_architecture))
                     {
                         binaries_with_invalid_architecture.push_back({file, Strings::join(",", machine_types)});
+                        break; // Only register binary once
                     }
                 }
             }

--- a/src/vcpkg/postbuildlint.cpp
+++ b/src/vcpkg/postbuildlint.cpp
@@ -542,7 +542,7 @@ namespace vcpkg::PostBuildLint
                            expected_architectures.size() == 1,
                            "Only expected one architecture, got: %s",
                            Strings::join(";", expected_architectures));
-        
+
         std::vector<FileAndArch> binaries_with_invalid_architecture;
         const auto& expected_architecture = expected_architectures[0];
 
@@ -596,7 +596,7 @@ namespace vcpkg::PostBuildLint
                 {
                     continue;
                 }
-                for (const auto & expected_architecture : expected_architectures)
+                for (const auto& expected_architecture : expected_architectures)
                 {
                     if (!Util::Vectors::contains(machine_types, expected_architecture))
                     {

--- a/src/vcpkg/postbuildlint.cpp
+++ b/src/vcpkg/postbuildlint.cpp
@@ -632,7 +632,8 @@ namespace vcpkg::PostBuildLint
 
         if (!binaries_with_invalid_architecture.empty())
         {
-            print_invalid_architecture_files(Strings::join(" ", expected_architectures), binaries_with_invalid_architecture);
+            print_invalid_architecture_files(Strings::join(" ", expected_architectures),
+                                             binaries_with_invalid_architecture);
             return LintStatus::PROBLEM_DETECTED;
         }
         return LintStatus::SUCCESS;

--- a/src/vcpkg/postbuildlint.cpp
+++ b/src/vcpkg/postbuildlint.cpp
@@ -595,7 +595,7 @@ namespace vcpkg::PostBuildLint
         else if (cmake_system_name == "Darwin")
         {
             auto requested_architectures = Strings::split(Strings::trim(expected_architecture), ';');
-            Util::transform(requested_architectures, [](std::string a){return a == "x64" ? "x86_64" : a;});
+            Util::transform(requested_architectures, [](std::string a) { return a == "x64" ? "x86_64" : a; });
 
             for (const Path& file : files)
             {

--- a/src/vcpkg/postbuildlint.cpp
+++ b/src/vcpkg/postbuildlint.cpp
@@ -595,9 +595,16 @@ namespace vcpkg::PostBuildLint
                 // we need at least one of the machine types to match.
                 // Agnostic example: Folly's debug library
                 // Multiple example: arm64x libraries
-                if (!machine_types.empty() && !Util::Vectors::contains(machine_types, expected_architecture))
+                if (machine_types.empty())
                 {
-                    binaries_with_invalid_architecture.push_back({file, Strings::join(",", machine_types)});
+                    continue;
+                }
+                for (const auto & expected_architecture : expected_architectures)
+                {
+                    if (!Util::Vectors::contains(machine_types, expected_architecture))
+                    {
+                        binaries_with_invalid_architecture.push_back({file, Strings::join(",", machine_types)});
+                    }
                 }
             }
         }

--- a/src/vcpkg/postbuildlint.cpp
+++ b/src/vcpkg/postbuildlint.cpp
@@ -540,7 +540,7 @@ namespace vcpkg::PostBuildLint
     {
         std::vector<FileAndArch> binaries_with_invalid_architecture;
         Checks::check_maybe_upgrade(VCPKG_LINE_INFO,
-                                    expected_architectures.size() > 1,
+                                    expected_architectures.size() == 1,
                                     "Only expected one architecture, got: %s",
                                     Strings::join(";", expected_architectures));
         const auto& expected_architecture = expected_architectures[0];
@@ -579,7 +579,7 @@ namespace vcpkg::PostBuildLint
         if (Util::Vectors::contains(windows_system_names, cmake_system_name))
         {
             Checks::check_maybe_upgrade(VCPKG_LINE_INFO,
-                                        expected_architectures.size() > 1,
+                                        expected_architectures.size() == 1,
                                         "Only expected one architecture, got: %s",
                                         Strings::join(";", expected_architectures));
             for (const Path& file : files)

--- a/src/vcpkg/postbuildlint.cpp
+++ b/src/vcpkg/postbuildlint.cpp
@@ -538,11 +538,12 @@ namespace vcpkg::PostBuildLint
                                              const std::vector<Path>& files,
                                              const Filesystem& fs)
     {
+        Checks::check_exit(VCPKG_LINE_INFO,
+                           expected_architectures.size() == 1,
+                           "Only expected one architecture, got: %s",
+                           Strings::join(";", expected_architectures));
+        
         std::vector<FileAndArch> binaries_with_invalid_architecture;
-        Checks::check_maybe_upgrade(VCPKG_LINE_INFO,
-                                    expected_architectures.size() == 1,
-                                    "Only expected one architecture, got: %s",
-                                    Strings::join(";", expected_architectures));
         const auto& expected_architecture = expected_architectures[0];
 
         for (const Path& file : files)
@@ -578,10 +579,6 @@ namespace vcpkg::PostBuildLint
         std::vector<FileAndArch> binaries_with_invalid_architecture;
         if (Util::Vectors::contains(windows_system_names, cmake_system_name))
         {
-            Checks::check_maybe_upgrade(VCPKG_LINE_INFO,
-                                        expected_architectures.size() == 1,
-                                        "Only expected one architecture, got: %s",
-                                        Strings::join(";", expected_architectures));
             for (const Path& file : files)
             {
                 Checks::check_exit(VCPKG_LINE_INFO,


### PR DESCRIPTION
Fixes issue [#25295 ](https://github.com/microsoft/vcpkg/issues/25295) where VCPKG_TARGET_ARCHITECTURE is not treated as a list on MacOS, triggering a warning about architecture "x86_64 arm64" not matching requested architecture "x86_64;arm64".