### PR TITLE
e2e tests: Color output

### DIFF
--- a/azure-pipelines/end-to-end-tests-prelude.ps1
+++ b/azure-pipelines/end-to-end-tests-prelude.ps1
@@ -100,9 +100,9 @@ function Run-Vcpkg {
         [string[]]$TestArgs
     )
     $Script:CurrentTest = "$VcpkgExe $($testArgs -join ' ')"
-    if (!$EndToEndTestSilent) { Write-Host $Script:CurrentTest }
+    if (!$EndToEndTestSilent) { Write-Host -ForegroundColor red $Script:CurrentTest }
     $result = (& $VcpkgExe @testArgs) | Out-String
-    if (!$EndToEndTestSilent) { Write-Host $result }
+    if (!$EndToEndTestSilent) { Write-Host -ForegroundColor Gray $result }
     $result
 }
 

--- a/azure-pipelines/end-to-end-tests.ps1
+++ b/azure-pipelines/end-to-end-tests.ps1
@@ -96,7 +96,7 @@ $envvars = $envvars_clear + @("VCPKG_DOWNLOADS", "X_VCPKG_REGISTRIES_CACHE", "PA
 
 foreach ($Test in $AllTests)
 {
-    Write-Host "[end-to-end-tests.ps1] [$n/$m] Running suite $Test"
+    Write-Host -ForegroundColor Green "[end-to-end-tests.ps1] [$n/$m] Running suite $Test"
 
     $envbackup = @{}
     foreach ($var in $envvars)
@@ -136,5 +136,5 @@ foreach ($Test in $AllTests)
     $n += 1
 }
 
-Write-Host "[end-to-end-tests.ps1] All tests passed."
+Write-Host -ForegroundColor Green "[end-to-end-tests.ps1] All tests passed."
 $LASTEXITCODE = 0


### PR DESCRIPTION
Currently it is really hard to read the output because it is only a wall of text. 

Another improvement would be to not print the output of vcpkg twice.  