### PR TITLE
pass VERSION to cmake when building port

### DIFF
--- a/azure-pipelines/e2e_ports/version-variable/version-date/portfile.cmake
+++ b/azure-pipelines/e2e_ports/version-variable/version-date/portfile.cmake
@@ -1,0 +1,4 @@
+if (NOT VERSION STREQUAL "2020-10-10")
+    message(FATAL_ERROR "\${VERSION} should be '2020-10-10' but is '${VERSION}'")
+endif()
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/azure-pipelines/e2e_ports/version-variable/version-date/vcpkg.json
+++ b/azure-pipelines/e2e_ports/version-variable/version-date/vcpkg.json
@@ -1,0 +1,4 @@
+{
+	"name": "version-date",
+	"version-date": "2020-10-10"
+}

--- a/azure-pipelines/e2e_ports/version-variable/version-semver/portfile.cmake
+++ b/azure-pipelines/e2e_ports/version-variable/version-semver/portfile.cmake
@@ -1,0 +1,4 @@
+if (NOT VERSION STREQUAL "1.0.0")
+    message(FATAL_ERROR "\${VERSION} should be '1.0.0' but is '${VERSION}'")
+endif()
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/azure-pipelines/e2e_ports/version-variable/version-semver/vcpkg.json
+++ b/azure-pipelines/e2e_ports/version-variable/version-semver/vcpkg.json
@@ -1,0 +1,4 @@
+{
+	"name": "version-semver",
+	"version-semver": "1.0.0"
+}

--- a/azure-pipelines/e2e_ports/version-variable/version-string/portfile.cmake
+++ b/azure-pipelines/e2e_ports/version-variable/version-string/portfile.cmake
@@ -1,0 +1,4 @@
+if (NOT VERSION STREQUAL "1.0.0")
+    message(FATAL_ERROR "\${VERSION} should be '1.0.0' but is '${VERSION}'")
+endif()
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/azure-pipelines/e2e_ports/version-variable/version-string/vcpkg.json
+++ b/azure-pipelines/e2e_ports/version-variable/version-string/vcpkg.json
@@ -1,0 +1,4 @@
+{
+	"name": "version-string",
+	"version-string": "1.0.0"
+}

--- a/azure-pipelines/e2e_ports/version-variable/version/portfile.cmake
+++ b/azure-pipelines/e2e_ports/version-variable/version/portfile.cmake
@@ -1,0 +1,4 @@
+if (NOT VERSION STREQUAL "1.0.0")
+    message(FATAL_ERROR "\${VERSION} should be '1.0.0' but is '${VERSION}'")
+endif()
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/azure-pipelines/e2e_ports/version-variable/version/vcpkg.json
+++ b/azure-pipelines/e2e_ports/version-variable/version/vcpkg.json
@@ -1,0 +1,4 @@
+{
+	"name": "version",
+	"version": "1.0.0"
+}

--- a/azure-pipelines/end-to-end-tests-dir/version-variable.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/version-variable.ps1
@@ -1,0 +1,11 @@
+. $PSScriptRoot/../end-to-end-tests-prelude.ps1
+
+$portsPath = "$PSScriptRoot/../e2e_ports/version-variable"
+
+$CurrentTest = "version variable in portfile.cmake"
+Run-Vcpkg install @commonArgs `
+    "--x-builtin-ports-root=$portsPath" `
+    --binarysource=clear `
+    version version-string version-date version-semver
+Throw-IfFailed
+Refresh-TestRoot

--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -720,7 +720,7 @@ namespace vcpkg
             {"_HOST_TRIPLET", action.host_triplet.canonical_name()},
             {"FEATURES", Strings::join(";", action.feature_list)},
             {"PORT", scf.core_paragraph->name},
-            {"PORT_VERSION", scf.core_paragraph->raw_version},
+            {"VERSION", scf.core_paragraph->raw_version},
             {"VCPKG_USE_HEAD_VERSION", Util::Enum::to_bool(action.build_options.use_head_version) ? "1" : "0"},
             {"_VCPKG_DOWNLOAD_TOOL", to_string(action.build_options.download_tool)},
             {"_VCPKG_EDITABLE", Util::Enum::to_bool(action.build_options.editable) ? "1" : "0"},

--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -720,6 +720,7 @@ namespace vcpkg
             {"_HOST_TRIPLET", action.host_triplet.canonical_name()},
             {"FEATURES", Strings::join(";", action.feature_list)},
             {"PORT", scf.core_paragraph->name},
+            {"PORT_VERSION", scf.core_paragraph->raw_version},
             {"VCPKG_USE_HEAD_VERSION", Util::Enum::to_bool(action.build_options.use_head_version) ? "1" : "0"},
             {"_VCPKG_DOWNLOAD_TOOL", to_string(action.build_options.download_tool)},
             {"_VCPKG_EDITABLE", Util::Enum::to_bool(action.build_options.editable) ? "1" : "0"},


### PR DESCRIPTION
This is a frequently requested feature. With this one can use the `${PORT_VERSION}` variable inside `portfile.cmake` to get the currents port version. 