### PR TITLE
Disable metrics when the user is not opted in to Visual Studio telemetry when deployed w/VS.

### DIFF
--- a/include/vcpkg/base/messages.h
+++ b/include/vcpkg/base/messages.h
@@ -2645,6 +2645,7 @@ namespace vcpkg
                     "Pushing {vendor} to \"{path}\" failed. Use --debug for more information.");
     DECLARE_MESSAGE(RegistryCreated, (msg::path), "", "Successfully created registry at {path}");
     DECLARE_MESSAGE(RegeneratesArtifactRegistry, (), "", "Regenerates an artifact registry.");
+    DECLARE_MESSAGE(RegistryValueWrongType, (msg::path), "", "The registry value {path} was an unexpected type.");
     DECLARE_MESSAGE(RemoveDependencies,
                     (),
                     "",

--- a/include/vcpkg/base/system.h
+++ b/include/vcpkg/base/system.h
@@ -29,9 +29,11 @@ namespace vcpkg
     std::wstring get_username();
 
     bool test_registry_key(void* base_hkey, StringView sub_key);
-#endif
 
-    Optional<std::string> get_registry_string(void* base_hkey, StringView subkey, StringView valuename);
+    ExpectedL<std::string> get_registry_string(void* base_hkey, StringView subkey, StringView valuename);
+
+    ExpectedL<std::uint32_t> get_registry_dword(void* base_hkey, StringView subkey, StringView valuename);
+#endif
 
     long get_process_id();
 

--- a/include/vcpkg/bundlesettings.h
+++ b/include/vcpkg/bundlesettings.h
@@ -22,6 +22,7 @@ namespace vcpkg
         bool use_git_registry = false;
         Optional<std::string> embedded_git_sha;
         DeploymentKind deployment = DeploymentKind::Git;
+        Optional<std::string> vsversion;
 
         std::string to_string() const;
     };

--- a/include/vcpkg/vcpkgpaths.h
+++ b/include/vcpkg/vcpkgpaths.h
@@ -6,6 +6,7 @@
 
 #include <vcpkg/fwd/binaryparagraph.h>
 #include <vcpkg/fwd/build.h>
+#include <vcpkg/fwd/bundlesettings.h>
 #include <vcpkg/fwd/configuration.h>
 #include <vcpkg/fwd/installedpaths.h>
 #include <vcpkg/fwd/registries.h>
@@ -59,7 +60,7 @@ namespace vcpkg
 
     struct VcpkgPaths
     {
-        VcpkgPaths(Filesystem& filesystem, const VcpkgCmdArguments& args);
+        VcpkgPaths(Filesystem& filesystem, const VcpkgCmdArguments& args, const BundleSettings& bundle);
         VcpkgPaths(const VcpkgPaths&) = delete;
         VcpkgPaths& operator=(const VcpkgPaths&) = delete;
         ~VcpkgPaths();

--- a/locales/messages.json
+++ b/locales/messages.json
@@ -1193,6 +1193,8 @@
   "RegeneratesArtifactRegistry": "Regenerates an artifact registry.",
   "RegistryCreated": "Successfully created registry at {path}",
   "_RegistryCreated.comment": "An example of {path} is /foo/bar.",
+  "RegistryValueWrongType": "The registry value {path} was an unexpected type.",
+  "_RegistryValueWrongType.comment": "An example of {path} is /foo/bar.",
   "RemoveDependencies": "To remove dependencies in manifest mode, edit your manifest (vcpkg.json) and run 'install'.",
   "RemovePackageConflict": "{spec} is not installed, but {package_name} is installed for {triplet}. Did you mean {package_name}:{triplet}?",
   "_RemovePackageConflict.comment": "An example of {package_name} is zlib. An example of {spec} is zlib:x64-windows. An example of {triplet} is x64-windows.",

--- a/src/vcpkg-test/bundlesettings.cpp
+++ b/src/vcpkg-test/bundlesettings.cpp
@@ -26,6 +26,7 @@ TEST_CASE ("parse-no-fields", "[bundle-settings]")
     CHECK(result.use_git_registry == false);
     CHECK(!result.embedded_git_sha.has_value());
     CHECK(result.deployment == DeploymentKind::Git);
+    CHECK(!result.vsversion.has_value());
 }
 
 TEST_CASE ("parse-all-fields", "[bundle-settings]")
@@ -34,7 +35,8 @@ TEST_CASE ("parse-all-fields", "[bundle-settings]")
     "readonly": true,
     "usegitregistry": true,
     "embeddedsha": "a7a6d5edaff9d850db2d5f1378e5d9af59805e81",
-    "deployment": "OneLiner"
+    "deployment": "OneLiner",
+    "vsversion": "16.0"
 })json",
                                              "test"})
                       .value_or_exit(VCPKG_LINE_INFO);
@@ -42,6 +44,7 @@ TEST_CASE ("parse-all-fields", "[bundle-settings]")
     CHECK(result.use_git_registry == true);
     CHECK(result.embedded_git_sha.value_or_exit(VCPKG_LINE_INFO) == "a7a6d5edaff9d850db2d5f1378e5d9af59805e81");
     CHECK(result.deployment == DeploymentKind::OneLiner);
+    CHECK(result.vsversion.value_or_exit(VCPKG_LINE_INFO) == "16.0");
 }
 
 TEST_CASE ("parse-each-deployment", "[bundle-settings]")
@@ -59,16 +62,56 @@ TEST_CASE ("parse-each-deployment", "[bundle-settings]")
 
 TEST_CASE ("parse-error", "[bundle-settings]")
 {
-    auto bad_case = GENERATE("",                          // not an object
-                             "[]",                        // not an object
-                             R"({"readonly": {}})",       // readonly isn't a bool
-                             R"({"usegitregistry": {}})", // usegitregistry isn't a bool
-                             R"({"embeddedsha": {}})",    // embeddedsha isn't a string
-                             R"({"deployment": true})",   // deployment isn't a string
-                             R"({"deployment": "bogus"})" // deployment isn't one of the expected values
+    auto bad_case = GENERATE("",                           // not an object
+                             "[]",                         // not an object
+                             R"({"readonly": {}})",        // readonly isn't a bool
+                             R"({"usegitregistry": {}})",  // usegitregistry isn't a bool
+                             R"({"embeddedsha": {}})",     // embeddedsha isn't a string
+                             R"({"deployment": true})",    // deployment isn't a string
+                             R"({"deployment": "bogus"})", // deployment isn't one of the expected values
+                             R"({"vsversion": true})"      // vsversion isn't a string
     );
 
     auto result = try_parse_bundle_settings({bad_case, "test"});
     REQUIRE(!result.has_value());
     REQUIRE_THAT(result.error().data(), Catch::StartsWith("Invalid bundle definition."));
+}
+
+TEST_CASE ("to_string", "[bundle-settings]")
+{
+    BundleSettings uut;
+    uut.deployment = GENERATE(DeploymentKind::Git, DeploymentKind::OneLiner, DeploymentKind::VisualStudio);
+    std::string expected_git_sha;
+    bool has_git_sha = GENERATE(false, true);
+    if (has_git_sha)
+    {
+        uut.embedded_git_sha.emplace("a7a6d5edaff9d850db2d5f1378e5d9af59805e81");
+        expected_git_sha = "a7a6d5edaff9d850db2d5f1378e5d9af59805e81";
+    }
+    else
+    {
+        expected_git_sha = "nullopt";
+    }
+
+    uut.read_only = GENERATE(false, true);
+    uut.use_git_registry = GENERATE(false, true);
+    std::string expected_vs_version;
+    bool has_vsver = GENERATE(false, true);
+    if (has_vsver)
+    {
+        uut.vsversion.emplace("16.0");
+        expected_vs_version = "16.0";
+    }
+    else
+    {
+        expected_vs_version = "nullopt";
+    }
+
+    REQUIRE(uut.to_string() ==
+            fmt::format("readonly={}, usegitregistry={}, embeddedsha={}, deployment={}, vsversion={}",
+                        uut.read_only,
+                        uut.use_git_registry,
+                        expected_git_sha,
+                        uut.deployment,
+                        expected_vs_version));
 }

--- a/src/vcpkg/base/messages.cpp
+++ b/src/vcpkg/base/messages.cpp
@@ -1138,6 +1138,7 @@ namespace vcpkg
     REGISTER_MESSAGE(PushingVendorFailed);
     REGISTER_MESSAGE(RegistryCreated);
     REGISTER_MESSAGE(RegeneratesArtifactRegistry);
+    REGISTER_MESSAGE(RegistryValueWrongType);
     REGISTER_MESSAGE(RemoveDependencies);
     REGISTER_MESSAGE(RemovePackageConflict);
     REGISTER_MESSAGE(ResponseFileCode);

--- a/src/vcpkg/base/system.cpp
+++ b/src/vcpkg/base/system.cpp
@@ -21,6 +21,117 @@
 extern char** environ;
 #endif
 
+namespace
+{
+    using namespace vcpkg;
+#ifdef _WIN32
+    struct RegistryValue
+    {
+        DWORD type;
+        std::vector<unsigned char> data;
+    };
+
+    const HKEY INVALID_HKEY_VALUE = ((HKEY)(ULONG_PTR)((LONG)0xFFFFFFFF));
+    struct HKey
+    {
+        HKEY hkey = INVALID_HKEY_VALUE;
+
+        static ExpectedL<HKey> open(void* base_hkey, StringView sub_key, DWORD desired_access)
+        {
+            HKEY constructed_hkey = nullptr;
+            const LSTATUS ec = RegOpenKeyExW(reinterpret_cast<HKEY>(base_hkey),
+                                             Strings::to_utf16(sub_key).c_str(),
+                                             0,
+                                             desired_access,
+                                             &constructed_hkey);
+            if (ec == ERROR_SUCCESS)
+            {
+                return HKey{constructed_hkey};
+            }
+            else
+            {
+                return LocalizedString::from_raw(std::system_category().message(static_cast<int>(ec)));
+            }
+        }
+
+        HKey(HKey&& other) : hkey(std::exchange(other.hkey, INVALID_HKEY_VALUE)) { }
+        HKey& operator=(HKey&& other)
+        {
+            HKey moved{std::move(other)};
+            std::swap(hkey, moved.hkey);
+            return *this;
+        }
+        ~HKey()
+        {
+            if (hkey != INVALID_HKEY_VALUE)
+            {
+                RegCloseKey(hkey);
+            }
+        }
+
+        ExpectedL<RegistryValue> query_value(StringView valuename) const
+        {
+            if (hkey == INVALID_HKEY_VALUE)
+            {
+                Checks::unreachable(VCPKG_LINE_INFO, "Tried to query invalid key");
+            }
+
+            auto w_valuename = Strings::to_utf16(valuename);
+            RegistryValue result;
+            DWORD dw_buffer_size = 4;
+            for (;;)
+            {
+                result.data.resize(dw_buffer_size);
+                LSTATUS attempt_result = ::RegQueryValueExW(
+                    hkey, w_valuename.c_str(), nullptr, &result.type, result.data.data(), &dw_buffer_size);
+                switch (attempt_result)
+                {
+                    case ERROR_SUCCESS: result.data.resize(dw_buffer_size); return result;
+                    case ERROR_MORE_DATA: continue;
+                    default: return LocalizedString::from_raw(std::system_category().message(attempt_result));
+                }
+            }
+        }
+
+        explicit operator bool() const noexcept { return hkey != INVALID_HKEY_VALUE; }
+
+    private:
+        explicit HKey(HKEY constructed_hkey) : hkey(constructed_hkey) { }
+    };
+
+    StringLiteral format_base_hkey_name(void* base_hkey)
+    {
+        // copied these values out of winreg.h because HKEY can't be used as a switch/case as it isn't integral
+        switch (reinterpret_cast<std::uintptr_t>(base_hkey))
+        {
+            case 0x80000000u: return "HKEY_CLASSES_ROOT";
+            case 0x80000001u: return "HKEY_CURRENT_USER";
+            case 0x80000002u: return "HKEY_LOCAL_MACHINE";
+            case 0x80000003u: return "HKEY_USERS";
+            case 0x80000004u: return "HKEY_PERFORMANCE_DATA";
+            case 0x80000005u: return "HKEY_CURRENT_CONFIG";
+            case 0x80000050u: return "HKEY_PERFORMANCE_TEXT";
+            case 0x80000060u: return "HKEY_PERFORMANCE_NLSTEXT";
+            default: return "UNKNOWN_BASE_HKEY";
+        }
+    }
+
+    std::string format_registry_value_name(void* base_hkey, StringView sub_key, StringView valuename)
+    {
+        auto result = format_base_hkey_name(base_hkey).to_string();
+        if (!sub_key.empty())
+        {
+            result.push_back('\\');
+            result.append(sub_key.data(), sub_key.size());
+        }
+
+        result.append(2, '\\');
+        result.append(valuename.data(), valuename.size());
+        return result;
+    }
+#endif // ^^^ _WIN32
+}
+
 namespace vcpkg
 {
     long get_process_id()
@@ -394,11 +505,6 @@ namespace vcpkg
     }
 
 #if defined(_WIN32)
-    static bool is_string_keytype(const DWORD hkey_type)
-    {
-        return hkey_type == REG_SZ || hkey_type == REG_MULTI_SZ || hkey_type == REG_EXPAND_SZ;
-    }
-
     std::wstring get_username()
     {
         DWORD buffer_size = UNLEN + 1;
@@ -411,40 +517,68 @@ namespace vcpkg
 
     bool test_registry_key(void* base_hkey, StringView sub_key)
     {
-        HKEY k = nullptr;
-        const LSTATUS ec =
-            RegOpenKeyExW(reinterpret_cast<HKEY>(base_hkey), Strings::to_utf16(sub_key).c_str(), 0, KEY_READ, &k);
-        return (ERROR_SUCCESS == ec);
+        return HKey::open(base_hkey, sub_key, KEY_QUERY_VALUE).has_value();
     }
 
-    Optional<std::string> get_registry_string(void* base_hkey, StringView sub_key, StringView valuename)
+    ExpectedL<std::string> get_registry_string(void* base_hkey, StringView sub_key, StringView valuename)
     {
-        HKEY k = nullptr;
-        const LSTATUS ec =
-            RegOpenKeyExW(reinterpret_cast<HKEY>(base_hkey), Strings::to_utf16(sub_key).c_str(), 0, KEY_READ, &k);
-        if (ec != ERROR_SUCCESS) return nullopt;
+        auto maybe_k = HKey::open(base_hkey, sub_key, KEY_QUERY_VALUE);
+        if (auto k = maybe_k.get())
+        {
+            auto maybe_value = k->query_value(valuename);
+            if (auto value = maybe_value.get())
+            {
+                switch (value->type)
+                {
+                    case REG_SZ:
+                    case REG_EXPAND_SZ:
+                        // remove trailing nulls
+                        while (!value->data.empty() && !value->data.back())
+                        {
+                            value->data.pop_back();
+                        }
 
-        auto w_valuename = Strings::to_utf16(valuename);
+                        {
+                            auto length_in_wchar_ts = value->data.size() >> 1;
+                            return Strings::to_utf8(reinterpret_cast<const wchar_t*>(value->data.data()),
+                                                    length_in_wchar_ts);
+                        }
+                    default:
+                        return msg::format_error(msgRegistryValueWrongType,
+                                                 msg::path = format_registry_value_name(base_hkey, sub_key, valuename));
+                }
+            }
 
-        DWORD dw_buffer_size = 0;
-        DWORD dw_type = 0;
-        auto rc = RegQueryValueExW(k, w_valuename.c_str(), nullptr, &dw_type, nullptr, &dw_buffer_size);
-        if (rc != ERROR_SUCCESS || !is_string_keytype(dw_type) || dw_buffer_size == 0 ||
-            dw_buffer_size % sizeof(wchar_t) != 0)
-            return nullopt;
-        std::wstring ret;
-        ret.resize(dw_buffer_size / sizeof(wchar_t));
+            return std::move(maybe_value).error();
+        }
 
-        rc = RegQueryValueExW(
-            k, w_valuename.c_str(), nullptr, &dw_type, reinterpret_cast<LPBYTE>(ret.data()), &dw_buffer_size);
-        if (rc != ERROR_SUCCESS || !is_string_keytype(dw_type) || dw_buffer_size != sizeof(wchar_t) * ret.size())
-            return nullopt;
-
-        ret.pop_back(); // remove extra trailing null byte
-        return Strings::to_utf8(ret);
+        return std::move(maybe_k).error();
     }
-#else
-    Optional<std::string> get_registry_string(void*, StringView, StringView) { return nullopt; }
+
+    ExpectedL<std::uint32_t> get_registry_dword(void* base_hkey, StringView sub_key, StringView valuename)
+    {
+        auto maybe_k = HKey::open(base_hkey, sub_key, KEY_QUERY_VALUE);
+        if (auto k = maybe_k.get())
+        {
+            auto maybe_value = k->query_value(valuename);
+            if (auto value = maybe_value.get())
+            {
+                if (value->type == REG_DWORD && value->data.size() >= sizeof(DWORD))
+                {
+                    DWORD result{};
+                    ::memcpy(&result, value->data.data(), sizeof(DWORD));
+                    return result;
+                }
+
+                return msg::format_error(msgRegistryValueWrongType,
+                                         msg::path = format_registry_value_name(base_hkey, sub_key, valuename));
+            }
+
+            return std::move(maybe_value).error();
+        }
+
+        return std::move(maybe_k).error();
+    }
 #endif
 
     static const Optional<Path>& get_program_files()

--- a/src/vcpkg/bundlesettings.cpp
+++ b/src/vcpkg/bundlesettings.cpp
@@ -64,11 +64,12 @@ namespace vcpkg
 
     std::string BundleSettings::to_string() const
     {
-        return fmt::format("readonly={}, usegitregistry={}, embeddedsha={}, deployment={}",
+        return fmt::format("readonly={}, usegitregistry={}, embeddedsha={}, deployment={}, vsversion={}",
                            read_only,
                            use_git_registry,
                            embedded_git_sha.value_or("nullopt"),
-                           deployment);
+                           deployment,
+                           vsversion.value_or("nullopt"));
     }
 
     ExpectedL<BundleSettings> try_parse_bundle_settings(const FileContents& bundle_contents)
@@ -85,7 +86,8 @@ namespace vcpkg
         if (!parse_optional_json_bool(*doc, "readonly", ret.read_only) ||
             !parse_optional_json_bool(*doc, "usegitregistry", ret.use_git_registry) ||
             !parse_optional_json_string(*doc, "embeddedsha", ret.embedded_git_sha) ||
-            !parse_optional_json_string(*doc, "deployment", maybe_deployment_string))
+            !parse_optional_json_string(*doc, "deployment", maybe_deployment_string) ||
+            !parse_optional_json_string(*doc, "vsversion", ret.vsversion))
         {
             return msg::format(msgInvalidBundleDefinition);
         }

--- a/src/vcpkg/commands.edit.cpp
+++ b/src/vcpkg/commands.edit.cpp
@@ -38,7 +38,7 @@ namespace
 
         for (auto&& keypath : REGKEYS)
         {
-            const Optional<std::string> code_installpath =
+            const ExpectedL<std::string> code_installpath =
                 get_registry_string(keypath.root, keypath.subkey, "InstallLocation");
             if (const auto c = code_installpath.get())
             {

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -200,17 +200,10 @@ namespace
         return ret;
     }
 
-    BundleSettings load_bundle_file(const Filesystem& fs, const Path& root)
-    {
-        return fs.try_read_contents(root / "vcpkg-bundle.json")
-            .then(&try_parse_bundle_settings)
-            .value_or(BundleSettings{});
-    }
-
     Optional<Path> maybe_get_tmp_path(const Filesystem& fs,
-                                      const BundleSettings& bundle,
                                       const Optional<InstalledPaths>& installed,
                                       const Path& root,
+                                      bool root_read_only,
                                       const std::string* arg_path,
                                       StringLiteral root_subpath,
                                       StringLiteral readonly_subpath,
@@ -220,7 +213,7 @@ namespace
         {
             return fs.almost_canonical(*arg_path, li);
         }
-        else if (bundle.read_only)
+        else if (root_read_only)
         {
             if (auto i = installed.get())
             {
@@ -293,11 +286,15 @@ namespace
     // 2. Are const (and therefore initialized in the initializer list)
     struct VcpkgPathsImplStage1 : VcpkgPathsImplStage0
     {
-        VcpkgPathsImplStage1(Filesystem& fs, const VcpkgCmdArguments& args, const Path& root, const Path& original_cwd)
+        VcpkgPathsImplStage1(Filesystem& fs,
+                             const VcpkgCmdArguments& args,
+                             const BundleSettings& bundle,
+                             const Path& root,
+                             const Path& original_cwd)
             : m_fs(fs)
             , m_ff_settings(args.feature_flag_settings())
             , m_manifest_dir(compute_manifest_dir(fs, args, original_cwd))
-            , m_bundle(load_bundle_file(fs, root))
+            , m_bundle(bundle)
             , m_download_manager(std::make_shared<DownloadManager>(
                   parse_download_configuration(args.asset_sources_template()).value_or_exit(VCPKG_LINE_INFO)))
             , m_builtin_ports(process_output_directory(fs, args.builtin_ports_root_dir.get(), root / "ports"))
@@ -309,10 +306,7 @@ namespace
             , scripts(process_input_directory(fs, root, args.scripts_root_dir.get(), "scripts", VCPKG_LINE_INFO))
             , m_registries_cache(compute_registries_cache_root(fs, args))
         {
-            Debug::println("Bundle config: ", m_bundle.to_string());
             Debug::println("Using builtin-ports: ", m_builtin_ports);
-            get_global_metrics_collector().track_string(StringMetric::DeploymentKind,
-                                                        to_string_literal(m_bundle.deployment));
         }
 
         Filesystem& m_fs;
@@ -326,15 +320,12 @@ namespace
         const Path m_registries_cache;
     };
 
-    Optional<InstalledPaths> compute_installed(Filesystem& fs,
-                                               const VcpkgCmdArguments& args,
-                                               const Path& root,
-                                               const Path& manifest_dir,
-                                               const BundleSettings& bundle)
+    Optional<InstalledPaths> compute_installed(
+        Filesystem& fs, const VcpkgCmdArguments& args, const Path& root, bool root_read_only, const Path& manifest_dir)
     {
         if (manifest_dir.empty())
         {
-            if (!bundle.read_only)
+            if (!root_read_only)
             {
                 return InstalledPaths{process_output_directory(fs, args.install_root_dir.get(), root / "installed")};
             }
@@ -350,14 +341,14 @@ namespace
     Path compute_downloads_root(const Filesystem& fs,
                                 const VcpkgCmdArguments& args,
                                 const Path& root,
-                                const BundleSettings& bundle)
+                                bool root_read_only)
     {
         Path ret;
         if (auto downloads_root_dir = args.downloads_root_dir.get())
         {
             ret = *downloads_root_dir;
         }
-        else if (bundle.read_only)
+        else if (root_read_only)
         {
             ret = get_platform_cache_home().value_or_exit(VCPKG_LINE_INFO) / "vcpkg" / "downloads";
         }
@@ -517,26 +508,36 @@ namespace vcpkg
 
     struct VcpkgPathsImpl : VcpkgPathsImplStage1
     {
-        VcpkgPathsImpl(Filesystem& fs, const VcpkgCmdArguments& args, const Path& root, const Path& original_cwd)
-            : VcpkgPathsImplStage1(fs, args, root, original_cwd)
+        VcpkgPathsImpl(Filesystem& fs,
+                       const VcpkgCmdArguments& args,
+                       const BundleSettings bundle,
+                       const Path& root,
+                       const Path& original_cwd)
+            : VcpkgPathsImplStage1(fs, args, bundle, root, original_cwd)
             , m_config_dir(m_manifest_dir.empty() ? root : m_manifest_dir)
             , m_manifest_path(m_manifest_dir.empty() ? Path{} : m_manifest_dir / "vcpkg.json")
             , m_registries_work_tree_dir(m_registries_cache / "git")
             , m_registries_dot_git_dir(m_registries_cache / "git" / ".git")
             , m_registries_git_trees(m_registries_cache / "git-trees")
-            , downloads(compute_downloads_root(fs, args, root, m_bundle))
+            , downloads(compute_downloads_root(fs, args, root, bundle.read_only))
             , tools(downloads / "tools")
-            , m_installed(compute_installed(fs, args, root, m_manifest_dir, m_bundle))
+            , m_installed(compute_installed(fs, args, root, bundle.read_only, m_manifest_dir))
             , buildtrees(maybe_get_tmp_path(fs,
-                                            m_bundle,
                                             m_installed,
                                             root,
+                                            m_bundle.read_only,
                                             args.buildtrees_root_dir.get(),
                                             "buildtrees",
                                             "blds",
                                             VCPKG_LINE_INFO))
-            , packages(maybe_get_tmp_path(
-                  fs, m_bundle, m_installed, root, args.packages_root_dir.get(), "packages", "pkgs", VCPKG_LINE_INFO))
+            , packages(maybe_get_tmp_path(fs,
+                                          m_installed,
+                                          root,
+                                          m_bundle.read_only,
+                                          args.packages_root_dir.get(),
+                                          "packages",
+                                          "pkgs",
+                                          VCPKG_LINE_INFO))
             , m_tool_cache(get_tool_cache(fs,
                                           m_download_manager,
                                           downloads,
@@ -610,11 +611,11 @@ namespace vcpkg
         ConfigurationAndSource m_config;
     };
 
-    VcpkgPaths::VcpkgPaths(Filesystem& filesystem, const VcpkgCmdArguments& args)
+    VcpkgPaths::VcpkgPaths(Filesystem& filesystem, const VcpkgCmdArguments& args, const BundleSettings& bundle)
         : original_cwd(preferred_current_path(filesystem))
         , root(determine_root(filesystem, original_cwd, args))
         // this is used during the initialization of the below public members
-        , m_pimpl(std::make_unique<VcpkgPathsImpl>(filesystem, args, root, original_cwd))
+        , m_pimpl(std::make_unique<VcpkgPathsImpl>(filesystem, args, bundle, root, original_cwd))
         , scripts(m_pimpl->scripts)
         , downloads(m_pimpl->downloads)
         , tools(m_pimpl->tools)

--- a/vcpkg-init/mint-standalone-bundle.ps1
+++ b/vcpkg-init/mint-standalone-bundle.ps1
@@ -12,7 +12,23 @@ Param(
     [string]$SignedFilesRoot
 )
 
-[bool]$ReadOnly = $Deployment -eq 'VisualStudio';
+if ($Deployment -eq 'VisualStudio') {
+    $BundleConfig = @{
+        'readonly'       = $True;
+        'usegitregistry' = $True;
+        'embeddedsha'    = $sha;
+        'deployment'     = $Deployment;
+        'vsversion'      = "17.0";
+    }
+} else {
+    $BundleConfig = @{
+        'readonly'       = $False;
+        'usegitregistry' = $True;
+        'embeddedsha'    = $sha;
+        'deployment'     = $Deployment;
+    }
+}
+
 $sha = Get-Content "$PSScriptRoot/vcpkg-scripts-sha.txt" -Raw
 $sha = $sha.Trim()
 
@@ -75,16 +91,9 @@ try {
     New-Item -Path 'out/scripts/posh-vcpkg/0.0.1' -ItemType 'Directory' -Force
     Copy-Item -Path "$SignedFilesRoot/posh-vcpkg.psm1" -Destination 'out/scripts/posh-vcpkg/0.0.1/posh-vcpkg.psm1'
 
-    $bundleConfig = @{
-        'readonly'       = $ReadOnly;
-        'usegitregistry' = $True;
-        'embeddedsha'    = $sha;
-        'deployment'     = $Deployment;
-    }
-
     New-Item -Path "out/.vcpkg-root" -ItemType "File"
     Set-Content -Path "out/vcpkg-bundle.json" `
-        -Value (ConvertTo-Json -InputObject $bundleConfig) `
+        -Value (ConvertTo-Json -InputObject $BundleConfig) `
         -Encoding Ascii
 
     if (-not [String]::IsNullOrEmpty($DestinationTarball)) {


### PR DESCRIPTION
When deployed with Visual Studio, we should listen to the privacy setting like the rest of Visual Studio:
<img width="516" alt="Visual Studio Privacy Settings Dialog" src="https://user-images.githubusercontent.com/1544943/221352838-16f158c0-9763-4cda-b581-adcc24e972d0.png">

This required moving the bundleconfig to "next to the .exe" rather than "within vcpkg_root", and corresponding test changes, since we need to know information out of the bundle before we know where VCPKG_ROOT is (and maybe for commands that don't need VCPKG_ROOT in the first place).

This also changes `--no-disablemetrics` to force enable metrics if the user does that for some reason, even if there's a file named vcpkg.disable-metrics.

Drive bys:
* test_registry_key and get_registry_string where leaktrocities.
* get_registry_string was racy.
* get_registry_string accepted REG_MULTI_SZ despite that not actually being a string type. (It's `vector<string>`)

Example output when enabled:

<img width="674" alt="VS Metrics Opted In Example Output" src="https://user-images.githubusercontent.com/1544943/221352883-3e52cdb9-6768-4fc2-80ce-390793d512fe.png">

Example output when disabled:

<img width="672" alt="VS Metrics Not Opted In Example Output" src="https://user-images.githubusercontent.com/1544943/221352902-ac4344f4-e7c7-412d-ac9d-75b401f5b9f1.png">
