### PR TITLE
Statically enforce some metrics properties at compile time.

### DIFF
--- a/include/vcpkg/metrics.h
+++ b/include/vcpkg/metrics.h
@@ -2,19 +2,14 @@
 
 #include <vcpkg/base/files.h>
 #include <vcpkg/base/lockguarded.h>
+#include <vcpkg/base/stringview.h>
 #include <vcpkg/base/util.h>
 
+#include <array>
 #include <string>
 
 namespace vcpkg
 {
-    template<typename T>
-    struct MetricEntry
-    {
-        T metric;
-        StringLiteral name;
-    };
-
     enum class DefineMetric
     {
         AssetSource,
@@ -45,6 +40,14 @@ namespace vcpkg
         COUNT // always keep COUNT last
     };
 
+    struct DefineMetricEntry
+    {
+        DefineMetric metric;
+        StringLiteral name;
+    };
+
+    extern const std::array<DefineMetricEntry, static_cast<size_t>(DefineMetric::COUNT)> all_define_metrics;
+
     enum class StringMetric
     {
         BuildError,
@@ -63,12 +66,29 @@ namespace vcpkg
         COUNT // always keep COUNT last
     };
 
+    struct StringMetricEntry
+    {
+        StringMetric metric;
+        StringLiteral name;
+        StringLiteral preregister_value; // mock values
+    };
+
+    extern const std::array<StringMetricEntry, static_cast<size_t>(StringMetric::COUNT)> all_string_metrics;
+
     enum class BoolMetric
     {
         InstallManifestMode,
         OptionOverlayPorts,
         COUNT // always keep COUNT last
     };
+
+    struct BoolMetricEntry
+    {
+        BoolMetric metric;
+        StringLiteral name;
+    };
+
+    extern const std::array<BoolMetricEntry, static_cast<size_t>(BoolMetric::COUNT)> all_bool_metrics;
 
     struct Metrics
     {
@@ -95,12 +115,6 @@ namespace vcpkg
 
         void upload(const std::string& payload);
         void flush(Filesystem& fs);
-
-        // exposed for testing
-        static View<MetricEntry<DefineMetric>> get_define_metrics();
-        static View<MetricEntry<StringMetric>> get_string_metrics();
-        static View<MetricEntry<StringMetric>> get_string_metrics_preregister_values();
-        static View<MetricEntry<BoolMetric>> get_bool_metrics();
     };
 
     extern LockGuarded<Metrics> g_metrics;

--- a/src/vcpkg-test/metrics.cpp
+++ b/src/vcpkg-test/metrics.cpp
@@ -6,10 +6,11 @@
 
 using namespace vcpkg;
 
-template<typename T>
-void validate_enum_values_and_names(View<MetricEntry<T>> entries, const size_t expected_size)
+template<typename MetricEntry, size_t Size>
+void validate_enum_values_and_names(const std::array<MetricEntry, Size>& entries)
 {
-    REQUIRE(expected_size == entries.size());
+    static_assert(static_cast<size_t>(decltype(entries[0].metric)::COUNT) == Size,
+                  "COUNT must be the last enum entry.");
 
     size_t enum_value = 0;
     std::set<StringView> used_names;
@@ -33,34 +34,25 @@ TEST_CASE ("Check metric enum types", "[metrics]")
 {
     SECTION ("define metrics")
     {
-        validate_enum_values_and_names(Metrics::get_define_metrics(), static_cast<size_t>(DefineMetric::COUNT));
+        validate_enum_values_and_names(all_define_metrics);
     }
 
     SECTION ("string metrics")
     {
-        validate_enum_values_and_names(Metrics::get_string_metrics(), static_cast<size_t>(StringMetric::COUNT));
+        validate_enum_values_and_names(all_string_metrics);
     }
 
     SECTION ("bool metrics")
     {
-        validate_enum_values_and_names(Metrics::get_bool_metrics(), static_cast<size_t>(BoolMetric::COUNT));
+        validate_enum_values_and_names(all_bool_metrics);
     }
 }
 
 TEST_CASE ("Check string metrics initialization values", "[metrics]")
 {
-    auto known_metrics = Metrics::get_string_metrics();
-    auto init_values = Metrics::get_string_metrics_preregister_values();
-
-    // check that all init values are complete and in order
-    size_t enum_value = 0;
-    REQUIRE(init_values.size() == known_metrics.size());
-    for (auto&& init_value : init_values)
+    // check that all init values are complete
+    for (auto&& string_metric : all_string_metrics)
     {
-        REQUIRE(enum_value == static_cast<size_t>(init_value.metric));
-        ++enum_value;
-
-        // initialization value should not be empty
-        REQUIRE(!init_value.name.empty());
+        REQUIRE(!string_metric.preregister_value.empty());
     }
 }

--- a/src/vcpkg/commands.zpreregistertelemetry.cpp
+++ b/src/vcpkg/commands.zpreregistertelemetry.cpp
@@ -9,7 +9,7 @@ namespace
     static void set_define_metrics()
     {
         auto metrics = LockGuardPtr<Metrics>(g_metrics);
-        for (auto metric : Metrics::get_define_metrics())
+        for (auto&& metric : all_define_metrics)
         {
             metrics->track_define_property(metric.metric);
         }
@@ -18,7 +18,7 @@ namespace
     static void set_bool_metrics()
     {
         auto metrics = LockGuardPtr<Metrics>(g_metrics);
-        for (auto metric : Metrics::get_bool_metrics())
+        for (auto&& metric : all_bool_metrics)
         {
             metrics->track_bool_property(metric.metric, false);
         }
@@ -27,9 +27,9 @@ namespace
     static void set_string_metrics()
     {
         auto metrics = LockGuardPtr<Metrics>(g_metrics);
-        for (auto&& kv : Metrics::get_string_metrics_preregister_values())
+        for (auto&& metric : all_string_metrics)
         {
-            metrics->track_string_property(kv.metric, kv.name.to_string());
+            metrics->track_string_property(metric.metric, metric.preregister_value);
         }
     }
 

--- a/src/vcpkg/metrics.cpp
+++ b/src/vcpkg/metrics.cpp
@@ -23,8 +23,8 @@ namespace
 {
     using namespace vcpkg;
 
-    template<typename T>
-    StringLiteral get_metric_name(const T metric, View<MetricEntry<T>> entries)
+    template<typename T, typename MetricEntry, size_t Size>
+    constexpr StringLiteral get_metric_name(const T metric, const std::array<MetricEntry, Size>& entries) noexcept
     {
         auto metric_index = static_cast<size_t>(metric);
         if (metric_index < entries.size())
@@ -40,87 +40,56 @@ namespace vcpkg
 {
     LockGuarded<Metrics> g_metrics;
 
-    View<MetricEntry<DefineMetric>> Metrics::get_define_metrics()
-    {
-        static constexpr std::array<MetricEntry<DefineMetric>, static_cast<size_t>(DefineMetric::COUNT)> ENTRIES{{
-            {DefineMetric::AssetSource, "asset-source"},
-            {DefineMetric::BinaryCachingAws, "binarycaching_aws"},
-            {DefineMetric::BinaryCachingAzBlob, "binarycaching_azblob"},
-            {DefineMetric::BinaryCachingCos, "binarycaching_cos"},
-            {DefineMetric::BinaryCachingDefault, "binarycaching_default"},
-            {DefineMetric::BinaryCachingFiles, "binarycaching_files"},
-            {DefineMetric::BinaryCachingGcs, "binarycaching_gcs"},
-            {DefineMetric::BinaryCachingHttp, "binarycaching_http"},
-            {DefineMetric::BinaryCachingNuget, "binarycaching_nuget"},
-            {DefineMetric::BinaryCachingSource, "binarycaching-source"},
-            {DefineMetric::ErrorVersioningDisabled, "error-versioning-disabled"},
-            {DefineMetric::ErrorVersioningNoBaseline, "error-versioning-no-baseline"},
-            {DefineMetric::GitHubRepository, "GITHUB_REPOSITORY"},
-            {DefineMetric::ManifestBaseline, "manifest_baseline"},
-            {DefineMetric::ManifestOverrides, "manifest_overrides"},
-            {DefineMetric::ManifestVersionConstraint, "manifest_version_constraint"},
-            {DefineMetric::RegistriesErrorCouldNotFindBaseline, "registries-error-could-not-find-baseline"},
-            {DefineMetric::RegistriesErrorNoVersionsAtCommit, "registries-error-no-versions-at-commit"},
-            {DefineMetric::VcpkgBinarySources, "VCPKG_BINARY_SOURCES"},
-            {DefineMetric::VcpkgDefaultBinaryCache, "VCPKG_DEFAULT_BINARY_CACHE"},
-            {DefineMetric::VcpkgNugetRepository, "VCPKG_NUGET_REPOSITORY"},
-            {DefineMetric::VersioningErrorBaseline, "versioning-error-baseline"},
-            {DefineMetric::VersioningErrorVersion, "versioning-error-version"},
-            {DefineMetric::X_VcpkgRegistriesCache, "X_VCPKG_REGISTRIES_CACHE"},
-            {DefineMetric::X_WriteNugetPackagesConfig, "x-write-nuget-packages-config"},
-        }};
-        return {ENTRIES.data(), ENTRIES.size()};
-    }
+    const constexpr std::array<DefineMetricEntry, static_cast<size_t>(DefineMetric::COUNT)> all_define_metrics{{
+        {DefineMetric::AssetSource, "asset-source"},
+        {DefineMetric::BinaryCachingAws, "binarycaching_aws"},
+        {DefineMetric::BinaryCachingAzBlob, "binarycaching_azblob"},
+        {DefineMetric::BinaryCachingCos, "binarycaching_cos"},
+        {DefineMetric::BinaryCachingDefault, "binarycaching_default"},
+        {DefineMetric::BinaryCachingFiles, "binarycaching_files"},
+        {DefineMetric::BinaryCachingGcs, "binarycaching_gcs"},
+        {DefineMetric::BinaryCachingHttp, "binarycaching_http"},
+        {DefineMetric::BinaryCachingNuget, "binarycaching_nuget"},
+        {DefineMetric::BinaryCachingSource, "binarycaching-source"},
+        {DefineMetric::ErrorVersioningDisabled, "error-versioning-disabled"},
+        {DefineMetric::ErrorVersioningNoBaseline, "error-versioning-no-baseline"},
+        {DefineMetric::GitHubRepository, "GITHUB_REPOSITORY"},
+        {DefineMetric::ManifestBaseline, "manifest_baseline"},
+        {DefineMetric::ManifestOverrides, "manifest_overrides"},
+        {DefineMetric::ManifestVersionConstraint, "manifest_version_constraint"},
+        {DefineMetric::RegistriesErrorCouldNotFindBaseline, "registries-error-could-not-find-baseline"},
+        {DefineMetric::RegistriesErrorNoVersionsAtCommit, "registries-error-no-versions-at-commit"},
+        {DefineMetric::VcpkgBinarySources, "VCPKG_BINARY_SOURCES"},
+        {DefineMetric::VcpkgDefaultBinaryCache, "VCPKG_DEFAULT_BINARY_CACHE"},
+        {DefineMetric::VcpkgNugetRepository, "VCPKG_NUGET_REPOSITORY"},
+        {DefineMetric::VersioningErrorBaseline, "versioning-error-baseline"},
+        {DefineMetric::VersioningErrorVersion, "versioning-error-version"},
+        {DefineMetric::X_VcpkgRegistriesCache, "X_VCPKG_REGISTRIES_CACHE"},
+        {DefineMetric::X_WriteNugetPackagesConfig, "x-write-nuget-packages-config"},
+    }};
 
-    View<MetricEntry<StringMetric>> Metrics::get_string_metrics()
-    {
-        static constexpr std::array<MetricEntry<StringMetric>, static_cast<size_t>(StringMetric::COUNT)> ENTRIES{{
-            {StringMetric::BuildError, "build_error"},
-            {StringMetric::CommandArgs, "command_args"},
-            {StringMetric::CommandContext, "command_context"},
-            {StringMetric::CommandName, "command_name"},
-            {StringMetric::Error, "error"},
-            {StringMetric::InstallPlan_1, "installplan_1"},
-            {StringMetric::ListFile, "listfile"},
-            {StringMetric::RegistriesDefaultRegistryKind, "registries-default-registry-kind"},
-            {StringMetric::RegistriesKindsUsed, "registries-kinds-used"},
-            {StringMetric::Title, "title"},
-            {StringMetric::UserMac, "user_mac"},
-            {StringMetric::VcpkgVersion, "vcpkg_version"},
-            {StringMetric::Warning, "warning"},
-        }};
-        return {ENTRIES.data(), ENTRIES.size()};
-    }
+    const constexpr std::array<StringMetricEntry, static_cast<size_t>(StringMetric::COUNT)> all_string_metrics{{
+        {StringMetric::BuildError, "build_error", "gsl:x64-windows"},
+        {StringMetric::CommandArgs, "command_args", "0000000011111111aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff"},
+        {StringMetric::CommandContext, "command_context", "artifact"},
+        {StringMetric::CommandName, "command_name", "z-preregister-telemetry"},
+        {StringMetric::Error, "error", "build failed"},
+        {StringMetric::InstallPlan_1,
+         "installplan_1",
+         "0000000011111111aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff"},
+        {StringMetric::ListFile, "listfile", "update to new format"},
+        {StringMetric::RegistriesDefaultRegistryKind, "registries-default-registry-kind", "builtin-files"},
+        {StringMetric::RegistriesKindsUsed, "registries-kinds-used", "git,filesystem"},
+        {StringMetric::Title, "title", "title"},
+        {StringMetric::UserMac, "user_mac", "0"},
+        {StringMetric::VcpkgVersion, "vcpkg_version", "2999-12-31-unknownhash"},
+        {StringMetric::Warning, "warning", "warning"},
+    }};
 
-    View<MetricEntry<BoolMetric>> Metrics::get_bool_metrics()
-    {
-        static constexpr std::array<MetricEntry<BoolMetric>, static_cast<size_t>(BoolMetric::COUNT)> ENTRIES{{
-            {BoolMetric::InstallManifestMode, "install_manifest_mode"},
-            {BoolMetric::OptionOverlayPorts, "option_overlay_ports"},
-        }};
-        return {ENTRIES.data(), ENTRIES.size()};
-    }
-
-    View<MetricEntry<StringMetric>> Metrics::get_string_metrics_preregister_values()
-    {
-        // mock values in telemetry
-        static constexpr std::array<MetricEntry<StringMetric>, static_cast<size_t>(StringMetric::COUNT)> ENTRIES{{
-            {StringMetric::BuildError, "gsl:x64-windows"},
-            {StringMetric::CommandArgs, "0000000011111111aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff"},
-            {StringMetric::CommandContext, "artifact"},
-            {StringMetric::CommandName, "z-preregister-telemetry"},
-            {StringMetric::Error, "build failed"},
-            {StringMetric::InstallPlan_1, "0000000011111111aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff"},
-            {StringMetric::ListFile, "update to new format"},
-            {StringMetric::RegistriesDefaultRegistryKind, "builtin-files"},
-            {StringMetric::RegistriesKindsUsed, "git,filesystem"},
-            {StringMetric::Title, "title"},
-            {StringMetric::UserMac, "0"},
-            {StringMetric::VcpkgVersion, "2999-12-31-unknownhash"},
-            {StringMetric::Warning, "warning"},
-        }};
-        return {ENTRIES.data(), ENTRIES.size()};
-    }
+    const constexpr std::array<BoolMetricEntry, static_cast<size_t>(BoolMetric::COUNT)> all_bool_metrics{{
+        {BoolMetric::InstallManifestMode, "install_manifest_mode"},
+        {BoolMetric::OptionOverlayPorts, "option_overlay_ports"},
+    }};
 
     static std::string get_current_date_time_string()
     {
@@ -344,17 +313,17 @@ namespace vcpkg
 
     void Metrics::track_define_property(DefineMetric metric)
     {
-        g_metricmessage.track_string(get_metric_name(metric, get_define_metrics()), "defined");
+        g_metricmessage.track_string(get_metric_name(metric, all_define_metrics), "defined");
     }
 
     void Metrics::track_string_property(StringMetric metric, StringView value)
     {
-        g_metricmessage.track_string(get_metric_name(metric, get_string_metrics()), value);
+        g_metricmessage.track_string(get_metric_name(metric, all_string_metrics), value);
     }
 
     void Metrics::track_bool_property(BoolMetric metric, bool value)
     {
-        g_metricmessage.track_bool(get_metric_name(metric, get_bool_metrics()), value);
+        g_metricmessage.track_bool(get_metric_name(metric, all_bool_metrics), value);
     }
 
     void Metrics::track_feature(const std::string& name, bool value) { g_metricmessage.track_feature(name, value); }


### PR DESCRIPTION
This exposes that the lists of all metrics are actually std::arrays, which allows for compile time enforcement of properties like:

* All metrics have entries in the name list
* COUNT is the last entry in the enum list
* All string metrics have corresponding example values