### PR TITLE
Fix fetch tests on systems that already have Ninja on the PATH.

### DIFF
--- a/azure-pipelines/end-to-end-tests-dir/fetch.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/fetch.ps1
@@ -92,7 +92,10 @@ if (-not $IsMacOS -and -not $IsLinux) {
     Require-FileNotExists "$TestingRoot/down loads/tools/ninja-1.10.2-windows/ninja.exe"
 
     Remove-Item env:VCPKG_FORCE_SYSTEM_BINARIES
-    Run-Vcpkg -TestArgs ($commonArgs + @("fetch", "ninja", "--vcpkg-root=$TestingRoot"))
+    $out = Run-Vcpkg -TestArgs ($commonArgs + @("fetch", "ninja", "--vcpkg-root=$TestingRoot", "--x-stderr-status"))
     Throw-IfFailed
-    Require-FileExists "$TestingRoot/down loads/tools/ninja-1.10.2-windows/ninja.exe"
+    & $out --version
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Couldn''t run resulting ninja'
+    }
 }


### PR DESCRIPTION
Azure Pipelines has started putting a ninja on the PATH which causes the fetch test that assumes it needs to download ninja to fail. For example: https://dev.azure.com/vcpkg/public/_build/results?buildId=74025&view=results

```
2022-06-22T02:18:32.8686866Z D:\a\1\s\build.x86.debug\vcpkg.exe --triplet x86-windows --x-buildtrees-root=D:\a\1\s\build.x86.debug\work\testing\buildtrees --x-install-root=D:\a\1\s\build.x86.debug\work\testing\installed --x-packages-root=D:\a\1\s\build.x86.debug\work\testing\packages --overlay-ports=D:\a\1\s\azure-pipelines/e2e_ports/overlays --overlay-triplets=D:\a\1\s\azure-pipelines/e2e_ports/triplets fetch ninja --vcpkg-root=D:\a\1\s\build.x86.debug\work\testing
2022-06-22T02:18:32.9948628Z C:\ProgramData\Chocolatey\bin\ninja.exe
2022-06-22T02:18:33.0083411Z D:\a\1\s\azure-pipelines\end-to-end-tests-prelude.ps1:27: Write-Stack
2022-06-22T02:18:33.0096439Z D:\a\1\s\azure-pipelines\end-to-end-tests-prelude.ps1:38: Require-FileExists
2022-06-22T02:18:33.0110929Z D:\a\1\s\azure-pipelines\end-to-end-tests-dir\fetch.ps1:97: <ScriptBlock>
2022-06-22T02:18:33.0119456Z D:\a\1\s\azure-pipelines\end-to-end-tests.ps1:111: <ScriptBlock>
2022-06-22T02:18:33.0128974Z D:\a\_temp\830dcdf2-82d4-4370-bc09-bc6252f9e73a.ps1:3: <ScriptBlock>
2022-06-22T02:18:33.0178297Z :1: <ScriptBlock>
2022-06-22T02:18:33.1741237Z 'D:\a\1\s\build.x86.debug\vcpkg.exe --triplet x86-windows --x-buildtrees-root=D:\a\1\s\build.x86.debug\work\testing\buildtrees --x-install-root=D:\a\1\s\build.x86.debug\work\testing\installed --x-packages-root=D:\a\1\s\build.x86.debug\work\testing\packages --overlay-ports=D:\a\1\s\azure-pipelines/e2e_ports/overlays --overlay-triplets=D:\a\1\s\azure-pipelines/e2e_ports/triplets fetch ninja --vcpkg-root=D:\a\1\s\build.x86.debug\work\testing' failed to create file 'D:\a\1\s\build.x86.debug\work\testing/down loads/tools/ninja-1.10.2-windows/ninja.exe'
```

The file the test wants wasn't created because we used "C:\ProgramData\Chocolatey\bin\ninja.exe" instead.