### PR TITLE
Fix VersionConstraintUnresolvable message being dropped.

### DIFF
--- a/include/vcpkg/base/messages.h
+++ b/include/vcpkg/base/messages.h
@@ -147,10 +147,10 @@ namespace vcpkg::msg
         msg::write_unlocalized_text_to_stdout(Color::none, "\n");
     }
 
-    LocalizedString format_error();
-    LocalizedString format_error(const LocalizedString& s);
+    [[nodiscard]] LocalizedString format_error();
+    [[nodiscard]] LocalizedString format_error(const LocalizedString& s);
     template<VCPKG_DECL_MSG_TEMPLATE>
-    LocalizedString format_error(VCPKG_DECL_MSG_ARGS)
+    [[nodiscard]] LocalizedString format_error(VCPKG_DECL_MSG_ARGS)
     {
         return format_error(msg::format(VCPKG_EXPAND_MSG_ARGS));
     }
@@ -161,10 +161,10 @@ namespace vcpkg::msg
         println_error(msg::format(VCPKG_EXPAND_MSG_ARGS));
     }
 
-    LocalizedString format_warning();
-    LocalizedString format_warning(const LocalizedString& s);
+    [[nodiscard]] LocalizedString format_warning();
+    [[nodiscard]] LocalizedString format_warning(const LocalizedString& s);
     template<VCPKG_DECL_MSG_TEMPLATE>
-    LocalizedString format_warning(VCPKG_DECL_MSG_ARGS)
+    [[nodiscard]] LocalizedString format_warning(VCPKG_DECL_MSG_ARGS)
     {
         return format_warning(msg::format(VCPKG_EXPAND_MSG_ARGS));
     }

--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -1245,8 +1245,7 @@ namespace vcpkg
                         auto status_it = status_db.find(pspec);
                         if (status_it == status_db.end())
                         {
-                            Debug::println("Failed to find dependency abi for %s -> %s", action.spec, pspec);
-                            Checks::unreachable(VCPKG_LINE_INFO);
+                            Checks::unreachable(VCPKG_LINE_INFO, fmt::format("Failed to find dependency abi for {} -> {}", action.spec, pspec));
                         }
 
                         dependency_abis.emplace_back(pspec.name(), status_it->get()->package.abi);

--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -1245,7 +1245,9 @@ namespace vcpkg
                         auto status_it = status_db.find(pspec);
                         if (status_it == status_db.end())
                         {
-                            Checks::unreachable(VCPKG_LINE_INFO, fmt::format("Failed to find dependency abi for {} -> {}", action.spec, pspec));
+                            Checks::unreachable(
+                                VCPKG_LINE_INFO,
+                                fmt::format("Failed to find dependency abi for {} -> {}", action.spec, pspec));
                         }
 
                         dependency_abis.emplace_back(pspec.name(), status_it->get()->package.abi);

--- a/src/vcpkg/commands.dependinfo.cpp
+++ b/src/vcpkg/commands.dependinfo.cpp
@@ -230,8 +230,7 @@ namespace vcpkg::Commands::DependInfo
             auto iter = dependencies_map.find(package);
             if (iter == dependencies_map.end())
             {
-                Debug::println("Not found in dependency graph: ", package);
-                Checks::unreachable(VCPKG_LINE_INFO);
+                Checks::unreachable(VCPKG_LINE_INFO, fmt::format("Not found in dependency graph: {}", package));
             }
 
             PackageDependInfo& info = iter->second;
@@ -321,8 +320,7 @@ namespace vcpkg::Commands::DependInfo
 
         if (!action_plan.remove_actions.empty())
         {
-            Debug::println("Only install actions should exist in the plan");
-            Checks::unreachable(VCPKG_LINE_INFO);
+            Checks::unreachable(VCPKG_LINE_INFO, "Only install actions should exist in the plan");
         }
 
         std::vector<const InstallPlanAction*> install_actions =

--- a/src/vcpkg/dependencies.cpp
+++ b/src/vcpkg/dependencies.cpp
@@ -2000,9 +2000,9 @@ namespace vcpkg
                                 }
                                 else
                                 {
-                                    msg::format_error(msgVersionConstraintUnresolvable,
-                                                      msg::package_name = dep.name,
-                                                      msg::spec = spec);
+                                    return msg::format_error(msgVersionConstraintUnresolvable,
+                                                             msg::package_name = dep.name,
+                                                             msg::spec = spec);
                                 }
                             }
                         }


### PR DESCRIPTION
In https://github.com/microsoft/vcpkg-tool/pull/936/ , I accidentially forgot the return.

Additional related fixes:

* add [[nodiscard]] to the formatters; note that nodiscard was already in use in strings.h: https://github.com/microsoft/vcpkg-tool/blob/65fcbac58785083569ce63ad4a9255044bf6c35b/include/vcpkg/base/strings.h#L66
* fix a couple of places that were printing a debug message just before "Checks::unreachable" to include that in the Checks::unreachable output instead of a separate debug statement.

Thanks to @Neumann-A for pointing out this bug over Discord and @autoantwort for pointing out which line was messed up after I localized it to #936 .