### PR TITLE
Treat * as 'no filter' when searching a registry for versions.

### DIFF
--- a/ce/ce/registries/ArtifactRegistry.ts
+++ b/ce/ce/registries/ArtifactRegistry.ts
@@ -127,8 +127,9 @@ export abstract class ArtifactRegistry implements Registry {
       query.id.contains(criteria.keyword);
     }
 
-    if (criteria?.version) {
-      query.version.rangeMatch(criteria.version);
+    const version = criteria?.version;
+    if (version && version !== '*') {
+      query.version.rangeMatch(version);
     }
 
     return [...(await this.openArtifacts(query.items)).entries()];


### PR DESCRIPTION
This fixes being unable to add / use / etc. artifacts filtered for a particular registry.

Before:

```
PS C:\Dev\test> ..\vcpkg\vcpkg.exe find artifact gcc
warning: vcpkg-artifacts are experimental and may change at any time.
Downloading vcpkg-ce bundle 2022-10-17...
 Artifact                     Version         Summary
 microsoft:compilers/arm/gcc  2020.10.0       GCC compiler for ARM CPUs.
 arm:gcc                      10.3.0-2021.10  GCC compiler for ARM CPUs.

PS C:\Dev\test> ..\vcpkg\vcpkg.exe find artifact arm:gcc
warning: vcpkg-artifacts are experimental and may change at any time.
 Artifact  Version         Summary
 arm:gcc   10.3.0-2021.10  GCC compiler for ARM CPUs.

PS C:\Dev\test> ..\vcpkg\vcpkg.exe add artifact arm:gcc
warning: vcpkg-artifacts are experimental and may change at any time.
ERROR: Unable to resolve artifact: arm:gcc
PS C:\Dev\test>
```

After:

```
PS C:\Dev\test> C:\Dev\vcpkg-tool\out\build\x64-Debug\vcpkg.ps1 find artifact gcc
warning: vcpkg-artifacts are experimental and may change at any time.
Using in-development vcpkg-artifacts built at: C:/Dev/vcpkg-tool/ce/ce
 Artifact                     Version         Summary
 microsoft:compilers/arm/gcc  2020.10.0       GCC compiler for ARM CPUs.
 arm:gcc                      10.3.0-2021.10  GCC compiler for ARM CPUs.

PS C:\Dev\test> C:\Dev\vcpkg-tool\out\build\x64-Debug\vcpkg.ps1 find artifact arm:gcc
warning: vcpkg-artifacts are experimental and may change at any time.
Using in-development vcpkg-artifacts built at: C:/Dev/vcpkg-tool/ce/ce
 Artifact  Version         Summary
 arm:gcc   10.3.0-2021.10  GCC compiler for ARM CPUs.

PS C:\Dev\test> C:\Dev\vcpkg-tool\out\build\x64-Debug\vcpkg.ps1 add artifact arm:gcc
warning: vcpkg-artifacts are experimental and may change at any time.
Using in-development vcpkg-artifacts built at: C:/Dev/vcpkg-tool/ce/ce
 Artifact  Version         Status        Dependency  Summary
 arm:gcc   10.3.0-2021.10  will install              GCC compiler for ARM CPUs.

Run `vcpkg activate` to apply to the current terminal
PS C:\Dev\test>
```