### PR TITLE
Updated fmt to version 9.0.0

### DIFF
--- a/cmake/Findfmt.cmake
+++ b/cmake/Findfmt.cmake
@@ -1,11 +1,14 @@
 option(VCPKG_DEPENDENCY_EXTERNAL_FMT "Use an external version of the fmt library" OFF)
-set(VCPKG_FMT_URL "https://github.com/fmtlib/fmt/archive/refs/tags/8.1.1.tar.gz" CACHE STRING "URL to the fmt release tarball to use.")
+
+set(VCPKG_FMT_VERSION "9.0.0" CACHE STRING "Required fmt release version.")
+set(VCPKG_FMT_HASH "f9612a53c93654753572ac038e52c683f3485691493750d5c2fdb48f3a769e181bfeab8035041cae02bf14cd67df30ec3c5614d7db913f85699cd9da8072bdf8" CACHE STRING "SHA512 hash of the fmt release tarball.")
+set(VCPKG_FMT_URL "https://github.com/fmtlib/fmt/archive/refs/tags/${VCPKG_FMT_VERSION}.tar.gz" CACHE STRING "URL to the fmt release tarball to use.")
 
 include(FetchContent)
 FetchContent_Declare(
     fmt
     URL "${VCPKG_FMT_URL}"
-    URL_HASH SHA512=794a47d7cb352a2a9f2c050a60a46b002e4157e5ad23e15a5afc668e852b1e1847aeee3cda79e266c789ff79310d792060c94976ceef6352e322d60b94e23189
+    URL_HASH "SHA512=${VCPKG_FMT_HASH}"
 )
 
 if(NOT fmt_FIND_REQUIRED)
@@ -13,7 +16,7 @@ if(NOT fmt_FIND_REQUIRED)
 endif()
 
 if(VCPKG_DEPENDENCY_EXTERNAL_FMT)
-    find_package(fmt CONFIG REQUIRED)
+    find_package(fmt ${VCPKG_FMT_VERSION} CONFIG REQUIRED)
 else()
     FetchContent_MakeAvailable(fmt)
 endif()

--- a/include/vcpkg/base/fwd/format.h
+++ b/include/vcpkg/base/fwd/format.h
@@ -2,7 +2,7 @@
 
 namespace fmt
 {
-    inline namespace v8
+    inline namespace v9
     {
         template<typename T, typename Char, typename Enable>
         struct formatter;


### PR DESCRIPTION
* Fixed build against packaged fmt 9.0.0.
* Updated bundled fmt to version 9.0.0.
* Performed refactoring of `Findfmt.cmake`.

Closes https://github.com/microsoft/vcpkg/issues/25673