### PR TITLE
Fix use instructions for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ While the usage of `ce` is the same on all platforms, the installation/loading/r
 | OS              | Install                                             | Use                   | Remove                          |
 |-----------------|-----------------------------------------------------|-----------------------|---------------------------------|
 | **PowerShell/Pwsh** |`iex (iwr -useb https://aka.ms/vcpkg-init.ps1)`              |` . ~/.vcpkg/vcpkg-init.ps1`          | `rmdir -recurse -force ~/.vcpkg`          |
-| **Linux/OSX**       |`. <(curl https://aka.ms/vcpkg-init.sh -L)`                  |` . ~/.vcpkg/vcpkg-init.sh`          | `rm -rf ~/.ce`                  |
+| **Linux/OSX**       |`. <(curl https://aka.ms/vcpkg-init.sh -L)`                  |` . ~/.vcpkg/vcpkg-init`          | `rm -rf ~/.vcpkg`                  |
 | **CMD Shell**       |`curl -LO https://aka.ms/vcpkg-init.cmd && .\vcpkg-init.cmd` |`%USERPROFILE%\.vcpkg\vcpkg-init.cmd` | `rmdir /s /q %USERPROFILE%\.vcpkg` |
 
 ## Glossary


### PR DESCRIPTION
There is no file named `vcpkg-init.sh` in the installation directory, and `ce` is an old name for this product.