### PR TITLE
Remove z- prefix from bootstrap-standalone command

### DIFF
--- a/include/vcpkg/commands.bootstrap-standalone.h
+++ b/include/vcpkg/commands.bootstrap-standalone.h
@@ -4,7 +4,7 @@
 
 namespace vcpkg::Commands
 {
-    struct ZBootstrapStandaloneCommand : BasicCommand
+    struct BootstrapStandaloneCommand : BasicCommand
     {
         virtual void perform_and_exit(const VcpkgCmdArguments& args, Filesystem& fs) const override;
     };

--- a/src/vcpkg/commands.bootstrap-standalone.cpp
+++ b/src/vcpkg/commands.bootstrap-standalone.cpp
@@ -3,8 +3,8 @@
 #include <vcpkg/base/system.print.h>
 
 #include <vcpkg/archives.h>
+#include <vcpkg/commands.bootstrap-standalone.h>
 #include <vcpkg/commands.version.h>
-#include <vcpkg/commands.zbootstrap-standalone.h>
 #include <vcpkg/tools.h>
 #include <vcpkg/vcpkgcmdarguments.h>
 
@@ -13,14 +13,14 @@
 namespace vcpkg::Commands
 {
     static const CommandStructure COMMAND_STRUCTURE = {
-        create_example_string("z-bootstrap-standalone"),
+        create_example_string("bootstrap-standalone"),
         0,
         0,
         {{}, {}},
         nullptr,
     };
 
-    void ZBootstrapStandaloneCommand::perform_and_exit(const VcpkgCmdArguments& args, Filesystem& fs) const
+    void BootstrapStandaloneCommand::perform_and_exit(const VcpkgCmdArguments& args, Filesystem& fs) const
     {
         DownloadManager download_manager{{}};
         const auto maybe_vcpkg_root_env = args.vcpkg_root_dir_env.get();

--- a/src/vcpkg/commands.cpp
+++ b/src/vcpkg/commands.cpp
@@ -7,6 +7,7 @@
 #include <vcpkg/commands.add-version.h>
 #include <vcpkg/commands.add.h>
 #include <vcpkg/commands.autocomplete.h>
+#include <vcpkg/commands.bootstrap-standalone.h>
 #include <vcpkg/commands.buildexternal.h>
 #include <vcpkg/commands.cache.h>
 #include <vcpkg/commands.check-support.h>
@@ -43,7 +44,6 @@
 #include <vcpkg/commands.version.h>
 #include <vcpkg/commands.xdownload.h>
 #include <vcpkg/commands.xvsinstances.h>
-#include <vcpkg/commands.zbootstrap-standalone.h>
 #include <vcpkg/commands.zce.h>
 #include <vcpkg/commands.zpreregistertelemetry.h>
 #include <vcpkg/commands.zprintconfig.h>
@@ -63,7 +63,7 @@ namespace vcpkg::Commands
         static const X_Download::XDownloadCommand xdownload{};
         static const GenerateDefaultMessageMapCommand generate_message_map{};
         static const Hash::HashCommand hash{};
-        static const ZBootstrapStandaloneCommand zboostrap_standalone{};
+        static const BootstrapStandaloneCommand boostrap_standalone{};
         static const ZPreRegisterTelemetryCommand zpreregister_telemetry{};
 #if defined(_WIN32)
         static const UploadMetrics::UploadMetricsCommand upload_metrics{};
@@ -76,7 +76,7 @@ namespace vcpkg::Commands
             {"x-init-registry", &init_registry},
             {"x-download", &xdownload},
             {"x-generate-default-message-map", &generate_message_map},
-            {"z-bootstrap-standalone", &zboostrap_standalone},
+            {"bootstrap-standalone", &boostrap_standalone},
             {"z-preregister-telemetry", &zpreregister_telemetry},
 #if defined(_WIN32)
             {"x-upload-metrics", &upload_metrics},

--- a/vcpkg-init/vcpkg-init
+++ b/vcpkg-init/vcpkg-init
@@ -63,7 +63,7 @@ Z_VCPKG_bootstrap() {
   fi
 
   chmod +x "${VCPKG_ROOT}/vcpkg"
-  "${VCPKG_ROOT}/vcpkg" z-bootstrap-standalone
+  "${VCPKG_ROOT}/vcpkg" bootstrap-standalone
   echo $VCPKG_BASE_VERSION > "${VCPKG_ROOT}/vcpkg-one-liner-version.txt"
   return 0;
 }

--- a/vcpkg-init/vcpkg-init.ps1
+++ b/vcpkg-init/vcpkg-init.ps1
@@ -125,7 +125,7 @@ function bootstrap-vcpkg {
     download https://github.com/microsoft/vcpkg-tool/releases/latest/download/vcpkg-glibc $VCPKG
   }
 
-  & $VCPKG z-bootstrap-standalone
+  & $VCPKG bootstrap-standalone
 
   $PATH = $ENV:PATH
   $ENV:PATH="$VCPKG_ROOT;$PATH"


### PR DESCRIPTION
We're planning to start using this flag from a VS Code extension in January, so it probably shouldn't have the `z-` prefix any more.

cc @microsoft/embedded-dev 