### PR TITLE
No need to make tuples or objects in emplace-back

### DIFF
--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -1232,11 +1232,11 @@ namespace vcpkg
                             Checks::unreachable(VCPKG_LINE_INFO);
                         }
 
-                        dependency_abis.emplace_back(AbiEntry{pspec.name(), status_it->get()->package.abi});
+                        dependency_abis.emplace_back(pspec.name(), status_it->get()->package.abi);
                     }
                     else
                     {
-                        dependency_abis.emplace_back(AbiEntry{pspec.name(), it2->public_abi()});
+                        dependency_abis.emplace_back(pspec.name(), it2->public_abi());
                     }
                 }
             }

--- a/src/vcpkg/cmakevars.cpp
+++ b/src/vcpkg/cmakevars.cpp
@@ -22,7 +22,7 @@ namespace vcpkg::CMakeVars
         install_package_specs.reserve(action_plan.install_actions.size());
         for (auto&& action : action_plan.install_actions)
         {
-            install_package_specs.emplace_back(FullPackageSpec{action.spec, action.feature_list});
+            install_package_specs.emplace_back(action.spec, action.feature_list);
         }
 
         load_tag_vars(install_package_specs, port_provider, host_triplet);

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -757,7 +757,7 @@ namespace vcpkg
                 {
                     if (Strings::case_insensitive_ascii_equals(path.extension(), ".cmake"))
                     {
-                        output.emplace_back(TripletFile(path.stem(), triplets_dir));
+                        output.emplace_back(path.stem(), triplets_dir);
                     }
                 }
             }


### PR DESCRIPTION
We can pass each part directly instead of creating tuples or objects directly