### PR TITLE
Correct handling of PATH in VCPKG_KEEP_ENV_VARS

### DIFF
--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -388,7 +388,16 @@ namespace vcpkg
 
             for (auto&& var : vars)
             {
-                env_strings.push_back(var);
+                if (Strings::case_insensitive_ascii_equals(var, "PATH"))
+                {
+                    new_path.assign(prepend_to_path.data(), prepend_to_path.size());
+                    if (!new_path.empty()) new_path.push_back(';');
+                    new_path.append(get_environment_variable("PATH").value_or(""));
+                }
+                else
+                {
+                    env_strings.push_back(var);
+                }
             }
         }
 


### PR DESCRIPTION
Before this PR, using `set VCPKG_KEEP_ENV_VARS=PATH` would result in two copies of `PATH` in the environment block. This had (mostly) the correct results for windows processes which would take the first value, however msys2's bash takes the last value and thus has an incredibly mysterious behavior of apparently resetting the path.

This is a targeted fix for the PATH variable, however a more comprehensive rework of how the environment is handled is needed to ensure correct handling of all variables -- see https://github.com/microsoft/vcpkg-tool/pull/424.