### PR TITLE
Fix the formatting of duration

### DIFF
--- a/src/vcpkg-test/chrono.cpp
+++ b/src/vcpkg-test/chrono.cpp
@@ -32,3 +32,34 @@ TEST_CASE ("difference of times", "[chrono]")
 
     REQUIRE(std::chrono::duration_cast<std::chrono::hours>(delta).count() == 24 * 7);
 }
+
+TEST_CASE ("formatting of time", "[chrono]")
+{
+    using namespace std::literals;
+    REQUIRE(ElapsedTime{100ns}.to_string() == "100 ns");
+    REQUIRE(ElapsedTime{1010ns}.to_string() == "1.01 us");
+    REQUIRE(ElapsedTime{1500ns}.to_string() == "1.5 us");
+    REQUIRE(ElapsedTime{15010ns}.to_string() == "15 us");
+
+    REQUIRE(ElapsedTime{100us}.to_string() == "100 us");
+    REQUIRE(ElapsedTime{1010us}.to_string() == "1.01 ms");
+    REQUIRE(ElapsedTime{1500us}.to_string() == "1.5 ms");
+    REQUIRE(ElapsedTime{15010us}.to_string() == "15 ms");
+
+    REQUIRE(ElapsedTime{100ms}.to_string() == "100 ms");
+    REQUIRE(ElapsedTime{1010ms}.to_string() == "1 s");
+    REQUIRE(ElapsedTime{1500ms}.to_string() == "1.5 s");
+    REQUIRE(ElapsedTime{1501ms}.to_string() == "1.5 s");
+
+    REQUIRE(ElapsedTime{1s}.to_string() == "1 s");
+    REQUIRE(ElapsedTime{59s}.to_string() == "59 s");
+    REQUIRE(ElapsedTime{61s}.to_string() == "1 min");
+    REQUIRE(ElapsedTime{65s}.to_string() == "1.1 min");
+    REQUIRE(ElapsedTime{90s}.to_string() == "1.5 min");
+    REQUIRE(ElapsedTime{601s}.to_string() == "10 min");
+
+    REQUIRE(ElapsedTime{10min}.to_string() == "10 min");
+    REQUIRE(ElapsedTime{61min}.to_string() == "1 h");
+    REQUIRE(ElapsedTime{90min}.to_string() == "1.5 h");
+    REQUIRE(ElapsedTime{901min}.to_string() == "15 h");
+}

--- a/src/vcpkg/base/chrono.cpp
+++ b/src/vcpkg/base/chrono.cpp
@@ -74,34 +74,34 @@ namespace vcpkg
         if (duration_cast<hours>(nanos) > hours())
         {
             const auto t = nanos_as_double / duration_cast<nanoseconds>(hours(1)).count();
-            return fmt::format("{:4} h", t);
+            return fmt::format("{:.2} h", t);
         }
 
         if (duration_cast<minutes>(nanos) > minutes())
         {
             const auto t = nanos_as_double / duration_cast<nanoseconds>(minutes(1)).count();
-            return fmt::format("{:4} min", t);
+            return fmt::format("{:.2} min", t);
         }
 
         if (duration_cast<seconds>(nanos) > seconds())
         {
             const auto t = nanos_as_double / duration_cast<nanoseconds>(seconds(1)).count();
-            return fmt::format("{:4} s", t);
+            return fmt::format("{:.2} s", t);
         }
 
         if (duration_cast<milliseconds>(nanos) > milliseconds())
         {
             const auto t = nanos_as_double / duration_cast<nanoseconds>(milliseconds(1)).count();
-            return fmt::format("{:4} ms", t);
+            return fmt::format("{:.3} ms", t);
         }
 
         if (duration_cast<microseconds>(nanos) > microseconds())
         {
             const auto t = nanos_as_double / duration_cast<nanoseconds>(microseconds(1)).count();
-            return fmt::format("{:4} us", t);
+            return fmt::format("{:.3} us", t);
         }
 
-        return fmt::format("{:4} ns", nanos_as_double);
+        return fmt::format("{:.3} ns", nanos_as_double);
     }
 
     ElapsedTimer::ElapsedTimer() noexcept


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg-tool/pull/909#issuecomment-1471964306

Before:
```
Detecting compiler hash for triplet arm64-osx...
The following packages will be rebuilt:
    boost-uninstall[core]:arm64-osx -> 1.81.0#2
Removing 1/2 boost-uninstall:arm64-osx
Elapsed time to handle boost-uninstall:arm64-osx: 1.88325 ms
Restored 0 package(s) from /Users/leanderSchulten/.cache/vcpkg/archives in 682.708 us. Use --debug to see more details.
Attempting to fetch 1 package(s) from HTTP servers
Restored 0 package(s) from HTTP servers in 210.244292 ms. Use --debug to see more details.
Installing 2/2 boost-uninstall:arm64-osx...
Building boost-uninstall[core]:arm64-osx...
warning: -- Using community triplet arm64-osx. This triplet configuration is not guaranteed to succeed.
-- [COMMUNITY] Loading triplet configuration from: /Users/leanderSchulten/git_projekte/vcpkg/triplets/community/arm64-osx.cmake
-- 
Please use the following command when you need to remove all boost ports/components:
    "./vcpkg remove boost-uninstall:arm64-osx --recurse"

-- Performing post-build validation
Uploaded binaries to 1 HTTP remotes.
Stored binary cache: "/Users/leanderSchulten/.cache/vcpkg/archives/ea/ea1a7b9817b0c937939d837215893858a607c709475ce50a9119f085c3cf5089.zip"
Elapsed time to handle boost-uninstall:arm64-osx: 293.621666 ms
Total install time: 506.937584 ms
```
After:
```
Detecting compiler hash for triplet arm64-osx...
The following packages will be rebuilt:
    boost-uninstall[core]:arm64-osx -> 1.81.0#2
Removing 1/2 boost-uninstall:arm64-osx
Elapsed time to handle boost-uninstall:arm64-osx: 3.85 ms
Restored 0 package(s) from /Users/leanderSchulten/.cache/vcpkg/archives in 608 us. Use --debug to see more details.
Attempting to fetch 1 package(s) from HTTP servers
Restored 0 package(s) from HTTP servers in 48.7 ms. Use --debug to see more details.
Installing 2/2 boost-uninstall:arm64-osx...
Building boost-uninstall[core]:arm64-osx...
warning: -- Using community triplet arm64-osx. This triplet configuration is not guaranteed to succeed.
-- [COMMUNITY] Loading triplet configuration from: /Users/leanderSchulten/git_projekte/vcpkg/triplets/community/arm64-osx.cmake
-- 
Please use the following command when you need to remove all boost ports/components:
    "./vcpkg remove boost-uninstall:arm64-osx --recurse"

-- Performing post-build validation
Uploaded binaries to 1 HTTP remotes.
Stored binary cache: "/Users/leanderSchulten/.cache/vcpkg/archives/e6/e6662b667e7f7a6f36d61d7b468ec4a10a93d244d30aab378e5f0a5bf46c9de2.zip"
Elapsed time to handle boost-uninstall:arm64-osx: 105 ms
Total install time: 159 ms
```