### PR TITLE
Print unsupported warnings only once

### DIFF
--- a/include/vcpkg/dependencies.h
+++ b/include/vcpkg/dependencies.h
@@ -113,11 +113,12 @@ namespace vcpkg
     {
         bool empty() const { return remove_actions.empty() && already_installed.empty() && install_actions.empty(); }
         size_t size() const { return remove_actions.size() + already_installed.size() + install_actions.size(); }
+        void print_unsupported_warnings();
 
         std::vector<RemovePlanAction> remove_actions;
         std::vector<InstallPlanAction> already_installed;
         std::vector<InstallPlanAction> install_actions;
-        std::vector<std::string> warnings;
+        std::map<FeatureSpec, PlatformExpression::Expr> unsupported_features;
     };
 
     enum class ExportPlanType

--- a/locales/messages.json
+++ b/locales/messages.json
@@ -550,7 +550,7 @@
   "FollowingPackagesMissingControl": "The following packages do not have a valid CONTROL or vcpkg.json:",
   "FollowingPackagesNotInstalled": "The following packages are not installed:",
   "FollowingPackagesUpgraded": "The following packages are up-to-date:",
-  "ForceSystemBinariesOnWeirdPlatforms": "Environment variable VCPKG_FORCE_SYSTEM_BINARIES must be set on arm, s390x, and ppc64le platforms.",
+  "ForceSystemBinariesOnWeirdPlatforms": "Environment variable VCPKG_FORCE_SYSTEM_BINARIES must be set on arm, s390x, ppc64le and riscv platforms.",
   "FormattedParseMessageExpression": "on expression: {value}",
   "_FormattedParseMessageExpression.comment": "Example of {value} is 'x64 & windows'",
   "GenerateMsgErrorParsingFormatArgs": "parsing format string for {value}:",

--- a/src/vcpkg/commands.dependinfo.cpp
+++ b/src/vcpkg/commands.dependinfo.cpp
@@ -318,10 +318,7 @@ namespace vcpkg::Commands::DependInfo
         StatusParagraphs status_db;
         auto action_plan = create_feature_install_plan(
             provider, var_provider, specs, status_db, {host_triplet, UnsupportedPortAction::Warn});
-        for (const auto& warning : action_plan.warnings)
-        {
-            msg::write_unlocalized_text_to_stdout(Color::warning, warning + '\n');
-        }
+        action_plan.print_unsupported_warnings();
 
         if (!action_plan.remove_actions.empty())
         {

--- a/src/vcpkg/commands.upgrade.cpp
+++ b/src/vcpkg/commands.upgrade.cpp
@@ -198,10 +198,7 @@ namespace vcpkg::Commands::Upgrade
         }
 
         Checks::check_exit(VCPKG_LINE_INFO, !action_plan.empty());
-        for (const auto& warning : action_plan.warnings)
-        {
-            msg::write_unlocalized_text_to_stdout(Color::warning, warning + "\n");
-        }
+        action_plan.print_unsupported_warnings();
         // Set build settings for all install actions
         for (auto&& action : action_plan.install_actions)
         {

--- a/src/vcpkg/dependencies.cpp
+++ b/src/vcpkg/dependencies.cpp
@@ -303,7 +303,7 @@ namespace vcpkg
             const CMakeVars::CMakeVarProvider& m_var_provider;
 
             std::unique_ptr<ClusterGraph> m_graph;
-            std::vector<std::string> m_warnings;
+            std::map<FeatureSpec, PlatformExpression::Expr> m_unsupported_features;
         };
 
         /// <summary>
@@ -538,6 +538,29 @@ namespace vcpkg
                                        const RequestType& request_type)
         : spec(spec), plan_type(plan_type), request_type(request_type)
     {
+    }
+
+    void ActionPlan::print_unsupported_warnings()
+    {
+        for (const auto& entry : unsupported_features)
+        {
+            if (entry.first.feature() == "core")
+            {
+                msg::println_warning(msgUnsupportedSupportsExpressionWarning,
+                                     msg::package_name = entry.first.port(),
+                                     msg::supports_expression = to_string(entry.second),
+                                     msg::triplet = entry.first.triplet());
+            }
+            else
+            {
+                const auto feature_spec = format_name_only_feature_spec(entry.first.port(), entry.first.feature());
+                msg::println_warning(msgUnsupportedFeatureSupportsExpression,
+                                     msg::package_name = entry.first.port(),
+                                     msg::feature_spec = feature_spec,
+                                     msg::supports_expression = to_string(entry.second),
+                                     msg::triplet = entry.first.triplet());
+            }
+        }
     }
 
     bool ExportPlanAction::compare_by_name(const ExportPlanAction* left, const ExportPlanAction* right)
@@ -830,12 +853,7 @@ namespace vcpkg
                             }
                             else
                             {
-                                m_warnings.push_back(
-                                    msg::format_warning(msgUnsupportedSupportsExpressionWarning,
-                                                        msg::package_name = spec.port(),
-                                                        msg::supports_expression = supports_expression_text,
-                                                        msg::triplet = spec.triplet())
-                                        .extract_data());
+                                m_unsupported_features.emplace(spec, *supports_expression);
                             }
                         }
                     }
@@ -1060,7 +1078,7 @@ namespace vcpkg
                 plan.already_installed.emplace_back(InstalledPackageView(installed.ipv), p_cluster->request_type);
             }
         }
-        plan.warnings = m_warnings;
+        plan.unsupported_features = m_unsupported_features;
         return plan;
     }
 
@@ -1909,12 +1927,7 @@ namespace vcpkg
                                     .extract_data();
                             }
 
-                            ret.warnings.emplace_back(
-                                msg::format_warning(msgUnsupportedSupportsExpressionWarning,
-                                                    msg::package_name = spec.name(),
-                                                    msg::supports_expression = supports_expression_text,
-                                                    msg::triplet = spec.triplet())
-                                    .extract_data());
+                            ret.unsupported_features.insert({FeatureSpec(spec, "core"), supports_expr});
                         }
                     }
                 }
@@ -1934,10 +1947,10 @@ namespace vcpkg
                     {
                         if (!supports_expr.evaluate(m_var_provider.get_or_load_dep_info_vars(spec, m_host_triplet)))
                         {
-                            const auto feature_spec_text = format_name_only_feature_spec(spec.name(), f);
-                            const auto supports_expression_text = to_string(supports_expr);
                             if (unsupported_port_action == UnsupportedPortAction::Error)
                             {
+                                const auto feature_spec_text = format_name_only_feature_spec(spec.name(), f);
+                                const auto supports_expression_text = to_string(supports_expr);
                                 return msg::format_error(msgUnsupportedFeatureSupportsExpression,
                                                          msg::package_name = spec.name(),
                                                          msg::feature_spec = feature_spec_text,
@@ -1945,13 +1958,7 @@ namespace vcpkg
                                                          msg::triplet = spec.triplet())
                                     .extract_data();
                             }
-
-                            ret.warnings.emplace_back(
-                                msg::format_warning(msgUnsupportedFeatureSupportsExpressionWarning,
-                                                    msg::feature_spec = feature_spec_text,
-                                                    msg::supports_expression = supports_expression_text,
-                                                    msg::triplet = spec.triplet())
-                                    .extract_data());
+                            ret.unsupported_features.emplace(FeatureSpec{spec, f}, supports_expr);
                         }
                     }
                 }

--- a/src/vcpkg/install.cpp
+++ b/src/vcpkg/install.cpp
@@ -1156,10 +1156,7 @@ namespace vcpkg
                                                               unsupported_port_action)
                                     .value_or_exit(VCPKG_LINE_INFO);
 
-            for (const auto& warning : install_plan.warnings)
-            {
-                print2(Color::warning, warning, '\n');
-            }
+            install_plan.print_unsupported_warnings();
             for (InstallPlanAction& action : install_plan.install_actions)
             {
                 action.build_options = install_plan_options;
@@ -1203,10 +1200,7 @@ namespace vcpkg
         auto action_plan = create_feature_install_plan(
             provider, var_provider, specs, status_db, {host_triplet, unsupported_port_action});
 
-        for (const auto& warning : action_plan.warnings)
-        {
-            msg::write_unlocalized_text_to_stdout(Color::warning, warning + '\n');
-        }
+        action_plan.print_unsupported_warnings();
         for (auto&& action : action_plan.install_actions)
         {
             action.build_options = install_plan_options;


### PR DESCRIPTION
Currently `vcpkg install gtk[introspection] --allow-unsupported` yields:
```
warning: gobject-introspection is only supported on '!static & (native | (windows & x86))', which does not match arm64-osx. This usually means that there are known build failures, or runtime problems, when building other platforms. Proceeding anyway due to `--allow-unsupported`.
warning: gobject-introspection is only supported on '!static & (native | (windows & x86))', which does not match arm64-osx. This usually means that there are known build failures, or runtime problems, when building other platforms. Proceeding anyway due to `--allow-unsupported`.
warning: gobject-introspection is only supported on '!static & (native | (windows & x86))', which does not match arm64-osx. This usually means that there are known build failures, or runtime problems, when building other platforms. Proceeding anyway due to `--allow-unsupported`.
warning: gobject-introspection is only supported on '!static & (native | (windows & x86))', which does not match arm64-osx. This usually means that there are known build failures, or runtime problems, when building other platforms. Proceeding anyway due to `--allow-unsupported`.
warning: gobject-introspection is only supported on '!static & (native | (windows & x86))', which does not match arm64-osx. This usually means that there are known build failures, or runtime problems, when building other platforms. Proceeding anyway due to `--allow-unsupported`.
warning: gobject-introspection is only supported on '!static & (native | (windows & x86))', which does not match arm64-osx. This usually means that there are known build failures, or runtime problems, when building other platforms. Proceeding anyway due to `--allow-unsupported`.
Detecting compiler hash for triplet arm64-osx...
```
After this PR
```
warning: gobject-introspection is only supported on '!static & (native | (windows & x86))', which does not match arm64-osx. This usually means that there are known build failures, or runtime problems, when building other platforms. Proceeding anyway due to `--allow-unsupported`.
Detecting compiler hash for triplet arm64-osx...
```