### PR TITLE
Make for-loops more efficient

### DIFF
--- a/src/vcpkg/base/cofffilereader.cpp
+++ b/src/vcpkg/base/cofffilereader.cpp
@@ -180,9 +180,8 @@ namespace vcpkg
     {
         std::vector<MachineType> machine_types; // used as a set because n is tiny
         // Next we have the obj and pseudo-object files
-        for (size_t idx = 0; idx < member_offsets.size(); ++idx)
+        for (unsigned int offset : member_offsets)
         {
-            const auto offset = member_offsets[idx];
             // Skip the header, no need to read it
             Checks::check_exit(VCPKG_LINE_INFO, fs.seek(offset + sizeof(ArchiveMemberHeader), SEEK_SET) == 0);
             uint16_t machine_type_raw;

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -2358,7 +2358,7 @@ namespace vcpkg
         virtual std::vector<Path> get_files_recursive(const Path& dir, std::error_code& ec) const override
         {
             std::vector<Path> result;
-            Path out_base = dir;
+            const Path& out_base = dir;
             get_files_recursive_impl(result, dir, out_base, ec, true, true, true);
             return result;
         }
@@ -2373,7 +2373,7 @@ namespace vcpkg
         virtual std::vector<Path> get_directories_recursive(const Path& dir, std::error_code& ec) const override
         {
             std::vector<Path> result;
-            Path out_base = dir;
+            const Path& out_base = dir;
             get_files_recursive_impl(result, dir, out_base, ec, true, false, false);
 
             return result;
@@ -2403,7 +2403,7 @@ namespace vcpkg
         virtual std::vector<Path> get_regular_files_recursive(const Path& dir, std::error_code& ec) const override
         {
             std::vector<Path> result;
-            Path out_base = dir;
+            const Path& out_base = dir;
             get_files_recursive_impl(result, dir, out_base, ec, false, true, false);
             return result;
         }
@@ -3310,7 +3310,7 @@ namespace vcpkg
 #endif // ^^^!_WIN32
 
                 static const std::vector<Path> path_bases = calculate_path_bases();
-                for (Path path_base : path_bases)
+                for (const Path& path_base : path_bases)
                 {
                     for (auto&& stem : stems)
                     {

--- a/src/vcpkg/cmakevars.cpp
+++ b/src/vcpkg/cmakevars.cpp
@@ -19,6 +19,7 @@ namespace vcpkg::CMakeVars
                                          Triplet host_triplet) const
     {
         std::vector<FullPackageSpec> install_package_specs;
+        install_package_specs.reserve(action_plan.install_actions.size());
         for (auto&& action : action_plan.install_actions)
         {
             install_package_specs.emplace_back(FullPackageSpec{action.spec, action.feature_list});

--- a/src/vcpkg/commands.fetch.cpp
+++ b/src/vcpkg/commands.fetch.cpp
@@ -23,7 +23,7 @@ namespace vcpkg::Commands::Fetch
         const auto parsed = args.parse_arguments(COMMAND_STRUCTURE);
         const bool stderr_status = Util::Sets::contains(parsed.switches, STDERR_STATUS.name);
         const std::string tool = args.command_arguments[0];
-        const Path tool_path = paths.get_tool_exe(tool, stderr_status ? stderr_sink : stdout_sink);
+        const Path& tool_path = paths.get_tool_exe(tool, stderr_status ? stderr_sink : stdout_sink);
         msg::write_unlocalized_text_to_stdout(Color::none, tool_path.native() + '\n');
         Checks::exit_success(VCPKG_LINE_INFO);
     }

--- a/src/vcpkg/commands.format-manifest.cpp
+++ b/src/vcpkg/commands.format-manifest.cpp
@@ -25,7 +25,7 @@ namespace
 
     Optional<ToWrite> read_manifest(Filesystem& fs, Path&& manifest_path)
     {
-        auto path_string = manifest_path.native();
+        const auto& path_string = manifest_path.native();
         Debug::println("Reading ", path_string);
         auto contents = fs.read_contents(manifest_path, VCPKG_LINE_INFO);
         auto parsed_json_opt = Json::parse(contents, manifest_path);

--- a/src/vcpkg/export.prefab.cpp
+++ b/src/vcpkg/export.prefab.cpp
@@ -55,6 +55,7 @@ namespace vcpkg::Export::Prefab
     static std::string jsonify(const std::vector<std::string>& dependencies)
     {
         std::vector<std::string> deps;
+        deps.reserve(dependencies.size());
         for (const auto& dep : dependencies)
         {
             deps.push_back("\"" + dep + "\"");
@@ -497,6 +498,7 @@ namespace vcpkg::Export::Prefab
             utils.write_contents(prefab_path, pm.to_json(), VCPKG_LINE_INFO);
 
             std::vector<std::string> triplet_names;
+            triplet_names.reserve(triplets.size());
             for (auto&& triplet : triplets)
             {
                 triplet_names.push_back(triplet.canonical_name());
@@ -523,6 +525,7 @@ namespace vcpkg::Export::Prefab
 
                 std::vector<Path> modules_shared = find_modules(paths, libs, ".so");
 
+                modules.reserve(modules_shared.size());
                 for (const auto& module : modules_shared)
                 {
                     modules.push_back(module);

--- a/src/vcpkg/vcpkglib.cpp
+++ b/src/vcpkg/vcpkglib.cpp
@@ -28,6 +28,7 @@ namespace vcpkg
         auto pghs = Paragraphs::get_paragraphs(fs, vcpkg_dir_status_file).value_or_exit(VCPKG_LINE_INFO);
 
         std::vector<std::unique_ptr<StatusParagraph>> status_pghs;
+        status_pghs.reserve(pghs.size());
         for (auto&& p : pghs)
         {
             status_pghs.push_back(std::make_unique<StatusParagraph>(std::move(p)));

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -698,7 +698,7 @@ namespace vcpkg
             m_pimpl->m_registry_set = m_pimpl->m_config.instantiate_registry_set(*this);
         }
 
-        for (std::string triplet : this->overlay_triplets)
+        for (const std::string& triplet : this->overlay_triplets)
         {
             m_pimpl->triplets_dirs.emplace_back(filesystem.almost_canonical(triplet, VCPKG_LINE_INFO));
         }


### PR DESCRIPTION
It saves a lot of work reserving and working with references instead of copying directly