### PR TITLE
Don't let unsupported ports pull in dependencies

### DIFF
--- a/azure-pipelines/e2e_ci/zzz-expected-port/portfile.cmake
+++ b/azure-pipelines/e2e_ci/zzz-expected-port/portfile.cmake
@@ -1,0 +1,1 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/azure-pipelines/e2e_ci/zzz-expected-port/vcpkg.json
+++ b/azure-pipelines/e2e_ci/zzz-expected-port/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "zzz-expected-port",
+  "version": "1",
+  "features": {
+    "zzz-unexpected-feature": {
+      "description": "Cannot be installed",
+      "supports": "native & !native"
+    }
+  }
+}

--- a/azure-pipelines/e2e_ci/zzz-unexpected-port/portfile.cmake
+++ b/azure-pipelines/e2e_ci/zzz-unexpected-port/portfile.cmake
@@ -1,0 +1,1 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/azure-pipelines/e2e_ci/zzz-unexpected-port/vcpkg.json
+++ b/azure-pipelines/e2e_ci/zzz-unexpected-port/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "zzz-unexpected-port",
+  "version": "1",
+  "description": "Cannot be installed",
+  "supports": "native & !native",
+  "dependencies": [
+    {
+      "name": "zzz-expected-port",
+      "features": [
+        "zzz-unexpected-feature"
+      ]
+    }
+  ]
+}

--- a/azure-pipelines/end-to-end-tests-dir/ci.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/ci.ps1
@@ -11,3 +11,16 @@ Throw-IfNotFailed
 # Clearly not the correct answer
 Run-Vcpkg ci --triplet=$Triplet --x-skipped-cascade-count=1000
 Throw-IfNotFailed
+
+# Regular ci; may take a few seconds to complete
+$port_list = Run-VcpkgAndCaptureOutput ci --dry-run --triplet=$Triplet --binarysource=clear --overlay-ports="$PSScriptRoot/../e2e_ci"
+Throw-IfFailed
+if ($port_list -match "zzz-unexpected-port[^ ]*[ ]*->") {
+    throw 'Detected installation of "zzz-unexpected-port"'
+}
+if ($port_list -match "zzz-unexpected-feature[^ ]*[ ]*->") {
+    throw 'Detected installation of "zzz-unexpected-feature"'
+}
+if ($port_list -notmatch "zzz-expected-port[^ ]*[ ]*->") {
+    throw 'Did not detect installation of "zzz-expected-port"'
+}

--- a/azure-pipelines/end-to-end-tests-dir/ci.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/ci.ps1
@@ -1,15 +1,15 @@
 . $PSScriptRoot/../end-to-end-tests-prelude.ps1
 
 # Not a number
-Run-Vcpkg ci --triplet=$Triplet --x-skipped-cascade-count=fish
+Run-Vcpkg ci --dry-run --triplet=$Triplet --x-skipped-cascade-count=fish
 Throw-IfNotFailed
 
 # Negative
-Run-Vcpkg ci --triplet=$Triplet --x-skipped-cascade-count=-1
+Run-Vcpkg ci --dry-run --triplet=$Triplet --x-skipped-cascade-count=-1
 Throw-IfNotFailed
 
 # Clearly not the correct answer
-Run-Vcpkg ci --triplet=$Triplet --x-skipped-cascade-count=1000
+Run-Vcpkg ci --dry-run --triplet=$Triplet --x-skipped-cascade-count=1000
 Throw-IfNotFailed
 
 # Regular ci; may take a few seconds to complete


### PR DESCRIPTION
When a port `mapnik` is unsupported on `x64-uwp`, its dependency on `boost-regex[icu]` must not take effect during `vcpkg ci --triplet=x64-uwp` because it will make `boost-regex` unbuildable on `uwp` as long as icu is unsupported on this triplet.

Background: https://github.com/microsoft/vcpkg/pull/28619/files#r1059405866