### PR TITLE
Avoid needing to triple escape paths in z-applocal tests.

### DIFF
--- a/azure-pipelines/e2e_projects/applocal-test/build/build.bat
+++ b/azure-pipelines/e2e_projects/applocal-test/build/build.bat
@@ -1,3 +1,3 @@
-cd %1
+cd %~dp0
 cl /LD mylib.cpp
 cl /EHsc main.cpp mylib.lib

--- a/azure-pipelines/e2e_projects/applocal-test/plugins/azure_kinect_sensor_sdk/build.bat
+++ b/azure-pipelines/e2e_projects/applocal-test/plugins/azure_kinect_sensor_sdk/build.bat
@@ -1,4 +1,4 @@
-cd %1
+cd %~dp0
 cl /LD k4a.cpp
 cl /LD depthengine_2_0.cpp
 cl /EHsc main.cpp k4a.lib depthengine_2_0.lib

--- a/azure-pipelines/end-to-end-tests-dir/z-applocalcpp.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/z-applocalcpp.ps1
@@ -5,8 +5,8 @@ if ($IsWindows) {
     $buildDir = "$PSScriptRoot/../e2e_projects/applocal-test/build"
     $pluginsDir = "$PSScriptRoot/../e2e_projects/applocal-test/plugins"
 
-    Run-Vcpkg env "`"$buildDir/build.bat`" `"$buildDir`""
-    Run-Vcpkg env "`"$pluginsDir/azure_kinect_sensor_sdk/build.bat`" `"$pluginsDir`""
+    Run-Vcpkg env "$buildDir/build.bat"
+    Run-Vcpkg env "$pluginsDir/azure_kinect_sensor_sdk/build.bat"
 
     # Tests z-applocal command
     Run-Vcpkg z-applocal `


### PR DESCRIPTION
In https://github.com/microsoft/vcpkg-tool/pull/864#issuecomment-1404436205 I noted that these tests fail on my machine before making any changes; I'm not sure why, but when I try to run with cmd manually (outside of vcpkg env) I get the same "the filename, directory name, or volume label syntax is incorrect" error that vcpkg env gives.

This change just makes the batch files know the right path to use themselves rather than needing it passed in by the caller, so we don't need to deal with so many levels of confusing escaping.