### PR TITLE
Add initial risc-v support

### DIFF
--- a/include/vcpkg/base/messages.h
+++ b/include/vcpkg/base/messages.h
@@ -1344,7 +1344,7 @@ namespace vcpkg
         ForceSystemBinariesOnWeirdPlatforms,
         (),
         "",
-        "Environment variable VCPKG_FORCE_SYSTEM_BINARIES must be set on arm, s390x, and ppc64le platforms.");
+        "Environment variable VCPKG_FORCE_SYSTEM_BINARIES must be set on arm, s390x, ppc64le and riscv platforms.");
     DECLARE_MESSAGE(FormattedParseMessageExpression,
                     (msg::value),
                     "Example of {value} is 'x64 & windows'",

--- a/include/vcpkg/base/system.h
+++ b/include/vcpkg/base/system.h
@@ -44,6 +44,8 @@ namespace vcpkg
         ARM64EC,
         S390X,
         PPC64LE,
+        RISCV32,
+        RISCV64,
     };
 
     Optional<CPUArchitecture> to_cpu_architecture(StringView arch);

--- a/src/vcpkg.cpp
+++ b/src/vcpkg.cpp
@@ -272,7 +272,7 @@ int main(const int argc, const char* const* const argv)
 
     register_console_ctrl_handler();
 
-#if (defined(__aarch64__) || defined(__arm__) || defined(__s390x__) ||                                                 \
+#if (defined(__aarch64__) || defined(__arm__) || defined(__s390x__) || defined(__riscv) ||                             \
      ((defined(__ppc64__) || defined(__PPC64__) || defined(__ppc64le__) || defined(__PPC64LE__)) &&                    \
       defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)) ||                                       \
      defined(_M_ARM) || defined(_M_ARM64)) &&                                                                          \

--- a/src/vcpkg/base/system.cpp
+++ b/src/vcpkg/base/system.cpp
@@ -42,6 +42,9 @@ namespace vcpkg
         if (Strings::case_insensitive_ascii_equals(arch, "arm64ec")) return CPUArchitecture::ARM64EC;
         if (Strings::case_insensitive_ascii_equals(arch, "s390x")) return CPUArchitecture::S390X;
         if (Strings::case_insensitive_ascii_equals(arch, "ppc64le")) return CPUArchitecture::PPC64LE;
+        if (Strings::case_insensitive_ascii_equals(arch, "riscv32")) return CPUArchitecture::RISCV32;
+        if (Strings::case_insensitive_ascii_equals(arch, "riscv64")) return CPUArchitecture::RISCV64;
+
         return nullopt;
     }
 
@@ -56,6 +59,8 @@ namespace vcpkg
             case CPUArchitecture::ARM64EC: return "arm64ec";
             case CPUArchitecture::S390X: return "s390x";
             case CPUArchitecture::PPC64LE: return "ppc64le";
+            case CPUArchitecture::RISCV32: return "riscv32";
+            case CPUArchitecture::RISCV64: return "riscv64";
             default: Checks::exit_with_message(VCPKG_LINE_INFO, "unexpected vcpkg::CPUArchitecture");
         }
     }
@@ -149,6 +154,10 @@ namespace vcpkg
 #elif (defined(__ppc64__) || defined(__PPC64__) || defined(__ppc64le__) || defined(__PPC64LE__)) &&                    \
     defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
         return CPUArchitecture::PPC64LE;
+#elif defined(__riscv) && defined(__riscv_xlen) && (__riscv_xlen == 32)
+        return CPUArchitecture::RISCV32;
+#elif defined(__riscv) && defined(__riscv_xlen) && (__riscv_xlen == 64)
+        return CPUArchitecture::RISCV64;
 #else // choose architecture
 #error "Unknown host architecture"
 #endif // choose architecture

--- a/src/vcpkg/triplet.cpp
+++ b/src/vcpkg/triplet.cpp
@@ -72,6 +72,14 @@ namespace vcpkg
         {
             return CPUArchitecture::PPC64LE;
         }
+        if (Strings::starts_with(this->canonical_name(), "riscv32-"))
+        {
+            return CPUArchitecture::RISCV32;
+        }
+        if (Strings::starts_with(this->canonical_name(), "riscv64-"))
+        {
+            return CPUArchitecture::RISCV64;
+        }
 
         return nullopt;
     }


### PR DESCRIPTION
This PR allows building vcpkg on RISC-V machines. Tested with Ubuntu 22.04.1 LTS (GNU/Linux 5.19.0-1012-generic riscv64) and SiFive U74-MC.
