### PR TITLE
Don't extract vcpkg-artifacts under VCPKG_ROOT

### DIFF
--- a/include/vcpkg/base/system.h
+++ b/include/vcpkg/base/system.h
@@ -15,7 +15,7 @@ namespace vcpkg
 
     const ExpectedL<Path>& get_home_dir() noexcept;
 
-    const ExpectedL<Path>& get_platform_cache_home() noexcept;
+    const ExpectedL<Path>& get_platform_cache_vcpkg() noexcept;
 
     const ExpectedL<Path>& get_user_configuration_home() noexcept;
 

--- a/src/vcpkg/base/system.cpp
+++ b/src/vcpkg/base/system.cpp
@@ -484,13 +484,16 @@ namespace vcpkg
     }
 #endif
 
-    const ExpectedL<Path>& get_platform_cache_home() noexcept
+    const ExpectedL<Path>& get_platform_cache_vcpkg() noexcept
     {
+        static ExpectedL<Path> s_vcpkg =
 #ifdef _WIN32
-        return get_appdata_local();
+            get_appdata_local()
 #else
-        return get_xdg_cache_home();
+            get_xdg_cache_home()
 #endif
+                .map([](const Path& p) { return p / "vcpkg"; });
+        return s_vcpkg;
     }
 
     const ExpectedL<Path>& get_user_configuration_home() noexcept

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -1584,10 +1584,10 @@ namespace
             return std::move(path);
         }
 
-        return get_platform_cache_home().then([](Path p) -> ExpectedL<Path> {
+        return get_platform_cache_vcpkg().then([](Path p) -> ExpectedL<Path> {
             if (p.is_absolute())
             {
-                p /= "vcpkg/archives";
+                p /= "archives";
                 p.make_preferred();
                 return std::move(p);
             }

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -275,7 +275,7 @@ namespace
         }
         else
         {
-            ret = get_platform_cache_home().value_or_exit(VCPKG_LINE_INFO) / "vcpkg" / "registries";
+            ret = get_platform_cache_vcpkg().value_or_exit(VCPKG_LINE_INFO) / "registries";
         }
 
         return fs.almost_canonical(ret, VCPKG_LINE_INFO);
@@ -350,7 +350,7 @@ namespace
         }
         else if (root_read_only)
         {
-            ret = get_platform_cache_home().value_or_exit(VCPKG_LINE_INFO) / "vcpkg" / "downloads";
+            ret = get_platform_cache_vcpkg().value_or_exit(VCPKG_LINE_INFO) / "downloads";
         }
         else
         {


### PR DESCRIPTION
which allows artifacts to work when VCPKG_ROOT is read only.

Example with official build:
```
PS C:\Dev\vcpkg-tool\out\build\x64-Debug-Official-2022-11-10> .\vcpkg.exe find artifact gcc --debug
[DEBUG] To include the environment variables in debug output, pass --debug-env
[DEBUG] Trying to load bundleconfig from C:\Dev\vcpkg-tool\out\build\x64-Debug-Official-2022-11-10\vcpkg-bundle.json
[DEBUG] Failed to open: C:\Dev\vcpkg-tool\out\build\x64-Debug-Official-2022-11-10\vcpkg-bundle.json
[DEBUG] Bundle config: readonly=false, usegitregistry=false, embeddedsha=nullopt, deployment=Git, vsversion=nullopt
[DEBUG] Metrics enabled.
[DEBUG] Feature flag 'binarycaching' unset
[DEBUG] Feature flag 'compilertracking' unset
[DEBUG] Feature flag 'registries' unset
[DEBUG] Feature flag 'versions' unset
[DEBUG] Using scripts-root: C:\Dev\vcpkg\scripts
[DEBUG] Using builtin-ports: C:\Dev\vcpkg\ports
[DEBUG] Using installed-root: C:\Dev\vcpkg\installed
[DEBUG] Using buildtrees-root: C:\Dev\vcpkg\buildtrees
[DEBUG] Using packages-root: C:\Dev\vcpkg\packages
[DEBUG] Using vcpkg-root: C:\Dev\vcpkg
[DEBUG] Using scripts-root: C:\Dev\vcpkg\scripts
[DEBUG] Using builtin-registry: C:\Dev\vcpkg\versions
[DEBUG] Using downloads-root: C:\vcpkg-downloads
warning: vcpkg-ce ('configure environment') is experimental and may change at any time.
[DEBUG] Found path: C:\Program Files\nodejs\node.exe
[DEBUG] CreateProcessW("C:\Program Files\nodejs\node.exe" --version)
[DEBUG] ReadFile() finished with GetLastError(): 109
[DEBUG] 1000: cmd_execute_and_stream_data() returned 0 after    35701 us
[DEBUG] vcpkg-artifacts base path: C:\Users\billy\AppData\Local\vcpkg\vcpkg-artifacts-2022-11-10
Downloading vcpkg-artifacts bundle 2022-11-10...
Downloading https://github.com/microsoft/vcpkg-tool/releases/download/2022-11-10/vcpkg-ce.tgz
[DEBUG] CreateProcessW("C:\Program Files\nodejs\node.exe" "C:\Program Files\nodejs\node_modules\npm\bin\npm-cli.js" --force install --no-save --no-lockfile --scripts-prepend-node-path=true --silent "C:\vcpkg-downloads\vcpkg-ce-2022-11-10.tgz")
[DEBUG] cmd_execute() returned 0 after 9383110 us
[DEBUG] CreateProcessW("C:\Program Files\nodejs\node.exe" "C:\Users\billy\AppData\Local\vcpkg\vcpkg-artifacts-2022-11-10\node_modules\vcpkg-ce" find gcc --debug --z-telemetry-file "C:\Users\billy\AppData\Local\Temp\vcpkg\vcpkg_7d284443-7a35-4547-be21-cb69dadfb4af_artifacts_telemetry.txt" --vcpkg-root "C:\Dev\vcpkg" --z-vcpkg-command "C:\Dev\vcpkg-tool\out\build\x64-Debug-Official-2022-11-10\vcpkg.exe" --z-vcpkg-artifacts-root "C:\vcpkg-downloads\artifacts" --z-vcpkg-downloads "C:\vcpkg-downloads" --z-vcpkg-registries-cache "C:\Users\billy\AppData\Local\vcpkg\registries")
debug: [00:00.07] Loaded global configuration file 'c:\Dev\vcpkg\vcpkg-configuration.json'
debug: [00:00.10] Loading registry from 'c:\Users\billy\AppData\Local\vcpkg\registries\artifact\vcpkg-ce-default\index.yaml'
debug: [00:00.30] Loaded global manifest microsoft => https://aka.ms/vcpkg-ce-default
debug: [00:00.35] Loading registry from 'c:\Users\billy\AppData\Local\vcpkg\registries\artifact\vcpkg-artifacts-cmsis\index.yaml'
debug: [00:00.40] Loaded global manifest cmsis => https://aka.ms/vcpkg-artifacts-cmsis
debug: Postscript file undefined
debug: No project manifest
debug: [00:00.54] Matching demand query: 'windows'
 Artifact                     Version    Summary
 microsoft:compilers/arm/gcc  2020.10.0  GCC compiler for ARM CPUs. 

[DEBUG] cmd_execute() returned 0 after 453840 us
[DEBUG] Failed to open: C:\Users\billy\AppData\Local\Temp\vcpkg\vcpkg_7d284443-7a35-4547-be21-cb69dadfb4af_artifacts_telemetry.txt
[DEBUG] Telemetry file couldn't be read: no such file or directory
[DEBUG] C:\Dev\vcpkg-tool\src\vcpkg\commands.find.cpp(214): 
[DEBUG] Time in subprocesses: 9872651 us
[DEBUG] Time in parsing JSON: 78 us
[DEBUG] Time in JSON reader: 123 us
[DEBUG] Time in filesystem: 12613 us
[DEBUG] Time in loading ports: 0 us
[DEBUG] Exiting after 10.63 s (10627436 us)
PS C:\Dev\vcpkg-tool\out\build\x64-Debug-Official-2022-11-10> .\vcpkg.exe find artifact gcc --debug
[DEBUG] To include the environment variables in debug output, pass --debug-env
[DEBUG] Trying to load bundleconfig from C:\Dev\vcpkg-tool\out\build\x64-Debug-Official-2022-11-10\vcpkg-bundle.json
[DEBUG] Failed to open: C:\Dev\vcpkg-tool\out\build\x64-Debug-Official-2022-11-10\vcpkg-bundle.json
[DEBUG] Bundle config: readonly=false, usegitregistry=false, embeddedsha=nullopt, deployment=Git, vsversion=nullopt
[DEBUG] Metrics enabled.
[DEBUG] Feature flag 'binarycaching' unset
[DEBUG] Feature flag 'compilertracking' unset
[DEBUG] Feature flag 'registries' unset
[DEBUG] Feature flag 'versions' unset
[DEBUG] Using scripts-root: C:\Dev\vcpkg\scripts
[DEBUG] Using builtin-ports: C:\Dev\vcpkg\ports
[DEBUG] Using installed-root: C:\Dev\vcpkg\installed
[DEBUG] Using buildtrees-root: C:\Dev\vcpkg\buildtrees
[DEBUG] Using packages-root: C:\Dev\vcpkg\packages
[DEBUG] Using vcpkg-root: C:\Dev\vcpkg
[DEBUG] Using scripts-root: C:\Dev\vcpkg\scripts
[DEBUG] Using builtin-registry: C:\Dev\vcpkg\versions
[DEBUG] Using downloads-root: C:\vcpkg-downloads
warning: vcpkg-ce ('configure environment') is experimental and may change at any time.
[DEBUG] Found path: C:\Program Files\nodejs\node.exe
[DEBUG] CreateProcessW("C:\Program Files\nodejs\node.exe" --version)
[DEBUG] ReadFile() finished with GetLastError(): 109
[DEBUG] 1000: cmd_execute_and_stream_data() returned 0 after    27127 us
[DEBUG] vcpkg-artifacts base path: C:\Users\billy\AppData\Local\vcpkg\vcpkg-artifacts-2022-11-10
[DEBUG] CreateProcessW("C:\Program Files\nodejs\node.exe" "C:\Users\billy\AppData\Local\vcpkg\vcpkg-artifacts-2022-11-10\node_modules\vcpkg-ce" find gcc --debug --z-telemetry-file "C:\Users\billy\AppData\Local\Temp\vcpkg\vcpkg_3e7e830e-b9ac-4620-bde3-658474718ff2_artifacts_telemetry.txt" --vcpkg-root "C:\Dev\vcpkg" --z-vcpkg-command "C:\Dev\vcpkg-tool\out\build\x64-Debug-Official-2022-11-10\vcpkg.exe" --z-vcpkg-artifacts-root "C:\vcpkg-downloads\artifacts" --z-vcpkg-downloads "C:\vcpkg-downloads" --z-vcpkg-registries-cache "C:\Users\billy\AppData\Local\vcpkg\registries")     
debug: [00:00.09] Loaded global configuration file 'c:\Dev\vcpkg\vcpkg-configuration.json'
debug: [00:00.11] Loading registry from 'c:\Users\billy\AppData\Local\vcpkg\registries\artifact\vcpkg-ce-default\index.yaml'
debug: [00:00.33] Loaded global manifest microsoft => https://aka.ms/vcpkg-ce-default
debug: [00:00.37] Loading registry from 'c:\Users\billy\AppData\Local\vcpkg\registries\artifact\vcpkg-artifacts-cmsis\index.yaml'
debug: [00:00.42] Loaded global manifest cmsis => https://aka.ms/vcpkg-artifacts-cmsis
debug: Postscript file undefined
debug: No project manifest
debug: [00:00.59] Matching demand query: 'windows'
 Artifact                     Version    Summary
 microsoft:compilers/arm/gcc  2020.10.0  GCC compiler for ARM CPUs.

[DEBUG] cmd_execute() returned 0 after 473819 us
[DEBUG] Failed to open: C:\Users\billy\AppData\Local\Temp\vcpkg\vcpkg_3e7e830e-b9ac-4620-bde3-658474718ff2_artifacts_telemetry.txt
[DEBUG] Telemetry file couldn't be read: no such file or directory
[DEBUG] C:\Dev\vcpkg-tool\src\vcpkg\commands.find.cpp(214):
[DEBUG] Time in subprocesses: 500946 us
[DEBUG] Time in parsing JSON: 81 us
[DEBUG] Time in JSON reader: 126 us
[DEBUG] Time in filesystem: 1982 us
[DEBUG] Time in loading ports: 0 us
[DEBUG] Exiting after 516.7 ms (514011 us)
PS C:\Dev\vcpkg-tool\out\build\x64-Debug-Official-2022-11-10>
```

Example with unofficial build that always picks latest:

```
PS C:\Dev\vcpkg-tool\out\build\x64-Debug-NoArtifacts> .\vcpkg.exe find artifact gcc --debug
[DEBUG] To include the environment variables in debug output, pass --debug-env
[DEBUG] Trying to load bundleconfig from C:\Dev\vcpkg-tool\out\build\x64-Debug-NoArtifacts\vcpkg-bundle.json
[DEBUG] Failed to open: C:\Dev\vcpkg-tool\out\build\x64-Debug-NoArtifacts\vcpkg-bundle.json
[DEBUG] Bundle config: readonly=false, usegitregistry=false, embeddedsha=nullopt, deployment=Git, vsversion=nullopt
[DEBUG] Metrics enabled.
[DEBUG] Feature flag 'binarycaching' unset
[DEBUG] Feature flag 'compilertracking' unset
[DEBUG] Feature flag 'registries' unset
[DEBUG] Feature flag 'versions' unset
[DEBUG] Using scripts-root: C:\Dev\vcpkg\scripts
[DEBUG] Using builtin-ports: C:\Dev\vcpkg\ports
[DEBUG] Using installed-root: C:\Dev\vcpkg\installed
[DEBUG] Using buildtrees-root: C:\Dev\vcpkg\buildtrees
[DEBUG] Using packages-root: C:\Dev\vcpkg\packages
[DEBUG] Using vcpkg-root: C:\Dev\vcpkg
[DEBUG] Using scripts-root: C:\Dev\vcpkg\scripts
[DEBUG] Using builtin-registry: C:\Dev\vcpkg\versions
[DEBUG] Using downloads-root: C:\vcpkg-downloads
warning: vcpkg-ce ('configure environment') is experimental and may change at any time.
[DEBUG] Found path: C:\Program Files\nodejs\node.exe
[DEBUG] CreateProcessW("C:\Program Files\nodejs\node.exe" --version)
[DEBUG] ReadFile() finished with GetLastError(): 109
[DEBUG] 1000: cmd_execute_and_stream_data() returned 0 after    25236 us
[DEBUG] vcpkg-artifacts base path: C:\Dev\vcpkg\artifacts
Downloading latest vcpkg-artifacts bundle...
Downloading https://github.com/microsoft/vcpkg-tool/releases/latest/download/vcpkg-ce.tgz
[DEBUG] CreateProcessW("C:\Program Files\nodejs\node.exe" "C:\Program Files\nodejs\node_modules\npm\bin\npm-cli.js" --force install --no-save --no-lockfile --scripts-prepend-node-path=true --silent "C:\vcpkg-downloads\vcpkg-ce-latest.tgz")
[DEBUG] cmd_execute() returned 0 after 3707945 us
[DEBUG] CreateProcessW("C:\Program Files\nodejs\node.exe" "C:\Dev\vcpkg\artifacts\node_modules\vcpkg-ce" find gcc --debug --z-telemetry-file "C:\Users\billy\AppData\Local\Temp\vcpkg\vcpkg_a68fa51d-97a7-4fdd-b96c-704939db1206_artifacts_telemetry.txt" --vcpkg-root "C:\Dev\vcpkg" --z-vcpkg-command "C:\Dev\vcpkg-tool\out\build\x64-Debug-NoArtifacts\vcpkg.exe" --z-vcpkg-artifacts-root "C:\vcpkg-downloads\artifacts" --z-vcpkg-downloads "C:\vcpkg-downloads" --z-vcpkg-registries-cache "C:\Users\billy\AppData\Local\vcpkg\registries")
debug: [00:00.14] Loaded global configuration file 'c:\Dev\vcpkg\vcpkg-configuration.json'
debug: [00:00.17] Loading registry from 'c:\Users\billy\AppData\Local\vcpkg\registries\artifact\vcpkg-ce-default\index.yaml'
debug: [00:00.41] Loaded global manifest microsoft => https://aka.ms/vcpkg-ce-default
debug: [00:00.44] Loading registry from 'c:\Users\billy\AppData\Local\vcpkg\registries\artifact\vcpkg-artifacts-cmsis\index.yaml'
debug: [00:00.48] Loaded global manifest cmsis => https://aka.ms/vcpkg-artifacts-cmsis
debug: Postscript file undefined
debug: No project manifest
debug: [00:00.58] Matching demand query: 'windows'
Artifact                    Version   Summary
microsoft:compilers/arm/gcc 2020.10.0 GCC compiler for ARM CPUs.

[DEBUG] cmd_execute() returned 0 after 309404 us
[DEBUG] Failed to open: C:\Users\billy\AppData\Local\Temp\vcpkg\vcpkg_a68fa51d-97a7-4fdd-b96c-704939db1206_artifacts_telemetry.txt
[DEBUG] Telemetry file couldn't be read: no such file or directory
[DEBUG] C:\Dev\vcpkg-tool\src\vcpkg\commands.find.cpp(214): 
[DEBUG] Time in subprocesses: 4042585 us
[DEBUG] Time in parsing JSON: 97 us
[DEBUG] Time in JSON reader: 157 us
[DEBUG] Time in filesystem: 1380 us
[DEBUG] Time in loading ports: 0 us
[DEBUG] Exiting after 4.587 s (4585544 us)
PS C:\Dev\vcpkg-tool\out\build\x64-Debug-NoArtifacts>
```