### PR TITLE
Fix removal instructions for PowerShell

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ While the usage of `ce` is the same on all platforms, the installation/loading/r
 
 | OS              | Install                                             | Use                   | Remove                          |
 |-----------------|-----------------------------------------------------|-----------------------|---------------------------------|
-| **PowerShell/Pwsh** |`iex (iwr -useb https://aka.ms/vcpkg-init.ps1)`              |` . ~/.vcpkg/vcpkg-init.ps1`          | `rmdir -recurse ~/.vcpkg`          |
+| **PowerShell/Pwsh** |`iex (iwr -useb https://aka.ms/vcpkg-init.ps1)`              |` . ~/.vcpkg/vcpkg-init.ps1`          | `rmdir -recurse -force ~/.vcpkg`          |
 | **Linux/OSX**       |`. <(curl https://aka.ms/vcpkg-init.sh -L)`                  |` . ~/.vcpkg/vcpkg-init.sh`          | `rm -rf ~/.ce`                  |
 | **CMD Shell**       |`curl -LO https://aka.ms/vcpkg-init.cmd && .\vcpkg-init.cmd` |`%USERPROFILE%\.vcpkg\vcpkg-init.cmd` | `rmdir /s /q %USERPROFILE%\.vcpkg` |
 


### PR DESCRIPTION
Following the instructions as-is fails because of junction points.

```powershell
rmdir : C:\Users\bemcmorr\.vcpkg\node_modules\vcpkg-ce\common\temp\node_modules\.pnpm\node_modules\keyv is an NTFS
junction point. Use the Force parameter to delete or modify this object.
At line:1 char:1
+ rmdir -recurse ~/.vcpkg
+ ~~~~~~~~~~~~~~~~~~~~~~~
```