### PR TITLE
Fix ICU post build checks.

### DIFF
--- a/include/vcpkg/base/cofffilereader.h
+++ b/include/vcpkg/base/cofffilereader.h
@@ -361,6 +361,7 @@ namespace vcpkg
         std::vector<ImageDataDirectory> data_directories;
         std::vector<SectionTableHeader> section_headers;
 
+        const ImageDataDirectory* try_get_image_data_directory(size_t directory_index) const noexcept;
         MachineType get_machine_type() const noexcept;
         bool is_arm64_ec() const noexcept;
     };


### PR DESCRIPTION
This fixes a regression I introduced in https://github.com/microsoft/vcpkg-tool/pull/834 . (Specifically, this was always broken but now we are exposing ICU's x64-windows binaries to this code)

try_read_image_config_directory checked for a LOAD_CONFIG data directory, but didn't check that it was non-nullptr, like the import and export checks did. Extract a common function to make it easier to verify that we always do this.

```
C:\Dev>dumpbin /imports "C:\Dev\vcpkg\packages\icu_x64-windows\bin\icudt72.dll" Microsoft (R) COFF/PE Dumper Version 14.34.31942.0 Copyright (C) Microsoft Corporation.  All rights reserved.

Dump of file C:\Dev\vcpkg\packages\icu_x64-windows\bin\icudt72.dll

File Type: DLL

  Summary

     1DCE000 .rdata
        1000 .rsrc

C:\Dev>
```