### PR TITLE
Never print directly from deserialization code

### DIFF
--- a/include/vcpkg/base/jsonreader.h
+++ b/include/vcpkg/base/jsonreader.h
@@ -60,6 +60,10 @@ namespace vcpkg::Json
             m_errors.push_back(Strings::concat(path(), " (", type, "): ", args...));
         }
 
+        void add_warning(StringView type, StringView msg);
+
+        const std::vector<LocalizedString>& warnings() const { return m_warnings; }
+
         std::string path() const noexcept;
 
     private:
@@ -67,6 +71,7 @@ namespace vcpkg::Json
         friend struct IDeserializer;
 
         std::vector<std::string> m_errors;
+        std::vector<LocalizedString> m_warnings;
         struct JsonPathElement
         {
             constexpr JsonPathElement() = default;

--- a/include/vcpkg/base/messages.h
+++ b/include/vcpkg/base/messages.h
@@ -395,6 +395,7 @@ namespace vcpkg
         ~MessageSink() = default;
     };
 
+    extern MessageSink& null_sink;
     extern MessageSink& stdout_sink;
     extern MessageSink& stderr_sink;
 }

--- a/include/vcpkg/paragraphs.h
+++ b/include/vcpkg/paragraphs.h
@@ -21,7 +21,10 @@ namespace vcpkg::Paragraphs
     bool is_port_directory(const Filesystem& fs, const Path& maybe_directory);
 
     ParseExpected<SourceControlFile> try_load_port(const Filesystem& fs, const Path& port_directory);
-    ParseExpected<SourceControlFile> try_load_port_text(const std::string& text, StringView origin, bool is_manifest);
+    ParseExpected<SourceControlFile> try_load_port_text(const std::string& text,
+                                                        StringView origin,
+                                                        bool is_manifest,
+                                                        MessageSink& warning_sink);
 
     ExpectedS<BinaryControlFile> try_load_cached_package(const Filesystem& fs,
                                                          const Path& package_dir,

--- a/include/vcpkg/sourceparagraph.h
+++ b/include/vcpkg/sourceparagraph.h
@@ -103,7 +103,7 @@ namespace vcpkg
 
         static ParseExpected<SourceControlFile> parse_manifest_object(StringView origin,
                                                                       const Json::Object& object,
-                                                                      MessageSink* warnings_sink = nullptr);
+                                                                      MessageSink& warnings_sink);
 
         static ParseExpected<SourceControlFile> parse_control_file(StringView origin,
                                                                    std::vector<Paragraph>&& control_paragraphs);

--- a/include/vcpkg/sourceparagraph.h
+++ b/include/vcpkg/sourceparagraph.h
@@ -101,7 +101,9 @@ namespace vcpkg
     {
         SourceControlFile clone() const;
 
-        static ParseExpected<SourceControlFile> parse_manifest_object(StringView origin, const Json::Object& object);
+        static ParseExpected<SourceControlFile> parse_manifest_object(StringView origin,
+                                                                      const Json::Object& object,
+                                                                      MessageSink* warnings_sink = nullptr);
 
         static ParseExpected<SourceControlFile> parse_control_file(StringView origin,
                                                                    std::vector<Paragraph>&& control_paragraphs);

--- a/src/vcpkg-test/manifests.cpp
+++ b/src/vcpkg-test/manifests.cpp
@@ -40,7 +40,7 @@ enum class PrintErrors : bool
 static ParseExpected<SourceControlFile> test_parse_manifest(const Json::Object& obj,
                                                             PrintErrors print = PrintErrors::Yes)
 {
-    auto res = SourceControlFile::parse_manifest_object("<test manifest>", obj);
+    auto res = SourceControlFile::parse_manifest_object("<test manifest>", obj, null_sink);
     if (!res.has_value() && print == PrintErrors::Yes)
     {
         print_error_message(res.error());
@@ -741,7 +741,7 @@ TEST_CASE ("manifest construct maximum", "[manifests]")
         }
 })json";
     auto object = parse_json_object(raw);
-    auto res = SourceControlFile::parse_manifest_object("<test manifest>", object);
+    auto res = SourceControlFile::parse_manifest_object("<test manifest>", object, null_sink);
     if (!res.has_value())
     {
         print_error_message(res.error());

--- a/src/vcpkg/base/json.cpp
+++ b/src/vcpkg/base/json.cpp
@@ -1394,6 +1394,11 @@ namespace vcpkg::Json
         }
     }
 
+    void Reader::add_warning(StringView type, StringView msg)
+    {
+        m_warnings.push_back(LocalizedString::from_raw(Strings::concat(path(), " (", type, "): ", msg)));
+    }
+
     std::string Reader::path() const noexcept
     {
         std::string p("$");

--- a/src/vcpkg/base/messages.cpp
+++ b/src/vcpkg/base/messages.cpp
@@ -379,6 +379,13 @@ namespace vcpkg::msg
 
 namespace
 {
+    struct NullMessageSink : MessageSink
+    {
+        virtual void print(Color, StringView) override { }
+    };
+
+    NullMessageSink null_sink_instance;
+
     struct StdOutMessageSink : MessageSink
     {
         virtual void print(Color c, StringView sv) override { msg::write_unlocalized_text_to_stdout(c, sv); }
@@ -396,6 +403,7 @@ namespace
 
 namespace vcpkg
 {
+    MessageSink& null_sink = null_sink_instance;
     MessageSink& stdout_sink = stdout_sink_instance;
     MessageSink& stderr_sink = stderr_sink_instance;
 }

--- a/src/vcpkg/base/parse.cpp
+++ b/src/vcpkg/base/parse.cpp
@@ -51,8 +51,9 @@ namespace vcpkg
 
     LocalizedString ParseMessage::format(StringView origin, MessageKind kind) const
     {
-        LocalizedString res =
-            LocalizedString::from_raw(fmt::format("{}:{}:{}: ", origin, location.row, location.column));
+        LocalizedString res;
+        if (!origin.empty())
+            res = LocalizedString::from_raw(fmt::format("{}:{}:{}: ", origin, location.row, location.column));
         if (kind == MessageKind::Warning)
         {
             res.append(msg::msgWarningMessage);

--- a/src/vcpkg/commands.add.cpp
+++ b/src/vcpkg/commands.add.cpp
@@ -102,7 +102,7 @@ namespace vcpkg::Commands
             }
 
             auto maybe_manifest_scf =
-                SourceControlFile::parse_manifest_object(manifest->path, manifest->manifest, &stdout_sink);
+                SourceControlFile::parse_manifest_object(manifest->path, manifest->manifest, stdout_sink);
             if (!maybe_manifest_scf)
             {
                 print_error_message(maybe_manifest_scf.error());

--- a/src/vcpkg/commands.add.cpp
+++ b/src/vcpkg/commands.add.cpp
@@ -101,7 +101,8 @@ namespace vcpkg::Commands
                 specs.push_back(std::move(value));
             }
 
-            auto maybe_manifest_scf = SourceControlFile::parse_manifest_object(manifest->path, manifest->manifest);
+            auto maybe_manifest_scf =
+                SourceControlFile::parse_manifest_object(manifest->path, manifest->manifest, &stdout_sink);
             if (!maybe_manifest_scf)
             {
                 print_error_message(maybe_manifest_scf.error());

--- a/src/vcpkg/commands.civerifyversions.cpp
+++ b/src/vcpkg/commands.civerifyversions.cpp
@@ -97,7 +97,8 @@ namespace vcpkg::Commands::CIVerifyVersions
                     if (!maybe_file) continue;
 
                     const auto& file = maybe_file.value_or_exit(VCPKG_LINE_INFO);
-                    auto maybe_scf = Paragraphs::try_load_port_text(file, treeish, control_file == "vcpkg.json");
+                    auto maybe_scf =
+                        Paragraphs::try_load_port_text(file, treeish, control_file == "vcpkg.json", stdout_sink);
                     if (!maybe_scf)
                     {
                         return {

--- a/src/vcpkg/commands.format-manifest.cpp
+++ b/src/vcpkg/commands.format-manifest.cpp
@@ -44,7 +44,7 @@ namespace
 
         auto parsed_json_obj = parsed_json.object();
 
-        auto scf = SourceControlFile::parse_manifest_object(manifest_path, parsed_json_obj);
+        auto scf = SourceControlFile::parse_manifest_object(path_string, parsed_json_obj, &stdout_sink);
         if (!scf)
         {
             vcpkg::printf(Color::error, "Failed to parse manifest file: %s\n", path_string);

--- a/src/vcpkg/commands.format-manifest.cpp
+++ b/src/vcpkg/commands.format-manifest.cpp
@@ -44,7 +44,7 @@ namespace
 
         auto parsed_json_obj = parsed_json.object();
 
-        auto scf = SourceControlFile::parse_manifest_object(path_string, parsed_json_obj, &stdout_sink);
+        auto scf = SourceControlFile::parse_manifest_object(path_string, parsed_json_obj, stdout_sink);
         if (!scf)
         {
             vcpkg::printf(Color::error, "Failed to parse manifest file: %s\n", path_string);
@@ -104,7 +104,7 @@ namespace
         }
         auto res = serialize_manifest(data.scf);
 
-        auto check = SourceControlFile::parse_manifest_object(StringView{}, res);
+        auto check = SourceControlFile::parse_manifest_object(StringView{}, res, null_sink);
         if (!check)
         {
             vcpkg::printf(Color::error,

--- a/src/vcpkg/commands.porthistory.cpp
+++ b/src/vcpkg/commands.porthistory.cpp
@@ -41,7 +41,8 @@ namespace vcpkg::Commands::PortHistory
                                                               const std::string& port_name,
                                                               bool is_manifest)
         {
-            auto res = Paragraphs::try_load_port_text(text, Strings::concat(commit_id, ":", port_name), is_manifest);
+            auto res = Paragraphs::try_load_port_text(
+                text, Strings::concat(commit_id, ":", port_name), is_manifest, stdout_sink);
             if (const auto& maybe_scf = res.get())
             {
                 if (const auto& scf = maybe_scf->get())

--- a/src/vcpkg/install.cpp
+++ b/src/vcpkg/install.cpp
@@ -1023,7 +1023,7 @@ namespace vcpkg::Install
                 pkgsconfig = Path(it_pkgsconfig->second);
             }
             auto maybe_manifest_scf =
-                SourceControlFile::parse_manifest_object(manifest->path, manifest->manifest, &stdout_sink);
+                SourceControlFile::parse_manifest_object(manifest->path, manifest->manifest, stdout_sink);
             if (!maybe_manifest_scf)
             {
                 print_error_message(maybe_manifest_scf.error());

--- a/src/vcpkg/install.cpp
+++ b/src/vcpkg/install.cpp
@@ -1022,7 +1022,8 @@ namespace vcpkg::Install
                 LockGuardPtr<Metrics>(g_metrics)->track_property("x-write-nuget-packages-config", "defined");
                 pkgsconfig = Path(it_pkgsconfig->second);
             }
-            auto maybe_manifest_scf = SourceControlFile::parse_manifest_object(manifest->path, manifest->manifest);
+            auto maybe_manifest_scf =
+                SourceControlFile::parse_manifest_object(manifest->path, manifest->manifest, &stdout_sink);
             if (!maybe_manifest_scf)
             {
                 print_error_message(maybe_manifest_scf.error());

--- a/src/vcpkg/paragraphs.cpp
+++ b/src/vcpkg/paragraphs.cpp
@@ -353,7 +353,9 @@ namespace vcpkg::Paragraphs
                fs.exists(maybe_directory / "vcpkg.json", IgnoreErrors{});
     }
 
-    static ParseExpected<SourceControlFile> try_load_manifest_text(const std::string& text, StringView origin)
+    static ParseExpected<SourceControlFile> try_load_manifest_text(const std::string& text,
+                                                                   StringView origin,
+                                                                   MessageSink& warning_sink)
     {
         auto res = Json::parse(text, origin);
 
@@ -362,7 +364,7 @@ namespace vcpkg::Paragraphs
         {
             if (val->first.is_object())
             {
-                return SourceControlFile::parse_manifest_object(origin, val->first.object());
+                return SourceControlFile::parse_manifest_object(origin, val->first.object(), warning_sink);
             }
 
             error = "Manifest files must have a top-level object";
@@ -377,13 +379,16 @@ namespace vcpkg::Paragraphs
         return error_info;
     }
 
-    ParseExpected<SourceControlFile> try_load_port_text(const std::string& text, StringView origin, bool is_manifest)
+    ParseExpected<SourceControlFile> try_load_port_text(const std::string& text,
+                                                        StringView origin,
+                                                        bool is_manifest,
+                                                        MessageSink& warning_sink)
     {
         StatsTimer timer(g_load_ports_stats);
 
         if (is_manifest)
         {
-            return try_load_manifest_text(text, origin);
+            return try_load_manifest_text(text, origin, warning_sink);
         }
 
         ExpectedS<std::vector<Paragraph>> pghs = get_paragraphs_text(text, origin);
@@ -424,7 +429,7 @@ namespace vcpkg::Paragraphs
                                       "Found both manifest and CONTROL file in port %s; please rename one or the other",
                                       port_directory);
 
-            return try_load_manifest_text(manifest_contents, manifest_path);
+            return try_load_manifest_text(manifest_contents, manifest_path, stdout_sink);
         }
 
         if (fs.exists(control_path, IgnoreErrors{}))

--- a/src/vcpkg/sourceparagraph.cpp
+++ b/src/vcpkg/sourceparagraph.cpp
@@ -1271,18 +1271,15 @@ namespace vcpkg
 
     ParseExpected<SourceControlFile> SourceControlFile::parse_manifest_object(StringView origin,
                                                                               const Json::Object& manifest,
-                                                                              MessageSink* warnings_sink)
+                                                                              MessageSink& warnings_sink)
     {
         Json::Reader reader;
 
         auto res = reader.visit(manifest, ManifestDeserializer::instance);
 
-        if (warnings_sink)
+        for (auto&& w : reader.warnings())
         {
-            for (auto&& w : reader.warnings())
-            {
-                warnings_sink->print(Color::warning, LocalizedString::from_raw(Strings::concat(origin, ": ", w, '\n')));
-            }
+            warnings_sink.print(Color::warning, LocalizedString::from_raw(Strings::concat(origin, ": ", w, '\n')));
         }
 
         if (!reader.errors().empty())


### PR DESCRIPTION
SPDX license parsing warnings were being emitted directly to stdout during manifest deserialization. We should never do this.

Drive-by fixes:
1. I've added a missing trailing newline as part of `print_error_message()`.
2. Added detection of `error: ` as another valid "error" message.

New behavior:
```
$ vcpkg format-manifest vcpkg.json
/workspaces/vcpkg-tool/vcpkg.json: $.license (an SPDX license expression): warning: Unknown license identifier 'hello'. Known values are listed at https://spdx.org/licenses/
    on expression: hello
                   ^
Failed to parse manifest file: /workspaces/vcpkg-tool/vcpkg.json
error: while loading /workspaces/vcpkg-tool/vcpkg.json:
$ (a manifest): missing required field 'name' (an identifier)
$ (a manifest): expected a versioning field (example: version-string)
```