### PR TITLE
Delete vestigial alias port parts

### DIFF
--- a/include/vcpkg/base/messages.h
+++ b/include/vcpkg/base/messages.h
@@ -2186,11 +2186,6 @@ namespace vcpkg
     DECLARE_MESSAGE(PortsRemoved, (msg::count), "", "The following {count} ports were removed:");
     DECLARE_MESSAGE(PortsUpdated, (msg::count), "", "\nThe following {count} ports were updated:");
     DECLARE_MESSAGE(PortSupportsField, (msg::supports_expression), "", "(supports: \"{supports_expression}\")");
-    DECLARE_MESSAGE(PortTypeConflict,
-                    (msg::spec),
-                    "",
-                    "The port type of {spec} differs between the installed and available portfile.\nPlease manually "
-                    "remove {spec} and re-run this command.");
     DECLARE_MESSAGE(PortVersionConflict, (), "", "The following packages differ from their port versions:");
     DECLARE_MESSAGE(PrebuiltPackages, (), "", "There are packages that have not been built. To build them run:");
     DECLARE_MESSAGE(PreviousIntegrationFileRemains, (), "", "Previous integration file was not removed.");

--- a/include/vcpkg/base/system.process.h
+++ b/include/vcpkg/base/system.process.h
@@ -18,12 +18,14 @@ namespace vcpkg
     {
         CMakeVariable(const StringView varname, const char* varvalue);
         CMakeVariable(const StringView varname, const std::string& varvalue);
+        CMakeVariable(const StringView varname, StringLiteral varvalue);
         CMakeVariable(const StringView varname, const Path& varvalue);
-        CMakeVariable(std::string var);
+        CMakeVariable(const std::string& var);
 
         std::string s;
     };
 
+    std::string format_cmake_variable(StringView key, StringView value);
     void append_shell_escaped(std::string& target, StringView content);
 
     struct Command

--- a/include/vcpkg/binaryparagraph.h
+++ b/include/vcpkg/binaryparagraph.h
@@ -43,7 +43,6 @@ namespace vcpkg
         std::vector<std::string> default_features;
         std::vector<PackageSpec> dependencies;
         std::string abi;
-        Type type = {Type::PORT};
     };
 
     bool operator==(const BinaryParagraph&, const BinaryParagraph&);

--- a/include/vcpkg/build.h
+++ b/include/vcpkg/build.h
@@ -65,7 +65,8 @@ namespace vcpkg
                               Triplet host_triplet);
     } // namespace vcpkg::Build
 
-    const std::string& to_string(DownloadTool tool);
+    StringLiteral to_string_view(DownloadTool tool);
+    std::string to_string(DownloadTool tool);
 
     struct BuildPackageOptions
     {
@@ -211,7 +212,8 @@ namespace vcpkg
     // could be constexpr, but we want to generate this and that's not constexpr in C++14
     extern const std::array<BuildPolicy, size_t(BuildPolicy::COUNT)> ALL_POLICIES;
 
-    const std::string& to_string(BuildPolicy policy);
+    StringLiteral to_string_view(BuildPolicy policy);
+    std::string to_string(BuildPolicy policy);
     ZStringView to_cmake_variable(BuildPolicy policy);
 
     struct BuildPolicies

--- a/include/vcpkg/paragraphparser.h
+++ b/include/vcpkg/paragraphparser.h
@@ -22,7 +22,7 @@ namespace vcpkg
         std::string name;
         std::vector<std::string> missing_fields;
         std::vector<std::string> extra_fields;
-        std::map<std::string, std::string> expected_types;
+        std::map<StringLiteral, std::string, std::less<>> expected_types;
         std::vector<std::string> other_errors;
         std::string error;
 
@@ -46,27 +46,27 @@ namespace vcpkg
     template<class P>
     using ParseExpected = vcpkg::ExpectedT<std::unique_ptr<P>, std::unique_ptr<ParseControlErrorInfo>>;
 
-    using Paragraph = std::unordered_map<std::string, std::pair<std::string, TextRowCol>>;
+    using Paragraph = std::map<std::string, std::pair<std::string, TextRowCol>, std::less<>>;
 
     struct ParagraphParser
     {
         ParagraphParser(Paragraph&& fields) : fields(std::move(fields)) { }
 
-        std::string required_field(StringView fieldname);
-        void required_field(StringView fieldname, std::string& out);
-        void required_field(StringView fieldname, std::pair<std::string&, TextRowCol&> out);
+        std::string required_field(StringLiteral fieldname);
+        void required_field(StringLiteral fieldname, std::string& out);
+        void required_field(StringLiteral fieldname, std::pair<std::string&, TextRowCol&> out);
 
-        std::string optional_field(StringView fieldname);
-        void optional_field(StringView fieldname, std::pair<std::string&, TextRowCol&> out);
+        std::string optional_field(StringLiteral fieldname);
+        void optional_field(StringLiteral fieldname, std::pair<std::string&, TextRowCol&> out);
 
-        void add_type_error(const std::string& fieldname, const char* type) { expected_types[fieldname] = type; }
+        void add_type_error(StringLiteral fieldname, const char* type) { expected_types[fieldname] = type; }
 
         std::unique_ptr<ParseControlErrorInfo> error_info(StringView name) const;
 
     private:
         Paragraph&& fields;
         std::vector<std::string> missing_fields;
-        std::map<std::string, std::string> expected_types;
+        std::map<StringLiteral, std::string, std::less<>> expected_types;
     };
 
     ExpectedS<std::vector<std::string>> parse_default_features_list(const std::string& str,

--- a/include/vcpkg/sourceparagraph.h
+++ b/include/vcpkg/sourceparagraph.h
@@ -23,22 +23,6 @@ namespace vcpkg
                                                      const std::unordered_map<std::string, std::string>& cmake_vars,
                                                      ImplicitDefault id);
 
-    struct Type
-    {
-        enum
-        {
-            UNKNOWN,
-            PORT,
-            ALIAS,
-        } type;
-
-        static std::string to_string(const Type&);
-        static Type from_string(const std::string&);
-    };
-
-    bool operator==(const Type&, const Type&);
-    bool operator!=(const Type&, const Type&);
-
     /// <summary>
     /// Port metadata of additional feature in a package (part of CONTROL file)
     /// </summary>
@@ -83,7 +67,6 @@ namespace vcpkg
         // Currently contacts is only a Json::Object but it will eventually be unified with maintainers
         Json::Object contacts;
 
-        Type type = {Type::PORT};
         PlatformExpression::Expr supports_expression;
 
         Json::Object extra_info;

--- a/locales/messages.json
+++ b/locales/messages.json
@@ -976,8 +976,6 @@
   "_PortNotInBaseline.comment": "An example of {package_name} is zlib.",
   "PortSupportsField": "(supports: \"{supports_expression}\")",
   "_PortSupportsField.comment": "An example of {supports_expression} is windows & !static.",
-  "PortTypeConflict": "The port type of {spec} differs between the installed and available portfile.\nPlease manually remove {spec} and re-run this command.",
-  "_PortTypeConflict.comment": "An example of {spec} is zlib:x64-windows.",
   "PortVersionConflict": "The following packages differ from their port versions:",
   "PortsAdded": "The following {count} ports were added:",
   "_PortsAdded.comment": "An example of {count} is 42.",

--- a/src/vcpkg-test/paragraph.cpp
+++ b/src/vcpkg-test/paragraph.cpp
@@ -468,12 +468,11 @@ TEST_CASE ("BinaryParagraph serialize min", "[paragraph]")
     auto pghs = vcpkg::Paragraphs::parse_paragraphs(ss, "").value_or_exit(VCPKG_LINE_INFO);
 
     REQUIRE(pghs.size() == 1);
-    REQUIRE(pghs[0].size() == 5);
+    REQUIRE(pghs[0].size() == 4);
     REQUIRE(pghs[0]["Package"].first == "zlib");
     REQUIRE(pghs[0]["Version"].first == "1.2.8");
     REQUIRE(pghs[0]["Architecture"].first == "x86-windows");
     REQUIRE(pghs[0]["Multi-Arch"].first == "same");
-    REQUIRE(pghs[0]["Type"].first == "Port");
 }
 
 TEST_CASE ("BinaryParagraph serialize max", "[paragraph]")
@@ -491,14 +490,13 @@ TEST_CASE ("BinaryParagraph serialize max", "[paragraph]")
     auto pghs = vcpkg::Paragraphs::parse_paragraphs(ss, "").value_or_exit(VCPKG_LINE_INFO);
 
     REQUIRE(pghs.size() == 1);
-    REQUIRE(pghs[0].size() == 8);
+    REQUIRE(pghs[0].size() == 7);
     REQUIRE(pghs[0]["Package"].first == "zlib");
     REQUIRE(pghs[0]["Version"].first == "1.2.8");
     REQUIRE(pghs[0]["Architecture"].first == "x86-windows");
     REQUIRE(pghs[0]["Multi-Arch"].first == "same");
     REQUIRE(pghs[0]["Description"].first == "first line\n    second line");
     REQUIRE(pghs[0]["Depends"].first == "dep");
-    REQUIRE(pghs[0]["Type"].first == "Port");
 }
 
 TEST_CASE ("BinaryParagraph serialize multiple deps", "[paragraph]")

--- a/src/vcpkg/base/messages.cpp
+++ b/src/vcpkg/base/messages.cpp
@@ -984,7 +984,6 @@ namespace vcpkg
     REGISTER_MESSAGE(PortsRemoved);
     REGISTER_MESSAGE(PortsUpdated);
     REGISTER_MESSAGE(PortSupportsField);
-    REGISTER_MESSAGE(PortTypeConflict);
     REGISTER_MESSAGE(PreviousIntegrationFileRemains);
     REGISTER_MESSAGE(ProgramReturnedNonzeroExitCode);
     REGISTER_MESSAGE(ProvideExportType);

--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -246,18 +246,24 @@ namespace vcpkg
     }
 
     CMakeVariable::CMakeVariable(const StringView varname, const char* varvalue)
-        : s(Strings::format("-D%s=%s", varname, varvalue))
+        : s(format_cmake_variable(varname, varvalue))
     {
     }
     CMakeVariable::CMakeVariable(const StringView varname, const std::string& varvalue)
-        : CMakeVariable(varname, varvalue.c_str())
+        : s(format_cmake_variable(varname, varvalue))
+    {
+    }
+    CMakeVariable::CMakeVariable(const StringView varname, StringLiteral varvalue)
+        : s(format_cmake_variable(varname, varvalue))
     {
     }
     CMakeVariable::CMakeVariable(const StringView varname, const Path& varvalue)
-        : CMakeVariable(varname, varvalue.generic_u8string())
+        : s(format_cmake_variable(varname, varvalue.generic_u8string()))
     {
     }
-    CMakeVariable::CMakeVariable(std::string var) : s(std::move(var)) { }
+    CMakeVariable::CMakeVariable(const std::string& var) : s(var) { }
+
+    std::string format_cmake_variable(StringView key, StringView value) { return fmt::format("-D{}={}", key, value); }
 
     Command make_basic_cmake_cmd(const Path& cmake_tool_path,
                                  const Path& cmake_script,

--- a/src/vcpkg/binaryparagraph.cpp
+++ b/src/vcpkg/binaryparagraph.cpp
@@ -10,22 +10,21 @@ namespace vcpkg
 {
     namespace Fields
     {
-        static const std::string PACKAGE = "Package";
-        static const std::string VERSION = "Version";
-        static const std::string PORT_VERSION = "Port-Version";
-        static const std::string ARCHITECTURE = "Architecture";
-        static const std::string MULTI_ARCH = "Multi-Arch";
+        static constexpr StringLiteral PACKAGE = "Package";
+        static constexpr StringLiteral VERSION = "Version";
+        static constexpr StringLiteral PORT_VERSION = "Port-Version";
+        static constexpr StringLiteral ARCHITECTURE = "Architecture";
+        static constexpr StringLiteral MULTI_ARCH = "Multi-Arch";
     }
 
     namespace Fields
     {
-        static const std::string ABI = "Abi";
-        static const std::string FEATURE = "Feature";
-        static const std::string DESCRIPTION = "Description";
-        static const std::string MAINTAINER = "Maintainer";
-        static const std::string DEPENDS = "Depends";
-        static const std::string DEFAULT_FEATURES = "Default-Features";
-        static const std::string TYPE = "Type";
+        static constexpr StringLiteral ABI = "Abi";
+        static constexpr StringLiteral FEATURE = "Feature";
+        static constexpr StringLiteral DESCRIPTION = "Description";
+        static constexpr StringLiteral MAINTAINER = "Maintainer";
+        static constexpr StringLiteral DEPENDS = "Depends";
+        static constexpr StringLiteral DEFAULT_FEATURES = "Default-Features";
     }
 
     BinaryParagraph::BinaryParagraph() = default;
@@ -86,8 +85,8 @@ namespace vcpkg
                                          .value_or_exit(VCPKG_LINE_INFO);
         }
 
-        this->type = Type::from_string(parser.optional_field(Fields::TYPE));
-
+        // This is leftover from a previous attempt to add "alias ports", not currently used.
+        (void)parser.optional_field("Type");
         if (const auto err = parser.error_info(this->spec.to_string()))
         {
             msg::println_error(msgErrorParsingBinaryParagraph, msg::spec = this->spec);
@@ -114,7 +113,6 @@ namespace vcpkg
         , default_features(spgh.default_features)
         , dependencies()
         , abi(abi_tag)
-        , type(spgh.type)
     {
         this->dependencies = Util::fmap(deps, [](const FeatureSpec& spec) { return spec.spec(); });
         canonicalize();
@@ -133,7 +131,6 @@ namespace vcpkg
         , default_features()
         , dependencies()
         , abi()
-        , type(spgh.type)
     {
         this->dependencies = Util::fmap(deps, [](const FeatureSpec& spec) { return spec.spec(); });
         canonicalize();
@@ -191,7 +188,6 @@ namespace vcpkg
         if (lhs.default_features != rhs.default_features) return false;
         if (lhs.dependencies != rhs.dependencies) return false;
         if (lhs.abi != rhs.abi) return false;
-        if (lhs.type != rhs.type) return false;
 
         return true;
     }
@@ -249,7 +245,10 @@ namespace vcpkg
         serialize_string(Fields::VERSION, pgh.version, out_str);
         if (pgh.port_version != 0)
         {
-            out_str.append(Fields::PORT_VERSION).append(": ").append(std::to_string(pgh.port_version)).push_back('\n');
+            out_str.append(Fields::PORT_VERSION.data(), Fields::PORT_VERSION.size())
+                .append(": ")
+                .append(std::to_string(pgh.port_version))
+                .push_back('\n');
         }
 
         if (pgh.is_feature())
@@ -271,7 +270,6 @@ namespace vcpkg
 
         serialize_paragraph(Fields::DESCRIPTION, pgh.description, out_str);
 
-        serialize_string(Fields::TYPE, Type::to_string(pgh.type), out_str);
         serialize_array(Fields::DEFAULT_FEATURES, pgh.default_features, out_str);
 
         // sanity check the serialized data
@@ -304,7 +302,7 @@ namespace vcpkg
         constexpr StringLiteral join_str = R"(", ")";
         return fmt::format(
             "\nspec: \"{}\"\nversion: \"{}\"\nport_version: {}\ndescription: [\"{}\"]\nmaintainers: [\"{}\"]\nfeature: "
-            "\"{}\"\ndefault_features: [\"{}\"]\ndependencies: [\"{}\"]\nabi: \"{}\"\ntype: {}",
+            "\"{}\"\ndefault_features: [\"{}\"]\ndependencies: [\"{}\"]\nabi: \"{}\"",
             paragraph.spec.to_string(),
             paragraph.version,
             paragraph.port_version,
@@ -313,7 +311,6 @@ namespace vcpkg
             paragraph.feature,
             Strings::join(join_str, paragraph.default_features),
             Strings::join(join_str, paragraph.dependencies),
-            paragraph.abi,
-            Type::to_string(paragraph.type));
+            paragraph.abi);
     }
 }

--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -277,7 +277,7 @@ namespace vcpkg
         }
     }
 
-    static constexpr StringLiteral NAME_BUILD_IN_DOWNLOAD = "BUILT_IN";
+    static constexpr StringLiteral NAME_BUILTIN_DOWNLOAD = "BUILT_IN";
     static constexpr StringLiteral NAME_ARIA2_DOWNLOAD = "ARIA2";
 
     StringLiteral to_string_view(DownloadTool tool)

--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -207,19 +207,19 @@ namespace vcpkg
         Build::perform_and_exit(args, paths, default_triplet, host_triplet);
     }
 
-    static const std::string NAME_EMPTY_PACKAGE = "PolicyEmptyPackage";
-    static const std::string NAME_DLLS_WITHOUT_LIBS = "PolicyDLLsWithoutLIBs";
-    static const std::string NAME_DLLS_WITHOUT_EXPORTS = "PolicyDLLsWithoutExports";
-    static const std::string NAME_DLLS_IN_STATIC_LIBRARY = "PolicyDLLsInStaticLibrary";
-    static const std::string NAME_MISMATCHED_NUMBER_OF_BINARIES = "PolicyMismatchedNumberOfBinaries";
-    static const std::string NAME_ONLY_RELEASE_CRT = "PolicyOnlyReleaseCRT";
-    static const std::string NAME_EMPTY_INCLUDE_FOLDER = "PolicyEmptyIncludeFolder";
-    static const std::string NAME_ALLOW_OBSOLETE_MSVCRT = "PolicyAllowObsoleteMsvcrt";
-    static const std::string NAME_ALLOW_RESTRICTED_HEADERS = "PolicyAllowRestrictedHeaders";
-    static const std::string NAME_SKIP_DUMPBIN_CHECKS = "PolicySkipDumpbinChecks";
-    static const std::string NAME_SKIP_ARCHITECTURE_CHECK = "PolicySkipArchitectureCheck";
-    static const std::string NAME_CMAKE_HELPER_PORT = "PolicyCmakeHelperPort";
-    static const std::string NAME_SKIP_ABSOLUTE_PATHS_CHECK = "PolicySkipAbsolutePathsCheck";
+    static constexpr StringLiteral NAME_EMPTY_PACKAGE = "PolicyEmptyPackage";
+    static constexpr StringLiteral NAME_DLLS_WITHOUT_LIBS = "PolicyDLLsWithoutLIBs";
+    static constexpr StringLiteral NAME_DLLS_WITHOUT_EXPORTS = "PolicyDLLsWithoutExports";
+    static constexpr StringLiteral NAME_DLLS_IN_STATIC_LIBRARY = "PolicyDLLsInStaticLibrary";
+    static constexpr StringLiteral NAME_MISMATCHED_NUMBER_OF_BINARIES = "PolicyMismatchedNumberOfBinaries";
+    static constexpr StringLiteral NAME_ONLY_RELEASE_CRT = "PolicyOnlyReleaseCRT";
+    static constexpr StringLiteral NAME_EMPTY_INCLUDE_FOLDER = "PolicyEmptyIncludeFolder";
+    static constexpr StringLiteral NAME_ALLOW_OBSOLETE_MSVCRT = "PolicyAllowObsoleteMsvcrt";
+    static constexpr StringLiteral NAME_ALLOW_RESTRICTED_HEADERS = "PolicyAllowRestrictedHeaders";
+    static constexpr StringLiteral NAME_SKIP_DUMPBIN_CHECKS = "PolicySkipDumpbinChecks";
+    static constexpr StringLiteral NAME_SKIP_ARCHITECTURE_CHECK = "PolicySkipArchitectureCheck";
+    static constexpr StringLiteral NAME_CMAKE_HELPER_PORT = "PolicyCmakeHelperPort";
+    static constexpr StringLiteral NAME_SKIP_ABSOLUTE_PATHS_CHECK = "PolicySkipAbsolutePathsCheck";
 
     static std::remove_const_t<decltype(ALL_POLICIES)> generate_all_policies()
     {
@@ -234,7 +234,7 @@ namespace vcpkg
 
     decltype(ALL_POLICIES) ALL_POLICIES = generate_all_policies();
 
-    const std::string& to_string(BuildPolicy policy)
+    StringLiteral to_string_view(BuildPolicy policy)
     {
         switch (policy)
         {
@@ -254,6 +254,7 @@ namespace vcpkg
             default: Checks::unreachable(VCPKG_LINE_INFO);
         }
     }
+    std::string to_string(BuildPolicy policy) { return to_string_view(policy).to_string(); }
 
     ZStringView to_cmake_variable(BuildPolicy policy)
     {
@@ -276,10 +277,10 @@ namespace vcpkg
         }
     }
 
-    static const std::string NAME_BUILD_IN_DOWNLOAD = "BUILT_IN";
-    static const std::string NAME_ARIA2_DOWNLOAD = "ARIA2";
+    static constexpr StringLiteral NAME_BUILD_IN_DOWNLOAD = "BUILT_IN";
+    static constexpr StringLiteral NAME_ARIA2_DOWNLOAD = "ARIA2";
 
-    const std::string& to_string(DownloadTool tool)
+    StringLiteral to_string_view(DownloadTool tool)
     {
         switch (tool)
         {
@@ -288,6 +289,8 @@ namespace vcpkg
             default: Checks::unreachable(VCPKG_LINE_INFO);
         }
     }
+
+    std::string to_string(DownloadTool tool) { return to_string_view(tool).to_string(); }
 
     Optional<LinkageType> to_linkage_type(StringView str)
     {
@@ -298,8 +301,8 @@ namespace vcpkg
 
     namespace BuildInfoRequiredField
     {
-        static const std::string CRT_LINKAGE = "CRTLinkage";
-        static const std::string LIBRARY_LINKAGE = "LibraryLinkage";
+        static constexpr StringLiteral CRT_LINKAGE = "CRTLinkage";
+        static constexpr StringLiteral LIBRARY_LINKAGE = "LibraryLinkage";
     }
 
 #if defined(_WIN32)
@@ -728,7 +731,7 @@ namespace vcpkg
             {"PORT", scf.core_paragraph->name},
             {"VERSION", scf.core_paragraph->raw_version},
             {"VCPKG_USE_HEAD_VERSION", Util::Enum::to_bool(action.build_options.use_head_version) ? "1" : "0"},
-            {"_VCPKG_DOWNLOAD_TOOL", to_string(action.build_options.download_tool)},
+            {"_VCPKG_DOWNLOAD_TOOL", to_string_view(action.build_options.download_tool)},
             {"_VCPKG_EDITABLE", Util::Enum::to_bool(action.build_options.editable) ? "1" : "0"},
             {"_VCPKG_NO_DOWNLOADS", !Util::Enum::to_bool(action.build_options.allow_downloads) ? "1" : "0"},
             {"Z_VCPKG_CHAINLOAD_TOOLCHAIN_FILE", action.pre_build_info(VCPKG_LINE_INFO).toolchain_file()},
@@ -1570,15 +1573,17 @@ namespace vcpkg
         std::unordered_map<BuildPolicy, bool> policies;
         for (const auto& policy : ALL_POLICIES)
         {
-            const auto setting = parser.optional_field(to_string(policy));
+            const auto setting = parser.optional_field(to_string_view(policy));
             if (setting.empty()) continue;
             if (setting == "enabled")
                 policies.emplace(policy, true);
             else if (setting == "disabled")
                 policies.emplace(policy, false);
             else
-                Checks::msg_exit_maybe_upgrade(
-                    VCPKG_LINE_INFO, msgUnknownPolicySetting, msg::option = setting, msg::value = to_string(policy));
+                Checks::msg_exit_maybe_upgrade(VCPKG_LINE_INFO,
+                                               msgUnknownPolicySetting,
+                                               msg::option = setting,
+                                               msg::value = to_string_view(policy));
         }
 
         if (const auto err = parser.error_info("PostBuildInformation"))

--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -284,7 +284,7 @@ namespace vcpkg
     {
         switch (tool)
         {
-            case DownloadTool::BUILT_IN: return NAME_BUILD_IN_DOWNLOAD;
+            case DownloadTool::BUILT_IN: return NAME_BUILTIN_DOWNLOAD;
             case DownloadTool::ARIA2: return NAME_ARIA2_DOWNLOAD;
             default: Checks::unreachable(VCPKG_LINE_INFO);
         }

--- a/src/vcpkg/commands.integrate.cpp
+++ b/src/vcpkg/commands.integrate.cpp
@@ -618,24 +618,24 @@ namespace vcpkg::Commands::Integrate
 
     namespace Subcommand
     {
-        static const std::string INSTALL = "install";
-        static const std::string REMOVE = "remove";
-        static const std::string PROJECT = "project";
-        static const std::string POWERSHELL = "powershell";
-        static const std::string BASH = "bash";
-        static const std::string ZSH = "zsh";
-        static const std::string FISH = "x-fish";
+        static constexpr StringLiteral INSTALL = "install";
+        static constexpr StringLiteral REMOVE = "remove";
+        static constexpr StringLiteral PROJECT = "project";
+        static constexpr StringLiteral POWERSHELL = "powershell";
+        static constexpr StringLiteral BASH = "bash";
+        static constexpr StringLiteral ZSH = "zsh";
+        static constexpr StringLiteral FISH = "x-fish";
     }
 
     static std::vector<std::string> valid_arguments(const VcpkgPaths&)
     {
         return
         {
-            Subcommand::INSTALL, Subcommand::REMOVE,
+            Subcommand::INSTALL.to_string(), Subcommand::REMOVE.to_string(),
 #if defined(_WIN32)
-                Subcommand::PROJECT, Subcommand::POWERSHELL,
+                Subcommand::PROJECT.to_string(), Subcommand::POWERSHELL.to_string(),
 #else
-                Subcommand::BASH, Subcommand::FISH,
+                Subcommand::BASH.to_string(), Subcommand::FISH.to_string(),
 #endif
         };
     }

--- a/src/vcpkg/commands.integrate.cpp
+++ b/src/vcpkg/commands.integrate.cpp
@@ -620,8 +620,10 @@ namespace vcpkg::Commands::Integrate
     {
         static constexpr StringLiteral INSTALL = "install";
         static constexpr StringLiteral REMOVE = "remove";
+#if defined(_WIN32)
         static constexpr StringLiteral PROJECT = "project";
         static constexpr StringLiteral POWERSHELL = "powershell";
+#endif // ^^^ _WIN32
         static constexpr StringLiteral BASH = "bash";
         static constexpr StringLiteral ZSH = "zsh";
         static constexpr StringLiteral FISH = "x-fish";

--- a/src/vcpkg/commands.portsdiff.cpp
+++ b/src/vcpkg/commands.portsdiff.cpp
@@ -113,7 +113,7 @@ namespace vcpkg::Commands::PortsDiff
 
     static void check_commit_exists(const VcpkgPaths& paths, const std::string& git_commit_id)
     {
-        static const std::string VALID_COMMIT_OUTPUT = "commit\n";
+        static constexpr StringLiteral VALID_COMMIT_OUTPUT = "commit\n";
         auto cmd = paths.git_cmd_builder(paths.root / ".git", paths.root)
                        .string_arg("cat-file")
                        .string_arg("-t")

--- a/src/vcpkg/dependencies.cpp
+++ b/src/vcpkg/dependencies.cpp
@@ -355,15 +355,6 @@ namespace vcpkg
                 ExpectedS<const SourceControlFileAndLocation&> maybe_scfl =
                     m_port_provider.get_control_file(ipv.spec().name());
 
-                if (const auto scfl = maybe_scfl.get())
-                {
-                    Checks::msg_check_exit(VCPKG_LINE_INFO,
-                                           scfl->source_control_file->core_paragraph->type.type ==
-                                               ipv.core->package.type.type,
-                                           msgPortTypeConflict,
-                                           msg::spec = ipv.spec());
-                }
-
                 return m_graph
                     .emplace(std::piecewise_construct,
                              std::forward_as_tuple(ipv.spec()),

--- a/src/vcpkg/paragraphs.cpp
+++ b/src/vcpkg/paragraphs.cpp
@@ -90,7 +90,7 @@ namespace vcpkg
         return value;
     }
 
-    void ParagraphParser::required_field(StringView fieldname, std::pair<std::string&, TextRowCol&> out)
+    void ParagraphParser::required_field(StringLiteral fieldname, std::pair<std::string&, TextRowCol&> out)
     {
         auto maybe_field = remove_field(&fields, fieldname);
         if (const auto field = maybe_field.get())
@@ -98,24 +98,24 @@ namespace vcpkg
         else
             missing_fields.emplace_back(fieldname.data());
     }
-    void ParagraphParser::optional_field(StringView fieldname, std::pair<std::string&, TextRowCol&> out)
+    void ParagraphParser::optional_field(StringLiteral fieldname, std::pair<std::string&, TextRowCol&> out)
     {
         auto maybe_field = remove_field(&fields, fieldname);
         if (auto field = maybe_field.get()) out = std::move(*field);
     }
-    void ParagraphParser::required_field(StringView fieldname, std::string& out)
+    void ParagraphParser::required_field(StringLiteral fieldname, std::string& out)
     {
         TextRowCol ignore;
         required_field(fieldname, {out, ignore});
     }
-    std::string ParagraphParser::optional_field(StringView fieldname)
+    std::string ParagraphParser::optional_field(StringLiteral fieldname)
     {
         std::string out;
         TextRowCol ignore;
         optional_field(fieldname, {out, ignore});
         return out;
     }
-    std::string ParagraphParser::required_field(StringView fieldname)
+    std::string ParagraphParser::required_field(StringLiteral fieldname)
     {
         std::string out;
         TextRowCol ignore;

--- a/src/vcpkg/sourceparagraph.cpp
+++ b/src/vcpkg/sourceparagraph.cpp
@@ -42,7 +42,6 @@ namespace vcpkg
         if (lhs.default_features != rhs.default_features) return false;
         if (lhs.license != rhs.license) return false;
 
-        if (lhs.type != rhs.type) return false;
         if (!structurally_equal(lhs.supports_expression, rhs.supports_expression)) return false;
 
         if (lhs.extra_info != rhs.extra_info) return false;
@@ -73,17 +72,17 @@ namespace vcpkg
 
     namespace SourceParagraphFields
     {
-        static const std::string BUILD_DEPENDS = "Build-Depends";
-        static const std::string DEFAULT_FEATURES = "Default-Features";
-        static const std::string DESCRIPTION = "Description";
-        static const std::string FEATURE = "Feature";
-        static const std::string MAINTAINERS = "Maintainer";
-        static const std::string NAME = "Source";
-        static const std::string VERSION = "Version";
-        static const std::string PORT_VERSION = "Port-Version";
-        static const std::string HOMEPAGE = "Homepage";
-        static const std::string TYPE = "Type";
-        static const std::string SUPPORTS = "Supports";
+        static constexpr StringLiteral BUILD_DEPENDS = "Build-Depends";
+        static constexpr StringLiteral DEFAULT_FEATURES = "Default-Features";
+        static constexpr StringLiteral DESCRIPTION = "Description";
+        static constexpr StringLiteral FEATURE = "Feature";
+        static constexpr StringLiteral MAINTAINERS = "Maintainer";
+        static constexpr StringLiteral NAME = "Source";
+        static constexpr StringLiteral VERSION = "Version";
+        static constexpr StringLiteral PORT_VERSION = "Port-Version";
+        static constexpr StringLiteral HOMEPAGE = "Homepage";
+        static constexpr StringLiteral TYPE = "Type";
+        static constexpr StringLiteral SUPPORTS = "Supports";
     }
 
     static Span<const StringView> get_list_of_valid_fields()
@@ -105,26 +104,6 @@ namespace vcpkg
     }
 
     void print_error_message(Span<const std::unique_ptr<ParseControlErrorInfo>> error_info_list);
-
-    std::string Type::to_string(const Type& t)
-    {
-        switch (t.type)
-        {
-            case Type::ALIAS: return "Alias";
-            case Type::PORT: return "Port";
-            default: return "Unknown";
-        }
-    }
-
-    Type Type::from_string(const std::string& t)
-    {
-        if (t == "Alias") return Type{Type::ALIAS};
-        if (t == "Port" || t.empty()) return Type{Type::PORT};
-        return Type{Type::UNKNOWN};
-    }
-
-    bool operator==(const Type& lhs, const Type& rhs) { return lhs.type == rhs.type; }
-    bool operator!=(const Type& lhs, const Type& rhs) { return !(lhs == rhs); }
 
     static void trim_all(std::vector<std::string>& arr)
     {
@@ -326,7 +305,8 @@ namespace vcpkg
             }
         }
 
-        spgh->type = Type::from_string(parser.optional_field(SourceParagraphFields::TYPE));
+        // This is leftover from a previous attempt to add "alias ports", not currently used.
+        (void)parser.optional_field(SourceParagraphFields::TYPE);
         auto err = parser.error_info(spgh->name.empty() ? origin : spgh->name);
         if (err)
             return err;

--- a/src/vcpkg/statusparagraph.cpp
+++ b/src/vcpkg/statusparagraph.cpp
@@ -6,7 +6,7 @@ namespace vcpkg
 {
     namespace BinaryParagraphRequiredField
     {
-        static const std::string STATUS = "Status";
+        static constexpr StringLiteral STATUS = "Status";
     }
 
     StatusParagraph::StatusParagraph() noexcept : want(Want::ERROR_STATE), state(InstallState::ERROR_STATE) { }

--- a/src/vcpkg/tools.cpp
+++ b/src/vcpkg/tools.cpp
@@ -79,7 +79,7 @@ namespace vcpkg
 
     Optional<ToolData> parse_tool_data_from_xml(StringView XML, StringView XML_PATH, StringView tool, StringView os)
     {
-        static const std::string XML_VERSION = "2";
+        static const char* XML_VERSION = "2";
         static const std::regex XML_VERSION_REGEX{R"###(<tools[\s]+version="([^"]+)">)###"};
         std::cmatch match_xml_version;
         const bool has_xml_version = std::regex_search(XML.begin(), XML.end(), match_xml_version, XML_VERSION_REGEX);


### PR DESCRIPTION
and replace static const std::strings with StringLiterals.

Saves about 5kb of executable size and several dynamic initializers.