### PR TITLE
integrate install/project: Don't write to VCPKG_ROOT.

### DIFF
--- a/src/vcpkg/commands.integrate.cpp
+++ b/src/vcpkg/commands.integrate.cpp
@@ -123,7 +123,7 @@ namespace vcpkg::Commands::Integrate
 #endif
 
 #if defined(_WIN32)
-    static std::string create_system_targets_shortcut() noexcept
+    static std::string create_system_targets_shortcut()
     {
         return R"###(
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -139,7 +139,7 @@ namespace vcpkg::Commands::Integrate
 #endif
 
 #if defined(_WIN32)
-    static std::string create_nuget_targets_file_contents(const Path& msbuild_vcpkg_targets_file) noexcept
+    static std::string create_nuget_targets_file_contents(const Path& msbuild_vcpkg_targets_file)
     {
         return fmt::format(R"###(
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -155,16 +155,13 @@ namespace vcpkg::Commands::Integrate
 #endif
 
 #if defined(_WIN32)
-    static std::string create_nuget_props_file_contents() noexcept
-    {
-        return R"###(
+    static constexpr StringLiteral NUGET_PROPS_FILE_CONTENTS = R"###(
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <VCPkgLocalAppDataDisabled>true</VCPkgLocalAppDataDisabled>
   </PropertyGroup>
 </Project>
 )###";
-    }
 #endif
 
 #if defined(_WIN32)
@@ -247,23 +244,12 @@ namespace vcpkg::Commands::Integrate
     }
 #endif
 
-#if defined(_WIN32)
-    static Path get_appdata_targets_path()
-    {
-        return get_appdata_local().value_or_exit(VCPKG_LINE_INFO) / "vcpkg\\vcpkg.user.targets";
-    }
-#endif
-#if defined(_WIN32)
-    static Path get_appdata_props_path()
-    {
-        return get_appdata_local().value_or_exit(VCPKG_LINE_INFO) / "vcpkg\\vcpkg.user.props";
-    }
-#endif
-
-    static constexpr StringLiteral vcpkg_path_txt_name = "vcpkg.path.txt";
+    static constexpr StringLiteral vcpkg_user_props = "vcpkg.user.props";
+    static constexpr StringLiteral vcpkg_user_targets = "vcpkg.user.targets";
+    static constexpr StringLiteral vcpkg_path_txt = "vcpkg.path.txt";
 
 #if defined(_WIN32)
-    static void integrate_install_msbuild14(Filesystem& fs, const Path& tmp_dir)
+    static void integrate_install_msbuild14(Filesystem& fs)
     {
         std::array<Path, 2> OLD_SYSTEM_TARGET_FILES = {
             get_program_files_32_bit().value_or_exit(VCPKG_LINE_INFO) /
@@ -304,6 +290,7 @@ namespace vcpkg::Commands::Integrate
 
         if (should_install_system)
         {
+            const auto tmp_dir = fs.create_or_get_temp_directory(VCPKG_LINE_INFO);
             const auto sys_src_path = tmp_dir / "vcpkg.system.targets";
             fs.write_contents(sys_src_path, create_system_targets_shortcut(), VCPKG_LINE_INFO);
 
@@ -312,6 +299,7 @@ namespace vcpkg::Commands::Integrate
                                                   sys_src_path,
                                                   SYSTEM_WIDE_TARGETS_FILE);
             const ElevationPromptChoice user_choice = elevated_cmd_execute(param);
+            fs.remove_all(tmp_dir, VCPKG_LINE_INFO);
             switch (user_choice)
             {
                 case ElevationPromptChoice::YES: break;
@@ -331,62 +319,42 @@ namespace vcpkg::Commands::Integrate
     {
         auto& fs = paths.get_filesystem();
 
-#if defined(_WIN32)
-        {
-            const auto tmp_dir = paths.buildsystems / "tmp";
-            fs.create_directory(paths.buildsystems, VCPKG_LINE_INFO);
-            fs.create_directory(tmp_dir, VCPKG_LINE_INFO);
-
-            integrate_install_msbuild14(fs, tmp_dir);
-
-            const auto appdata_src_path = tmp_dir / "vcpkg.user.targets";
-            fs.write_contents(
-                appdata_src_path, create_appdata_shortcut(paths.buildsystems_msbuild_targets), VCPKG_LINE_INFO);
-            auto appdata_dst_path = get_appdata_targets_path();
-
-            const auto vcpkg_appdata_local = get_appdata_local().value_or_exit(VCPKG_LINE_INFO) / "vcpkg";
-            fs.create_directory(vcpkg_appdata_local, VCPKG_LINE_INFO);
-
-            fs.copy_file(appdata_src_path, appdata_dst_path, CopyOptions::overwrite_existing, VCPKG_LINE_INFO);
-
-            const Path appdata_src_path2 = tmp_dir / "vcpkg.user.props";
-            fs.write_contents(
-                appdata_src_path2, create_appdata_shortcut(paths.buildsystems_msbuild_props), VCPKG_LINE_INFO);
-            auto appdata_dst_path2 = get_appdata_props_path();
-
-            fs.copy_file(appdata_src_path2, appdata_dst_path2, CopyOptions::overwrite_existing, VCPKG_LINE_INFO);
-        }
-#endif
-
         auto user_configuration_home = get_user_configuration_home().value_or_exit(VCPKG_LINE_INFO);
-        fs.create_directories(user_configuration_home, IgnoreErrors{});
-        fs.write_contents(
-            user_configuration_home / vcpkg_path_txt_name, paths.root.generic_u8string(), VCPKG_LINE_INFO);
+        fs.create_directories(user_configuration_home, VCPKG_LINE_INFO);
+        fs.write_contents(user_configuration_home / vcpkg_path_txt, paths.root.generic_u8string(), VCPKG_LINE_INFO);
+
+#if defined(_WIN32)
+        integrate_install_msbuild14(fs);
+
+        fs.write_contents(user_configuration_home / vcpkg_user_props,
+                          create_appdata_shortcut(paths.buildsystems_msbuild_props),
+                          VCPKG_LINE_INFO);
+        fs.write_contents(user_configuration_home / vcpkg_user_targets,
+                          create_appdata_shortcut(paths.buildsystems_msbuild_targets),
+                          VCPKG_LINE_INFO);
+#endif
         msg::println(Color::success, msgAppliedUserIntegration);
 
         const auto cmake_toolchain = paths.buildsystems / "vcpkg.cmake";
 
+        auto message = msg::format(msgCMakeToolChainFile, msg::path = cmake_toolchain.generic_u8string());
 #if defined(_WIN32)
-        msg::println(msg::format(msgCMakeToolChainFile, msg::path = cmake_toolchain.generic_u8string())
-                         .append_raw("\n\n")
-                         .append(msgAutomaticLinkingForMSBuildProjects));
-#else
-        msg::println(msgCMakeToolChainFile, msg::path = cmake_toolchain.generic_u8string());
+        message.append_raw("\n\n").append(msgAutomaticLinkingForMSBuildProjects);
 #endif
+
+        msg::println(message);
         Checks::exit_success(VCPKG_LINE_INFO);
     }
 
     static void integrate_remove(Filesystem& fs)
     {
         bool was_deleted = false;
-
-#if defined(_WIN32)
-        was_deleted |= fs.remove(get_appdata_targets_path(), VCPKG_LINE_INFO);
-        was_deleted |= fs.remove(get_appdata_props_path(), VCPKG_LINE_INFO);
-#endif
-
         auto user_configuration_home = get_user_configuration_home().value_or_exit(VCPKG_LINE_INFO);
-        was_deleted |= fs.remove(user_configuration_home / vcpkg_path_txt_name, VCPKG_LINE_INFO);
+#if defined(_WIN32)
+        was_deleted |= fs.remove(user_configuration_home / vcpkg_user_props, VCPKG_LINE_INFO);
+        was_deleted |= fs.remove(user_configuration_home / vcpkg_user_targets, VCPKG_LINE_INFO);
+#endif
+        was_deleted |= fs.remove(user_configuration_home / vcpkg_path_txt, VCPKG_LINE_INFO);
 
         if (was_deleted)
         {
@@ -407,11 +375,7 @@ namespace vcpkg::Commands::Integrate
 
         const Path& nuget_exe = paths.get_tool_exe(Tools::NUGET, stdout_sink);
 
-        const Path& buildsystems_dir = paths.buildsystems;
-        const auto tmp_dir = buildsystems_dir / "tmp";
-        fs.create_directory(buildsystems_dir, IgnoreErrors{});
-        fs.create_directory(tmp_dir, IgnoreErrors{});
-
+        const auto tmp_dir = fs.create_or_get_temp_directory(VCPKG_LINE_INFO);
         const auto targets_file_path = tmp_dir / "vcpkg.nuget.targets";
         const auto props_file_path = tmp_dir / "vcpkg.nuget.props";
         const auto nuspec_file_path = tmp_dir / "vcpkg.nuget.nuspec";
@@ -420,7 +384,7 @@ namespace vcpkg::Commands::Integrate
 
         fs.write_contents(
             targets_file_path, create_nuget_targets_file_contents(paths.buildsystems_msbuild_targets), VCPKG_LINE_INFO);
-        fs.write_contents(props_file_path, create_nuget_props_file_contents(), VCPKG_LINE_INFO);
+        fs.write_contents(props_file_path, NUGET_PROPS_FILE_CONTENTS, VCPKG_LINE_INFO);
         fs.write_contents(
             nuspec_file_path, create_nuspec_file_contents(paths.root, nuget_id, nupkg_version), VCPKG_LINE_INFO);
 
@@ -428,27 +392,29 @@ namespace vcpkg::Commands::Integrate
         auto cmd_line = Command(nuget_exe)
                             .string_arg("pack")
                             .string_arg("-OutputDirectory")
-                            .string_arg(buildsystems_dir)
+                            .string_arg(paths.original_cwd)
                             .string_arg(nuspec_file_path);
 
         const auto maybe_nuget_output = flatten(
             cmd_execute_and_capture_output(cmd_line, default_working_directory, get_clean_environment()), Tools::NUGET);
+
         if (!maybe_nuget_output)
         {
-            msg::println_error(msg::format(msgCommandFailed, msg::command_line = cmd_line.command_line())
-                                   .append_raw('\n')
-                                   .append(maybe_nuget_output.error()));
-            Checks::unreachable(VCPKG_LINE_INFO);
+            Checks::msg_exit_with_message(VCPKG_LINE_INFO,
+                                          msg::format(msgCommandFailed, msg::command_line = cmd_line.command_line())
+                                              .append_raw('\n')
+                                              .append(maybe_nuget_output.error()));
         }
 
-        const auto nuget_package = buildsystems_dir / fmt::format("{}.{}.nupkg", nuget_id, nupkg_version);
+        fs.remove_all(tmp_dir, VCPKG_LINE_INFO);
+        const auto nuget_package = paths.original_cwd / fmt::format("{}.{}.nupkg", nuget_id, nupkg_version);
         Checks::msg_check_exit(VCPKG_LINE_INFO,
                                fs.exists(nuget_package, IgnoreErrors{}),
                                msgNugetPackageFileSucceededButCreationFailed,
                                msg::path = nuget_package);
         msg::println(Color::success, msgCreatedNuGetPackage, msg::path = nuget_package);
 
-        auto source_path = Strings::replace_all(buildsystems_dir, "`", "``");
+        auto source_path = Strings::replace_all(paths.original_cwd, "`", "``");
 
         msg::println(msgInstallPackageInstruction, msg::value = nuget_id, msg::path = source_path);
         Checks::exit_success(VCPKG_LINE_INFO);

--- a/src/vcpkg/commands.integrate.cpp
+++ b/src/vcpkg/commands.integrate.cpp
@@ -244,11 +244,12 @@ namespace vcpkg::Commands::Integrate
     }
 #endif
 
-    static constexpr StringLiteral vcpkg_user_props = "vcpkg.user.props";
-    static constexpr StringLiteral vcpkg_user_targets = "vcpkg.user.targets";
     static constexpr StringLiteral vcpkg_path_txt = "vcpkg.path.txt";
 
 #if defined(_WIN32)
+    static constexpr StringLiteral vcpkg_user_props = "vcpkg.user.props";
+    static constexpr StringLiteral vcpkg_user_targets = "vcpkg.user.targets";
+
     static void integrate_install_msbuild14(Filesystem& fs)
     {
         std::array<Path, 2> OLD_SYSTEM_TARGET_FILES = {


### PR DESCRIPTION
* Move the "tmp" directory to the normal place we do temp things.
* Fix not clearing the tmp directory after use. Fixes https://github.com/microsoft/vcpkg/issues/10537 .
* For MSBuild 14, only use a tmp directory at all if we need to do the file copy from an elevated prompt instead of always using a temp directory.
* For MSBuild != 14, just write the files into the correct place rather than writing to a temp place then copying over.
* For MSBuild all, reuse that on Windows `user_configuration_home` is already `%LOCALAPPDATA\vcpkg` instead of deriving that path all over the place.
* `StringLiteral`-ize create_nuget_props_file_contents since it was a constant.
* Remove noexcept from functions that allocate and return `std::string`s.
* In integrate project, put the resulting nupkg in CWD rather than always in buildsystems.

Before:

![before access denied error](https://user-images.githubusercontent.com/1544943/226755432-7cb5384a-a85c-4995-9206-4e8dbb064b97.png)

After:

![after success](https://user-images.githubusercontent.com/1544943/226755632-38489453-3bae-4e08-acc5-ddb8390cfb3f.png)
