### PR TITLE
Avoid calling memcmp for empty string views

### DIFF
--- a/src/vcpkg/base/stringview.cpp
+++ b/src/vcpkg/base/stringview.cpp
@@ -29,6 +29,10 @@ namespace vcpkg
 
     bool operator==(StringView lhs, StringView rhs) noexcept
     {
+        if (lhs.empty() && rhs.empty())
+        {
+            return false;
+        }
         return lhs.size() == rhs.size() && memcmp(lhs.data(), rhs.data(), lhs.size()) == 0;
     }
 

--- a/src/vcpkg/base/stringview.cpp
+++ b/src/vcpkg/base/stringview.cpp
@@ -31,7 +31,7 @@ namespace vcpkg
     {
         if (lhs.empty() && rhs.empty())
         {
-            return false;
+            return true;
         }
         return lhs.size() == rhs.size() && memcmp(lhs.data(), rhs.data(), lhs.size()) == 0;
     }


### PR DESCRIPTION
This gives a 3.3x performance improvement: https://quick-bench.com/q/RXyLBXqCsm-QHSHGxBDSou6N_Fs

Also gets rid of `/home/vsts/work/1/s/src/vcpkg/base/stringview.cpp:32:50: runtime error: null pointer passed as argument 2, which is declared to never be null`

Code used for benchmarking:

```c++
#include <cstring>

struct SV {
  const char* data = nullptr;
  std::size_t size = 0;

  bool operator==(const SV& other) const noexcept
  {
    return size == other.size && memcmp(data, other.data, size) == 0;
  }
};

struct SV_2 {
  const char* data = nullptr;
  std::size_t size = 0;

  bool operator==(const SV_2& other) const noexcept
  {
    if (size == 0 && other.size == 0) return true;
    return size == other.size && memcmp(data, other.data, size) == 0;
  }
};


static void StringCreation(benchmark::State& state) {
  for (auto _ : state) {
    SV sv {};
    benchmark::DoNotOptimize(sv);
    SV sv_2{};
    benchmark::DoNotOptimize(sv_2);
    bool res = sv == sv_2;
    benchmark::DoNotOptimize(res);
  }
}
// Register the function as a benchmark
BENCHMARK(StringCreation);

static void StringCopy(benchmark::State& state) {
  for (auto _ : state) {
    SV_2 sv {};
    benchmark::DoNotOptimize(sv);
    SV_2 sv_2{};
    benchmark::DoNotOptimize(sv_2);
    bool res = sv == sv_2;
    benchmark::DoNotOptimize(res);
  }
}
BENCHMARK(StringCopy);
```

Settings: GCC 9.4, c++17, O3