### PR TITLE
Fix build on FreeBSD 13.1-RELEASE

### DIFF
--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -17,6 +17,7 @@ extern char** environ;
 #endif
 
 #if defined(__FreeBSD__)
+extern char** environ;
 #include <sys/sysctl.h>
 #include <sys/wait.h>
 #endif
@@ -225,10 +226,10 @@ namespace vcpkg
         int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1};
         char exePath[2048];
         size_t len = sizeof(exePath);
-        auto rcode = sysctl(mib, 4, exePath, &len, NULL, 0);
+        auto rcode = sysctl(mib, 4, exePath, &len, nullptr, 0);
         Checks::check_exit(VCPKG_LINE_INFO, rcode == 0, "Could not determine current executable path.");
         Checks::check_exit(VCPKG_LINE_INFO, len > 0, "Could not determine current executable path.");
-        return Path(exePath, exePath + len - 1);
+        return Path(exePath, len - 1);
 #elif defined(__OpenBSD__)
         const char* progname = getprogname();
         char resolved_path[PATH_MAX];


### PR DESCRIPTION
Fixes build failure on FreeBSD 13.1-RELEASE as described by microsoft/vcpkg#28535.

Basically declares the missing `environ` variable the same way it is done on OS X, and the call to an invalid Path constructor in FreeBSD-specific code.