### PR TITLE
[Telemetry] Detect if vcpkg is running in a container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ node_modules/
 /ce/test/vcpkg-ce.test.build.log
 /ce/common/temp
 /vcpkg-root
+/CMakePresets.json

--- a/include/vcpkg/base/system.h
+++ b/include/vcpkg/base/system.h
@@ -23,6 +23,10 @@ namespace vcpkg
     const ExpectedS<Path>& get_system_root() noexcept;
 
     const ExpectedS<Path>& get_system32() noexcept;
+
+    std::string get_username();
+
+    bool test_registry_key(void* base_hkey, StringView sub_key);
 #endif
 
     Optional<std::string> get_registry_string(void* base_hkey, StringView subkey, StringView valuename);

--- a/include/vcpkg/base/system.h
+++ b/include/vcpkg/base/system.h
@@ -24,7 +24,7 @@ namespace vcpkg
 
     const ExpectedS<Path>& get_system32() noexcept;
 
-    std::string get_username();
+    std::wstring get_username();
 
     bool test_registry_key(void* base_hkey, StringView sub_key);
 #endif

--- a/include/vcpkg/cgroup-parser.h
+++ b/include/vcpkg/cgroup-parser.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <vcpkg/base/fwd/stringview.h>
+
+#include <string>
+
+namespace vcpkg
+{
+    struct ControlGroup
+    {
+        long hierarchy_id;
+        std::string subsystems;
+        std::string control_group;
+
+        ControlGroup(long id, StringView s, StringView c);
+    };
+
+    std::vector<ControlGroup> parse_cgroup_file(StringView text, StringView origin);
+
+    bool detect_docker_in_cgroup_file(StringView text, StringView origin);
+}

--- a/include/vcpkg/metrics.h
+++ b/include/vcpkg/metrics.h
@@ -78,9 +78,9 @@ namespace vcpkg
 
     enum class BoolMetric
     {
+        DetectedContainerEnvironment,
         InstallManifestMode,
         OptionOverlayPorts,
-        DetectedContainerEnvironment,
         COUNT // always keep COUNT last
     };
 

--- a/include/vcpkg/metrics.h
+++ b/include/vcpkg/metrics.h
@@ -78,7 +78,7 @@ namespace vcpkg
 
     enum class BoolMetric
     {
-        DetectedContainerEnvironment,
+        DetectedContainer,
         InstallManifestMode,
         OptionOverlayPorts,
         COUNT // always keep COUNT last

--- a/include/vcpkg/metrics.h
+++ b/include/vcpkg/metrics.h
@@ -80,6 +80,7 @@ namespace vcpkg
     {
         InstallManifestMode,
         OptionOverlayPorts,
+        DetectedContainerEnvironment,
         COUNT // always keep COUNT last
     };
 

--- a/src/vcpkg-test/cgroup-parser.cpp
+++ b/src/vcpkg-test/cgroup-parser.cpp
@@ -1,0 +1,66 @@
+#include <catch2/catch.hpp>
+
+#include <vcpkg/base/stringview.h>
+
+#include <vcpkg/cgroup-parser.h>
+
+using namespace vcpkg;
+
+TEST_CASE ("parse", "[cgroup-parser]")
+{
+    auto ok_text = R"(
+3:cpu:/
+2:cpuset:/
+1:memory:/
+0::/
+)";
+
+    auto cgroups = parse_cgroup_file(ok_text, "ok_text");
+    REQUIRE(cgroups.size() == 4);
+    CHECK(cgroups[0].hierarchy_id == 3);
+    CHECK(cgroups[0].subsystems == "cpu");
+    CHECK(cgroups[0].control_group == "/");
+    CHECK(cgroups[1].hierarchy_id == 2);
+    CHECK(cgroups[1].subsystems == "cpuset");
+    CHECK(cgroups[1].control_group == "/");
+    CHECK(cgroups[2].hierarchy_id == 1);
+    CHECK(cgroups[2].subsystems == "memory");
+    CHECK(cgroups[2].control_group == "/");
+    CHECK(cgroups[3].hierarchy_id == 0);
+    CHECK(cgroups[3].subsystems == "");
+    CHECK(cgroups[3].control_group == "/");
+
+    auto cgroups_short = parse_cgroup_file("2::", "short_text");
+    REQUIRE(cgroups_short.size() == 1);
+    CHECK(cgroups_short[0].hierarchy_id == 2);
+    CHECK(cgroups_short[0].subsystems == "");
+    CHECK(cgroups_short[0].control_group == "");
+
+    auto cgroups_incomplete = parse_cgroup_file("0:/", "incomplete_text");
+    CHECK(cgroups_incomplete.empty());
+
+    auto cgroups_bad_id = parse_cgroup_file("ab::", "non_numeric_id_text");
+    CHECK(cgroups_bad_id.empty());
+
+    auto cgroups_empty = parse_cgroup_file("", "empty");
+    CHECK(cgroups_empty.empty());
+}
+
+TEST_CASE ("detect docker", "[cgroup-parser]")
+{
+    auto with_docker = R"(
+2:memory:/docker/66a5f8000f3f2e2a19c3f7d60d870064d26996bdfe77e40df7e3fc955b811d14
+1:name=systemd:/docker/66a5f8000f3f2e2a19c3f7d60d870064d26996bdfe77e40df7e3fc955b811d14
+0::/docker/66a5f8000f3f2e2a19c3f7d60d870064d26996bdfe77e40df7e3fc955b811d14
+)";
+
+    auto without_docker = R"(
+3:cpu:/
+2:cpuset:/
+1:memory:/
+0::/
+)";
+
+    CHECK(detect_docker_in_cgroup_file(with_docker, "with_docker"));
+    CHECK(!detect_docker_in_cgroup_file(without_docker, "without_docker"));
+}

--- a/src/vcpkg.cpp
+++ b/src/vcpkg.cpp
@@ -114,7 +114,7 @@ static void inner(vcpkg::Filesystem& fs, const VcpkgCmdArguments& args)
         auto metrics = LockGuardPtr<Metrics>(g_metrics);
         if (metrics->metrics_enabled())
         {
-            metrics->track_bool_property(BoolMetric::DetectedContainerEnvironment, detect_container(fs));
+            metrics->track_bool_property(BoolMetric::DetectedContainer, detect_container(fs));
         }
     }
 

--- a/src/vcpkg.cpp
+++ b/src/vcpkg.cpp
@@ -53,7 +53,7 @@ static bool detect_container(vcpkg::Filesystem& fs)
     }
 
     auto username = get_username();
-    if (!wcscmp(username.data(), L"ContainerUser") || !wcscmp(username.data(), L"ContainerAdministrator"))
+    if (username == L"ContainerUser" || username == L"ContainerAdministrator")
     {
         Debug::println("Detected container username");
         return true;

--- a/src/vcpkg.cpp
+++ b/src/vcpkg.cpp
@@ -43,8 +43,8 @@ static void invalid_command(const std::string& cmd)
 
 static void try_container_heuristics(vcpkg::Filesystem& fs)
 {
-#if defined(_WIN32)
     (void)fs;
+#if defined(_WIN32)
     auto registry_heuristic = test_registry_key(HKEY_LOCAL_MACHINE, R"(SYSTEM\CurrentControlSet\Services\cexecsvc)");
     if (registry_heuristic)
     {
@@ -52,8 +52,7 @@ static void try_container_heuristics(vcpkg::Filesystem& fs)
     }
 
     auto username = get_username();
-    if (Strings::case_insensitive_ascii_equals(username, "ContainerUser") ||
-        Strings::case_insensitive_ascii_equals(username, "ContainerAdministrator"))
+    if (!wcscmp(username.data(), L"ContainerUser") || !wcscmp(username.data(), L"ContainerAdministrator"))
     {
         Debug::println("Detected container username");
     }

--- a/src/vcpkg/base/system.cpp
+++ b/src/vcpkg/base/system.cpp
@@ -354,6 +354,7 @@ namespace vcpkg
         std::wstring buffer;
         buffer.resize(static_cast<size_t>(buffer_size));
         GetUserNameW(buffer.data(), &buffer_size);
+        buffer.resize(buffer_size);
         return buffer;
     }
 

--- a/src/vcpkg/base/system.cpp
+++ b/src/vcpkg/base/system.cpp
@@ -13,8 +13,8 @@
 #endif
 
 #if defined(_WIN32)
-#include <winbase.h>
 #include <lmcons.h>
+#include <winbase.h>
 // needed for mingw
 #include <processenv.h>
 #else
@@ -342,19 +342,18 @@ namespace vcpkg
 #endif
     }
 
-
 #if defined(_WIN32)
     static bool is_string_keytype(const DWORD hkey_type)
     {
         return hkey_type == REG_SZ || hkey_type == REG_MULTI_SZ || hkey_type == REG_EXPAND_SZ;
     }
 
-    std::string get_username()
-    { 
+    std::wstring get_username()
+    {
         DWORD buffer_size = UNLEN + 1;
-        std::string buffer;
+        std::wstring buffer;
         buffer.resize(static_cast<size_t>(buffer_size));
-        GetUserNameA(buffer.data(), &buffer_size);
+        GetUserNameW(buffer.data(), &buffer_size);
         return buffer;
     }
 

--- a/src/vcpkg/cgroup-parser.cpp
+++ b/src/vcpkg/cgroup-parser.cpp
@@ -1,0 +1,70 @@
+#include <vcpkg/base/parse.h>
+#include <vcpkg/base/stringview.h>
+#include <vcpkg/base/system.debug.h>
+#include <vcpkg/base/util.h>
+
+#include <vcpkg/cgroup-parser.h>
+
+namespace vcpkg
+{
+    ControlGroup::ControlGroup(long id, StringView s, StringView c)
+        : hierarchy_id(id), subsystems(std::move(s.to_string())), control_group(std::move(c.to_string()))
+    {
+    }
+
+    // parses /proc/[pid]/cgroup file as specified in https://linux.die.net/man/5/proc
+    // The file describes control groups to which the process/tasks belongs.
+    // For each cgroup hierarchy there is one entry
+    // containing colon-separated fields of the form:
+    //    5:cpuacct,cpu,cpuset:/daemos
+    //
+    // The colon separated fields are, from left to right:
+    //
+    // 1. hierarchy ID number
+    // 2. set of subsystems bound to the hierarchy
+    // 3. control group in the hierarchy to which the process belongs
+    std::vector<ControlGroup> parse_cgroup_file(StringView text, StringView origin)
+    {
+        using P = ParserBase;
+        constexpr auto is_separator_or_lineend = [](auto ch) { return ch == ':' || P::is_lineend(ch); };
+
+        auto parser = ParserBase(text, origin);
+        parser.skip_whitespace();
+
+        std::vector<ControlGroup> ret;
+        while (!parser.at_eof())
+        {
+            auto id = parser.match_until(is_separator_or_lineend);
+            auto maybe_numeric_id = Strings::strto<long>(id);
+            if (!maybe_numeric_id || P::is_lineend(parser.cur()))
+            {
+                ret.clear();
+                break;
+            }
+
+            parser.next();
+            auto subsystems = parser.match_until(is_separator_or_lineend);
+            if (P::is_lineend(parser.cur()))
+            {
+                ret.clear();
+                break;
+            }
+
+            parser.next();
+            auto control_group = parser.match_until(P::is_lineend);
+            parser.skip_whitespace();
+
+            ret.emplace_back(*maybe_numeric_id.get(), subsystems, control_group);
+        }
+
+        return ret;
+    }
+
+    bool detect_docker_in_cgroup_file(StringView text, StringView origin)
+    {
+        return Util::any_of(parse_cgroup_file(text, origin), [](auto&& cgroup) {
+            return Strings::starts_with(cgroup.control_group, "/docker") ||
+                   Strings::starts_with(cgroup.control_group, "/lxc");
+        });
+    }
+}

--- a/src/vcpkg/cgroup-parser.cpp
+++ b/src/vcpkg/cgroup-parser.cpp
@@ -8,7 +8,7 @@
 namespace vcpkg
 {
     ControlGroup::ControlGroup(long id, StringView s, StringView c)
-        : hierarchy_id(id), subsystems(std::move(s.to_string())), control_group(std::move(c.to_string()))
+        : hierarchy_id(id), subsystems(s.data(), s.size()), control_group(c.data(), c.size())
     {
     }
 

--- a/src/vcpkg/metrics.cpp
+++ b/src/vcpkg/metrics.cpp
@@ -90,6 +90,7 @@ namespace vcpkg
     const constexpr std::array<BoolMetricEntry, static_cast<size_t>(BoolMetric::COUNT)> all_bool_metrics{{
         {BoolMetric::InstallManifestMode, "install_manifest_mode"},
         {BoolMetric::OptionOverlayPorts, "option_overlay_ports"},
+        {BoolMetric::DetectedContainerEnvironment, "detected_container_environment"},
     }};
 
     static std::string get_current_date_time_string()

--- a/src/vcpkg/metrics.cpp
+++ b/src/vcpkg/metrics.cpp
@@ -88,9 +88,9 @@ namespace vcpkg
     }};
 
     const constexpr std::array<BoolMetricEntry, static_cast<size_t>(BoolMetric::COUNT)> all_bool_metrics{{
+        {BoolMetric::DetectedContainerEnvironment, "detected_container_environment"},
         {BoolMetric::InstallManifestMode, "install_manifest_mode"},
         {BoolMetric::OptionOverlayPorts, "option_overlay_ports"},
-        {BoolMetric::DetectedContainerEnvironment, "detected_container_environment"},
     }};
 
     static std::string get_current_date_time_string()

--- a/src/vcpkg/metrics.cpp
+++ b/src/vcpkg/metrics.cpp
@@ -88,7 +88,7 @@ namespace vcpkg
     }};
 
     const constexpr std::array<BoolMetricEntry, static_cast<size_t>(BoolMetric::COUNT)> all_bool_metrics{{
-        {BoolMetric::DetectedContainerEnvironment, "detected_container_environment"},
+        {BoolMetric::DetectedContainer, "detected_container"},
         {BoolMetric::InstallManifestMode, "install_manifest_mode"},
         {BoolMetric::OptionOverlayPorts, "option_overlay_ports"},
     }};


### PR DESCRIPTION
Implement basic container detection heuristics:

- [X] Windows containers
    - [X] Try to find Container Execution Service through registry
    - [X] Try to find username `ContainerAdministrator` or `ContainerUser` 
- [x] Linux containers 
    - [X] Try to find `/.dockerenv` file
    - [X] Try to check control groups
- [X] Verify working on Linux container
- [X] Verify working on Windows container
- [x] Hook detection to telemetry
- [x] Don't run heuristics if metrics are disabled
- [x] Tests (how do we test this?)

Working on Linux container:
<img width="484" alt="vcpkg on linux container" src="https://user-images.githubusercontent.com/3526662/194651762-7335cf79-29f6-4372-ab78-75146671dc3a.png">

Working on Windows container
<img width="484" alt="vcpkg on windows container" src="https://user-images.githubusercontent.com/3526662/194677451-a770784f-1f9b-46a3-ad3c-4d224dfbdb9e.png">
