### PR TITLE
Delete VcpkgPaths from portfileprovider machinery.

### DIFF
--- a/include/vcpkg/portfileprovider.h
+++ b/include/vcpkg/portfileprovider.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <vcpkg/fwd/portfileprovider.h>
-#include <vcpkg/fwd/vcpkgpaths.h>
 
 #include <vcpkg/base/expected.h>
 #include <vcpkg/base/util.h>
@@ -56,7 +55,9 @@ namespace vcpkg
 
     struct PathsPortFileProvider : PortFileProvider
     {
-        explicit PathsPortFileProvider(const vcpkg::VcpkgPaths& paths, std::unique_ptr<IOverlayProvider>&& overlay);
+        explicit PathsPortFileProvider(const Filesystem& fs,
+                                       const RegistrySet& registry_set,
+                                       std::unique_ptr<IOverlayProvider>&& overlay);
         ExpectedS<const SourceControlFileAndLocation&> get_control_file(const std::string& src_name) const override;
         std::vector<const SourceControlFileAndLocation*> load_all_control_files() const override;
 
@@ -66,11 +67,14 @@ namespace vcpkg
         std::unique_ptr<IOverlayProvider> m_overlay;
     };
 
-    std::unique_ptr<IBaselineProvider> make_baseline_provider(const vcpkg::VcpkgPaths& paths);
-    std::unique_ptr<IVersionedPortfileProvider> make_versioned_portfile_provider(const vcpkg::VcpkgPaths& paths);
-    std::unique_ptr<IOverlayProvider> make_overlay_provider(const vcpkg::VcpkgPaths& paths,
+    std::unique_ptr<IBaselineProvider> make_baseline_provider(const RegistrySet& registry_set);
+    std::unique_ptr<IVersionedPortfileProvider> make_versioned_portfile_provider(const Filesystem& fs,
+                                                                                 const RegistrySet& registry_set);
+    std::unique_ptr<IOverlayProvider> make_overlay_provider(const Filesystem& fs,
+                                                            const Path& original_cwd,
                                                             View<std::string> overlay_ports);
-    std::unique_ptr<IOverlayProvider> make_manifest_provider(const vcpkg::VcpkgPaths& paths,
+    std::unique_ptr<IOverlayProvider> make_manifest_provider(const Filesystem& fs,
+                                                             const Path& original_cwd,
                                                              View<std::string> overlay_ports,
                                                              const Path& manifest_path,
                                                              std::unique_ptr<SourceControlFile>&& manifest_scf);

--- a/include/vcpkg/vcpkgpaths.h
+++ b/include/vcpkg/vcpkgpaths.h
@@ -158,7 +158,7 @@ namespace vcpkg
         Optional<const ManifestAndPath&> get_manifest() const;
         bool manifest_mode_enabled() const;
         const ConfigurationAndSource& get_configuration() const;
-        const RegistrySet& get_registry_set() const;
+        std::unique_ptr<RegistrySet> make_registry_set() const;
 
         // Retrieve a toolset matching the requirements in prebuildinfo
         const Toolset& get_toolset(const PreBuildInfo& prebuildinfo) const;

--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -189,7 +189,10 @@ namespace vcpkg::Build
         const FullPackageSpec spec = check_and_get_full_package_spec(
             std::move(first_arg), default_triplet, COMMAND_STRUCTURE.example_text, paths);
 
-        PathsPortFileProvider provider(paths, make_overlay_provider(paths, paths.overlay_ports));
+        auto& fs = paths.get_filesystem();
+        auto registry_set = paths.make_registry_set();
+        PathsPortFileProvider provider(
+            fs, *registry_set, make_overlay_provider(fs, paths.original_cwd, paths.overlay_ports));
         return perform_ex(args, spec, host_triplet, provider, binary_cache, null_build_logs_recorder(), paths);
     }
 } // namespace vcpkg::Build

--- a/src/vcpkg/commands.buildexternal.cpp
+++ b/src/vcpkg/commands.buildexternal.cpp
@@ -32,7 +32,9 @@ namespace vcpkg::Commands::BuildExternal
         auto overlays = paths.overlay_ports;
         overlays.insert(overlays.begin(), args.command_arguments.at(1));
 
-        PathsPortFileProvider provider(paths, make_overlay_provider(paths, overlays));
+        auto& fs = paths.get_filesystem();
+        auto registry_set = paths.make_registry_set();
+        PathsPortFileProvider provider(fs, *registry_set, make_overlay_provider(fs, paths.original_cwd, overlays));
         Build::perform_and_exit_ex(args, spec, host_triplet, provider, binary_cache, null_build_logs_recorder(), paths);
     }
 

--- a/src/vcpkg/commands.check-support.cpp
+++ b/src/vcpkg/commands.check-support.cpp
@@ -114,7 +114,10 @@ namespace vcpkg::Commands
                 std::string(arg), default_triplet, COMMAND_STRUCTURE.example_text, paths);
         });
 
-        PathsPortFileProvider provider(paths, make_overlay_provider(paths, paths.overlay_ports));
+        auto& fs = paths.get_filesystem();
+        auto registry_set = paths.make_registry_set();
+        PathsPortFileProvider provider(
+            fs, *registry_set, make_overlay_provider(fs, paths.original_cwd, paths.overlay_ports));
         auto cmake_vars = CMakeVars::make_triplet_cmake_var_provider(paths);
 
         // for each spec in the user-requested specs, check all dependencies

--- a/src/vcpkg/commands.ci.cpp
+++ b/src/vcpkg/commands.ci.cpp
@@ -389,7 +389,9 @@ namespace vcpkg::Commands::CI
         const IBuildLogsRecorder& build_logs_recorder =
             build_logs_recorder_storage ? *(build_logs_recorder_storage.get()) : null_build_logs_recorder();
 
-        PathsPortFileProvider provider(paths, make_overlay_provider(paths, paths.overlay_ports));
+        auto registry_set = paths.make_registry_set();
+        PathsPortFileProvider provider(
+            filesystem, *registry_set, make_overlay_provider(filesystem, paths.original_cwd, paths.overlay_ports));
         auto var_provider_storage = CMakeVars::make_triplet_cmake_var_provider(paths);
         auto& var_provider = *var_provider_storage;
 

--- a/src/vcpkg/commands.dependinfo.cpp
+++ b/src/vcpkg/commands.dependinfo.cpp
@@ -309,7 +309,10 @@ namespace vcpkg::Commands::DependInfo
                 std::string{arg}, default_triplet, COMMAND_STRUCTURE.example_text, paths);
         });
 
-        PathsPortFileProvider provider(paths, make_overlay_provider(paths, paths.overlay_ports));
+        auto& fs = paths.get_filesystem();
+        auto registry_set = paths.make_registry_set();
+        PathsPortFileProvider provider(
+            fs, *registry_set, make_overlay_provider(fs, paths.original_cwd, paths.overlay_ports));
         auto var_provider_storage = CMakeVars::make_triplet_cmake_var_provider(paths);
         auto& var_provider = *var_provider_storage;
 

--- a/src/vcpkg/commands.edit.cpp
+++ b/src/vcpkg/commands.edit.cpp
@@ -6,6 +6,7 @@
 #include <vcpkg/commands.edit.h>
 #include <vcpkg/help.h>
 #include <vcpkg/paragraphs.h>
+#include <vcpkg/registries.h>
 #include <vcpkg/vcpkgcmdarguments.h>
 #include <vcpkg/vcpkgpaths.h>
 
@@ -88,8 +89,8 @@ namespace vcpkg::Commands::Edit
 
     static std::vector<std::string> valid_arguments(const VcpkgPaths& paths)
     {
-        auto sources_and_errors =
-            Paragraphs::try_load_all_registry_ports(paths.get_filesystem(), paths.get_registry_set());
+        auto registry_set = paths.make_registry_set();
+        auto sources_and_errors = Paragraphs::try_load_all_registry_ports(paths.get_filesystem(), *registry_set);
 
         return Util::fmap(sources_and_errors.paragraphs, Paragraphs::get_name_of_control_file);
     }

--- a/src/vcpkg/commands.env.cpp
+++ b/src/vcpkg/commands.env.cpp
@@ -44,7 +44,9 @@ namespace vcpkg::Commands::Env
 
         const ParsedArguments options = args.parse_arguments(COMMAND_STRUCTURE);
 
-        PathsPortFileProvider provider(paths, make_overlay_provider(paths, paths.overlay_ports));
+        auto registry_set = paths.make_registry_set();
+        PathsPortFileProvider provider(
+            fs, *registry_set, make_overlay_provider(fs, paths.original_cwd, paths.overlay_ports));
         auto var_provider_storage = CMakeVars::make_triplet_cmake_var_provider(paths);
         auto& var_provider = *var_provider_storage;
 

--- a/src/vcpkg/commands.find.cpp
+++ b/src/vcpkg/commands.find.cpp
@@ -121,7 +121,9 @@ namespace vcpkg::Commands
                                     Optional<StringView> filter,
                                     View<std::string> overlay_ports)
     {
-        PathsPortFileProvider provider(paths, make_overlay_provider(paths, overlay_ports));
+        auto& fs = paths.get_filesystem();
+        auto registry_set = paths.make_registry_set();
+        PathsPortFileProvider provider(fs, *registry_set, make_overlay_provider(fs, paths.original_cwd, overlay_ports));
         auto source_paragraphs =
             Util::fmap(provider.load_all_control_files(),
                        [](auto&& port) -> const SourceControlFile* { return port->source_control_file.get(); });

--- a/src/vcpkg/commands.info.cpp
+++ b/src/vcpkg/commands.info.cpp
@@ -53,9 +53,10 @@ namespace vcpkg::Commands::Info
                                           msg::option = OPTION_INSTALLED);
         }
 
+        auto& fs = paths.get_filesystem();
         if (installed)
         {
-            const StatusParagraphs status_paragraphs = database_load_check(paths.get_filesystem(), paths.installed());
+            const StatusParagraphs status_paragraphs = database_load_check(fs, paths.installed());
             std::set<PackageSpec> specs_written;
             std::vector<PackageSpec> specs_to_write;
             for (auto&& arg : args.command_arguments)
@@ -115,7 +116,9 @@ namespace vcpkg::Commands::Info
         {
             Json::Object response;
             Json::Object results;
-            PathsPortFileProvider provider(paths, make_overlay_provider(paths, paths.overlay_ports));
+            auto registry_set = paths.make_registry_set();
+            PathsPortFileProvider provider(
+                fs, *registry_set, make_overlay_provider(fs, paths.original_cwd, paths.overlay_ports));
 
             for (auto&& arg : args.command_arguments)
             {

--- a/src/vcpkg/commands.setinstalled.cpp
+++ b/src/vcpkg/commands.setinstalled.cpp
@@ -173,7 +173,10 @@ namespace vcpkg::Commands::SetInstalled
         const PrintUsage print_cmake_usage =
             Util::Sets::contains(options.switches, OPTION_NO_PRINT_USAGE) ? PrintUsage::NO : PrintUsage::YES;
 
-        PathsPortFileProvider provider(paths, make_overlay_provider(paths, paths.overlay_ports));
+        auto& fs = paths.get_filesystem();
+        auto registry_set = paths.make_registry_set();
+        PathsPortFileProvider provider(
+            fs, *registry_set, make_overlay_provider(fs, paths.original_cwd, paths.overlay_ports));
         auto cmake_vars = CMakeVars::make_triplet_cmake_var_provider(paths);
 
         Optional<Path> pkgsconfig;

--- a/src/vcpkg/commands.upgrade.cpp
+++ b/src/vcpkg/commands.upgrade.cpp
@@ -85,7 +85,10 @@ namespace vcpkg::Commands::Upgrade
         StatusParagraphs status_db = database_load_check(paths.get_filesystem(), paths.installed());
 
         // Load ports from ports dirs
-        PathsPortFileProvider provider(paths, make_overlay_provider(paths, paths.overlay_ports));
+        auto& fs = paths.get_filesystem();
+        auto registry_set = paths.make_registry_set();
+        PathsPortFileProvider provider(
+            fs, *registry_set, make_overlay_provider(fs, paths.original_cwd, paths.overlay_ports));
         auto var_provider_storage = CMakeVars::make_triplet_cmake_var_provider(paths);
         auto& var_provider = *var_provider_storage;
 

--- a/src/vcpkg/export.cpp
+++ b/src/vcpkg/export.cpp
@@ -592,7 +592,10 @@ namespace vcpkg::Export
         const auto opts = handle_export_command_arguments(paths, args, default_triplet, status_db);
 
         // Load ports from ports dirs
-        PathsPortFileProvider provider(paths, make_overlay_provider(paths, paths.overlay_ports));
+        auto& fs = paths.get_filesystem();
+        auto registry_set = paths.make_registry_set();
+        PathsPortFileProvider provider(
+            fs, *registry_set, make_overlay_provider(fs, paths.original_cwd, paths.overlay_ports));
 
         // create the plan
         std::vector<ExportPlanAction> export_plan = create_export_plan(opts.specs, status_db);

--- a/src/vcpkg/remove.cpp
+++ b/src/vcpkg/remove.cpp
@@ -205,7 +205,10 @@ namespace vcpkg::Remove
             }
 
             // Load ports from ports dirs
-            PathsPortFileProvider provider(paths, make_overlay_provider(paths, paths.overlay_ports));
+            auto& fs = paths.get_filesystem();
+            auto registry_set = paths.make_registry_set();
+            PathsPortFileProvider provider(
+                fs, *registry_set, make_overlay_provider(fs, paths.original_cwd, paths.overlay_ports));
 
             specs = Util::fmap(Update::find_outdated_packages(provider, status_db),
                                [](auto&& outdated) { return outdated.spec; });

--- a/src/vcpkg/update.cpp
+++ b/src/vcpkg/update.cpp
@@ -64,9 +64,12 @@ namespace vcpkg::Update
         (void)args.parse_arguments(COMMAND_STRUCTURE);
         msg::println(msgLocalPortfileVersion);
 
-        const StatusParagraphs status_db = database_load_check(paths.get_filesystem(), paths.installed());
+        auto& fs = paths.get_filesystem();
+        const StatusParagraphs status_db = database_load_check(fs, paths.installed());
 
-        PathsPortFileProvider provider(paths, make_overlay_provider(paths, paths.overlay_ports));
+        auto registry_set = paths.make_registry_set();
+        PathsPortFileProvider provider(
+            fs, *registry_set, make_overlay_provider(fs, paths.original_cwd, paths.overlay_ports));
 
         const auto outdated_packages = SortedVector<OutdatedPackage, decltype(&OutdatedPackage::compare_by_name)>(
             find_outdated_packages(provider, status_db), &OutdatedPackage::compare_by_name);


### PR DESCRIPTION
This removes a ton of false dependencies from portfileprovider et al. (portfile provider needs git infrastructure?!), and avoids actually trying to parse and resolve registries in commands that don't actually care.