### PR TITLE
Add FreeBSD support

### DIFF
--- a/src/vcpkg/base/system.mac.cpp
+++ b/src/vcpkg/base/system.mac.cpp
@@ -8,7 +8,7 @@
 
 #if !defined(_WIN32)
 #include <net/if.h>
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(__FreeBSD__)
 #include <ifaddrs.h>
 
 #include <net/if_dl.h>
@@ -147,7 +147,7 @@ namespace vcpkg
                 }
             }
         }
-#elif defined(__linux__) || defined(__APPLE__)
+#elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
         // The getifaddrs(ifaddrs** ifap) function creates a linked list of structures
         // describing the network interfaces of the local system, and stores
         // the address of the first item of the list in *ifap.
@@ -188,7 +188,7 @@ namespace vcpkg
             auto address = reinterpret_cast<sockaddr_ll*>(interface->ifa_addr);
             if (address->sll_halen != MAC_BYTES_LENGTH) continue;
             auto mac_bytes = Span<char>(reinterpret_cast<char*>(address->sll_addr), MAC_BYTES_LENGTH);
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) || defined(__FreeBSD__)
             auto address = reinterpret_cast<sockaddr_dl*>(interface->ifa_addr);
             if (address->sdl_alen != MAC_BYTES_LENGTH) continue;
             // The macro LLADDR() returns the start of the link-layer network address.


### PR DESCRIPTION
Treat FreeBSD like macOS (which is accurate in terms of development!) in the code to determine the MAC address of a network interface.

With this change, vcpkg-tool compiles fine on FreeBSD 13. The test suite passes.