### PR TITLE
Add option --no-print-usage to disable manifest-mode usage info

### DIFF
--- a/include/vcpkg/commands.setinstalled.h
+++ b/include/vcpkg/commands.setinstalled.h
@@ -18,7 +18,8 @@ namespace vcpkg::Commands::SetInstalled
                              const Optional<Path>& pkgsconfig_path,
                              Triplet host_triplet,
                              const KeepGoing keep_going,
-                             const bool only_downloads);
+                             const bool only_downloads,
+                             const PrintUsage print_cmake_usage);
     void perform_and_exit(const VcpkgCmdArguments& args,
                           const VcpkgPaths& paths,
                           Triplet default_triplet,

--- a/src/vcpkg/commands.setinstalled.cpp
+++ b/src/vcpkg/commands.setinstalled.cpp
@@ -19,10 +19,11 @@ namespace vcpkg::Commands::SetInstalled
     static constexpr StringLiteral OPTION_KEEP_GOING = "keep-going";
     static constexpr StringLiteral OPTION_ONLY_DOWNLOADS = "only-downloads";
     static constexpr StringLiteral OPTION_WRITE_PACKAGES_CONFIG = "x-write-nuget-packages-config";
+    static constexpr StringLiteral OPTION_NO_PRINT_USAGE = "no-print-usage";
 
     static constexpr CommandSwitch INSTALL_SWITCHES[] = {
         {OPTION_DRY_RUN, "Do not actually build or install"},
-    };
+        {OPTION_NO_PRINT_USAGE, "Don't print cmake usage information after install."}};
     static constexpr CommandSetting INSTALL_SETTINGS[] = {
         {OPTION_WRITE_PACKAGES_CONFIG,
          "Writes out a NuGet packages.config-formatted file for use with external binary caching.\n"
@@ -47,7 +48,8 @@ namespace vcpkg::Commands::SetInstalled
                              const Optional<Path>& maybe_pkgsconfig,
                              Triplet host_triplet,
                              const KeepGoing keep_going,
-                             const bool only_downloads)
+                             const bool only_downloads,
+                             const PrintUsage print_cmake_usage)
     {
         auto& fs = paths.get_filesystem();
 
@@ -134,13 +136,16 @@ namespace vcpkg::Commands::SetInstalled
             }
         }
 
-        std::set<std::string> printed_usages;
-        for (auto&& ur_spec : user_requested_specs)
+        if (print_cmake_usage == PrintUsage::YES)
         {
-            auto it = status_db.find_installed(ur_spec);
-            if (it != status_db.end())
+            std::set<std::string> printed_usages;
+            for (auto&& ur_spec : user_requested_specs)
             {
-                Install::print_usage_information(it->get()->package, printed_usages, fs, paths.installed());
+                auto it = status_db.find_installed(ur_spec);
+                if (it != status_db.end())
+                {
+                    Install::print_usage_information(it->get()->package, printed_usages, fs, paths.installed());
+                }
             }
         }
 
@@ -167,6 +172,8 @@ namespace vcpkg::Commands::SetInstalled
         const KeepGoing keep_going = Util::Sets::contains(options.switches, OPTION_KEEP_GOING) || only_downloads
                                          ? KeepGoing::YES
                                          : KeepGoing::NO;
+        const PrintUsage print_cmake_usage =
+            Util::Sets::contains(options.switches, OPTION_NO_PRINT_USAGE) ? PrintUsage::NO : PrintUsage::YES;
 
         PathsPortFileProvider provider(paths, make_overlay_provider(paths, args.overlay_ports));
         auto cmake_vars = CMakeVars::make_triplet_cmake_var_provider(paths);
@@ -199,7 +206,8 @@ namespace vcpkg::Commands::SetInstalled
                             pkgsconfig,
                             host_triplet,
                             keep_going,
-                            only_downloads);
+                            only_downloads,
+                            print_cmake_usage);
     }
 
     void SetInstalledCommand::perform_and_exit(const VcpkgCmdArguments& args,

--- a/src/vcpkg/install.cpp
+++ b/src/vcpkg/install.cpp
@@ -890,7 +890,8 @@ namespace vcpkg
         const auto unsupported_port_action = Util::Sets::contains(options.switches, OPTION_ALLOW_UNSUPPORTED_PORT)
                                                  ? UnsupportedPortAction::Warn
                                                  : UnsupportedPortAction::Error;
-        const bool no_print_usage = Util::Sets::contains(options.switches, OPTION_NO_PRINT_USAGE);
+        const PrintUsage print_cmake_usage =
+            Util::Sets::contains(options.switches, OPTION_NO_PRINT_USAGE) ? PrintUsage::NO : PrintUsage::YES;
 
         LockGuardPtr<Metrics>(g_metrics)->track_bool_property(BoolMetric::InstallManifestMode,
                                                               paths.manifest_mode_enabled());
@@ -971,8 +972,7 @@ namespace vcpkg
             PurgeDecompressFailure::NO,
             Util::Enum::to_enum<Editable>(is_editable),
             prohibit_backcompat_features ? BackcompatFeatures::PROHIBIT : BackcompatFeatures::ALLOW,
-            Util::Enum::to_enum<PrintUsage>(!no_print_usage),
-        };
+            print_cmake_usage};
 
         auto var_provider_storage = CMakeVars::make_triplet_cmake_var_provider(paths);
         auto& var_provider = *var_provider_storage;
@@ -1112,7 +1112,8 @@ namespace vcpkg
                                                         pkgsconfig,
                                                         host_triplet,
                                                         keep_going,
-                                                        only_downloads);
+                                                        only_downloads,
+                                                        print_cmake_usage);
         }
 
         PathsPortFileProvider provider(paths, make_overlay_provider(paths, args.overlay_ports));


### PR DESCRIPTION
Simple change to support --no-print-usage for manifest-mode installs.