### PR TITLE
Check for error, warning, and message in vcpkg-configuration.json.

### DIFF
--- a/ce/ce/cli/commands/activate.ts
+++ b/ce/ce/cli/commands/activate.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { buildRegistryResolver, resolveDependencies } from '../../artifacts/artifact';
+import { buildRegistryResolver, checkDemands, resolveDependencies } from '../../artifacts/artifact';
+import { configurationName } from '../../constants';
 import { i } from '../../i18n';
 import { trackActivation } from '../../insights';
 import { session } from '../../main';
@@ -51,6 +52,10 @@ export class ActivateCommand extends Command {
 
     // track what got installed
     const projectResolver = await buildRegistryResolver(session, projectManifest.metadata.registries);
+    if (!checkDemands(session, (await this.project.resolvedValue)?.fsPath ?? configurationName, projectManifest.applicableDemands)) {
+      return false;
+    }
+
     const resolved = await resolveDependencies(session, projectResolver, [projectManifest], 3);
 
     // print the status of what is going to be activated.


### PR DESCRIPTION
```
$ type .\vcpkg-configuration.json
{
  "default-registry": { /* ... */ },
  "registries": [ /* ... */ ],
  "demands": {
    "example:hello": {
      "error": "example:hello matched"
    },
    "example:world and x86": {
      "error": "example:world & x86 matched"
    },
    "example:world and x64": {
      "error": "example:world & x64 matched"
    },
    "arm": {
      "error": "arm matched"
    }
  }
}
$ vcpkg activate --example hello
warning: vcpkg-artifacts are experimental and may change at any time.
ERROR: c:\Dev\test\vcpkg-configuration.json - example:hello matched
$ vcpkg activate --example world
warning: vcpkg-artifacts are experimental and may change at any time.
ERROR: c:\Dev\test\vcpkg-configuration.json - example:world & x64 matched
$ vcpkg activate --example world --x86
warning: vcpkg-artifacts are experimental and may change at any time.
ERROR: c:\Dev\test\vcpkg-configuration.json - example:world & x86 matched
$ vcpkg activate --arm
warning: vcpkg-artifacts are experimental and may change at any time.
ERROR: c:\Dev\test\vcpkg-configuration.json - arm matched
```
