### PR TITLE
Use system CMake to unpack if available during 7z bootstrap

### DIFF
--- a/include/vcpkg/tools.h
+++ b/include/vcpkg/tools.h
@@ -31,6 +31,8 @@ namespace vcpkg
         static constexpr StringLiteral ARIA2 = "aria2";
         static constexpr StringLiteral NODE = "node";
         static constexpr StringLiteral IFW_INSTALLER_BASE = "ifw_installerbase";
+        // This duplicate of CMake should only be used as a fallback to unpack
+        static constexpr StringLiteral CMAKE_SYSTEM = "cmake_system";
         // This duplicate of 7zip uses msiexec to unpack, which is a fallback for Windows 7.
         static constexpr StringLiteral SEVEN_ZIP_MSI = "7zip_msi";
         static constexpr StringLiteral PYTHON3 = "python3";
@@ -51,6 +53,7 @@ namespace vcpkg
                                                           const Path& exe_path);
 
     ExpectedL<Path> find_system_tar(const Filesystem& fs);
+    ExpectedL<Path> find_system_cmake(const Filesystem& fs);
 
     std::unique_ptr<ToolCache> get_tool_cache(Filesystem& fs,
                                               std::shared_ptr<const DownloadManager> downloader,

--- a/src/vcpkg/archives.cpp
+++ b/src/vcpkg/archives.cpp
@@ -236,12 +236,20 @@ namespace vcpkg
         }
         else
         {
-            // On Windows <10, we attempt to use msiexec to unpack 7zip.
-
-            // Example:
-            // msiexec unpacks 7zip_msi unpacks cmake unpacks 7zip unpacks git
-            win32_extract_with_seven_zip(
-                tools.get_tool_path(Tools::SEVEN_ZIP_MSI, status_sink), archive, to_path_partial);
+            auto maybe_cmake_tool = find_system_cmake(fs);
+            if (maybe_cmake_tool)
+            {
+                // If the user has a CMake version installed we can use that to unpack.
+                extract_tar_cmake(maybe_cmake_tool.value_or_exit(VCPKG_LINE_INFO), archive, to_path_partial);
+            }
+            else
+            {
+                // On Windows <10, we attempt to use msiexec to unpack 7zip.
+                // Example:
+                // msiexec unpacks 7zip_msi unpacks cmake unpacks 7zip unpacks git
+                win32_extract_with_seven_zip(
+                    tools.get_tool_path(Tools::SEVEN_ZIP_MSI, status_sink), archive, to_path_partial);
+            }
         }
         fs.rename_with_retry(to_path_partial, to_path, VCPKG_LINE_INFO);
     }


### PR DESCRIPTION
A user provided CMake can be used to extract vcpkg's copy of CMake during the `downloads/tools` bootstrap process.

The current fallbacks are:
* System32/tar
* User CMake
* 7zip MSI