### PR TITLE
Remove the ee-ts dependency.

### DIFF
--- a/azure-pipelines/signing.yml
+++ b/azure-pipelines/signing.yml
@@ -117,7 +117,7 @@ jobs:
     - task: ComponentGovernanceComponentDetection@0
       displayName: Detect Components
       inputs:
-        ignoreDirectories: ce/common/temp
+        sourceScanPath: "$(Build.BinariesDirectory)/ce"
     # Inject the NOTICE file. This must run after component detection.
     - task: msospo.ospo-extension.8d7f9abb-6896-461d-9e25-4f74ed65ddb2.notice@0
       displayName: Generate NOTICE File

--- a/ce/assets/package.json
+++ b/ce/assets/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "postinstall": "node ./create-links create",
     "uninstall": "node ./create-links remove",
-    "prepack": "npx rimraf ./common/temp/node_modules/.pnpm/typescript* ./common/temp/node_modules/.pnpm/translate-strings*  ./common/temp/node_modules/.pnpm/ts-morph*  ./common/temp/node_modules/.pnpm/@types* && node ./prepare-deploy.js"
+    "prepack": "node ./prepare-deploy.js"
   },
   "repository": {
     "type": "git",

--- a/ce/ce/artifacts/activation.ts
+++ b/ce/ce/artifacts/activation.ts
@@ -125,11 +125,13 @@ export class Activation {
   addDefine(name: string, value: string) {
     const v = findCaseInsensitiveOnWindows(this.#defines, name);
 
-    if (v && v !== value) {
+    if (v === undefined) {
+      this.#defines.set(name, value);
+    } else if (v !== value) {
       // conflict. todo: what do we want to do?
       this.#session.channels.warning(i`Duplicate define ${name} during activation. New value will replace old.`);
+      this.#defines.set(name, value);
     }
-    this.#defines.set(name, value);
   }
 
   get defines() {
@@ -144,10 +146,12 @@ export class Activation {
   /** a collection of tool locations from artifacts */
   addTool(name: string, value: string) {
     const t = findCaseInsensitiveOnWindows(this.#tools, name);
-    if (t && t !== value) {
-      this.#session.channels.error(i`Duplicate tool declared ${name} during activation.  New value will replace old.`);
+    if (t === undefined) {
+      this.#tools.set(name, value);
+    } else if (t !== value) {
+      this.#session.channels.warning(i`Duplicate tool declared ${name} during activation.  New value will replace old.`);
+      this.#tools.set(name, value);
     }
-    this.#tools.set(name, value);
   }
 
   get tools() {
@@ -166,10 +170,12 @@ export class Activation {
   /** Aliases are tools that get exposed to the user as shell aliases */
   addAlias(name: string, value: string) {
     const a = findCaseInsensitiveOnWindows(this.#aliases, name);
-    if (a && a !== value) {
-      this.#session.channels.error(i`Duplicate alias declared ${name} during activation.  New value will replace old.`);
+    if (a === undefined) {
+      this.#aliases.set(name, value);
+    } else if (a !== value) {
+      this.#session.channels.warning(i`Duplicate alias declared ${name} during activation.  New value will replace old.`);
+      this.#aliases.set(name, value);
     }
-    this.#aliases.set(name, value);
   }
 
   async getAlias(name: string, refcheck = new Set<string>()): Promise<string | undefined> {
@@ -196,10 +202,12 @@ export class Activation {
     location = typeof location === 'string' ? location : location.fsPath;
 
     const l = this.#locations.get(name);
-    if (l !== location) {
-      this.#session.channels.error(i`Duplicate location declared ${name} during activation. New value will replace old.`);
+    if (l === undefined) {
+      this.#locations.set(name, location);
+    } else if (l !== location) {
+      this.#session.channels.warning(i`Duplicate location declared ${name} during activation. New value will replace old.`);
+      this.#locations.set(name, location);
     }
-    this.#locations.set(name, location);
   }
 
   get locations() {
@@ -276,7 +284,7 @@ export class Activation {
       return;
     }
     let v = this.#properties.get(name);
-    if (!v) {
+    if (v === undefined) {
       v = new Set<string>();
       this.#properties.set(name, v);
     }

--- a/ce/ce/fs/filesystem.ts
+++ b/ce/ce/fs/filesystem.ts
@@ -3,7 +3,7 @@
 
 /* eslint-disable @typescript-eslint/ban-types */
 
-import { EventEmitter } from 'ee-ts';
+import { EventEmitter } from 'node:events';
 import { Readable, Writable } from 'stream';
 import { Session } from '../session';
 import { Uri } from '../util/uri';
@@ -196,7 +196,7 @@ async function* asyncIterableOverHandle(start: number, end: number, handle: Read
   }
 }
 
-export abstract class FileSystem extends EventEmitter<FileSystemEvents> {
+export abstract class FileSystem extends EventEmitter {
 
   protected baseUri?: Uri;
 

--- a/ce/ce/package.json
+++ b/ce/ce/package.json
@@ -55,7 +55,6 @@
   "dependencies": {
     "@snyk/nuget-semver": "1.3.0",
     "vscode-uri": "3.0.3",
-    "ee-ts": "2.0.0-rc.6",
     "yaml": "2.0.0-10",
     "semver": "7.3.5",
     "tar-stream": "~2.3.0",

--- a/ce/ce/util/channels.ts
+++ b/ce/ce/util/channels.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { EventEmitter } from 'ee-ts';
+import { EventEmitter } from 'node:events';
 import { Session } from '../session';
 
 /** Event defintions for channel events */
@@ -40,7 +40,7 @@ export class Stopwatch {
  *
  * Warning, Error, Message, Debug
  */
-export class Channels extends EventEmitter<ChannelEvents> {
+export class Channels extends EventEmitter {
   /** @internal */
   readonly stopwatch: Stopwatch;
 

--- a/ce/common/config/rush/pnpm-lock.yaml
+++ b/ce/common/config/rush/pnpm-lock.yaml
@@ -16,7 +16,6 @@ specifiers:
   '@typescript-eslint/parser': 5.10.2
   chalk: 4.1.2
   cli-progress: 3.11.1
-  ee-ts: 2.0.0-rc.6
   end-of-stream: ^1.4.1
   eslint: 8.8.0
   eslint-plugin-notice: 0.9.10
@@ -56,7 +55,6 @@ dependencies:
   '@typescript-eslint/parser': 5.10.2_eslint@8.8.0+typescript@4.5.5
   chalk: 4.1.2
   cli-progress: 3.11.1
-  ee-ts: 2.0.0-rc.6_typescript@4.5.5
   end-of-stream: 1.4.4
   eslint: 8.8.0
   eslint-plugin-notice: 0.9.10_eslint@8.8.0
@@ -71,7 +69,7 @@ dependencies:
   shx: 0.3.4
   sorted-btree: 1.6.0
   source-map-support: 0.5.21
-  tape: 4.16.1
+  tape: 4.16.2
   translate-strings: 1.1.15
   txtgen: 2.2.8
   typescript: 4.5.5
@@ -122,7 +120,7 @@ packages:
       '@azure/core-auth': 1.4.0
       abort-controller: 3.0.0
       form-data: 2.5.1
-      node-fetch: 2.6.7
+      node-fetch: 2.6.8
       tough-cookie: 3.0.1
       tslib: 1.14.1
       tunnel: 0.0.6
@@ -147,15 +145,15 @@ packages:
       is-negated-glob: 1.0.0
     dev: false
 
-  /@eslint/eslintrc/1.3.3:
-    resolution: {integrity: sha1-KwRKs5/fp1tGiBhPnlc848Ww/5U=}
+  /@eslint/eslintrc/1.4.1:
+    resolution: {integrity: sha1-r1h3IBmi0nG34tTCP/Tdy6PM+z4=}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
       debug: 4.3.4
       espree: 9.4.1
-      globals: 13.18.0
-      ignore: 5.2.1
+      globals: 13.19.0
+      ignore: 5.2.4
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       minimatch: 3.1.2
@@ -197,7 +195,7 @@ packages:
     engines: {node: '>= 8'}
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
-      fastq: 1.13.0
+      fastq: 1.15.0
     dev: false
 
   /@snyk/nuget-semver/1.3.0:
@@ -281,7 +279,7 @@ packages:
       debug: 4.3.4
       eslint: 8.8.0
       functional-red-black-tree: 1.0.1
-      ignore: 5.2.1
+      ignore: 5.2.4
       regexpp: 3.2.0
       semver: 7.3.5
       tsutils: 3.21.0_typescript@4.5.5
@@ -400,16 +398,16 @@ packages:
       event-target-shim: 5.0.1
     dev: false
 
-  /acorn-jsx/5.3.2_acorn@8.8.1:
+  /acorn-jsx/5.3.2_acorn@8.8.2:
     resolution: {integrity: sha1-ftW7VZCLOy8bxVxq8WU7rafweTc=}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      acorn: 8.8.1
+      acorn: 8.8.2
     dev: false
 
-  /acorn/8.8.1:
-    resolution: {integrity: sha1-Cj+cvsxOw76m8KgLZq6N0tolC3M=}
+  /acorn/8.8.2:
+    resolution: {integrity: sha1-Gy8l2wKvllOZuXdrDCw5EnbTfEo=}
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: false
@@ -489,6 +487,11 @@ packages:
     resolution: {integrity: sha1-x57Zf380y48robyXkLzDZkdLS3k=}
     dev: false
 
+  /available-typed-arrays/1.0.5:
+    resolution: {integrity: sha1-kvlWFlAQadB9EO2y/DfT4cZRI7c=}
+    engines: {node: '>= 0.4'}
+    dev: false
+
   /balanced-match/1.0.2:
     resolution: {integrity: sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=}
     dev: false
@@ -535,7 +538,7 @@ packages:
     resolution: {integrity: sha1-sdTonmiBGcPJqQOtMKuy9qkZvjw=}
     dependencies:
       function-bind: 1.1.1
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
     dev: false
 
   /callsites/3.1.0:
@@ -581,8 +584,8 @@ packages:
       supports-color: 7.2.0
     dev: false
 
-  /chalk/5.1.2:
-    resolution: {integrity: sha1-2VfzcAOLdaxXJHHoO+TFyp+OjEU=}
+  /chalk/5.2.0:
+    resolution: {integrity: sha1-JJYjt9ZoacZzaZ+2bWVyPlTfz7M=}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
     dev: false
 
@@ -758,15 +761,6 @@ packages:
       minimatch: 3.1.2
     dev: false
 
-  /ee-ts/2.0.0-rc.6_typescript@4.5.5:
-    resolution: {integrity: sha1-NTUc7iqIhwlp/0S/9ByQqqb6fTA=}
-    engines: {node: '>=6'}
-    peerDependencies:
-      typescript: '>=3'
-    dependencies:
-      typescript: 4.5.5
-    dev: false
-
   /emoji-regex/8.0.0:
     resolution: {integrity: sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=}
     dev: false
@@ -777,34 +771,52 @@ packages:
       once: 1.4.0
     dev: false
 
-  /es-abstract/1.20.4:
-    resolution: {integrity: sha1-HRA/n4141M8HE+3NbQ7RpG7tWGE=}
+  /es-abstract/1.21.1:
+    resolution: {integrity: sha1-5hBaCZlnwIN3gwoMnLWJ1XDdhsY=}
     engines: {node: '>= 0.4'}
     dependencies:
+      available-typed-arrays: 1.0.5
       call-bind: 1.0.2
+      es-set-tostringtag: 2.0.1
       es-to-primitive: 1.2.1
       function-bind: 1.1.1
       function.prototype.name: 1.1.5
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
       get-symbol-description: 1.0.0
+      globalthis: 1.0.3
+      gopd: 1.0.1
       has: 1.0.3
       has-property-descriptors: 1.0.0
+      has-proto: 1.0.1
       has-symbols: 1.0.3
-      internal-slot: 1.0.3
+      internal-slot: 1.0.4
+      is-array-buffer: 3.0.1
       is-callable: 1.2.7
       is-negative-zero: 2.0.2
       is-regex: 1.1.4
       is-shared-array-buffer: 1.0.2
       is-string: 1.0.7
+      is-typed-array: 1.1.10
       is-weakref: 1.0.2
-      object-inspect: 1.12.2
+      object-inspect: 1.12.3
       object-keys: 1.1.1
       object.assign: 4.1.4
       regexp.prototype.flags: 1.4.3
       safe-regex-test: 1.0.0
       string.prototype.trimend: 1.0.6
       string.prototype.trimstart: 1.0.6
+      typed-array-length: 1.0.4
       unbox-primitive: 1.0.2
+      which-typed-array: 1.1.9
+    dev: false
+
+  /es-set-tostringtag/2.0.1:
+    resolution: {integrity: sha1-M41QL29nQwHXELgMhZLeihXwnNg=}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      get-intrinsic: 1.2.0
+      has: 1.0.3
+      has-tostringtag: 1.0.0
     dev: false
 
   /es-to-primitive/1.2.1:
@@ -883,7 +895,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
     dependencies:
-      '@eslint/eslintrc': 1.3.3
+      '@eslint/eslintrc': 1.4.1
       '@humanwhocodes/config-array': 0.9.5
       ajv: 6.12.6
       chalk: 4.1.2
@@ -901,8 +913,8 @@ packages:
       file-entry-cache: 6.0.1
       functional-red-black-tree: 1.0.1
       glob-parent: 6.0.2
-      globals: 13.18.0
-      ignore: 5.2.1
+      globals: 13.19.0
+      ignore: 5.2.4
       import-fresh: 3.3.0
       imurmurhash: 0.1.4
       is-glob: 4.0.3
@@ -926,8 +938,8 @@ packages:
     resolution: {integrity: sha1-UdYJJhVWeiws/3gzRF43wowAZb0=}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      acorn: 8.8.1
-      acorn-jsx: 5.3.2_acorn@8.8.1
+      acorn: 8.8.2
+      acorn-jsx: 5.3.2_acorn@8.8.2
       eslint-visitor-keys: 3.3.0
     dev: false
 
@@ -994,8 +1006,8 @@ packages:
     resolution: {integrity: sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=}
     dev: false
 
-  /fastq/1.13.0:
-    resolution: {integrity: sha1-YWdg+Ip1Jr38WWt8q4wYk4w2uYw=}
+  /fastq/1.15.0:
+    resolution: {integrity: sha1-0E0HxqKmj+RZn+qNLhA6k3+uazo=}
     dependencies:
       reusify: 1.0.4
     dev: false
@@ -1084,7 +1096,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.4
+      es-abstract: 1.21.1
       functions-have-names: 1.2.3
     dev: false
 
@@ -1101,8 +1113,8 @@ packages:
     engines: {node: 6.* || 8.* || >= 10.*}
     dev: false
 
-  /get-intrinsic/1.1.3:
-    resolution: {integrity: sha1-BjyEMprZPoOJPH9PJD72P/o1E4U=}
+  /get-intrinsic/1.2.0:
+    resolution: {integrity: sha1-etHcBTXzopBLugdXcnY+UFH20F8=}
     dependencies:
       function-bind: 1.1.1
       has: 1.0.3
@@ -1114,7 +1126,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
     dev: false
 
   /glob-parent/5.1.2:
@@ -1153,11 +1165,18 @@ packages:
       path-is-absolute: 1.0.1
     dev: false
 
-  /globals/13.18.0:
-    resolution: {integrity: sha1-+yJNrusrt9JUzSxkDwA1KLjQwdw=}
+  /globals/13.19.0:
+    resolution: {integrity: sha1-ekLejmrU9yQvvMon6lsjrKNntcg=}
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.20.2
+    dev: false
+
+  /globalthis/1.0.3:
+    resolution: {integrity: sha1-WFKIKlK4DcMBsGYCc+HtCC8LbM8=}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      define-properties: 1.1.4
     dev: false
 
   /globby/11.1.0:
@@ -1167,9 +1186,15 @@ packages:
       array-union: 2.1.0
       dir-glob: 3.0.1
       fast-glob: 3.2.12
-      ignore: 5.2.1
+      ignore: 5.2.4
       merge2: 1.4.1
       slash: 3.0.0
+    dev: false
+
+  /gopd/1.0.1:
+    resolution: {integrity: sha1-Kf923mnax0ibfAkYpXiOVkd8Myw=}
+    dependencies:
+      get-intrinsic: 1.2.0
     dev: false
 
   /growl/1.10.5:
@@ -1194,7 +1219,12 @@ packages:
   /has-property-descriptors/1.0.0:
     resolution: {integrity: sha1-YQcIYAYG02lh7QTBlhk7amB/qGE=}
     dependencies:
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
+    dev: false
+
+  /has-proto/1.0.1:
+    resolution: {integrity: sha1-GIXBMFU4lYr/Rp/vN5N8InlUCOA=}
+    engines: {node: '>= 0.4'}
     dev: false
 
   /has-symbols/1.0.3:
@@ -1225,8 +1255,8 @@ packages:
     resolution: {integrity: sha1-jrehCmP/8l0VpXsAFYbRd9Gw01I=}
     dev: false
 
-  /ignore/5.2.1:
-    resolution: {integrity: sha1-wrH3bLmZ7eFQLzoiapMQ/f6I1Gw=}
+  /ignore/5.2.4:
+    resolution: {integrity: sha1-opHAxheP8blgvv5H/N7DAWdKYyQ=}
     engines: {node: '>= 4'}
     dev: false
 
@@ -1254,11 +1284,11 @@ packages:
     resolution: {integrity: sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=}
     dev: false
 
-  /internal-slot/1.0.3:
-    resolution: {integrity: sha1-c0fjB97uovqsKsYgXUvH00ln9Zw=}
+  /internal-slot/1.0.4:
+    resolution: {integrity: sha1-hVHnuvdKemul90nPsWqmByLw1vM=}
     engines: {node: '>= 0.4'}
     dependencies:
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
       has: 1.0.3
       side-channel: 1.0.4
     dev: false
@@ -1287,6 +1317,14 @@ packages:
     dependencies:
       call-bind: 1.0.2
       has-tostringtag: 1.0.0
+    dev: false
+
+  /is-array-buffer/3.0.1:
+    resolution: {integrity: sha1-3rHbT8rkgwjVTvJEJwbAOTmXBSo=}
+    dependencies:
+      call-bind: 1.0.2
+      get-intrinsic: 1.2.0
+      is-typed-array: 1.1.10
     dev: false
 
   /is-bigint/1.0.4:
@@ -1407,6 +1445,17 @@ packages:
       has-symbols: 1.0.3
     dev: false
 
+  /is-typed-array/1.1.10:
+    resolution: {integrity: sha1-NqW1y0GJtXXRo+SwhTa/tIWAHj8=}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      available-typed-arrays: 1.0.5
+      call-bind: 1.0.2
+      for-each: 0.3.3
+      gopd: 1.0.1
+      has-tostringtag: 1.0.0
+    dev: false
+
   /is-unc-path/1.0.0:
     resolution: {integrity: sha1-1zHoiY7QkKEsNSrS6u1Qla0yLJ0=}
     engines: {node: '>=0.10.0'}
@@ -1495,7 +1544,7 @@ packages:
     dependencies:
       ansi-escapes: 5.0.0
       cardinal: 2.1.1
-      chalk: 5.1.2
+      chalk: 5.2.0
       cli-table3: 0.6.3
       marked: 4.0.12
       node-emoji: 1.11.0
@@ -1552,6 +1601,10 @@ packages:
 
   /minimist/1.2.6:
     resolution: {integrity: sha1-hjelt1nqDW6YcCz7OpKDMjyTr0Q=}
+    dev: false
+
+  /minimist/1.2.7:
+    resolution: {integrity: sha1-2qHE2R9Qc5BDfGqLwBB45wAMTRg=}
     dev: false
 
   /mkdirp/1.0.4:
@@ -1626,8 +1679,8 @@ packages:
       lodash: 4.17.21
     dev: false
 
-  /node-fetch/2.6.7:
-    resolution: {integrity: sha1-JN6fuoJ+O0rkTciyAlajeRYAUq0=}
+  /node-fetch/2.6.8:
+    resolution: {integrity: sha1-po0wsWK8HY/XGjZ+gbmX4fTUk34=}
     engines: {node: 4.x || >=6.0.0}
     peerDependencies:
       encoding: ^0.1.0
@@ -1643,8 +1696,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /object-inspect/1.12.2:
-    resolution: {integrity: sha1-wGQfJjlFMvKKuNeWq5VOQ8AJqOo=}
+  /object-inspect/1.12.3:
+    resolution: {integrity: sha1-umLf/WfuJWyMCG365p4BbNHxmLk=}
     dev: false
 
   /object-is/1.1.5:
@@ -1747,8 +1800,8 @@ packages:
     resolution: {integrity: sha1-0N8qE38AeUVl/K87LADNCfjVpac=}
     dev: false
 
-  /punycode/2.1.1:
-    resolution: {integrity: sha1-tYsBCsQMIsVldhbI0sLALHv0eew=}
+  /punycode/2.3.0:
+    resolution: {integrity: sha1-9n+mfJTaj00M//mBruQRgGQZm48=}
     engines: {node: '>=6'}
     dev: false
 
@@ -1847,7 +1900,7 @@ packages:
     resolution: {integrity: sha1-eTuHTVJOs2QNGHOq0DWW2y1PIpU=}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
       is-regex: 1.1.4
     dev: false
 
@@ -1908,8 +1961,8 @@ packages:
     resolution: {integrity: sha1-785cj9wQTudRslxY1CkAEfpeos8=}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.1.3
-      object-inspect: 1.12.2
+      get-intrinsic: 1.2.0
+      object-inspect: 1.12.3
     dev: false
 
   /slash/3.0.0:
@@ -1948,7 +2001,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.4
+      es-abstract: 1.21.1
     dev: false
 
   /string.prototype.trimend/1.0.6:
@@ -1956,7 +2009,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.4
+      es-abstract: 1.21.1
     dev: false
 
   /string.prototype.trimstart/1.0.6:
@@ -1964,7 +2017,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.4
+      es-abstract: 1.21.1
     dev: false
 
   /strip-ansi/6.0.1:
@@ -2013,8 +2066,8 @@ packages:
     engines: {node: '>= 0.4'}
     dev: false
 
-  /tape/4.16.1:
-    resolution: {integrity: sha1-jVEbOgvhowRBiFlyBHwdrIIv2b4=}
+  /tape/4.16.2:
+    resolution: {integrity: sha1-dWXmryBCZWVVcmbp3achWGmyl7Y=}
     hasBin: true
     dependencies:
       call-bind: 1.0.2
@@ -2026,8 +2079,8 @@ packages:
       has: 1.0.3
       inherits: 2.0.4
       is-regex: 1.1.4
-      minimist: 1.2.6
-      object-inspect: 1.12.2
+      minimist: 1.2.7
+      object-inspect: 1.12.3
       resolve: 1.22.1
       resumer: 0.0.0
       string.prototype.trim: 1.2.7
@@ -2055,7 +2108,7 @@ packages:
     dependencies:
       ip-regex: 2.1.0
       psl: 1.9.0
-      punycode: 2.1.1
+      punycode: 2.3.0
     dev: false
 
   /tr46/0.0.3:
@@ -2128,6 +2181,14 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
+  /typed-array-length/1.0.4:
+    resolution: {integrity: sha1-idg3heXECYvscuCLMZZR8OrJwbs=}
+    dependencies:
+      call-bind: 1.0.2
+      for-each: 0.3.3
+      is-typed-array: 1.1.10
+    dev: false
+
   /typescript/4.1.6:
     resolution: {integrity: sha1-G+zYXXdWfDx0EXIznpPOLmmTITg=}
     engines: {node: '>=4.2.0'}
@@ -2164,7 +2225,7 @@ packages:
   /uri-js/4.4.1:
     resolution: {integrity: sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=}
     dependencies:
-      punycode: 2.1.1
+      punycode: 2.3.0
     dev: false
 
   /uuid/8.3.2:
@@ -2199,6 +2260,18 @@ packages:
       is-number-object: 1.0.7
       is-string: 1.0.7
       is-symbol: 1.0.4
+    dev: false
+
+  /which-typed-array/1.1.9:
+    resolution: {integrity: sha1-MHz4mAJYSM+ZXnlehCPH8zfvveY=}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      available-typed-arrays: 1.0.5
+      call-bind: 1.0.2
+      for-each: 0.3.3
+      gopd: 1.0.1
+      has-tostringtag: 1.0.0
+      is-typed-array: 1.1.10
     dev: false
 
   /which/2.0.2:
@@ -2304,7 +2377,7 @@ packages:
       end-of-stream: 1.4.4
       fs-constants: 1.0.0
       inherits: 2.0.4
-      tape: 4.16.1
+      tape: 4.16.2
     dev: false
 
   file:projects/vcpkg-ce.test.tgz:
@@ -2331,7 +2404,7 @@ packages:
     dev: false
 
   file:projects/vcpkg-ce.tgz:
-    resolution: {integrity: sha512-O5GxN+ZoF3hquqt2ub09md3GjVfGH9yfH3MYDTa4hB8NF69g7tunlrBPZ6qFOdx/71FchtIWuDvA2MO2oAJgHw==, tarball: file:projects/vcpkg-ce.tgz}
+    resolution: {integrity: sha512-8/AkMQQI9607q4wrxkqQd5oW4w28Y9KIbZakDgxUNZFxHqnRnQaaY4kvjoAJn9zIG70ecIDklugDtRvI82gMfw==, tarball: file:projects/vcpkg-ce.tgz}
     name: '@rush-temp/vcpkg-ce'
     version: 0.0.0
     dependencies:
@@ -2347,7 +2420,6 @@ packages:
       '@typescript-eslint/parser': 5.10.2_eslint@8.8.0+typescript@4.5.5
       chalk: 4.1.2
       cli-progress: 3.11.1
-      ee-ts: 2.0.0-rc.6_typescript@4.5.5
       eslint: 8.8.0
       eslint-plugin-notice: 0.9.10_eslint@8.8.0
       marked: 4.0.12


### PR DESCRIPTION
Fixes signed builds. The previous prepare-deploy was attempting to remove what it thought was a phantom dependency on the typescript compiler from the deployed output. This failed because the DevDiv build lab pushed out changes that blocked the unrestrained dependency on rimraf used by that script. This change drops the dependency on ee-ts which created the need to include the typescript compiler in the first place.

Also fixed test failures that ee-ts was apparently hiding?!