### PR TITLE
Fix macro warnings

### DIFF
--- a/include/vcpkg/export.prefab.h
+++ b/include/vcpkg/export.prefab.h
@@ -8,6 +8,14 @@
 
 #include <vector>
 
+// glibc defines major and minor in sys/types.h, and should not
+#ifdef major
+#undef major
+#endif
+#ifdef minor
+#undef minor
+#endif
+
 namespace vcpkg::Export::Prefab
 {
     constexpr int kFragmentSize = 3;


### PR DESCRIPTION
Similar to `system_headers.h`, but in the header which actually uses `major` and `minor`.