### PR TITLE
Fix removal of unreadable directories

### DIFF
--- a/src/vcpkg-test/files.cpp
+++ b/src/vcpkg-test/files.cpp
@@ -146,6 +146,15 @@ namespace
                     FAIL("chmod failed with " << failure_message);
                 }
             }
+            if (urbg() & 2u)
+            {
+                const auto chmod_result = ::chmod(base.c_str(), 0000); // e.g. bazel sandbox
+                if (chmod_result != 0)
+                {
+                    const auto failure_message = std::generic_category().message(errno);
+                    FAIL("chmod failed with " << failure_message);
+                }
+            }
 #endif // ^^^ !_WIN32
         }
 

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -856,11 +856,11 @@ namespace
 
     void vcpkg_remove_all_directory(const Path& base, std::error_code& ec, Path& failure_point, struct stat& base_lstat)
     {
-        // ensure that the directory is writable and executable
+        // ensure that the directory is readable, writable and executable
         // NOTE: the execute bit on directories is needed to allow opening files inside of that directory
-        if ((base_lstat.st_mode & (S_IWUSR | S_IXUSR)) != (S_IWUSR | S_IXUSR))
+        if ((base_lstat.st_mode & (S_IRUSR | S_IWUSR | S_IXUSR)) != (S_IRUSR | S_IWUSR | S_IXUSR))
         {
-            if (::chmod(base.c_str(), base_lstat.st_mode | S_IWUSR | S_IXUSR) != 0)
+            if (::chmod(base.c_str(), base_lstat.st_mode | S_IRUSR | S_IWUSR | S_IXUSR) != 0)
             {
                 ec.assign(errno, std::generic_category());
                 mark_recursive_error(base, ec, failure_point);


### PR DESCRIPTION
If you cannot read a dir, you cannot deal with its entries (without knowing them in advance). 
To fix CI errors after failed bazel build in previous run. Example from [x64-linux raw log](https://dev.azure.com/vcpkg/public/_build/results?buildId=84154&view=logs&j=f79cfdd7-47a8-597f-8f57-dc3e21a8f2ad):
~~~
2023-01-25T08:40:22.5334048Z ##[section]Starting: *** Test Modified Ports
2023-01-25T08:40:22.5340577Z ==============================================================================
2023-01-25T08:40:22.5340937Z Task         : PowerShell
2023-01-25T08:40:22.5341095Z Description  : Run a PowerShell script on Linux, macOS, or Windows
2023-01-25T08:40:22.5341325Z Version      : 2.212.0
2023-01-25T08:40:22.5341482Z Author       : Microsoft Corporation
2023-01-25T08:40:22.5341634Z Help         : https://docs.microsoft.com/azure/devops/pipelines/tasks/utility/powershell
2023-01-25T08:40:22.5341888Z ==============================================================================
2023-01-25T08:41:03.5357067Z ##[warning]Failed to publish telemetry data. Error Service Unavailable
2023-01-25T08:41:03.6251819Z Generating script.
2023-01-25T08:41:03.6273532Z ========================== Starting Command Output ===========================
2023-01-25T08:41:03.6280153Z [command]/usr/bin/pwsh -NoLogo -NoProfile -NonInteractive -Command . '/agent/_work/_temp/1e986dd9-1af6-4d54-86dd-44d6f99a3017.ps1'
2023-01-25T08:41:03.9455123Z Build reason was Pull Request, using binary caching in read write mode, skipping failures.
2023-01-25T08:41:03.9502334Z Clearing contents of /mnt/vcpkg-ci/buildtrees
2023-01-25T08:41:15.7025931Z Failure to remove_all_inside("/mnt/vcpkg-ci/buildtrees") due to file "/mnt/vcpkg-ci/buildtrees/tensorflow-cc/.bzl/353ecfe648b6ff04087186cd23694d8c/sandbox/inaccessibleHelperDir": Permission denied
2023-01-25T08:41:15.8325513Z [31;1mException: [0m/agent/_work/1/s/scripts/azure-pipelines/test-modified-ports.ps1:133[0m
2023-01-25T08:41:15.8327108Z [31;1m[0m[36;1mLine |[0m
2023-01-25T08:41:15.8328449Z [31;1m[0m[36;1m[36;1m 133 | [0m     [36;1mthrow "vcpkg clean failed"[0m
2023-01-25T08:41:15.8329513Z [31;1m[0m[36;1m[36;1m[0m[36;1m[0m[36;1m     | [31;1m     ~~~~~~~~~~~~~~~~~~~~~~~~~~[0m
2023-01-25T08:41:15.8330210Z [31;1m[0m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m     | [31;1mvcpkg clean failed[0m
2023-01-25T08:41:16.2238645Z ##[error]PowerShell exited with code '1'.
2023-01-25T08:41:16.2243729Z ##[error]PowerShell wrote one or more lines to the standard error stream.
2023-01-25T08:41:16.2246636Z ##[error][31;1mException: [0m/agent/_work/1/s/scripts/azure-pipelines/test-modified-ports.ps1:133[0m
[31;1m[0m[36;1mLine |[0m
[31;1m[0m[36;1m[36;1m 133 | [0m     [36;1mthrow "vcpkg clean failed"[0m
[31;1m[0m[36;1m[36;1m[0m[36;1m[0m[36;1m     | [31;1m     ~~~~~~~~~~~~~~~~~~~~~~~~~~[0m
[31;1m[0m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m     | [31;1mvcpkg clean failed[0m

2023-01-25T08:41:16.2249738Z ##[section]Finishing: *** Test Modified Ports
~~~
AFAIU that particular ran into yesterday's global Microsoft services problem.