### PR TITLE
Get exit code of 0 with --only-downloads option

### DIFF
--- a/include/vcpkg/commands.setinstalled.h
+++ b/include/vcpkg/commands.setinstalled.h
@@ -17,7 +17,8 @@ namespace vcpkg::Commands::SetInstalled
                              DryRun dry_run,
                              const Optional<Path>& pkgsconfig_path,
                              Triplet host_triplet,
-                             const KeepGoing keep_going);
+                             const KeepGoing keep_going,
+                             const bool only_downloads);
     void perform_and_exit(const VcpkgCmdArguments& args,
                           const VcpkgPaths& paths,
                           Triplet default_triplet,

--- a/src/vcpkg/commands.setinstalled.cpp
+++ b/src/vcpkg/commands.setinstalled.cpp
@@ -46,7 +46,8 @@ namespace vcpkg::Commands::SetInstalled
                              DryRun dry_run,
                              const Optional<Path>& maybe_pkgsconfig,
                              Triplet host_triplet,
-                             const KeepGoing keep_going)
+                             const KeepGoing keep_going,
+                             const bool only_downloads)
     {
         auto& fs = paths.get_filesystem();
 
@@ -127,7 +128,10 @@ namespace vcpkg::Commands::SetInstalled
         if (keep_going == KeepGoing::YES && summary.failed())
         {
             summary.print_failed();
-            Checks::exit_fail(VCPKG_LINE_INFO);
+            if (!only_downloads)
+            {
+                Checks::exit_fail(VCPKG_LINE_INFO);
+            }
         }
 
         std::set<std::string> printed_usages;
@@ -194,7 +198,8 @@ namespace vcpkg::Commands::SetInstalled
                             dry_run ? DryRun::Yes : DryRun::No,
                             pkgsconfig,
                             host_triplet,
-                            keep_going);
+                            keep_going,
+                            only_downloads);
     }
 
     void SetInstalledCommand::perform_and_exit(const VcpkgCmdArguments& args,

--- a/src/vcpkg/install.cpp
+++ b/src/vcpkg/install.cpp
@@ -1111,7 +1111,8 @@ namespace vcpkg
                                                         dry_run ? Commands::DryRun::Yes : Commands::DryRun::No,
                                                         pkgsconfig,
                                                         host_triplet,
-                                                        keep_going);
+                                                        keep_going,
+                                                        only_downloads);
         }
 
         PathsPortFileProvider provider(paths, make_overlay_provider(paths, args.overlay_ports));


### PR DESCRIPTION
## Without this fix

#697 changed vcpkg's behavior.

It used to be possible to call `$VCPKG_ROOT/vcpkg install --only-downloads`  and get an exit code of `0`. This could be useful to, for instance, download dependencies' sources in order to scan them with [Snyk](https://snyk.io/).

After #697, the exit code is now `1`, and the GitHub Workflow fails before the Snyk scan.

## With this fix

I do not change the behavior of `--keep-going`, but I re-establish the original behavior of `--only-downloads`. Hence, `$VCPKG_ROOT/vcpkg install --only-downloads` succeeds with the exit code `0`.

I tested that the fix behaves as expected manually, making sure that I get an exit code of `1` without the fix and an exit code of `0` with the fix.

c.c. @ras0219-msft from #697 and @BillyONeal from our discussion on Discord.