### PR TITLE
Force disable file locking when invoking vcpkg recursively.

### DIFF
--- a/include/vcpkg/vcpkgcmdarguments.h
+++ b/include/vcpkg/vcpkgcmdarguments.h
@@ -193,6 +193,8 @@ namespace vcpkg
         constexpr static StringLiteral IGNORE_LOCK_FAILURES_ENV = "X_VCPKG_IGNORE_LOCK_FAILURES";
         Optional<bool> ignore_lock_failures = nullopt;
 
+        bool do_not_take_lock = false;
+
         constexpr static StringLiteral JSON_SWITCH = "x-json";
         Optional<bool> json = nullopt;
 

--- a/include/vcpkg/vcpkgpaths.h
+++ b/include/vcpkg/vcpkgpaths.h
@@ -156,6 +156,7 @@ namespace vcpkg
         ExpectedS<Path> git_checkout_object_from_remote_registry(StringView tree) const;
 
         Optional<const ManifestAndPath&> get_manifest() const;
+        bool manifest_mode_enabled() const;
         const ConfigurationAndSource& get_configuration() const;
         const RegistrySet& get_registry_set() const;
 
@@ -167,10 +168,8 @@ namespace vcpkg
         const Environment& get_action_env(const AbiInfo& abi_info) const;
         const std::string& get_triplet_info(const AbiInfo& abi_info) const;
         const CompilerInfo& get_compiler_info(const AbiInfo& abi_info) const;
-        bool manifest_mode_enabled() const { return get_manifest().has_value(); }
 
         const FeatureFlagSettings& get_feature_flags() const;
-        void track_feature_flag_metrics() const;
 
         // the directory of the builtin ports
         // this should be used only for helper commands, not core commands like `install`.

--- a/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/src/vcpkg/vcpkgcmdarguments.cpp
@@ -836,6 +836,8 @@ namespace vcpkg
                 args.disable_metrics = true;
             }
 
+            args.do_not_take_lock = true;
+
             // Setting the recursive data to 'poison' prevents more than one level of recursion because
             // Json::parse() will fail.
             set_environment_variable(RECURSIVE_DATA_ENV, "poison");


### PR DESCRIPTION
I think this is is the "artifacts version" of https://github.com/microsoft/vcpkg/commit/b2544fd780b2e9a05d903314cbbd37268ba43d81

More generally, we need to stop doing so much stuff like this in VcpkgPaths: if a command wants a downloads tree (like `fetch`) it shouldn't need to resolve whether we are using a manifest and similar.

Drive by fix to enable checking for manifest mode being enabled without actually parsing the content.