### PR TITLE
Add arch support for vcpkgTools.xml

### DIFF
--- a/azure-pipelines/end-to-end-tests-dir/fetch.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/fetch.ps1
@@ -64,7 +64,7 @@ if (-not $IsMacOS -and -not $IsLinux) {
     $env:VCPKG_DOWNLOADS = Join-Path $TestingRoot 'down loads'
     Run-Vcpkg -TestArgs ($commonArgs + @("fetch", "7zip", "--vcpkg-root=$TestingRoot"))
     Throw-IfFailed
-    Require-FileExists "$TestingRoot/down loads/tools/7zip-19.00-windows/Files/7-Zip/7z.exe"
+    Require-FileExists "$TestingRoot/down loads/tools/7zip-19.00-windows-generic/Files/7-Zip/7z.exe"
 
     Run-Vcpkg -TestArgs ($commonArgs + @("fetch", "ninja-testing", "--vcpkg-root=$TestingRoot"))
     Throw-IfFailed
@@ -75,12 +75,12 @@ if (-not $IsMacOS -and -not $IsLinux) {
     $env:PATH = "$path;$TestingRoot/down loads/tools/ninja-testing-1.10.2-windows"
     Run-Vcpkg -TestArgs ($commonArgs + @("fetch", "ninja", "--vcpkg-root=$TestingRoot"))
     Throw-IfFailed
-    Require-FileNotExists "$TestingRoot/down loads/tools/ninja-1.10.2-windows/ninja.exe"
+    Require-FileNotExists "$TestingRoot/down loads/tools/ninja-1.10.2-windows-generic/ninja.exe"
 
     $env:VCPKG_FORCE_DOWNLOADED_BINARIES = "1"
     Run-Vcpkg -TestArgs ($commonArgs + @("fetch", "ninja", "--vcpkg-root=$TestingRoot"))
     Throw-IfFailed
-    Require-FileExists "$TestingRoot/down loads/tools/ninja-1.10.2-windows/ninja.exe"
+    Require-FileExists "$TestingRoot/down loads/tools/ninja-1.10.2-windows-generic/ninja.exe"
 
     Remove-Item -Recurse -Force "$TestingRoot/down loads/tools/ninja-1.10.2-windows" -ErrorAction SilentlyContinue
     Remove-Item env:VCPKG_FORCE_DOWNLOADED_BINARIES
@@ -89,7 +89,7 @@ if (-not $IsMacOS -and -not $IsLinux) {
     $env:PATH = "$PSScriptRoot\..\e2e_assets\fetch;$path"
     Run-Vcpkg -TestArgs ($commonArgs + @("fetch", "ninja", "--vcpkg-root=$TestingRoot"))
     Throw-IfFailed
-    Require-FileNotExists "$TestingRoot/down loads/tools/ninja-1.10.2-windows/ninja.exe"
+    Require-FileNotExists "$TestingRoot/down loads/tools/ninja-1.10.2-windows-generic/ninja.exe"
 
     Remove-Item env:VCPKG_FORCE_SYSTEM_BINARIES
     $out = Run-VcpkgAndCaptureOutput -TestArgs ($commonArgs + @("fetch", "ninja", "--vcpkg-root=$TestingRoot", "--x-stderr-status"))

--- a/azure-pipelines/end-to-end-tests-dir/fetch.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/fetch.ps1
@@ -68,11 +68,11 @@ if (-not $IsMacOS -and -not $IsLinux) {
 
     Run-Vcpkg -TestArgs ($commonArgs + @("fetch", "ninja-testing", "--vcpkg-root=$TestingRoot"))
     Throw-IfFailed
-    Require-FileExists "$TestingRoot/down loads/tools/ninja-testing-1.10.2-windows/ninja.exe"
+    Require-FileExists "$TestingRoot/down loads/tools/ninja-testing-1.10.2-windows-generic/ninja.exe"
 
     $path = $env:PATH
 
-    $env:PATH = "$path;$TestingRoot/down loads/tools/ninja-testing-1.10.2-windows"
+    $env:PATH = "$path;$TestingRoot/down loads/tools/ninja-testing-1.10.2-windows-generic"
     Run-Vcpkg -TestArgs ($commonArgs + @("fetch", "ninja", "--vcpkg-root=$TestingRoot"))
     Throw-IfFailed
     Require-FileNotExists "$TestingRoot/down loads/tools/ninja-1.10.2-windows-generic/ninja.exe"
@@ -82,7 +82,7 @@ if (-not $IsMacOS -and -not $IsLinux) {
     Throw-IfFailed
     Require-FileExists "$TestingRoot/down loads/tools/ninja-1.10.2-windows-generic/ninja.exe"
 
-    Remove-Item -Recurse -Force "$TestingRoot/down loads/tools/ninja-1.10.2-windows" -ErrorAction SilentlyContinue
+    Remove-Item -Recurse -Force "$TestingRoot/down loads/tools/ninja-1.10.2-windows-generic" -ErrorAction SilentlyContinue
     Remove-Item env:VCPKG_FORCE_DOWNLOADED_BINARIES
 
     $env:VCPKG_FORCE_SYSTEM_BINARIES = "1"

--- a/azure-pipelines/signing.yml
+++ b/azure-pipelines/signing.yml
@@ -290,6 +290,15 @@ jobs:
           cmake.exe -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DVCPKG_DEVELOPMENT_WARNINGS=ON -DVCPKG_WARNINGS_AS_ERRORS=ON -DVCPKG_BUILD_FUZZING=OFF -DVCPKG_BUILD_TLS12_DOWNLOADER=ON -DVCPKG_EMBED_GIT_SHA=ON -DVCPKG_OFFICIAL_BUILD=ON "-DVCPKG_FMT_URL=$(fmt-tarball-url)" "-DVCPKG_CMAKERC_URL=$(cmakerc-tarball-url)" "-DVCPKG_BASE_VERSION=$(VCPKG_BASE_VERSION)" "-DVCPKG_STANDALONE_BUNDLE_SHA=$(VCPKG_STANDALONE_BUNDLE_SHA)" "-DVCPKG_CE_SHA=$(VCPKG_CE_SHA)" -B "$(Build.BinariesDirectory)\x86"
           ninja.exe -C "$(Build.BinariesDirectory)\x86"
     - task: CmdLine@2
+      displayName: "Build vcpkg x64 with CMake"
+      inputs:
+        failOnStderr: true
+        script: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=x64 -host_arch=x86
+          cmake.exe --version
+          cmake.exe -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DVCPKG_DEVELOPMENT_WARNINGS=ON -DVCPKG_WARNINGS_AS_ERRORS=ON -DVCPKG_BUILD_FUZZING=OFF -DVCPKG_BUILD_TLS12_DOWNLOADER=ON -DVCPKG_EMBED_GIT_SHA=ON -DVCPKG_OFFICIAL_BUILD=ON -DVCPKG_PDB_SUFFIX="-win64" "-DVCPKG_FMT_URL=$(fmt-tarball-url)" "-DVCPKG_CMAKERC_URL=$(cmakerc-tarball-url)" "-DVCPKG_BASE_VERSION=$(VCPKG_BASE_VERSION)" "-DVCPKG_STANDALONE_BUNDLE_SHA=$(VCPKG_STANDALONE_BUNDLE_SHA)" "-DVCPKG_CE_SHA=$(VCPKG_CE_SHA)" -B "$(Build.BinariesDirectory)\x64"
+          ninja.exe -C "$(Build.BinariesDirectory)\x64"
+    - task: CmdLine@2
       displayName: "Build vcpkg arm64 with CMake"
       inputs:
         failOnStderr: true

--- a/include/vcpkg/tools.test.h
+++ b/include/vcpkg/tools.test.h
@@ -29,7 +29,8 @@ namespace vcpkg
         Path exe_path(const Path& tools_base_path) const { return tools_base_path / tool_dir_subpath / exe_subpath; }
     };
 
-    Optional<ToolData> parse_tool_data_from_xml(StringView XML, StringView XML_PATH, StringView tool, StringView os, StringView arch);
+    Optional<ToolData> parse_tool_data_from_xml(
+        StringView XML, StringView XML_PATH, StringView tool, StringView os, StringView arch);
 
     Optional<std::array<int, 3>> parse_tool_version_string(StringView string_version);
 }

--- a/include/vcpkg/tools.test.h
+++ b/include/vcpkg/tools.test.h
@@ -29,7 +29,7 @@ namespace vcpkg
         Path exe_path(const Path& tools_base_path) const { return tools_base_path / tool_dir_subpath / exe_subpath; }
     };
 
-    Optional<ToolData> parse_tool_data_from_xml(StringView XML, StringView XML_PATH, StringView tool, StringView os);
+    Optional<ToolData> parse_tool_data_from_xml(StringView XML, StringView XML_PATH, StringView tool, StringView os, StringView arch);
 
     Optional<std::array<int, 3>> parse_tool_version_string(StringView string_version);
 }

--- a/src/vcpkg-test/tools.cpp
+++ b/src/vcpkg-test/tools.cpp
@@ -58,13 +58,25 @@ TEST_CASE ("parse_tool_data_from_xml", "[tools]")
         <url></url>
         <sha512></sha512>
     </tool>
-    <tool name="nuget" os="osx">
+    <tool name="git" os="linux" arch="arm64">
+        <version>3.9.9</version>
+        <exeRelativePath></exeRelativePath>
+        <url></url>
+        <sha512></sha512>
+    </tool>
+    <tool name="nuget" os="osx" arch="x64">
         <version>5.11.0</version>
         <exeRelativePath>nuget.exe</exeRelativePath>
         <url>https://dist.nuget.org/win-x86-commandline/v5.11.0/nuget.exe</url>
         <sha512>06a337c9404dec392709834ef2cdbdce611e104b510ef40201849595d46d242151749aef65bc2d7ce5ade9ebfda83b64c03ce14c8f35ca9957a17a8c02b8c4b7</sha512>
     </tool>
-    <tool name="node" os="windows">
+    <tool name="nuget" os="osx" arch="x86">
+        <version>5.11.0</version>
+        <exeRelativePath>nuget.exe</exeRelativePath>
+        <url>https://dist.nuget.org/win-x86-commandline/v5.11.0/nuget.exe</url>
+        <sha512>06a337c9404dec392709834ef2cdbdce611e104b510ef40201849595d46d242151749aef65bc2d7ce5ade9ebfda83b64c03ce14c8f35ca9957a17a8c02b8c4b7</sha512>
+    </tool>
+    <tool name="node" os="windows" arch="x64">
         <version>16.12.0</version>
         <exeRelativePath>node-v16.12.0-win-x64\node.exe</exeRelativePath>
         <url>https://nodejs.org/dist/v16.12.0/node-v16.12.0-win-x64.7z</url>
@@ -75,20 +87,28 @@ TEST_CASE ("parse_tool_data_from_xml", "[tools]")
 )";
 
     {
-        auto data = parse_tool_data_from_xml(tool_doc, "vcpkgTools.xml", "tool1", "windows");
+        auto data = parse_tool_data_from_xml(tool_doc, "vcpkgTools.xml", "tool1", "windows", "x86");
         REQUIRE(!data.has_value());
     }
     {
-        auto data = parse_tool_data_from_xml(tool_doc, "vcpkgTools.xml", "node", "unknown");
+        auto data = parse_tool_data_from_xml(tool_doc, "vcpkgTools.xml", "tool1", "windows", "arm64");
         REQUIRE(!data.has_value());
     }
     {
-        auto data = parse_tool_data_from_xml(tool_doc, "vcpkgTools.xml", "node", "windows");
+        auto data = parse_tool_data_from_xml(tool_doc, "vcpkgTools.xml", "node", "unknown", "unknown");
+        REQUIRE(!data.has_value());
+    }
+    {
+        auto data = parse_tool_data_from_xml(tool_doc, "vcpkgTools.xml", "nuget", "osx", "arm64");
+        REQUIRE(!data.has_value());
+    }
+    {
+        auto data = parse_tool_data_from_xml(tool_doc, "vcpkgTools.xml", "node", "windows", "x64");
         REQUIRE(data.has_value());
         auto& p = *data.get();
         CHECK(p.is_archive);
         CHECK(p.version == decltype(p.version){16, 12, 0});
-        CHECK(p.tool_dir_subpath == "node-16.12.0-windows");
+        CHECK(p.tool_dir_subpath == "node-16.12.0-windows-x64");
         CHECK(p.exe_subpath == "node-v16.12.0-win-x64\\node.exe");
         CHECK(p.download_subpath == "node-v16.12.0-win-x64.7z");
         CHECK(p.sha512 == "0bb793fce8140bd59c17f3ac9661b062eac0f611d704117774f5cb2453d717da94b1e8b17d021d47baff598dc023"
@@ -96,12 +116,12 @@ TEST_CASE ("parse_tool_data_from_xml", "[tools]")
         CHECK(p.url == "https://nodejs.org/dist/v16.12.0/node-v16.12.0-win-x64.7z");
     }
     {
-        auto data = parse_tool_data_from_xml(tool_doc, "vcpkgTools.xml", "nuget", "osx");
+        auto data = parse_tool_data_from_xml(tool_doc, "vcpkgTools.xml", "nuget", "osx", "x86");
         REQUIRE(data.has_value());
         auto& p = *data.get();
         CHECK_FALSE(p.is_archive);
         CHECK(p.version == decltype(p.version){5, 11, 0});
-        CHECK(p.tool_dir_subpath == "nuget-5.11.0-osx");
+        CHECK(p.tool_dir_subpath == "nuget-5.11.0-osx-x86");
         CHECK(p.exe_subpath == "nuget.exe");
         CHECK(p.download_subpath == "06a337c9-nuget.exe");
         CHECK(p.sha512 == "06a337c9404dec392709834ef2cdbdce611e104b510ef40201849595d46d242151749aef65bc2d7ce5ade9ebfda8"
@@ -109,12 +129,49 @@ TEST_CASE ("parse_tool_data_from_xml", "[tools]")
         CHECK(p.url == "https://dist.nuget.org/win-x86-commandline/v5.11.0/nuget.exe");
     }
     {
-        auto data = parse_tool_data_from_xml(tool_doc, "vcpkgTools.xml", "git", "linux");
+        auto data = parse_tool_data_from_xml(tool_doc, "vcpkgTools.xml", "nuget", "osx", "x64");
+        REQUIRE(data.has_value());
+        auto& p = *data.get();
+        CHECK_FALSE(p.is_archive);
+        CHECK(p.version == decltype(p.version){5, 11, 0});
+        CHECK(p.tool_dir_subpath == "nuget-5.11.0-osx-x64");
+        CHECK(p.exe_subpath == "nuget.exe");
+        CHECK(p.download_subpath == "06a337c9-nuget.exe");
+        CHECK(p.sha512 == "06a337c9404dec392709834ef2cdbdce611e104b510ef40201849595d46d242151749aef65bc2d7ce5ade9ebfda8"
+                          "3b64c03ce14c8f35ca9957a17a8c02b8c4b7");
+        CHECK(p.url == "https://dist.nuget.org/win-x86-commandline/v5.11.0/nuget.exe");
+    }
+    {
+        auto data = parse_tool_data_from_xml(tool_doc, "vcpkgTools.xml", "git", "linux", "x86");
         REQUIRE(data.has_value());
         auto& p = *data.get();
         CHECK_FALSE(p.is_archive);
         CHECK(p.version == decltype(p.version){2, 7, 4});
-        CHECK(p.tool_dir_subpath == "git-2.7.4-linux");
+        CHECK(p.tool_dir_subpath == "git-2.7.4-linux-generic");
+        CHECK(p.exe_subpath == "");
+        CHECK(p.download_subpath == "");
+        CHECK(p.sha512 == "");
+        CHECK(p.url == "");
+    }
+    {
+        auto data = parse_tool_data_from_xml(tool_doc, "vcpkgTools.xml", "git", "linux", "x64");
+        REQUIRE(data.has_value());
+        auto& p = *data.get();
+        CHECK_FALSE(p.is_archive);
+        CHECK(p.version == decltype(p.version){2, 7, 4});
+        CHECK(p.tool_dir_subpath == "git-2.7.4-linux-generic");
+        CHECK(p.exe_subpath == "");
+        CHECK(p.download_subpath == "");
+        CHECK(p.sha512 == "");
+        CHECK(p.url == "");
+    }
+    {
+        auto data = parse_tool_data_from_xml(tool_doc, "vcpkgTools.xml", "git", "linux", "arm64");
+        REQUIRE(data.has_value());
+        auto& p = *data.get();
+        CHECK_FALSE(p.is_archive);
+        CHECK(p.version == decltype(p.version){3, 9, 9});
+        CHECK(p.tool_dir_subpath == "git-3.9.9-linux-arm64");
         CHECK(p.exe_subpath == "");
         CHECK(p.download_subpath == "");
         CHECK(p.sha512 == "");


### PR DESCRIPTION
Makes vcpkgTools.xml arch aware. Not specifying an `arch=` field means that the tool is generic and works on any architecture. Tools with a specific architecture take precedence over generic tools.

Currently supported archs are: `x86`, `x64`, and `arm64`.

Marked as draft for now because vcpkg-tool releases will need to build a Windows x64 version of vcpkg as well, because this checks for the target architecture at compile time.