### PR TITLE
Updated fmt to version 9.1.0

### DIFF
--- a/cmake/Findfmt.cmake
+++ b/cmake/Findfmt.cmake
@@ -1,11 +1,14 @@
 option(VCPKG_DEPENDENCY_EXTERNAL_FMT "Use an external version of the fmt library" OFF)
-set(VCPKG_FMT_URL "https://github.com/fmtlib/fmt/archive/refs/tags/8.1.1.tar.gz" CACHE STRING "URL to the fmt release tarball to use.")
+
+set(VCPKG_FMT_VERSION "9.1.0" CACHE STRING "Required fmt release version.")
+set(VCPKG_FMT_HASH "a18442042722dd48e20714ec034a12fcc0576c9af7be5188586970e2edf47529825bdc99af366b1d5891630c8dbf6f63bfa9f012e77ab3d3ed80d1a118e3b2be" CACHE STRING "SHA512 hash of the fmt release tarball.")
+set(VCPKG_FMT_URL "https://github.com/fmtlib/fmt/archive/refs/tags/${VCPKG_FMT_VERSION}.tar.gz" CACHE STRING "URL to the fmt release tarball to use.")
 
 include(FetchContent)
 FetchContent_Declare(
     fmt
     URL "${VCPKG_FMT_URL}"
-    URL_HASH SHA512=794a47d7cb352a2a9f2c050a60a46b002e4157e5ad23e15a5afc668e852b1e1847aeee3cda79e266c789ff79310d792060c94976ceef6352e322d60b94e23189
+    URL_HASH "SHA512=${VCPKG_FMT_HASH}"
 )
 
 if(NOT fmt_FIND_REQUIRED)
@@ -13,7 +16,7 @@ if(NOT fmt_FIND_REQUIRED)
 endif()
 
 if(VCPKG_DEPENDENCY_EXTERNAL_FMT)
-    find_package(fmt CONFIG REQUIRED)
+    find_package(fmt ${VCPKG_FMT_VERSION} CONFIG REQUIRED)
 else()
     FetchContent_MakeAvailable(fmt)
 endif()

--- a/include/vcpkg/base/fwd/format.h
+++ b/include/vcpkg/base/fwd/format.h
@@ -2,7 +2,7 @@
 
 namespace fmt
 {
-    inline namespace v8
+    inline namespace v9
     {
         template<typename T, typename Char, typename Enable>
         struct formatter;


### PR DESCRIPTION
* Fixed build against packaged fmt 9.1.0.
* Updated bundled fmt to version 9.1.0.
* Performed refactoring of `Findfmt.cmake`.

Closes https://github.com/microsoft/vcpkg/issues/25673

Copy of #634.