### PR TITLE
Fix formatting for usage suggestion

### DIFF
--- a/src/vcpkg/install.cpp
+++ b/src/vcpkg/install.cpp
@@ -788,7 +788,7 @@ namespace vcpkg
             }
             else
             {
-                auto msg = msg::format(msgCMakeTargetsUsage, msg::package_name = bpgh.spec.name()).append_raw('\n');
+                auto msg = msg::format(msgCMakeTargetsUsage, msg::package_name = bpgh.spec.name()).append_raw("\n\n");
                 msg.append_indent().append(msgCMakeTargetsUsageHeuristicMessage).append_raw('\n');
 
                 for (auto&& library_target_pair : library_targets)


### PR DESCRIPTION
The usage files in microsoft/vcpkg have an extra empty line between `xy provides CMake targets` and the `find_package` line.