### PR TITLE
Add missing \n to console output

### DIFF
--- a/src/vcpkg/install.cpp
+++ b/src/vcpkg/install.cpp
@@ -857,7 +857,7 @@ namespace vcpkg::Install
                     {
                         auto omitted = targets.size() - 4;
                         library_target_pair.second.erase(targets.begin() + 4, targets.end());
-                        msg.append_indent().append_raw("# ").append(msgCmakeTargetsExcluded, msg::count = omitted);
+                        msg.append_indent().append_raw("# ").append(msgCmakeTargetsExcluded, msg::count = omitted).append_raw('\n');
                     }
 
                     msg.append_indent()


### PR DESCRIPTION
Fixes the following formatting error on CMake usage heuristics:

```
urdfdom provides CMake targets:
    # this is heuristically generated, and may not be correct
    find_package(urdfdom CONFIG REQUIRED)
    # note: 1 additional targets are not displayed.    target_link_libraries(main PRIVATE urdfdom::urdf_parser urdfdom::urdfdom_model urdfdom::urdfdom_world urdfdom::urdfdom_sensor)
```