### PR TITLE
Add constructors for `ParseControlErrorInfo`

### DIFF
--- a/include/vcpkg/paragraphparser.h
+++ b/include/vcpkg/paragraphparser.h
@@ -19,6 +19,28 @@ namespace vcpkg
 {
     struct ParseControlErrorInfo
     {
+        ParseControlErrorInfo() = default;
+
+        ParseControlErrorInfo(std::string&& port_name, std::string&& error_msg)
+            : name(std::forward<std::string>(port_name)), error(std::forward<std::string>(error_msg))
+        {
+        }
+        ParseControlErrorInfo(StringView port_name, std::string&& error_msg)
+            : name(port_name.begin(), port_name.size()), error(std::forward<std::string>(error_msg))
+        {
+        }
+        ParseControlErrorInfo(std::string&& port_name, StringView error_msg)
+            : name(std::forward<std::string>(port_name)), error(error_msg.begin(), error_msg.size())
+        {
+        }
+        ParseControlErrorInfo(StringView port_name, StringView error_msg)
+            : name(port_name.begin(), port_name.size()), error(error_msg.begin(), error_msg.size())
+        {
+        }
+
+        ParseControlErrorInfo(std::string&& port_name) : name(std::forward<std::string>(port_name)) { }
+        ParseControlErrorInfo(StringView port_name) : name(port_name.begin(), port_name.size()) { }
+
         std::string name;
         std::vector<std::string> missing_fields;
         std::vector<std::string> extra_fields;
@@ -26,7 +48,7 @@ namespace vcpkg
         std::vector<std::string> other_errors;
         std::string error;
 
-        bool has_error() const
+        bool has_error() const noexcept
         {
             return !missing_fields.empty() || !extra_fields.empty() || !expected_types.empty() ||
                    !other_errors.empty() || !error.empty();

--- a/src/vcpkg/paragraphs.cpp
+++ b/src/vcpkg/paragraphs.cpp
@@ -126,7 +126,7 @@ namespace vcpkg
     std::unique_ptr<ParseControlErrorInfo> ParagraphParser::error_info(StringView name) const
     {
         if (fields.empty() && missing_fields.empty()) return nullptr;
-        
+
         auto err = std::make_unique<ParseControlErrorInfo>(name);
         err->extra_fields = Util::extract_keys(fields);
         err->missing_fields = missing_fields;
@@ -394,7 +394,7 @@ namespace vcpkg::Paragraphs
             if (fs.exists(control_path, IgnoreErrors{}))
             {
                 return std::make_unique<ParseControlErrorInfo>(
-                    std::move(port_directory.filename()),
+                    port_directory.filename(),
                     msg::format_error(msgManifestConflict, msg::path = port_directory).to_string());
             }
             return try_load_manifest_text(manifest_contents, manifest_path, stdout_sink);

--- a/src/vcpkg/sourceparagraph.cpp
+++ b/src/vcpkg/sourceparagraph.cpp
@@ -237,10 +237,10 @@ namespace vcpkg
                 {
                     return std::make_unique<ParseControlErrorInfo>(
                         scf.core_paragraph->name,
-                        std::move(Strings::format(R"(Multiple features with the same name for port %s: %s
+                        Strings::format(R"(Multiple features with the same name for port %s: %s
     This is invalid; please make certain that features have distinct names.)",
-                                                  scf.core_paragraph->name,
-                                                  (*adjacent_equal)->name)));
+                                        scf.core_paragraph->name,
+                                        (*adjacent_equal)->name));
                 }
                 return nullptr;
             }

--- a/src/vcpkg/sourceparagraph.cpp
+++ b/src/vcpkg/sourceparagraph.cpp
@@ -301,8 +301,7 @@ namespace vcpkg
         }
         else
         {
-            return std::make_unique<ParseControlErrorInfo>(origin,
-                                                           maybe_default_features.error());
+            return std::make_unique<ParseControlErrorInfo>(origin, maybe_default_features.error());
         }
 
         auto supports_expr = parser.optional_field(SourceParagraphFields::SUPPORTS);

--- a/src/vcpkg/sourceparagraph.cpp
+++ b/src/vcpkg/sourceparagraph.cpp
@@ -235,13 +235,12 @@ namespace vcpkg
                     std::adjacent_find(scf.feature_paragraphs.begin(), scf.feature_paragraphs.end(), FeatureEqual{});
                 if (adjacent_equal != scf.feature_paragraphs.end())
                 {
-                    auto error_info = std::make_unique<ParseControlErrorInfo>();
-                    error_info->name = scf.core_paragraph->name;
-                    error_info->error = Strings::format(R"(Multiple features with the same name for port %s: %s
+                    return std::make_unique<ParseControlErrorInfo>(
+                        scf.core_paragraph->name,
+                        std::move(Strings::format(R"(Multiple features with the same name for port %s: %s
     This is invalid; please make certain that features have distinct names.)",
-                                                        scf.core_paragraph->name,
-                                                        (*adjacent_equal)->name);
-                    return error_info;
+                                                  scf.core_paragraph->name,
+                                                  (*adjacent_equal)->name)));
                 }
                 return nullptr;
             }
@@ -289,10 +288,7 @@ namespace vcpkg
         }
         else
         {
-            auto error_info = std::make_unique<ParseControlErrorInfo>();
-            error_info->name = origin.to_string();
-            error_info->error = maybe_dependencies.error();
-            return error_info;
+            return std::make_unique<ParseControlErrorInfo>(origin, maybe_dependencies.error());
         }
 
         buf.clear();
@@ -305,10 +301,8 @@ namespace vcpkg
         }
         else
         {
-            auto error_info = std::make_unique<ParseControlErrorInfo>();
-            error_info->name = origin.to_string();
-            error_info->error = maybe_default_features.error();
-            return error_info;
+            return std::make_unique<ParseControlErrorInfo>(origin,
+                                                           maybe_default_features.error());
         }
 
         auto supports_expr = parser.optional_field(SourceParagraphFields::SUPPORTS);
@@ -352,10 +346,7 @@ namespace vcpkg
         }
         else
         {
-            auto error_info = std::make_unique<ParseControlErrorInfo>();
-            error_info->name = origin.to_string();
-            error_info->error = maybe_dependencies.error();
-            return error_info;
+            return std::make_unique<ParseControlErrorInfo>(origin, maybe_dependencies.error());
         }
 
         auto err = parser.error_info(fpgh->name.empty() ? origin : fpgh->name);
@@ -370,9 +361,7 @@ namespace vcpkg
     {
         if (control_paragraphs.size() == 0)
         {
-            auto ret = std::make_unique<ParseControlErrorInfo>();
-            ret->name = origin.to_string();
-            return ret;
+            return std::make_unique<ParseControlErrorInfo>(origin);
         }
 
         auto control_file = std::make_unique<SourceControlFile>();
@@ -1241,8 +1230,7 @@ namespace vcpkg
 
         if (!reader.errors().empty())
         {
-            auto err = std::make_unique<ParseControlErrorInfo>();
-            err->name = origin.to_string();
+            auto err = std::make_unique<ParseControlErrorInfo>(origin);
             err->other_errors = std::move(reader.errors());
             return err;
         }


### PR DESCRIPTION
Add multiple constructors to `ParseControlErrorInfo` to allow `std::make_unique<ParseControlErrorInfo>(name[, error])`. This results in better performance thanks to perfect forwarding of strings and use of `StringView`.