### PR TITLE
Make pushing back to vectors more efficient

### DIFF
--- a/include/vcpkg/base/files.h
+++ b/include/vcpkg/base/files.h
@@ -155,7 +155,7 @@ namespace vcpkg
             return ::_fseeki64(m_fs, static_cast<long long>(offset), origin);
 #else  // ^^^ _WIN32 / !_WIN32 vvv
             Checks::check_exit(VCPKG_LINE_INFO, offset < LLONG_MAX);
-            return ::fseek(m_fs, offset, origin);
+            return ::fseek(m_fs, static_cast<long>(offset), origin);
 #endif // ^^^ !_WIN32
         }
         int seek(long long offset, int origin) const noexcept

--- a/src/vcpkg-test/binarycaching.cpp
+++ b/src/vcpkg-test/binarycaching.cpp
@@ -458,7 +458,7 @@ Description: a spiffy compression library wrapper
     auto maybe_scf = SourceControlFile::parse_control_file("", std::move(*pghs.get()));
     REQUIRE(maybe_scf.has_value());
     SourceControlFileAndLocation scfl{std::move(*maybe_scf.get()), Path()};
-    plan.install_actions.push_back(InstallPlanAction());
+    plan.install_actions.emplace_back();
     plan.install_actions[0].spec = PackageSpec("zlib", Test::X64_ANDROID);
     plan.install_actions[0].source_control_file_and_location = scfl;
     plan.install_actions[0].abi_info = AbiInfo{};
@@ -481,7 +481,7 @@ Description: a spiffy compression library wrapper
     auto maybe_scf2 = SourceControlFile::parse_control_file("", std::move(*pghs2.get()));
     REQUIRE(maybe_scf2.has_value());
     SourceControlFileAndLocation scfl2{std::move(*maybe_scf2.get()), Path()};
-    plan.install_actions.push_back(InstallPlanAction());
+    plan.install_actions.emplace_back();
     plan.install_actions[1].spec = PackageSpec("zlib2", Test::X64_ANDROID);
     plan.install_actions[1].source_control_file_and_location = scfl2;
     plan.install_actions[1].abi_info = AbiInfo{};

--- a/src/vcpkg-test/dependencies.cpp
+++ b/src/vcpkg-test/dependencies.cpp
@@ -1569,7 +1569,7 @@ TEST_CASE ("version install default features", "[versionplan]")
 
     auto a_x = make_fpgh("x");
     auto& a_scf = vp.emplace("a", {"1", 0}, VersionScheme::Relaxed).source_control_file;
-    a_scf->core_paragraph->default_features.push_back("x");
+    a_scf->core_paragraph->default_features.emplace_back("x");
     a_scf->feature_paragraphs.push_back(std::move(a_x));
 
     MockCMakeVarProvider var_provider;
@@ -1590,7 +1590,7 @@ TEST_CASE ("version dont install default features", "[versionplan]")
 
     auto a_x = make_fpgh("x");
     auto& a_scf = vp.emplace("a", {"1", 0}, VersionScheme::Relaxed).source_control_file;
-    a_scf->core_paragraph->default_features.push_back("x");
+    a_scf->core_paragraph->default_features.emplace_back("x");
     a_scf->feature_paragraphs.push_back(std::move(a_x));
 
     MockCMakeVarProvider var_provider;
@@ -1612,7 +1612,7 @@ TEST_CASE ("version install transitive default features", "[versionplan]")
 
     auto a_x = make_fpgh("x");
     auto& a_scf = vp.emplace("a", {"1", 0}, VersionScheme::Relaxed).source_control_file;
-    a_scf->core_paragraph->default_features.push_back("x");
+    a_scf->core_paragraph->default_features.emplace_back("x");
     a_scf->feature_paragraphs.push_back(std::move(a_x));
 
     auto& b_scf = vp.emplace("b", {"1", 0}, VersionScheme::Relaxed).source_control_file;
@@ -1703,7 +1703,7 @@ TEST_CASE ("version install qualified default suppression", "[versionplan]")
     MockVersionedPortfileProvider vp;
 
     auto& a_scf = vp.emplace("a", {"1", 0}, VersionScheme::Relaxed).source_control_file;
-    a_scf->core_paragraph->default_features.push_back("x");
+    a_scf->core_paragraph->default_features.emplace_back("x");
     a_scf->feature_paragraphs.push_back(make_fpgh("x"));
 
     vp.emplace("b", {"1", 0}, VersionScheme::Relaxed)
@@ -1789,17 +1789,17 @@ TEST_CASE ("version install qualified features", "[versionplan]")
     MockVersionedPortfileProvider vp;
 
     auto& b_scf = vp.emplace("b", {"1", 0}, VersionScheme::Relaxed).source_control_file;
-    b_scf->core_paragraph->default_features.push_back("x");
+    b_scf->core_paragraph->default_features.emplace_back("x");
     b_scf->feature_paragraphs.push_back(make_fpgh("x"));
     b_scf->feature_paragraphs.back()->dependencies.push_back({"a", {}, parse_platform("!linux")});
 
     auto& a_scf = vp.emplace("a", {"1", 0}, VersionScheme::Relaxed).source_control_file;
-    a_scf->core_paragraph->default_features.push_back("y");
+    a_scf->core_paragraph->default_features.emplace_back("y");
     a_scf->feature_paragraphs.push_back(make_fpgh("y"));
     a_scf->feature_paragraphs.back()->dependencies.push_back({"c", {}, parse_platform("linux")});
 
     auto& c_scf = vp.emplace("c", {"1", 0}, VersionScheme::Relaxed).source_control_file;
-    c_scf->core_paragraph->default_features.push_back("z");
+    c_scf->core_paragraph->default_features.emplace_back("z");
     c_scf->feature_paragraphs.push_back(make_fpgh("z"));
     c_scf->feature_paragraphs.back()->dependencies.push_back({"d", {}, parse_platform("linux")});
 

--- a/src/vcpkg-test/files.cpp
+++ b/src/vcpkg-test/files.cpp
@@ -131,7 +131,7 @@ namespace
             // regular directory
             fs.create_directory(base, ec);
             CHECK_EC_ON_FILE(base, ec);
-            for (int i = 0; i < 5; ++i)
+            for (unsigned int i = 0; i < 5; ++i)
             {
                 create_directory_tree(urbg, fs, base / get_random_filename(urbg), remaining_depth - 1);
             }

--- a/src/vcpkg/archives.cpp
+++ b/src/vcpkg/archives.cpp
@@ -61,7 +61,7 @@ namespace
     {
         // MSI installation sometimes requires a global lock and fails if another installation is concurrent. Loop
         // to enable retries.
-        for (int i = 0;; ++i)
+        for (unsigned int i = 0;; ++i)
         {
             // msiexec is a WIN32/GUI application, not a console application and so needs special attention to wait
             // until it finishes (wrap in cmd /c).
@@ -333,7 +333,7 @@ namespace vcpkg
         auto results =
             cmd_execute_and_capture_output_parallel(jobs, default_working_directory, get_clean_environment());
 #ifdef __APPLE__
-        int i = 0;
+        size_t i = 0;
         for (auto& maybe_result : results)
         {
             if (const auto result = maybe_result.get())

--- a/src/vcpkg/base/cofffilereader.cpp
+++ b/src/vcpkg/base/cofffilereader.cpp
@@ -180,9 +180,8 @@ namespace vcpkg
     {
         std::vector<MachineType> machine_types; // used as a set because n is tiny
         // Next we have the obj and pseudo-object files
-        for (size_t idx = 0; idx < member_offsets.size(); ++idx)
+        for (unsigned int offset : member_offsets)
         {
-            const auto offset = member_offsets[idx];
             // Skip the header, no need to read it
             Checks::check_exit(VCPKG_LINE_INFO, fs.seek(offset + sizeof(ArchiveMemberHeader), SEEK_SET) == 0);
             uint16_t machine_type_raw;

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -361,7 +361,7 @@ namespace vcpkg
             auto res = cmd_execute_and_stream_lines(cmd, [out](StringView line) {
                            if (Strings::starts_with(line, guid_marker))
                            {
-                               out->push_back(std::strtol(line.data() + guid_marker.size(), nullptr, 10));
+                               out->push_back(static_cast<int>(std::strtol(line.data() + guid_marker.size(), nullptr, 10)));
                            }
                        }).value_or_exit(VCPKG_LINE_INFO);
 

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -358,12 +358,13 @@ namespace vcpkg
             {
                 cmd.string_arg(url.first).string_arg("-o").string_arg(url.second);
             }
-            auto res = cmd_execute_and_stream_lines(cmd, [out](StringView line) {
-                           if (Strings::starts_with(line, guid_marker))
-                           {
-                               out->push_back(static_cast<int>(std::strtol(line.data() + guid_marker.size(), nullptr, 10)));
-                           }
-                       }).value_or_exit(VCPKG_LINE_INFO);
+            auto res =
+                cmd_execute_and_stream_lines(cmd, [out](StringView line) {
+                    if (Strings::starts_with(line, guid_marker))
+                    {
+                        out->push_back(static_cast<int>(std::strtol(line.data() + guid_marker.size(), nullptr, 10)));
+                    }
+                }).value_or_exit(VCPKG_LINE_INFO);
 
             if (res != 0)
             {

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -2371,7 +2371,7 @@ namespace vcpkg
         virtual std::vector<Path> get_files_recursive(const Path& dir, std::error_code& ec) const override
         {
             std::vector<Path> result;
-            Path out_base = dir;
+            const Path& out_base = dir;
             get_files_recursive_impl(result, dir, out_base, ec, true, true, true);
             return result;
         }
@@ -2386,7 +2386,7 @@ namespace vcpkg
         virtual std::vector<Path> get_directories_recursive(const Path& dir, std::error_code& ec) const override
         {
             std::vector<Path> result;
-            Path out_base = dir;
+            const Path& out_base = dir;
             get_files_recursive_impl(result, dir, out_base, ec, true, false, false);
 
             return result;
@@ -2416,7 +2416,7 @@ namespace vcpkg
         virtual std::vector<Path> get_regular_files_recursive(const Path& dir, std::error_code& ec) const override
         {
             std::vector<Path> result;
-            Path out_base = dir;
+            const Path& out_base = dir;
             get_files_recursive_impl(result, dir, out_base, ec, false, true, false);
             return result;
         }
@@ -3337,7 +3337,7 @@ namespace vcpkg
 #endif // ^^^!_WIN32
 
                 static const std::vector<Path> path_bases = calculate_path_bases();
-                for (Path path_base : path_bases)
+                for (const Path& path_base : path_bases)
                 {
                     for (auto&& stem : stems)
                     {

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -2371,8 +2371,7 @@ namespace vcpkg
         virtual std::vector<Path> get_files_recursive(const Path& dir, std::error_code& ec) const override
         {
             std::vector<Path> result;
-            const Path& out_base = dir;
-            get_files_recursive_impl(result, dir, out_base, ec, true, true, true);
+            get_files_recursive_impl(result, dir, dir, ec, true, true, true);
             return result;
         }
 

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -2385,8 +2385,7 @@ namespace vcpkg
         virtual std::vector<Path> get_directories_recursive(const Path& dir, std::error_code& ec) const override
         {
             std::vector<Path> result;
-            const Path& out_base = dir;
-            get_files_recursive_impl(result, dir, out_base, ec, true, false, false);
+            get_files_recursive_impl(result, dir, dir, ec, true, false, false);
 
             return result;
         }
@@ -2415,8 +2414,7 @@ namespace vcpkg
         virtual std::vector<Path> get_regular_files_recursive(const Path& dir, std::error_code& ec) const override
         {
             std::vector<Path> result;
-            const Path& out_base = dir;
-            get_files_recursive_impl(result, dir, out_base, ec, false, true, false);
+            get_files_recursive_impl(result, dir, dir, ec, false, true, false);
             return result;
         }
 

--- a/src/vcpkg/base/json.cpp
+++ b/src/vcpkg/base/json.cpp
@@ -559,7 +559,7 @@ namespace vcpkg::Json
                     case 'u':
                     {
                         char16_t code_unit = 0;
-                        for (int i = 0; i < 4; ++i)
+                        for (unsigned int i = 0; i < 4; ++i)
                         {
                             current = next();
 

--- a/src/vcpkg/base/unicode.cpp
+++ b/src/vcpkg/base/unicode.cpp
@@ -31,7 +31,7 @@ namespace vcpkg::Unicode
         }
     }
 
-    int utf8_code_unit_count(char code_unit) noexcept { return utf8_code_unit_count(utf8_code_unit_kind(code_unit)); }
+    int utf8_code_unit_count(char code_unit) noexcept { return utf8_code_unit_count(utf8_code_unit_kind(static_cast<unsigned char>(code_unit))); }
 
     static constexpr int utf8_encode_code_unit_count(char32_t code_point) noexcept
     {
@@ -103,7 +103,7 @@ namespace vcpkg::Unicode
         }
 
         auto code_unit = *first;
-        auto kind = utf8_code_unit_kind(code_unit);
+        auto kind = utf8_code_unit_kind(static_cast<unsigned char>(code_unit));
         const int count = utf8_code_unit_count(kind);
 
         const char* it = first + 1;
@@ -137,7 +137,7 @@ namespace vcpkg::Unicode
         constexpr unsigned char continue_mask = 0b0011'1111;
         for (int byte = 1; byte < count; ++byte)
         {
-            code_unit = static_cast<unsigned char>(*it++);
+            code_unit = *it++;
 
             kind = utf8_code_unit_kind(code_unit);
             if (kind == Utf8CodeUnitKind::Invalid)

--- a/src/vcpkg/base/unicode.cpp
+++ b/src/vcpkg/base/unicode.cpp
@@ -31,7 +31,10 @@ namespace vcpkg::Unicode
         }
     }
 
-    int utf8_code_unit_count(char code_unit) noexcept { return utf8_code_unit_count(utf8_code_unit_kind(static_cast<unsigned char>(code_unit))); }
+    int utf8_code_unit_count(char code_unit) noexcept
+    {
+        return utf8_code_unit_count(utf8_code_unit_kind(static_cast<unsigned char>(code_unit)));
+    }
 
     static constexpr int utf8_encode_code_unit_count(char32_t code_point) noexcept
     {

--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -624,7 +624,7 @@ namespace vcpkg
                               });
         // Make sure GIT could be found
         const Path& git_exe_path = paths.get_tool_exe(Tools::GIT, stdout_sink);
-        out_vars.push_back({"GIT", git_exe_path});
+        out_vars.emplace_back("GIT", git_exe_path);
     }
 
     static CompilerInfo load_compiler_info(const VcpkgPaths& paths, const AbiInfo& abi_info)
@@ -730,12 +730,12 @@ namespace vcpkg
 
         if (action.build_options.download_tool == DownloadTool::ARIA2)
         {
-            variables.push_back({"ARIA2", paths.get_tool_exe(Tools::ARIA2, stdout_sink)});
+            variables.emplace_back("ARIA2", paths.get_tool_exe(Tools::ARIA2, stdout_sink));
         }
 
         for (const auto& cmake_arg : args.cmake_args)
         {
-            variables.push_back(CMakeVariable{cmake_arg});
+            variables.emplace_back(cmake_arg);
         }
 
         if (action.build_options.backcompat_features == BackcompatFeatures::PROHIBIT)
@@ -751,7 +751,7 @@ namespace vcpkg
 
         if (Util::Enum::to_bool(action.build_options.only_downloads))
         {
-            variables.push_back({"VCPKG_DOWNLOAD_MODE", "true"});
+            variables.emplace_back("VCPKG_DOWNLOAD_MODE", "true");
         }
 
         const Filesystem& fs = paths.get_filesystem();

--- a/src/vcpkg/cmakevars.cpp
+++ b/src/vcpkg/cmakevars.cpp
@@ -19,6 +19,7 @@ namespace vcpkg::CMakeVars
                                          Triplet host_triplet) const
     {
         std::vector<FullPackageSpec> install_package_specs;
+        install_package_specs.reserve(action_plan.install_actions.size());
         for (auto&& action : action_plan.install_actions)
         {
             install_package_specs.emplace_back(FullPackageSpec{action.spec, action.feature_list});

--- a/src/vcpkg/commands.ci.cpp
+++ b/src/vcpkg/commands.ci.cpp
@@ -201,7 +201,7 @@ namespace vcpkg::Commands::CI
 
             if (is_excluded(p->spec))
             {
-                ret->action_state_string.push_back("skip");
+                ret->action_state_string.emplace_back("skip");
                 ret->known.emplace(p->spec, BuildResult::EXCLUDED);
                 will_fail.emplace(p->spec);
             }
@@ -210,26 +210,26 @@ namespace vcpkg::Commands::CI
                 // This treats unsupported ports as if they are excluded
                 // which means the ports dependent on it will be cascaded due to missing dependencies
                 // Should this be changed so instead it is a failure to depend on a unsupported port?
-                ret->action_state_string.push_back("n/a");
+                ret->action_state_string.emplace_back("n/a");
                 ret->known.emplace(p->spec, BuildResult::EXCLUDED);
                 will_fail.emplace(p->spec);
             }
             else if (Util::any_of(p->package_dependencies,
                                   [&](const PackageSpec& spec) { return Util::Sets::contains(will_fail, spec); }))
             {
-                ret->action_state_string.push_back("cascade");
+                ret->action_state_string.emplace_back("cascade");
                 ret->cascade_count++;
                 ret->known.emplace(p->spec, BuildResult::CASCADED_DUE_TO_MISSING_DEPENDENCIES);
                 will_fail.emplace(p->spec);
             }
             else if (precheck_results[action_idx] == CacheAvailability::available)
             {
-                ret->action_state_string.push_back("pass");
+                ret->action_state_string.emplace_back("pass");
                 ret->known.emplace(p->spec, BuildResult::SUCCEEDED);
             }
             else
             {
-                ret->action_state_string.push_back("*");
+                ret->action_state_string.emplace_back("*");
             }
         }
         return ret;

--- a/src/vcpkg/commands.fetch.cpp
+++ b/src/vcpkg/commands.fetch.cpp
@@ -23,7 +23,7 @@ namespace vcpkg::Commands::Fetch
         const auto parsed = args.parse_arguments(COMMAND_STRUCTURE);
         const bool stderr_status = Util::Sets::contains(parsed.switches, STDERR_STATUS.name);
         const std::string tool = args.command_arguments[0];
-        const Path tool_path = paths.get_tool_exe(tool, stderr_status ? stderr_sink : stdout_sink);
+        const Path& tool_path = paths.get_tool_exe(tool, stderr_status ? stderr_sink : stdout_sink);
         msg::write_unlocalized_text_to_stdout(Color::none, tool_path.native() + '\n');
         Checks::exit_success(VCPKG_LINE_INFO);
     }

--- a/src/vcpkg/commands.find.cpp
+++ b/src/vcpkg/commands.find.cpp
@@ -200,7 +200,7 @@ namespace vcpkg::Commands
     void perform_find_artifact_and_exit(const VcpkgPaths& paths, Optional<StringView> filter)
     {
         std::vector<std::string> ce_args;
-        ce_args.push_back("find");
+        ce_args.emplace_back("find");
         if (auto* filter_str = filter.get())
         {
             ce_args.emplace_back(filter_str->data(), filter_str->size());

--- a/src/vcpkg/commands.format-manifest.cpp
+++ b/src/vcpkg/commands.format-manifest.cpp
@@ -25,7 +25,7 @@ namespace
 
     Optional<ToWrite> read_manifest(Filesystem& fs, Path&& manifest_path)
     {
-        auto path_string = manifest_path.native();
+        const auto& path_string = manifest_path.native();
         Debug::println("Reading ", path_string);
         auto contents = fs.read_contents(manifest_path, VCPKG_LINE_INFO);
         auto parsed_json_opt = Json::parse(contents, manifest_path);

--- a/src/vcpkg/commands.regenerate.cpp
+++ b/src/vcpkg/commands.regenerate.cpp
@@ -38,23 +38,23 @@ namespace vcpkg
     void RegenerateCommand::perform_and_exit(const VcpkgCmdArguments& args, const VcpkgPaths& paths) const
     {
         std::vector<std::string> forwarded_args;
-        forwarded_args.push_back("regenerate");
+        forwarded_args.emplace_back("regenerate");
         const auto parsed = args.parse_arguments(command_structure);
         forwarded_args.push_back(args.command_arguments[0]);
 
         if (Util::Sets::contains(parsed.switches, FORCE))
         {
-            forwarded_args.push_back("--force");
+            forwarded_args.emplace_back("--force");
         }
 
         if (Util::Sets::contains(parsed.switches, DRY_RUN))
         {
-            forwarded_args.push_back("--what-if");
+            forwarded_args.emplace_back("--what-if");
         }
 
         if (Util::Sets::contains(parsed.switches, NORMALIZE))
         {
-            forwarded_args.push_back("--normalize");
+            forwarded_args.emplace_back("--normalize");
         }
 
         Checks::exit_with_code(VCPKG_LINE_INFO, run_configure_environment_command(paths, forwarded_args));

--- a/src/vcpkg/export.prefab.cpp
+++ b/src/vcpkg/export.prefab.cpp
@@ -55,6 +55,7 @@ namespace vcpkg::Export::Prefab
     static std::string jsonify(const std::vector<std::string>& dependencies)
     {
         std::vector<std::string> deps;
+        deps.reserve(dependencies.size());
         for (const auto& dep : dependencies)
         {
             deps.push_back("\"" + dep + "\"");
@@ -497,6 +498,7 @@ namespace vcpkg::Export::Prefab
             utils.write_contents(prefab_path, pm.to_json(), VCPKG_LINE_INFO);
 
             std::vector<std::string> triplet_names;
+            triplet_names.reserve(triplets.size());
             for (auto&& triplet : triplets)
             {
                 triplet_names.push_back(triplet.canonical_name());
@@ -523,6 +525,7 @@ namespace vcpkg::Export::Prefab
 
                 std::vector<Path> modules_shared = find_modules(paths, libs, ".so");
 
+                modules.reserve(modules_shared.size());
                 for (const auto& module : modules_shared)
                 {
                     modules.push_back(module);

--- a/src/vcpkg/export.prefab.cpp
+++ b/src/vcpkg/export.prefab.cpp
@@ -461,7 +461,7 @@ namespace vcpkg::Export::Prefab
 
             if (dependencies_minus_empty_packages.size() > 0)
             {
-                pom_dependencies.push_back("\n<dependencies>");
+                pom_dependencies.emplace_back("\n<dependencies>");
             }
 
             for (const auto& it : dependencies_minus_empty_packages)
@@ -482,7 +482,7 @@ namespace vcpkg::Export::Prefab
 
             if (dependencies_minus_empty_packages.size() > 0)
             {
-                pom_dependencies.push_back("</dependencies>\n");
+                pom_dependencies.emplace_back("</dependencies>\n");
             }
 
             if (prefab_options.enable_debug)

--- a/src/vcpkg/install.cpp
+++ b/src/vcpkg/install.cpp
@@ -1009,7 +1009,7 @@ namespace vcpkg
             }
             if (Util::Sets::contains(options.switches, OPTION_MANIFEST_NO_DEFAULT_FEATURES))
             {
-                features.push_back("core");
+                features.emplace_back("core");
             }
 
             auto core_it = std::remove(features.begin(), features.end(), "core");

--- a/src/vcpkg/packagespec.cpp
+++ b/src/vcpkg/packagespec.cpp
@@ -163,7 +163,7 @@ namespace vcpkg
                 parser.skip_tabs_spaces();
                 if (parser.cur() == '*')
                 {
-                    features.push_back("*");
+                    features.emplace_back("*");
                     parser.next();
                 }
                 else

--- a/src/vcpkg/paragraphs.cpp
+++ b/src/vcpkg/paragraphs.cpp
@@ -96,7 +96,7 @@ namespace vcpkg
         if (const auto field = maybe_field.get())
             out = std::move(*field);
         else
-            missing_fields.push_back(fieldname.data());
+            missing_fields.emplace_back(fieldname.data());
     }
     void ParagraphParser::optional_field(StringView fieldname, std::pair<std::string&, TextRowCol&> out)
     {

--- a/src/vcpkg/sourceparagraph.cpp
+++ b/src/vcpkg/sourceparagraph.cpp
@@ -484,7 +484,7 @@ namespace vcpkg
             r.optional_object_field(obj, DEFAULT_FEATURES, default_features, Json::BooleanDeserializer::instance);
             if (!default_features)
             {
-                dep.features.push_back("core");
+                dep.features.emplace_back("core");
             }
             r.optional_object_field(obj, HOST, dep.host, Json::BooleanDeserializer::instance);
 

--- a/src/vcpkg/vcpkglib.cpp
+++ b/src/vcpkg/vcpkglib.cpp
@@ -28,6 +28,7 @@ namespace vcpkg
         auto pghs = Paragraphs::get_paragraphs(fs, vcpkg_dir_status_file).value_or_exit(VCPKG_LINE_INFO);
 
         std::vector<std::unique_ptr<StatusParagraph>> status_pghs;
+        status_pghs.reserve(pghs.size());
         for (auto&& p : pghs)
         {
             status_pghs.push_back(std::make_unique<StatusParagraph>(std::move(p)));

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -681,7 +681,7 @@ namespace vcpkg
             m_pimpl->m_registry_set = m_pimpl->m_config.instantiate_registry_set(*this);
         }
 
-        for (std::string triplet : this->overlay_triplets)
+        for (const std::string& triplet : this->overlay_triplets)
         {
             m_pimpl->triplets_dirs.emplace_back(filesystem.almost_canonical(triplet, VCPKG_LINE_INFO));
         }


### PR DESCRIPTION
In these places, emplace_back seems to be more efficient than push_back, and the better choice.

We can also improve performance further by reserving the size we know the vector will be so we do not have to waste time resizing.