### PR TITLE
[versioning] Add message when vcpkg is cloned to a shallow repository

### DIFF
--- a/include/vcpkg/base/expected.h
+++ b/include/vcpkg/base/expected.h
@@ -172,6 +172,18 @@ namespace vcpkg
         explicit constexpr operator bool() const noexcept { return !value_is_error; }
         constexpr bool has_value() const noexcept { return !value_is_error; }
 
+        template<class... Args>
+        T value_or(Args&&... or_args) &&
+        {
+            return !value_is_error ? std::move(*m_t.get()) : T(std::forward<Args>(or_args)...);
+        }
+
+        template<class... Args>
+        T value_or(Args&&... or_args) const&
+        {
+            return !value_is_error ? *m_t.get() : T(std::forward<Args>(or_args)...);
+        }
+
         const T&& value_or_exit(const LineInfo& line_info) const&&
         {
             exit_if_error(line_info);

--- a/include/vcpkg/base/git.h
+++ b/include/vcpkg/base/git.h
@@ -50,4 +50,7 @@ namespace vcpkg
 
     // Returns a list of ports that have uncommitted/unmerged changes
     ExpectedL<std::set<std::string>> git_ports_with_uncommitted_changes(const GitConfig& config);
+
+    // Check whether a repository is a shallow clone
+    ExpectedL<bool> is_shallow_clone(const GitConfig& config);
 }

--- a/include/vcpkg/base/messages.h
+++ b/include/vcpkg/base/messages.h
@@ -1379,6 +1379,11 @@ namespace vcpkg
                     "An example of env_var is \"HTTP(S)_PROXY\""
                     "'--' at the beginning must be preserved",
                     "-- Setting \"{env_var}\" environment variables to \"{url}\".");
+    DECLARE_MESSAGE(ShallowRepositoryDetected,
+                    (msg::path),
+                    "",
+                    "vcpkg was cloned as a shallow repository in: {path}\n"
+                    "Try again with a full vcpkg clone.");
     DECLARE_MESSAGE(ShaPassedAsArgAndOption,
                     (),
                     "",

--- a/include/vcpkg/vcpkgpaths.h
+++ b/include/vcpkg/vcpkgpaths.h
@@ -136,7 +136,6 @@ namespace vcpkg
         std::string get_current_git_sha_baseline_message() const;
         ExpectedS<Path> git_checkout_port(StringView port_name, StringView git_tree, const Path& dot_git_dir) const;
         ExpectedL<std::string> git_show(StringView treeish, const Path& dot_git_dir) const;
-        bool git_is_shallow_clone(const Path& dot_git_dir) const;
 
         const DownloadManager& get_download_manager() const;
 

--- a/include/vcpkg/vcpkgpaths.h
+++ b/include/vcpkg/vcpkgpaths.h
@@ -136,6 +136,7 @@ namespace vcpkg
         std::string get_current_git_sha_baseline_message() const;
         ExpectedS<Path> git_checkout_port(StringView port_name, StringView git_tree, const Path& dot_git_dir) const;
         ExpectedL<std::string> git_show(StringView treeish, const Path& dot_git_dir) const;
+        bool git_is_shallow_clone(const Path& dot_git_dir) const;
 
         const DownloadManager& get_download_manager() const;
 

--- a/locales/messages.en.json
+++ b/locales/messages.en.json
@@ -346,6 +346,7 @@
   "SettingEnvVar": "-- Setting \"{env_var}\" environment variables to \"{url}\".",
   "ShaPassedAsArgAndOption": "SHA512 passed as both an argument and as an option. Only pass one of these.",
   "ShaPassedWithConflict": "SHA512 passed, but --skip-sha512 was also passed; only do one or the other.",
+  "ShallowRepositoryDetected": "vcpkg was cloned as a shallow repository in: {path}\nTry again with a full vcpkg clone.",
   "SkipClearingInvalidDir": "Skipping clearing contents of {path} because it was not a directory.",
   "SourceFieldPortNameMismatch": "The 'Source' field inside the CONTROL file, or \"name\" field inside the vcpkg.json file has the name {package_name} and does not match the port directory \"{path}\".",
   "SpecifiedFeatureTurnedOff": "'{command_name}' feature specifically turned off, but --{option} was specified.",

--- a/locales/messages.json
+++ b/locales/messages.json
@@ -564,6 +564,8 @@
   "_SettingEnvVar.comment": "An example of env_var is \"HTTP(S)_PROXY\"'--' at the beginning must be preserved An example of {env_var} is VCPKG_DEFAULT_TRIPLET. An example of {url} is https://github.com/microsoft/vcpkg.",
   "ShaPassedAsArgAndOption": "SHA512 passed as both an argument and as an option. Only pass one of these.",
   "ShaPassedWithConflict": "SHA512 passed, but --skip-sha512 was also passed; only do one or the other.",
+  "ShallowRepositoryDetected": "vcpkg was cloned as a shallow repository in: {path}\nTry again with a full vcpkg clone.",
+  "_ShallowRepositoryDetected.comment": "An example of {path} is /foo/bar.",
   "SkipClearingInvalidDir": "Skipping clearing contents of {path} because it was not a directory.",
   "_SkipClearingInvalidDir.comment": "An example of {path} is /foo/bar.",
   "SourceFieldPortNameMismatch": "The 'Source' field inside the CONTROL file, or \"name\" field inside the vcpkg.json file has the name {package_name} and does not match the port directory \"{path}\".",

--- a/src/vcpkg-test/expected.cpp
+++ b/src/vcpkg-test/expected.cpp
@@ -379,3 +379,43 @@ TEST_CASE ("map", "[expected]")
     error.moves = 0;
     error.check_nothing();
 }
+
+TEST_CASE ("value_or", "[expected]")
+{
+    std::string value = "hello";
+    std::string fill_in_value = "world";
+    int error;
+
+    SECTION ("with_value")
+    {
+        ExpectedT<std::string, int> with_value(value);
+        auto result = with_value.value_or(fill_in_value);
+        CHECK(result == value);
+        CHECK(with_value.has_value());
+    }
+
+    SECTION ("with_error")
+    {
+        ExpectedT<std::string, int> with_error(error);
+        auto result = with_error.value_or(fill_in_value);
+        CHECK(result == fill_in_value);
+        CHECK(!with_error.has_value());
+    }
+
+    SECTION ("fill pass args")
+    {
+        struct Value
+        {
+            int code;
+            std::string message;
+            Value() = default;
+            Value(int c, const std::string& s) : code(c), message(s) { }
+        };
+
+        ExpectedT<Value, int> with_fill_in_value(error);
+        auto result = with_fill_in_value.value_or(1, "hello world");
+        CHECK(result.code == 1);
+        CHECK(result.message == "hello world");
+        CHECK(!with_fill_in_value.has_value());
+    }
+}

--- a/src/vcpkg/base/git.cpp
+++ b/src/vcpkg/base/git.cpp
@@ -6,6 +6,8 @@
 #include <vcpkg/base/stringview.h>
 #include <vcpkg/base/system.process.h>
 
+#include <vcpkg/tools.h>
+
 namespace
 {
     using namespace vcpkg;
@@ -186,5 +188,16 @@ namespace vcpkg
             return ret;
         }
         return std::move(maybe_results.error());
+    }
+
+    ExpectedL<bool> is_shallow_clone(const GitConfig& config)
+    {
+        auto cmd = git_cmd_builder(config).string_arg("rev-parse").string_arg("--is-shallow-repository");
+        auto output = flatten_out(cmd_execute_and_capture_output(cmd), Tools::GIT);
+        if (!output)
+        {
+            return output.error();
+        }
+        return "true" == Strings::trim(*output.get());
     }
 }

--- a/src/vcpkg/base/git.cpp
+++ b/src/vcpkg/base/git.cpp
@@ -193,11 +193,8 @@ namespace vcpkg
     ExpectedL<bool> is_shallow_clone(const GitConfig& config)
     {
         auto cmd = git_cmd_builder(config).string_arg("rev-parse").string_arg("--is-shallow-repository");
-        auto output = flatten_out(cmd_execute_and_capture_output(cmd), Tools::GIT);
-        if (!output)
-        {
-            return output.error();
-        }
-        return "true" == Strings::trim(*output.get());
+        return flatten_out(cmd_execute_and_capture_output(cmd), Tools::GIT).map([](std::string&& output) {
+            return "true" == Strings::trim(std::move(output));
+        });
     }
 }

--- a/src/vcpkg/base/messages.cpp
+++ b/src/vcpkg/base/messages.cpp
@@ -718,6 +718,7 @@ namespace vcpkg
     REGISTER_MESSAGE(ResultsHeader);
     REGISTER_MESSAGE(SerializedBinParagraphHeader);
     REGISTER_MESSAGE(SettingEnvVar);
+    REGISTER_MESSAGE(ShallowRepositoryDetected);
     REGISTER_MESSAGE(ShaPassedAsArgAndOption);
     REGISTER_MESSAGE(ShaPassedWithConflict);
     REGISTER_MESSAGE(SkipClearingInvalidDir);

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -975,8 +975,7 @@ namespace vcpkg
     std::string VcpkgPaths::get_current_git_sha_baseline_message() const
     {
         const auto& git_config = git_builtin_config();
-        auto maybe_shallow_clone = is_shallow_clone(git_config).get();
-        if (maybe_shallow_clone && *maybe_shallow_clone)
+        if (is_shallow_clone(git_config).value_or(false))
         {
             return msg::format(msgShallowRepositoryDetected, msg::path = git_config.git_dir).to_string();
         }
@@ -1092,8 +1091,7 @@ namespace vcpkg
                 Strings::concat(PRELUDE, "Error: Failed to tar port directory\n", std::move(maybe_tar_output).error());
 
             const auto& git_config = git_builtin_config();
-            auto maybe_shallow_clone = is_shallow_clone(git_config).get();
-            if (maybe_shallow_clone && *maybe_shallow_clone)
+            if (is_shallow_clone(git_config).value_or(false))
             {
                 message.push_back('\n');
                 message.append(msg::format(msgShallowRepositoryDetected, msg::path = git_config.git_dir).to_string());

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -976,7 +976,7 @@ namespace vcpkg
     {
         if (git_is_shallow_clone(this->root / ".git"))
         {
-            return "Error: vcpkg was cloned in a shallow repository. Try again with a full vcpkg clone.";
+            return msg::format(msgShallowRepositoryDetected, msg::path = this->root / ".git").to_string();
         }
 
         auto maybe_cur_sha = get_current_git_sha();
@@ -1009,7 +1009,7 @@ namespace vcpkg
             Debug::println(output.error());
             return false;
         }
-        return Strings::case_insensitive_ascii_equals("true", Strings::trim(output.value_or_exit(VCPKG_LINE_INFO)));
+        return Strings::case_insensitive_ascii_equals("true", Strings::trim(*output.get()));
     }
 
     ExpectedS<std::map<std::string, std::string, std::less<>>> VcpkgPaths::git_get_local_port_treeish_map() const
@@ -1103,10 +1103,13 @@ namespace vcpkg
                 Strings::concat(PRELUDE, "Error: Failed to tar port directory\n", std::move(maybe_tar_output).error());
             if (git_is_shallow_clone(this->root / ".git"))
             {
-                message.append("\n");
-                message.append("Error: vcpkg was cloned in a shallow repository. Try again with a full vcpkg clone.");
+                message.push_back('\n');
+                message.append(msg::format(msgShallowRepositoryDetected, msg::path = this->root / ".git").to_string());
             }
-            return {message, expected_right_tag};
+            return {
+                std::move(message),
+                expected_right_tag,
+            };
         }
 
         extract_tar_cmake(this->get_tool_exe(Tools::CMAKE, stdout_sink), destination_tar, destination_tmp);


### PR DESCRIPTION
Appends an additional error message when a built-in repository error occurs and vcpkg is cloned into a shallow repository.

Rough implementation. 

Improvements to how we handle versioning errors can be made but I believe is better to wait until #556 is merged to make more extensive changes. 

On baseline not in git history:
![image](https://user-images.githubusercontent.com/3526662/194741967-a55e9692-047c-401a-ac69-a451dd65a253.png)

On version not in git history:
![image](https://user-images.githubusercontent.com/3526662/194742017-49cab576-a044-44d1-b71e-06267fd9e354.png)
