### PR TITLE
The vcpkg-root e2e test currently wrongly detects manifest files above ...

### DIFF
--- a/azure-pipelines/e2e_projects/overlays-vcpkg-empty-port/vcpkg.json
+++ b/azure-pipelines/e2e_projects/overlays-vcpkg-empty-port/vcpkg.json
@@ -1,0 +1,5 @@
+{
+	"dependencies": [
+		"vcpkg-empty-port"
+	]
+}

--- a/azure-pipelines/end-to-end-tests-dir/vcpkg-root.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/vcpkg-root.ps1
@@ -4,7 +4,9 @@ $CurrentTest = "VCPKG_ROOT"
 
 $targetMessage = 'ignoring mismatched VCPKG_ROOT environment value'
 
-$defaultOutput = Run-VcpkgAndCaptureOutput -TestArgs ($commonArgs + @('install', 'vcpkg-empty-port'))
+$commonArgs += @('install', "--x-manifest-root=$PSScriptRoot/../e2e_projects/overlays-vcpkg-empty-port")
+
+$defaultOutput = Run-VcpkgAndCaptureOutput -TestArgs $commonArgs
 Throw-IfFailed
 if ($defaultOutput.Contains($targetMessage)) {
 	throw 'Expected no warning about VCPKG_ROOT when using the environment variable.'
@@ -14,20 +16,20 @@ $actualVcpkgRoot = $env:VCPKG_ROOT
 
 pushd $actualVcpkgRoot
 try {
-	$samePathOutput = Run-VcpkgAndCaptureOutput -TestArgs ($commonArgs + @('install', 'vcpkg-empty-port'))
+	$samePathOutput = Run-VcpkgAndCaptureOutput -TestArgs $commonArgs
 	Throw-IfFailed
 	if ($samePathOutput.Contains($targetMessage)) {
 		throw 'Expected no warning about VCPKG_ROOT when the detected path is the same as the configured path.'
 	}
 
 	$env:VCPKG_ROOT = Join-Path $actualVcpkgRoot 'ports' # any existing directory that isn't the detected root
-	$differentPathOutput = Run-VcpkgAndCaptureOutput -TestArgs ($commonArgs + @('install', 'vcpkg-empty-port', '--debug'))
+	$differentPathOutput = Run-VcpkgAndCaptureOutput -TestArgs ($commonArgs + @('--debug'))
 	Throw-IfFailed
 	if (-not ($differentPathOutput.Contains($targetMessage))) {
 		throw 'Expected a warning about VCPKG_ROOT differing when the detected path differs from the configured path.'
 	}
 
-	$setWithArgOutput = Run-VcpkgAndCaptureOutput -TestArgs ($commonArgs + @('install', 'vcpkg-empty-port', '--vcpkg-root', $actualVcpkgRoot, '--debug'))
+	$setWithArgOutput = Run-VcpkgAndCaptureOutput -TestArgs ($commonArgs + @('--vcpkg-root', $actualVcpkgRoot, '--debug'))
 	Throw-IfFailed
 	if ($setWithArgOutput.Contains($targetMessage)) {
 		throw 'Expected no warning about VCPKG_ROOT when the path is configured with a command line argument.'


### PR DESCRIPTION
$VCPKG_ROOT and fails if it finds one. The test should be independent of that.