### PR TITLE
Make e2e tests depend on fewer external resources.

### DIFF
--- a/azure-pipelines/e2e_projects/overlays-project-config-embedded/vcpkg.json
+++ b/azure-pipelines/e2e_projects/overlays-project-config-embedded/vcpkg.json
@@ -1,6 +1,5 @@
 {
 	"dependencies": [
-		"fmt",
 		"vcpkg-empty-port",
 		"another-vcpkg-empty-port",
 		"beicode"

--- a/azure-pipelines/e2e_projects/overlays-project-with-config/vcpkg.json
+++ b/azure-pipelines/e2e_projects/overlays-project-with-config/vcpkg.json
@@ -1,6 +1,5 @@
 {
 	"dependencies": [
-		"fmt",
 		"vcpkg-empty-port",
 		"another-vcpkg-empty-port",
 		"beicode"

--- a/azure-pipelines/end-to-end-tests-dir/binarycaching.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/binarycaching.ps1
@@ -6,62 +6,62 @@ $commonArgs += @(
 )
 
 # Test simple installation
-Run-Vcpkg -TestArgs ($commonArgs + @("install", "rapidjson", "vcpkg-cmake", "vcpkg-cmake-config", "--binarycaching", "--x-binarysource=clear;files,$ArchiveRoot,write"))
+Run-Vcpkg -TestArgs ($commonArgs + @("install", "vcpkg-hello-world-1", "vcpkg-cmake", "vcpkg-cmake-config", "--binarycaching", "--x-binarysource=clear;files,$ArchiveRoot,write"))
 Throw-IfFailed
 
 # Test simple removal
-Run-Vcpkg -TestArgs ($commonArgs + @("remove", "rapidjson", "vcpkg-cmake", "vcpkg-cmake-config"))
+Run-Vcpkg -TestArgs ($commonArgs + @("remove", "vcpkg-hello-world-1", "vcpkg-cmake", "vcpkg-cmake-config"))
 Throw-IfFailed
 Require-FileNotExists "$installRoot/$Triplet/include"
 
 if(-Not $IsLinux -and -Not $IsMacOS) {
     # Test simple nuget installation
-    Run-Vcpkg -TestArgs ($commonArgs + @("install", "rapidjson", "vcpkg-cmake", "vcpkg-cmake-config", "--binarycaching", "--x-binarysource=clear;nuget,$NuGetRoot,readwrite"))
+    Run-Vcpkg -TestArgs ($commonArgs + @("install", "vcpkg-hello-world-1", "vcpkg-cmake", "vcpkg-cmake-config", "--binarycaching", "--x-binarysource=clear;nuget,$NuGetRoot,readwrite"))
     Throw-IfFailed
 }
 
 # Test restoring from files archive
 Remove-Item -Recurse -Force $installRoot
 Remove-Item -Recurse -Force $buildtreesRoot
-Run-Vcpkg -TestArgs ($commonArgs + @("install","rapidjson", "vcpkg-cmake", "vcpkg-cmake-config","--binarycaching","--x-binarysource=clear;files,$ArchiveRoot,read"))
+Run-Vcpkg -TestArgs ($commonArgs + @("install","vcpkg-hello-world-1", "vcpkg-cmake", "vcpkg-cmake-config","--binarycaching","--x-binarysource=clear;files,$ArchiveRoot,read"))
 Throw-IfFailed
-Require-FileExists "$installRoot/$Triplet/include/rapidjson/rapidjson.h"
-Require-FileNotExists "$buildtreesRoot/rapidjson/src"
+Require-FileExists "$installRoot/$Triplet/include/hello-1.h"
+Require-FileNotExists "$buildtreesRoot/vcpkg-hello-world-1/src"
 Require-FileExists "$buildtreesRoot/detect_compiler"
 
 # Test --no-binarycaching
 Remove-Item -Recurse -Force $installRoot
 Remove-Item -Recurse -Force $buildtreesRoot
-Run-Vcpkg -TestArgs ($commonArgs + @("install","rapidjson", "vcpkg-cmake", "vcpkg-cmake-config","--no-binarycaching","--x-binarysource=clear;files,$ArchiveRoot,read"))
+Run-Vcpkg -TestArgs ($commonArgs + @("install","vcpkg-hello-world-1", "vcpkg-cmake", "vcpkg-cmake-config","--no-binarycaching","--x-binarysource=clear;files,$ArchiveRoot,read"))
 Throw-IfFailed
-Require-FileExists "$installRoot/$Triplet/include/rapidjson/rapidjson.h"
-Require-FileExists "$buildtreesRoot/rapidjson/src"
+Require-FileExists "$installRoot/$Triplet/include/hello-1.h"
+Require-FileExists "$buildtreesRoot/vcpkg-hello-world-1/src"
 Require-FileExists "$buildtreesRoot/detect_compiler"
 
 # Test --editable
 Remove-Item -Recurse -Force $installRoot
 Remove-Item -Recurse -Force $buildtreesRoot
-Run-Vcpkg -TestArgs ($commonArgs + @("install","rapidjson", "vcpkg-cmake", "vcpkg-cmake-config","--editable","--x-binarysource=clear;files,$ArchiveRoot,read"))
+Run-Vcpkg -TestArgs ($commonArgs + @("install","vcpkg-hello-world-1", "vcpkg-cmake", "vcpkg-cmake-config","--editable","--x-binarysource=clear;files,$ArchiveRoot,read"))
 Throw-IfFailed
-Require-FileExists "$installRoot/$Triplet/include/rapidjson/rapidjson.h"
-Require-FileExists "$buildtreesRoot/rapidjson/src"
+Require-FileExists "$installRoot/$Triplet/include/hello-1.h"
+Require-FileExists "$buildtreesRoot/vcpkg-hello-world-1/src"
 Require-FileNotExists "$buildtreesRoot/detect_compiler"
 
 if(-Not $IsLinux -and -Not $IsMacOS) {
     # Test restoring from nuget
     Remove-Item -Recurse -Force $installRoot
     Remove-Item -Recurse -Force $buildtreesRoot
-    Run-Vcpkg -TestArgs ($commonArgs + @("install", "rapidjson", "vcpkg-cmake", "vcpkg-cmake-config", "--binarycaching", "--x-binarysource=clear;nuget,$NuGetRoot"))
+    Run-Vcpkg -TestArgs ($commonArgs + @("install", "vcpkg-hello-world-1", "vcpkg-cmake", "vcpkg-cmake-config", "--binarycaching", "--x-binarysource=clear;nuget,$NuGetRoot"))
     Throw-IfFailed
-    Require-FileExists "$installRoot/$Triplet/include/rapidjson/rapidjson.h"
-    Require-FileNotExists "$buildtreesRoot/rapidjson/src"
+    Require-FileExists "$installRoot/$Triplet/include/hello-1.h"
+    Require-FileNotExists "$buildtreesRoot/vcpkg-hello-world-1/src"
 
     # Test four-phase flow
     Remove-Item -Recurse -Force $installRoot -ErrorAction SilentlyContinue
-    Run-Vcpkg -TestArgs ($commonArgs + @("install", "rapidjson", "vcpkg-cmake", "vcpkg-cmake-config", "--dry-run", "--x-write-nuget-packages-config=$TestingRoot/packages.config"))
+    Run-Vcpkg -TestArgs ($commonArgs + @("install", "vcpkg-hello-world-1", "vcpkg-cmake", "vcpkg-cmake-config", "--dry-run", "--x-write-nuget-packages-config=$TestingRoot/packages.config"))
     Throw-IfFailed
-    Require-FileNotExists "$installRoot/$Triplet/include/rapidjson/rapidjson.h"
-    Require-FileNotExists "$buildtreesRoot/rapidjson/src"
+    Require-FileNotExists "$installRoot/$Triplet/include/hello-1.h"
+    Require-FileNotExists "$buildtreesRoot/vcpkg-hello-world-1/src"
     Require-FileExists "$TestingRoot/packages.config"
     $fetchNuGetArgs = $commonArgs + @('fetch', 'nuget')
     if ($IsLinux -or $IsMacOS) {
@@ -72,12 +72,12 @@ if(-Not $IsLinux -and -Not $IsMacOS) {
     Throw-IfFailed
     Remove-Item -Recurse -Force $NuGetRoot -ErrorAction SilentlyContinue
     mkdir $NuGetRoot
-    Run-Vcpkg -TestArgs ($commonArgs + @("install", "rapidjson", "zlib", "vcpkg-cmake", "vcpkg-cmake-config", "--binarycaching", "--x-binarysource=clear;nuget,$NuGetRoot2;nuget,$NuGetRoot,write"))
+    Run-Vcpkg -TestArgs ($commonArgs + @("install", "vcpkg-hello-world-1", "vcpkg-hello-world-2", "vcpkg-cmake", "vcpkg-cmake-config", "--binarycaching", "--x-binarysource=clear;nuget,$NuGetRoot2;nuget,$NuGetRoot,write"))
     Throw-IfFailed
-    Require-FileExists "$installRoot/$Triplet/include/rapidjson/rapidjson.h"
-    Require-FileExists "$installRoot/$Triplet/include/zlib.h"
-    Require-FileNotExists "$buildtreesRoot/rapidjson/src"
-    Require-FileExists "$buildtreesRoot/zlib/src"
+    Require-FileExists "$installRoot/$Triplet/include/hello-1.h"
+    Require-FileExists "$installRoot/$Triplet/include/hello-2.h"
+    Require-FileNotExists "$buildtreesRoot/vcpkg-hello-world-1/src"
+    Require-FileExists "$buildtreesRoot/vcpkg-hello-world-2/src"
     if ((Get-ChildItem $NuGetRoot -Filter '*.nupkg' | Measure-Object).Count -ne 1) {
         throw "In '$CurrentTest': did not create exactly 1 NuGet package"
     }
@@ -87,7 +87,7 @@ if(-Not $IsLinux -and -Not $IsMacOS) {
     Require-FileNotExists "$TestingRoot/vcpkg-export-output"
     Require-FileNotExists "$TestingRoot/vcpkg-export.1.0.0.nupkg"
     Require-FileNotExists "$TestingRoot/vcpkg-export-output.zip"
-    Run-Vcpkg -TestArgs ($commonArgs + @("export", "rapidjson", "zlib", "vcpkg-cmake", "vcpkg-cmake-config", "--nuget", "--nuget-id=vcpkg-export", "--nuget-version=1.0.0", "--output=vcpkg-export-output", "--raw", "--zip", "--output-dir=$TestingRoot"))
+    Run-Vcpkg -TestArgs ($commonArgs + @("export", "vcpkg-hello-world-1", "vcpkg-hello-world-2", "vcpkg-cmake", "vcpkg-cmake-config", "--nuget", "--nuget-id=vcpkg-export", "--nuget-version=1.0.0", "--output=vcpkg-export-output", "--raw", "--zip", "--output-dir=$TestingRoot"))
     Require-FileExists "$TestingRoot/vcpkg-export-output"
     Require-FileExists "$TestingRoot/vcpkg-export.1.0.0.nupkg"
     Require-FileExists "$TestingRoot/vcpkg-export-output.zip"

--- a/azure-pipelines/end-to-end-tests-dir/build-missing.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/build-missing.ps1
@@ -2,17 +2,17 @@
 
 $CurrentTest = "Build Missing tests"
 
-Run-Vcpkg -TestArgs ($commonArgs + @("install", "rapidjson", "--only-binarycaching","--x-binarysource=clear;files,$ArchiveRoot,read"))
+Run-Vcpkg -TestArgs ($commonArgs + @("install", "vcpkg-hello-world-1", "--only-binarycaching","--x-binarysource=clear;files,$ArchiveRoot,read"))
 Throw-IfNotFailed
-Require-FileNotExists "$installRoot/$Triplet/include/rapidjson/rapidjson.h"
+Require-FileNotExists "$installRoot/$Triplet/include/hello-1.h"
 
-# Create the rapidjson archive
+# Create the vcpkg-hello-world-1 archive
 Remove-Item -Recurse -Force $installRoot
-Run-Vcpkg -TestArgs ($commonArgs + @("install", "rapidjson","--x-binarysource=clear;files,$ArchiveRoot,write"))
+Run-Vcpkg -TestArgs ($commonArgs + @("install", "vcpkg-hello-world-1","--x-binarysource=clear;files,$ArchiveRoot,write"))
 Throw-IfFailed
-Require-FileExists "$installRoot/$Triplet/include/rapidjson/rapidjson.h"
+Require-FileExists "$installRoot/$Triplet/include/hello-1.h"
 
 Remove-Item -Recurse -Force $installRoot
-Run-Vcpkg -TestArgs ($commonArgs + @("install", "rapidjson", "--only-binarycaching","--x-binarysource=clear;files,$ArchiveRoot,read"))
+Run-Vcpkg -TestArgs ($commonArgs + @("install", "vcpkg-hello-world-1", "--only-binarycaching","--x-binarysource=clear;files,$ArchiveRoot,read"))
 Throw-IfFailed
-Require-FileExists "$installRoot/$Triplet/include/rapidjson/rapidjson.h"
+Require-FileExists "$installRoot/$Triplet/include/hello-1.h"

--- a/azure-pipelines/end-to-end-tests-dir/bundles.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/bundles.ps1
@@ -118,7 +118,10 @@ New-Item -ItemType File -Force $bundle/.vcpkg-root | Out-Null
 @{
     name = "manifest"
     version = "0"
-    dependencies = @("rapidjson")
+    dependencies = @(@{
+        name = "vcpkg-cmake"
+        host = $true
+    })
 } | ConvertTo-JSON | out-file -enc ascii $manifestdir/vcpkg.json | Out-Null
 
 $a = Run-VcpkgAndCaptureOutput z-print-config `
@@ -146,7 +149,7 @@ foreach ($k in $b.keys) {
     }
 }
 
-Run-Vcpkg install zlib --dry-run @commonArgs `
+Run-Vcpkg install vcpkg-hello-world-1 --dry-run @commonArgs `
     --x-buildtrees-root=$buildtreesRoot `
     --x-builtin-ports-root=$env:VCPKG_ROOT/ports `
     --x-install-root=$installRoot `
@@ -172,7 +175,10 @@ New-Item -ItemType Directory -Force $manifestdir2 | Out-Null
 @{
     name = "manifest"
     version = "0"
-    dependencies = @("rapidjson")
+    dependencies = @(@{
+        name = "vcpkg-cmake"
+        host = $true
+    })
     "builtin-baseline" = "897ff9372f15c032f1e6cd1b97a59b57d66ee5b2"
 } | ConvertTo-JSON | out-file -enc ascii $manifestdir2/vcpkg.json | Out-Null
 
@@ -184,7 +190,7 @@ Run-Vcpkg install @commonArgs `
     --x-packages-root=$packagesRoot
 Throw-IfFailed
 
-Run-Vcpkg search zlib @commonArgs `
+Run-Vcpkg search vcpkg-hello-world-1 @commonArgs `
     --x-manifest-root=$manifestdir2 `
     --x-buildtrees-root=$buildtreesRoot `
     --x-builtin-ports-root=$env:VCPKG_ROOT/ports `

--- a/azure-pipelines/end-to-end-tests-dir/cli.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/cli.ps1
@@ -1,11 +1,11 @@
 . $PSScriptRoot/../end-to-end-tests-prelude.ps1
 
 # Test bad command lines
-Run-Vcpkg -TestArgs ($commonArgs + @("install", "zlib", "--vcpkg-rootttttt", "C:\"))
+Run-Vcpkg -TestArgs ($commonArgs + @("install", "vcpkg-hello-world-1", "--vcpkg-rootttttt", "C:\"))
 Throw-IfNotFailed
 
-Run-Vcpkg -TestArgs ($commonArgs + @("install", "zlib", "--vcpkg-rootttttt=C:\"))
+Run-Vcpkg -TestArgs ($commonArgs + @("install", "vcpkg-hello-world-1", "--vcpkg-rootttttt=C:\"))
 Throw-IfNotFailed
 
-Run-Vcpkg -TestArgs ($commonArgs + @("install", "zlib", "--fast")) # --fast is not a switch
+Run-Vcpkg -TestArgs ($commonArgs + @("install", "vcpkg-hello-world-1", "--fast")) # --fast is not a switch
 Throw-IfNotFailed

--- a/azure-pipelines/end-to-end-tests-dir/registries.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/registries.ps1
@@ -13,7 +13,7 @@ Throw-IfNotFailed
 Run-Vcpkg install @builtinRegistryArgs --feature-flags=registries 'vcpkg-internal-e2e-test-port'
 Throw-IfNotFailed
 
-Run-Vcpkg install @builtinRegistryArgs --feature-flags=registries 'zlib'
+Run-Vcpkg install @builtinRegistryArgs --feature-flags=registries 'vcpkg-cmake'
 Throw-IfFailed
 
 Write-Trace "Test git and filesystem registries"
@@ -373,9 +373,9 @@ try
     # We pre-seed the install root with a lockfile for the invalid repository, so it isn't actually fetched from
     $vcpkgLockJson = @{
         "/" = @{
-            "HEAD" = $gitMainBaselineCommit; 
-            $gitSecondaryBranch = $gitSecondaryBaselineCommit  
-        } 
+            "HEAD" = $gitMainBaselineCommit;
+            $gitSecondaryBranch = $gitSecondaryBaselineCommit
+        }
     }
    New-Item -Path $installRoot/vcpkg/vcpkg-lock.json -ItemType File `
         -Value (ConvertTo-Json -Depth 5 -InputObject $vcpkgLockJson)

--- a/azure-pipelines/pipelines.yml
+++ b/azure-pipelines/pipelines.yml
@@ -16,24 +16,24 @@ jobs:
       displayName: "Clone vcpkg repo to serve as root"
     - task: NodeTool@0
       inputs:
-        versionSpec: '16.x'
+        versionSpec: '18.x'
       displayName: 'Install Node.js'
     - script: |
         cd ce
 
-        npm install -g npm
+        npm install -g @microsoft/rush
         rc=$?; if [ $rc -ne 0 ]; then exit $rc ; fi
 
-        npx @microsoft/rush update
+        rush update
         rc=$?; if [ $rc -ne 0 ]; then exit $rc ; fi
 
-        npx @microsoft/rush rebuild
+        rush rebuild
         rc=$?; if [ $rc -ne 0 ]; then exit $rc ; fi
 
-        npx @microsoft/rush test
+        rush test
         rc=$?; if [ $rc -ne 0 ]; then exit $rc ; fi
 
-        npx @microsoft/rush lint
+        rush lint
         rc=$?; if [ $rc -ne 0 ]; then exit $rc ; fi
 
         if [ -n "$(git status --porcelain)" ]; then
@@ -81,7 +81,7 @@ jobs:
 - job: osx
   displayName: 'OSX'
   pool:
-    vmImage: 'macOS-11'
+    vmImage: 'macOS-12'
   variables:
     - name: 'VCPKG_ROOT'
       value: $(Build.SourcesDirectory)/vcpkg-root
@@ -132,9 +132,9 @@ jobs:
         filePath: 'azure-pipelines/Format-CxxCode.ps1'
         pwsh: true
     - task: UseNode@1
-      displayName: Use Node 16 or later
+      displayName: Use Node 18
       inputs:
-        version: "16.x"
+        version: "18.x"
     - task: npmAuthenticate@0
       inputs:
         workingFile: 'ce\common\config\rush\.npmrc'

--- a/azure-pipelines/pipelines.yml
+++ b/azure-pipelines/pipelines.yml
@@ -97,6 +97,8 @@ jobs:
       failOnStderr: true
     - bash: build.amd64.debug/vcpkg-test
       displayName: 'Run vcpkg tests'
+    - bash: brew install pkg-config
+      displayName: 'Install pkgconfig'
     - task: PowerShell@2
       displayName: 'Run vcpkg end-to-end tests'
       inputs:

--- a/azure-pipelines/signing.yml
+++ b/azure-pipelines/signing.yml
@@ -77,9 +77,9 @@ jobs:
         arguments: '-Destination "$(Build.BinariesDirectory)" -VcpkgBaseVersion $(VCPKG_INITIAL_BASE_VERSION)'
     # Build and test vcpkg-artifacts
     - task: UseNode@1
-      displayName: Use Node 16 or later
+      displayName: Use Node 18 or later
       inputs:
-        version: "16.x"
+        version: "18.x"
     - script: copy azure-pipelines\.npmrc-internal ce\common\config\rush\.npmrc
       displayName: Use internal .npmrc
     - task: npmAuthenticate@0
@@ -192,7 +192,7 @@ jobs:
     dependsOn:
       - arch_independent
     pool:
-      vmImage: macOS-11
+      vmImage: macOS-12
     variables:
       VCPKG_STANDALONE_BUNDLE_SHA: $[ dependencies.arch_independent.outputs['shas.VCPKG_STANDALONE_BUNDLE_SHA'] ]
       VCPKG_CE_SHA: $[ dependencies.arch_independent.outputs['shas.VCPKG_CE_SHA'] ]


### PR DESCRIPTION
Fixes macos failures caused by Azure Pipelines removing pkgconfig by default, and hopefully speeds some bits up a bit by building less.