### PR TITLE
Use a separately installed clang-format if the user has explicitly installed one.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -420,7 +420,7 @@ endif()
 
 # === Target: format ===
 
-find_program(CLANG_FORMAT clang-format)
+find_program(CLANG_FORMAT clang-format PATHS "$ENV{PROGRAMFILES}/LLVM/bin")
 if(CLANG_FORMAT)
     # doing all of these formats in one line has a tendency to overflow the command line length
     add_custom_target(format


### PR DESCRIPTION
This enables an easier escape hatch for vcpkg developers not in exactly the same VS update as vcpkg's CI.