### PR TITLE
Set CMP0115 to new

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15) # 3.15 for MSVC_RUNTIME_LIBRARY, removing d
 cmake_policy(SET CMP0091 NEW)
 cmake_policy(SET CMP0092 NEW)
 
-if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.20)
+if(POLICY CMP0115)
     cmake_policy(SET CMP0115 NEW)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,10 @@ cmake_minimum_required(VERSION 3.15) # 3.15 for MSVC_RUNTIME_LIBRARY, removing d
 cmake_policy(SET CMP0091 NEW)
 cmake_policy(SET CMP0092 NEW)
 
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.20)
+    cmake_policy(SET CMP0115 NEW)
+endif()
+
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
     cmake_policy(SET CMP0135 NEW)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,7 @@
-cmake_minimum_required(VERSION 3.15) # 3.15 for MSVC_RUNTIME_LIBRARY, removing default warning flags
+cmake_minimum_required(VERSION 3.15..3.24) # 3.15 for MSVC_RUNTIME_LIBRARY, removing default warning flags
 
 cmake_policy(SET CMP0091 NEW)
 cmake_policy(SET CMP0092 NEW)
-
-if(POLICY CMP0115)
-    cmake_policy(SET CMP0115 NEW)
-endif()
 
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
     cmake_policy(SET CMP0135 NEW)


### PR DESCRIPTION
Require explicit extensions for source files, do not guess.
The extra calls to GetFileAttributesW significantly slow down cmake on Windows. https://gitlab.kitware.com/cmake/cmake/-/issues/23154