### PR TITLE
Don't put global vcpkg-configuration.json in VCPKG_ROOT if readonly

### DIFF
--- a/ce/ce/cli/command-line.ts
+++ b/ce/ce/cli/command-line.ts
@@ -123,6 +123,10 @@ export class CommandLine {
     return this.switches['z-next-previous-environment']?.[0];
   }
 
+  get globalConfig() {
+    return this.switches['z-global-config']?.[0];
+  }
+
   get language() {
     const l = this.switches['language'] || [];
     strict.ok((l?.length || 0) < 2, i`Expected a single value for ${cmdSwitch('language')} - found multiple`);

--- a/ce/ce/constants.ts
+++ b/ce/ce/constants.ts
@@ -5,7 +5,6 @@ export const undo = 'Z_VCPKG_UNDO';
 export const postscriptVariable = 'Z_VCPKG_POSTSCRIPT';
 export const latestVersion = '*';
 export const vcpkgDownloadVariable = 'VCPKG_DOWNLOADS';
-export const globalConfigurationFile = 'vcpkg-configuration.json';
 export const manifestName = 'vcpkg.json';
 export const configurationName = 'vcpkg-configuration.json';
 export const registryIndexFile = 'index.yaml';

--- a/ce/ce/session.ts
+++ b/ce/ce/session.ts
@@ -6,7 +6,7 @@ import { createHash } from 'crypto';
 import { MetadataFile } from './amf/metadata-file';
 import { deactivate } from './artifacts/activation';
 import { Artifact, InstalledArtifact } from './artifacts/artifact';
-import { configurationName, defaultConfig, globalConfigurationFile, postscriptVariable, undo } from './constants';
+import { configurationName, defaultConfig, postscriptVariable, undo } from './constants';
 import { FileSystem } from './fs/filesystem';
 import { HttpsFileSystem } from './fs/http-filesystem';
 import { LocalFileSystem } from './fs/local-filesystem';
@@ -57,6 +57,7 @@ export type SessionSettings = {
   readonly vcpkgRegistriesCache?: string;
   readonly telemetryFile?: string;
   readonly nextPreviousEnvironment?: string;
+  readonly globalConfig?: string;
 }
 
 interface AcquiredArtifactEntry {
@@ -129,7 +130,7 @@ export class Session {
 
     this.homeFolder = this.fileSystem.file(settings.homeFolder);
     this.downloads = this.processVcpkgArg(settings.vcpkgDownloads, 'downloads');
-    this.globalConfig = this.homeFolder.join(globalConfigurationFile);
+    this.globalConfig = this.processVcpkgArg(settings.globalConfig, configurationName);
 
     this.registryFolder = this.processVcpkgArg(settings.vcpkgRegistriesCache, 'registries').join('artifact');
     this.installFolder = this.processVcpkgArg(settings.vcpkgArtifactsRoot, 'artifacts');

--- a/include/vcpkg/vcpkgpaths.h
+++ b/include/vcpkg/vcpkgpaths.h
@@ -84,6 +84,7 @@ namespace vcpkg
         const Optional<Path>& maybe_buildtrees() const;
         const Optional<Path>& maybe_packages() const;
 
+        const Path& global_config() const;
         const InstalledPaths& installed() const;
         const Path& buildtrees() const;
         const Path& packages() const;

--- a/src/vcpkg/configure-environment.cpp
+++ b/src/vcpkg/configure-environment.cpp
@@ -165,6 +165,7 @@ namespace vcpkg
         cmd_run.string_arg("--z-vcpkg-registries-cache").string_arg(paths.registries_cache());
         cmd_run.string_arg("--z-next-previous-environment")
             .string_arg(temp_directory / (generate_random_UUID() + "_previous_environment.txt"));
+        cmd_run.string_arg("--z-global-config").string_arg(paths.global_config());
 
         if (auto maybe_file = msg::get_file())
         {

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -514,6 +514,9 @@ namespace vcpkg
                        const Path& root,
                        const Path& original_cwd)
             : VcpkgPathsImplStage1(fs, args, bundle, root, original_cwd)
+            , m_global_config(bundle.read_only ? get_user_configuration_home().value_or_exit(VCPKG_LINE_INFO) /
+                                                     "vcpkg-configuration.json"
+                                               : root / "vcpkg-configuration.json")
             , m_config_dir(m_manifest_dir.empty() ? root : m_manifest_dir)
             , m_manifest_path(m_manifest_dir.empty() ? Path{} : m_manifest_dir / "vcpkg.json")
             , m_registries_work_tree_dir(m_registries_cache / "git")
@@ -590,6 +593,7 @@ namespace vcpkg
             }
         }
 
+        const Path m_global_config;
         const Path m_config_dir;
         const Path m_manifest_path;
         const Path m_registries_work_tree_dir;
@@ -788,6 +792,8 @@ namespace vcpkg
     const Optional<InstalledPaths>& VcpkgPaths::maybe_installed() const { return m_pimpl->m_installed; }
     const Optional<Path>& VcpkgPaths::maybe_buildtrees() const { return m_pimpl->buildtrees; }
     const Optional<Path>& VcpkgPaths::maybe_packages() const { return m_pimpl->packages; }
+
+    const Path& VcpkgPaths::global_config() const { return m_pimpl->m_global_config; }
 
     const InstalledPaths& VcpkgPaths::installed() const
     {


### PR DESCRIPTION
Smoke test demonstration. Note: debug: [00:00.08] Loaded global configuration file 'c:\Users\bion\.vcpkg\vcpkg-configuration.json'

```
PS C:\Dev\vcpkg-tool> get-command cmake

CommandType     Name                                               Version    Source
-----------     ----                                               -------    ------
Application     cmake.exe                                          3.25.2.0   C:\Program Files\CMake\bin\cmake.exe

PS C:\Dev\vcpkg-tool> .\out\build\x64-Debug\vcpkg.ps1 use cmake --debug
[DEBUG] To include the environment variables in debug output, pass --debug-env
[DEBUG] Trying to load bundleconfig from C:\Dev\vcpkg-tool\out\build\x64-Debug\vcpkg-bundle.json
[DEBUG] Bundle config: readonly=false, usegitregistry=false, embeddedsha=nullopt, deployment=Git, vsversion=nullopt
[DEBUG] Metrics enabled.
[DEBUG] Feature flag 'binarycaching' unset
[DEBUG] Feature flag 'compilertracking' unset
[DEBUG] Feature flag 'registries' unset
[DEBUG] Feature flag 'versions' unset
[DEBUG] Using scripts-root: C:\Users\bion\.vcpkg\scripts
[DEBUG] Using builtin-ports: C:\Users\bion\.vcpkg\ports
[DEBUG] Using installed-root: C:\Users\bion\.vcpkg\installed
[DEBUG] Using buildtrees-root: C:\Users\bion\.vcpkg\buildtrees
[DEBUG] Using packages-root: C:\Users\bion\.vcpkg\packages
[DEBUG] Using vcpkg-root: C:\Users\bion\.vcpkg
[DEBUG] Using scripts-root: C:\Users\bion\.vcpkg\scripts
[DEBUG] Using builtin-registry: C:\Users\bion\.vcpkg\versions
[DEBUG] Using downloads-root: C:\Dev\vcpkg_downloads
warning: vcpkg-ce ('configure environment') is experimental and may change at any time.
[DEBUG] Found path: C:\Program Files\nodejs\node.exe
[DEBUG] CreateProcessW("C:\Program Files\nodejs\node.exe" --version)
[DEBUG] ReadFile() finished with GetLastError(): 109
[DEBUG] 1000: cmd_execute_and_stream_data() returned 0 after    17586 us
Using in-development vcpkg-artifacts built at: C:/Dev/vcpkg-tool/ce/ce
[DEBUG] CreateProcessW("C:\Program Files\nodejs\node.exe" C:/Dev/vcpkg-tool/ce/ce use cmake --debug --debug --z-telemetry-file "C:\Users\bion\AppData\Local\Temp\vcpkg\4217ad2c-9b79-45b4-8d51-3aaa00181c5a_artifacts_telemetry.txt" --vcpkg-root "C:\Users\bion\.vcpkg" --z-vcpkg-command "C:\Dev\vcpkg-tool\out\build\x64-Debug\vcpkg.exe" --z-vcpkg-artifacts-root "C:\Dev\vcpkg_downloads\artifacts" --z-vcpkg-downloads "C:\Dev\vcpkg_downloads" --z-vcpkg-registries-cache "C:\Users\bion\AppData\Local\vcpkg\registries" --z-next-previous-environment "C:\Users\bion\AppData\Local\Temp\vcpkg\4fb0c0cb-bba5-466d-88ef-362249a26c6c_previous_environment.txt" --z-global-config "C:\Users\bion\.vcpkg\vcpkg-configuration.json")
debug: [00:00.08] Loaded global configuration file 'c:\Users\bion\.vcpkg\vcpkg-configuration.json'
debug: [00:00.11] Loading registry from 'c:\Users\bion\AppData\Local\vcpkg\registries\artifact\vcpkg-ce-default\index.yaml'
debug: [00:00.34] Loaded global manifest microsoft => https://aka.ms/vcpkg-ce-default
debug: [00:00.35] Loading registry from 'c:\Users\bion\AppData\Local\vcpkg\registries\artifact\vcpkg-artifacts-cmsis\index.yaml'
debug: [00:00.38] Loaded global manifest cmsis => https://aka.ms/vcpkg-artifacts-cmsis
debug: Postscript file file:///c%3A/Users/bion/.vcpkg/VCPKG_tmp_196627065.ps1
debug: No project manifest
debug: [00:00.45] Matching demand query: 'windows and x64'
debug: [00:00.46] Matching demand query: 'windows'
debug: [00:00.48] Matching demand query: 'windows and x64'
debug: [00:00.48] Matching demand query: 'windows'
debug: [00:00.50] Matching demand query: 'windows and x64'
debug: [00:00.50] Matching demand query: 'windows'
debug: [00:00.53] Matching demand query: 'windows and x64'
debug: [00:00.53] Matching demand query: 'windows'
debug: [00:00.54] Matching demand query: 'windows and x64'
debug: [00:00.54] Matching demand query: 'windows'
debug: [00:00.56] Matching demand query: 'windows and x64'
debug: [00:00.56] Matching demand query: 'windows'
debug: [00:00.57] Resolving https://aka.ms/vcpkg-ce-default::tools/kitware/cmake::3.25.2's dependencies...
debug: [00:00.57] The following are initial selections: https://aka.ms/vcpkg-ce-default::tools/kitware/cmake::3.25.2
Artifact                      Version Status    Dependency Summary
microsoft:tools/kitware/cmake 3.25.2  installed            Kitware's cmake tool

debug: [00:00.64] --------[START UNDO FILE]--------
{
  "environment": {
    "PATH": "C:\\Program Files\\PowerShell\\7;C:\\Program Files\\Python311\\Scripts\\;C:\\Program Files\\Python311\\;C:\\Program Files (x86)\\Microsoft SDKs\\Azure\\CLI2\\wbin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\Microsoft SQL Server\\130\\Tools\\Binn\\;C:\\Program Files\\Microsoft SQL Server\\Client SDK\\ODBC\\170\\Tools\\Binn\\;C:\\Program Files\\dotnet\\;C:\\Program Files\\Microsoft SQL Server\\150\\Tools\\Binn\\;C:\\Program Files\\CMake\\bin;C:\\Program Files\\Git\\cmd;C:\\Program Files\\LLVM\\bin;C:\\Program Files\\nodejs\\;C:\\Program Files\\PowerShell\\7\\;C:\\Users\\bion\\AppData\\Local\\CloudBuild;C:\\Users\\bion\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Users\\bion\\.dotnet\\tools;C:\\Users\\bion\\AppData\\Roaming\\npm",
    "cmake": "",
    "cmake_gui": "",
    "ctest": ""
  },
  "aliases": {}
}
--------[END UNDO FILE]---------
debug: [00:00.66] --------[START SHELL SCRIPT FILE]--------
${ENV:PATH}="c:\Dev\vcpkg_downloads\artifacts\vcpkg-ce-default\tools.kitware.cmake\3.25.2\bin;C:\Program Files\PowerShell\7;C:\Program Files\Python311\Scripts\;C:\Program Files\Python311\;C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\wbin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Program Files\Microsoft SQL Server\130\Tools\Binn\;C:\Program Files\Microsoft SQL Server\Client SDK\ODBC\170\Tools\Binn\;C:\Program Files\dotnet\;C:\Program Files\Microsoft SQL Server\150\Tools\Binn\;C:\Program Files\CMake\bin;C:\Program Files\Git\cmd;C:\Program Files\LLVM\bin;C:\Program Files\nodejs\;C:\Program Files\PowerShell\7\;C:\Users\bion\AppData\Local\CloudBuild;C:\Users\bion\AppData\Local\Microsoft\WindowsApps;C:\Users\bion\.dotnet\tools;C:\Users\bion\AppData\Roaming\npm"
${ENV:cmake}="c:\Dev\vcpkg_downloads\artifacts\vcpkg-ce-default\tools.kitware.cmake\3.25.2\bin\cmake.exe"
${ENV:cmake_gui}="c:\Dev\vcpkg_downloads\artifacts\vcpkg-ce-default\tools.kitware.cmake\3.25.2\bin\cmake-gui.exe"
${ENV:ctest}="c:\Dev\vcpkg_downloads\artifacts\vcpkg-ce-default\tools.kitware.cmake\3.25.2\bin\ctest.exe"
${ENV:Z_VCPKG_UNDO}="c:\Users\bion\AppData\Local\Temp\vcpkg\4fb0c0cb-bba5-466d-88ef-362249a26c6c_previous_environment.txt"

--------[END SHELL SCRIPT FILE]---------
Activating individual artifacts
[DEBUG] cmd_execute() returned 0 after 279249 us
[DEBUG] Failed to open: C:\Users\bion\AppData\Local\Temp\vcpkg\4217ad2c-9b79-45b4-8d51-3aaa00181c5a_artifacts_telemetry.txt
[DEBUG] Telemetry file couldn't be read: no such file or directory
[DEBUG] C:\Dev\vcpkg-tool\src\vcpkg\commands.use.cpp(11):
[DEBUG] Time in subprocesses: 296835 us
[DEBUG] Time in parsing JSON: 138 us
[DEBUG] Time in JSON reader: 101 us
[DEBUG] Time in filesystem: 7311 us
[DEBUG] Time in loading ports: 0 us
[DEBUG] Exiting after 312.1 ms (311459 us)
PS C:\Dev\vcpkg-tool> get-command cmake

CommandType     Name                                               Version    Source
-----------     ----                                               -------    ------
Application     cmake.exe                                          3.25.2.0   c:\Dev\vcpkg_downloads\artifacts\vcpkg-c…

PS C:\Dev\vcpkg-tool>
```