### PR TITLE
More human readable elapsed time

### DIFF
--- a/src/vcpkg/base/chrono.cpp
+++ b/src/vcpkg/base/chrono.cpp
@@ -62,45 +62,46 @@ namespace vcpkg
     {
         using std::chrono::duration_cast;
         using std::chrono::hours;
-        using std::chrono::microseconds;
         using std::chrono::milliseconds;
         using std::chrono::minutes;
         using std::chrono::nanoseconds;
         using std::chrono::seconds;
 
-        const auto nanos_as_double = static_cast<double>(nanos.count());
+        auto ns_total = nanos.count();
 
-        if (duration_cast<hours>(nanos) > hours())
-        {
-            const auto t = nanos_as_double / duration_cast<nanoseconds>(hours(1)).count();
-            return Strings::format("%.4g h", t);
+        std::string ret;
+
+        const auto one_day_ns = duration_cast<nanoseconds>(hours(24)).count();
+        if (ns_total >= one_day_ns) {
+            int64_t d = ns_total / one_day_ns;
+            ns_total %= one_day_ns;
+            if (d != 0) ret.append(Strings::format("%dd", d));
         }
 
-        if (duration_cast<minutes>(nanos) > minutes())
-        {
-            const auto t = nanos_as_double / duration_cast<nanoseconds>(minutes(1)).count();
-            return Strings::format("%.4g min", t);
+        const auto one_hour_ns = duration_cast<nanoseconds>(hours(1)).count();
+        if (ns_total >= one_hour_ns) {
+            int64_t h = ns_total / one_hour_ns;
+            ns_total %= one_hour_ns;
+            if (h != 0) ret.append(Strings::format("%dh", h));
         }
 
-        if (duration_cast<seconds>(nanos) > seconds())
-        {
-            const auto t = nanos_as_double / duration_cast<nanoseconds>(seconds(1)).count();
-            return Strings::format("%.4g s", t);
+        const auto one_minute_ns = duration_cast<nanoseconds>(minutes(1)).count();
+        if (ns_total >= one_minute_ns) {
+            int64_t m = ns_total / one_minute_ns;
+            ns_total %= one_minute_ns;
+            if (m != 0) ret.append(Strings::format("%dm", m));
         }
 
-        if (duration_cast<milliseconds>(nanos) > milliseconds())
-        {
-            const auto t = nanos_as_double / duration_cast<nanoseconds>(milliseconds(1)).count();
-            return Strings::format("%.4g ms", t);
+        const auto one_second_ns = duration_cast<nanoseconds>(seconds(1)).count();
+        const auto one_millisecond_ns = duration_cast<nanoseconds>(milliseconds(1)).count();
+        if (ns_total >= one_millisecond_ns) {
+            int64_t s = ns_total / one_second_ns;
+            ns_total %= one_second_ns;
+            int64_t ms = ns_total / one_millisecond_ns;
+            ret.append(Strings::format("%d.%03ds", s, ms));
         }
 
-        if (duration_cast<microseconds>(nanos) > microseconds())
-        {
-            const auto t = nanos_as_double / duration_cast<nanoseconds>(microseconds(1)).count();
-            return Strings::format("%.4g us", t);
-        }
-
-        return Strings::format("%.4g ns", nanos_as_double);
+        return ret;
     }
 
     ElapsedTimer::ElapsedTimer() noexcept

--- a/src/vcpkg/base/chrono.cpp
+++ b/src/vcpkg/base/chrono.cpp
@@ -72,21 +72,24 @@ namespace vcpkg
         std::vector<std::string> tokens;
 
         const auto one_day_ns = duration_cast<nanoseconds>(hours(24)).count();
-        if (ns_total >= one_day_ns) {
+        if (ns_total >= one_day_ns)
+        {
             const auto d = ns_total / one_day_ns;
             ns_total %= one_day_ns;
             if (d != 0) tokens.emplace_back(Strings::format("%dd", d));
         }
 
         const auto one_hour_ns = duration_cast<nanoseconds>(hours(1)).count();
-        if (ns_total >= one_hour_ns) {
+        if (ns_total >= one_hour_ns)
+        {
             const auto h = ns_total / one_hour_ns;
             ns_total %= one_hour_ns;
             if (h != 0) tokens.emplace_back(Strings::format("%dh", h));
         }
 
         const auto one_minute_ns = duration_cast<nanoseconds>(minutes(1)).count();
-        if (ns_total >= one_minute_ns) {
+        if (ns_total >= one_minute_ns)
+        {
             const auto m = ns_total / one_minute_ns;
             ns_total %= one_minute_ns;
             if (m != 0) tokens.emplace_back(Strings::format("%dm", m));

--- a/src/vcpkg/base/chrono.cpp
+++ b/src/vcpkg/base/chrono.cpp
@@ -73,21 +73,21 @@ namespace vcpkg
 
         const auto one_day_ns = duration_cast<nanoseconds>(hours(24)).count();
         if (ns_total >= one_day_ns) {
-            int64_t d = ns_total / one_day_ns;
+            const auto d = ns_total / one_day_ns;
             ns_total %= one_day_ns;
             if (d != 0) ret.append(Strings::format("%dd", d));
         }
 
         const auto one_hour_ns = duration_cast<nanoseconds>(hours(1)).count();
         if (ns_total >= one_hour_ns) {
-            int64_t h = ns_total / one_hour_ns;
+            const auto h = ns_total / one_hour_ns;
             ns_total %= one_hour_ns;
             if (h != 0) ret.append(Strings::format("%dh", h));
         }
 
         const auto one_minute_ns = duration_cast<nanoseconds>(minutes(1)).count();
         if (ns_total >= one_minute_ns) {
-            int64_t m = ns_total / one_minute_ns;
+            const auto m = ns_total / one_minute_ns;
             ns_total %= one_minute_ns;
             if (m != 0) ret.append(Strings::format("%dm", m));
         }
@@ -95,9 +95,9 @@ namespace vcpkg
         const auto one_second_ns = duration_cast<nanoseconds>(seconds(1)).count();
         const auto one_millisecond_ns = duration_cast<nanoseconds>(milliseconds(1)).count();
         if (ns_total >= one_millisecond_ns) {
-            int64_t s = ns_total / one_second_ns;
+            const auto s = ns_total / one_second_ns;
             ns_total %= one_second_ns;
-            int64_t ms = ns_total / one_millisecond_ns;
+            const auto ms = ns_total / one_millisecond_ns;
             ret.append(Strings::format("%d.%03ds", s, ms));
         }
 

--- a/src/vcpkg/base/chrono.cpp
+++ b/src/vcpkg/base/chrono.cpp
@@ -94,12 +94,10 @@ namespace vcpkg
 
         const auto one_second_ns = duration_cast<nanoseconds>(seconds(1)).count();
         const auto one_millisecond_ns = duration_cast<nanoseconds>(milliseconds(1)).count();
-        if (ns_total >= one_millisecond_ns) {
-            const auto s = ns_total / one_second_ns;
-            ns_total %= one_second_ns;
-            const auto ms = ns_total / one_millisecond_ns;
-            ret.append(Strings::format("%d.%03ds", s, ms));
-        }
+        const auto s = ns_total / one_second_ns;
+        ns_total %= one_second_ns;
+        const auto ms = ns_total / one_millisecond_ns;
+        ret.append(Strings::format("%d.%03ds", s, ms));
 
         return ret;
     }

--- a/src/vcpkg/base/chrono.cpp
+++ b/src/vcpkg/base/chrono.cpp
@@ -58,7 +58,7 @@ namespace vcpkg
         return to_utc_time(date_in_seconds).value_or_exit(VCPKG_LINE_INFO);
     }
 
-    static std::string format_time_userfriendly(const std::chrono::nanoseconds& nanos)
+    static std::string format_time_userfriendly(const std::chrono::nanoseconds& nanos, StringLiteral delimiter = " ")
     {
         using std::chrono::duration_cast;
         using std::chrono::hours;
@@ -99,7 +99,7 @@ namespace vcpkg
         const auto ms = ns_total / one_millisecond_ns;
         tokens.emplace_back(Strings::format("%d.%03ds", s, ms));
 
-        return Strings::join(" ", tokens);
+        return Strings::join(delimiter, tokens);
     }
 
     ElapsedTimer::ElapsedTimer() noexcept

--- a/src/vcpkg/base/chrono.cpp
+++ b/src/vcpkg/base/chrono.cpp
@@ -69,27 +69,27 @@ namespace vcpkg
 
         auto ns_total = nanos.count();
 
-        std::string ret;
+        std::vector<std::string> tokens;
 
         const auto one_day_ns = duration_cast<nanoseconds>(hours(24)).count();
         if (ns_total >= one_day_ns) {
             const auto d = ns_total / one_day_ns;
             ns_total %= one_day_ns;
-            if (d != 0) ret.append(Strings::format("%dd", d));
+            if (d != 0) tokens.emplace_back(Strings::format("%dd", d));
         }
 
         const auto one_hour_ns = duration_cast<nanoseconds>(hours(1)).count();
         if (ns_total >= one_hour_ns) {
             const auto h = ns_total / one_hour_ns;
             ns_total %= one_hour_ns;
-            if (h != 0) ret.append(Strings::format("%dh", h));
+            if (h != 0) tokens.emplace_back(Strings::format("%dh", h));
         }
 
         const auto one_minute_ns = duration_cast<nanoseconds>(minutes(1)).count();
         if (ns_total >= one_minute_ns) {
             const auto m = ns_total / one_minute_ns;
             ns_total %= one_minute_ns;
-            if (m != 0) ret.append(Strings::format("%dm", m));
+            if (m != 0) tokens.emplace_back(Strings::format("%dm", m));
         }
 
         const auto one_second_ns = duration_cast<nanoseconds>(seconds(1)).count();
@@ -97,9 +97,9 @@ namespace vcpkg
         const auto s = ns_total / one_second_ns;
         ns_total %= one_second_ns;
         const auto ms = ns_total / one_millisecond_ns;
-        ret.append(Strings::format("%d.%03ds", s, ms));
+        tokens.emplace_back(Strings::format("%d.%03ds", s, ms));
 
-        return ret;
+        return Strings::join(" ", tokens);
     }
 
     ElapsedTimer::ElapsedTimer() noexcept


### PR DESCRIPTION
```cpp
std::cout << format_time_userfriendly(std::chrono::milliseconds(3600l * 1000l + 123l)) << "\n";
std::cout << format_time_userfriendly(std::chrono::milliseconds(3600l * 1000l + 5123l)) << "\n";
std::cout << format_time_userfriendly(std::chrono::milliseconds(24l * 3600l * 1000l + 60l * 8l * 1000l + 5123l)) << "\n";
std::cout << format_time_userfriendly(std::chrono::milliseconds(25l * 3600l * 1000l + 60l * 8l * 1000l + 5123l)) << "\n";
std::cout << format_time_userfriendly(std::chrono::milliseconds((1l + 24l * 7l) * 3600l * 1000l + 60l * 8l * 1000l + 5123l)) << "\n";
```

It will prints

```
1h 0.123s
1h 5.123s
1d 8m 5.123s
1d 1h 8m 5.123s
7d 1h 8m 5.123s
```

The delimiter currently is default to ' ', it can be '' and prints
```
1h0.123s
1h5.123s
1d8m5.123s
1d1h8m5.123s
7d1h8m5.123s
```

current log
```
Elapsed time to handle qt5-base:x64-osx: 8.504 min
```
`8.504 min` is confusing, that will be
```
Elapsed time to handle qt5-base:x64-osx: 8m 30.240s
```

