### PR TITLE
Grab OS architecture at runtime

### DIFF
--- a/src/vcpkg/triplet.cpp
+++ b/src/vcpkg/triplet.cpp
@@ -89,11 +89,8 @@ namespace vcpkg
         {
             return Triplet::from_canonical_name(std::string(*args.triplet));
         }
-#if defined(_WIN32)
-        return Triplet::from_canonical_name("x86-windows");
-#else
+        
         return system_triplet();
-#endif
     }
 
     Triplet default_host_triplet(const VcpkgCmdArguments& args)


### PR DESCRIPTION
I saw several complaints in the old vcpkg repository where the tool installed by default 32-bit packages, with this PR, the package will be installed in the default architecture of the operating system.