### PR TITLE
Optimize the message of integrate install

### DIFF
--- a/src/vcpkg/commands.integrate.cpp
+++ b/src/vcpkg/commands.integrate.cpp
@@ -368,6 +368,7 @@ namespace vcpkg::Commands::Integrate
 
 #if defined(_WIN32)
         msg::println(msg::format(msgCMakeToolChainFile, msg::path = cmake_toolchain.generic_u8string())
+                         .append_raw("\n\n")
                          .append(msgAutomaticLinkingForMSBuildProjects));
 #else
         msg::println(msgCMakeToolChainFile, msg::path = cmake_toolchain.generic_u8string());


### PR DESCRIPTION
After the PR https://github.com/microsoft/vcpkg-tool/pull/619, the prompt information after executing `./vcpkg integrate install` under windows becomes the following:
![image](https://user-images.githubusercontent.com/38240633/190573520-4d79dd62-ac40-47d8-8590-7205c0e61b59.png)
The information here is all crowded together and the user experience will be bad.

For fixing this issue, I've added two newlines here, and the modified result looks like this:
![image](https://user-images.githubusercontent.com/38240633/190574463-272a8a13-2ba3-4a6e-84ca-843cf7fdcd2d.png)
