### PR TITLE
Add LICENSE.txt to the one-liner.

### DIFF
--- a/vcpkg-init/mint-standalone-bundle.ps1
+++ b/vcpkg-init/mint-standalone-bundle.ps1
@@ -52,6 +52,7 @@ try {
     New-Item -Path 'out/scripts' -ItemType 'Directory' -Force
     Push-Location "vcpkg-$sha"
     try {
+        Move-Item 'LICENSE.txt' '../out/LICENSE.txt'
         Move-Item 'triplets' '../out/triplets'
         foreach ($exclusion in $scripts_exclusions) {
             Remove-Item "scripts/$exclusion" -Recurse -Force


### PR DESCRIPTION
Olga discovered that vcpkg-cmake expects a LICENSE.txt in `VCPKG_ROOT`. This includes that in the standalone bundle.

See https://github.com/microsoft/vcpkg/blob/57d3194e702a2959e86a6748999ad71fc24f7922/ports/vcpkg-cmake/portfile.cmake#L13