### PR TITLE
Documenting our use of VSLANG

### DIFF
--- a/docs/localization.md
+++ b/docs/localization.md
@@ -136,3 +136,21 @@ namespace vcpkg::Commands
     }
 }
 ```
+## Selecting a Language
+
+Vcpkg chooses a language through the VSLANG environment variable, which should be set to a valid LCID (locale identifier, 4-byte value representing a language). Users can set VSLANG to any of the following LCIDs:
+
+1029: Czech                 \
+1031: German                \
+1033: English               \
+3082: Spanish (Spain)       \
+1036: French                \
+1040: Italian               \
+1041: Japanese              \
+1042: Korean                \
+1045: Polish                \
+1046: Portuguese (Brazil)   \
+1049: Russian               \
+1055: Turkish               \
+2052: Chinese (Simplified)  \
+1028: Chinese (Traditional)

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -138,7 +138,7 @@ namespace vcpkg::Commands
 ```
 ## Selecting a Language
 
-vcpkg chooses a language through the `VSLANG` environment variable, which should be set to a valid LCID (locale identifier, 4-byte value representing a language). If `VSLANG` is not set or is set to an invalid LCID, we default to English. That said, if you wish to change the language, then set VSLANG to any of the following LCIDs:
+vcpkg chooses a language through the `VSLANG` environment variable, which should be set to a valid LCID (locale identifier, 4-byte value representing a language). If `VSLANG` is not set or is set to an invalid LCID, we default to English. That said, if you wish to change the language, then set `VSLANG` to any of the following LCIDs:
 
 1029: Czech                 \
 1031: German                \

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -138,7 +138,7 @@ namespace vcpkg::Commands
 ```
 ## Selecting a Language
 
-Vcpkg chooses a language through the VSLANG environment variable, which should be set to a valid LCID (locale identifier, 4-byte value representing a language). If VSLANG is not set or is set to an invalid LCID, we default to English. That said, if you wish to change the language, then set VSLANG to any of the following LCIDs:
+vcpkg chooses a language through the `VSLANG` environment variable, which should be set to a valid LCID (locale identifier, 4-byte value representing a language). If `VSLANG` is not set or is set to an invalid LCID, we default to English. That said, if you wish to change the language, then set VSLANG to any of the following LCIDs:
 
 1029: Czech                 \
 1031: German                \

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -138,7 +138,7 @@ namespace vcpkg::Commands
 ```
 ## Selecting a Language
 
-Vcpkg chooses a language through the VSLANG environment variable, which should be set to a valid LCID (locale identifier, 4-byte value representing a language). Users can set VSLANG to any of the following LCIDs:
+Vcpkg chooses a language through the VSLANG environment variable, which should be set to a valid LCID (locale identifier, 4-byte value representing a language). If VSLANG is not set or is set to an invalid LCID, we default to English. That said, if you wish to change the language, then set VSLANG to any of the following LCIDs:
 
 1029: Czech                 \
 1031: German                \


### PR DESCRIPTION
This PR adds documentation for how to change the language in vcpkg ( i.e., documenting our use of the VSLANG environment variable).