### PR TITLE
vcpkg upgrade: Handle the removal of features in new port versions

### DIFF
--- a/src/vcpkg-test/plan.cpp
+++ b/src/vcpkg-test/plan.cpp
@@ -1265,6 +1265,25 @@ TEST_CASE ("basic upgrade scheme with features", "[plan]")
     features_check(plan.install_actions.at(0), "a", {"core", "a1"});
 }
 
+TEST_CASE ("basic upgrade scheme with removed features", "[plan]")
+{
+    std::vector<std::unique_ptr<StatusParagraph>> pghs;
+    pghs.push_back(make_status_pgh("a"));
+    pghs.push_back(make_status_feature_pgh("a", "a1"));
+    StatusParagraphs status_db(std::move(pghs));
+
+    PackageSpecMap spec_map;
+    auto spec_a = spec_map.emplace("a");
+
+    MapPortFileProvider provider(spec_map.map);
+    MockCMakeVarProvider var_provider;
+    auto plan = create_upgrade_plan(provider, var_provider, {spec_a}, status_db);
+
+    REQUIRE(plan.size() == 2);
+    remove_plan_check(plan.remove_actions.at(0), "a");
+    features_check(plan.install_actions.at(0), "a", {"core"});
+}
+
 TEST_CASE ("basic upgrade scheme with new default feature", "[plan]")
 {
     // only core of package "a" is installed

--- a/src/vcpkg/dependencies.cpp
+++ b/src/vcpkg/dependencies.cpp
@@ -183,9 +183,12 @@ namespace vcpkg
                 bool defaults_requested = false;
                 if (const ClusterInstalled* inst = m_installed.get())
                 {
+                    out_reinstall_requirements.emplace_back(m_spec, "core");
+                    auto& scfl = get_scfl_or_exit();
                     for (const std::string& installed_feature : inst->original_features)
                     {
-                        out_reinstall_requirements.emplace_back(m_spec, installed_feature);
+                        if (scfl.source_control_file->find_feature(installed_feature).has_value())
+                            out_reinstall_requirements.emplace_back(m_spec, installed_feature);
                     }
                     defaults_requested = inst->defaults_requested;
                 }


### PR DESCRIPTION
Currently the command simply fails to execute.