### PR TITLE
Move `ExpectedT<>::value_or_exit()` to call `Checks::msg_exit_with_message`. Create `ExpectedT<>::value()`.

### DIFF
--- a/include/vcpkg/base/expected.h
+++ b/include/vcpkg/base/expected.h
@@ -208,6 +208,18 @@ namespace vcpkg
             return *m_t.get();
         }
 
+        const T& value() const&
+        {
+            exit_if_error();
+            return *m_t.get();
+        }
+
+        T&& value() &&
+        {
+            exit_if_error();
+            return std::move(*m_t.get());
+        }
+
         const Error& error() const&
         {
             exit_if_not_error();
@@ -350,7 +362,15 @@ namespace vcpkg
         {
             if (value_is_error)
             {
-                Checks::exit_with_message(line_info, to_string(error()));
+                Checks::msg_exit_with_message(line_info, error());
+            }
+        }
+
+        void exit_if_error() const
+        {
+            if (value_is_error)
+            {
+                Checks::unreachable(VCPKG_LINE_INFO);
             }
         }
 

--- a/include/vcpkg/base/parse.h
+++ b/include/vcpkg/base/parse.h
@@ -35,14 +35,19 @@ namespace vcpkg
 
         std::string to_string() const;
     };
-} // namespace vcpkg
 
-VCPKG_FORMAT_WITH_TO_STRING(vcpkg::ParseError);
+    constexpr struct ParseErrorFormatter
+    {
+        LocalizedString operator()(const std::unique_ptr<ParseError>& up)
+        {
+            return LocalizedString::from_raw(up->to_string());
+        }
+    } parse_error_formatter;
+
+} // namespace vcpkg
 
 namespace vcpkg
 {
-    inline std::string to_string(const std::unique_ptr<ParseError>& up) { return up->to_string(); }
-
     struct SourceLoc
     {
         Unicode::Utf8Decoder it;

--- a/src/vcpkg-test/expected.cpp
+++ b/src/vcpkg-test/expected.cpp
@@ -213,8 +213,8 @@ TEST_CASE ("move assignment value value", "[expected]")
         ExpectedT<ConstructTracker<0>, ConstructTracker<1>> originally_value{value};
         ExpectedT<ConstructTracker<0>, ConstructTracker<1>> originally_value2{value};
         originally_value = std::move(originally_value2);
-        CHECK(!originally_value.value_or_exit(VCPKG_LINE_INFO).moved_from);
-        CHECK(originally_value2.value_or_exit(VCPKG_LINE_INFO).moved_from);
+        CHECK(!originally_value.value().moved_from);
+        CHECK(originally_value2.value().moved_from);
         CHECK(value.alive == 2);
         CHECK(value.copies == 0);
         CHECK(value.copy_assigns == 0);
@@ -267,8 +267,8 @@ TEST_CASE ("move assignment error value", "[expected]")
         ExpectedT<ConstructTracker<0>, ConstructTracker<1>> originally_value{value};
         ExpectedT<ConstructTracker<0>, ConstructTracker<1>> originally_error{error};
         originally_error = std::move(originally_value);
-        CHECK(originally_value.value_or_exit(VCPKG_LINE_INFO).moved_from);
-        CHECK(!originally_error.value_or_exit(VCPKG_LINE_INFO).moved_from);
+        CHECK(originally_value.value().moved_from);
+        CHECK(!originally_error.value().moved_from);
         error.check_nothing();
         CHECK(value.alive == 2);
         CHECK(value.copies == 0);
@@ -326,7 +326,7 @@ TEST_CASE ("map", "[expected]")
                 return 42;
             });
         static_assert(std::is_same_v<decltype(result), ExpectedT<int, ConstructTracker<1>>>, "Bad map(const&) type");
-        CHECK(result.value_or_exit(VCPKG_LINE_INFO) == 42);
+        CHECK(result.value() == 42);
     }
 
     value.check_nothing();
@@ -342,7 +342,7 @@ TEST_CASE ("map", "[expected]")
                     return 42;
                 });
         static_assert(std::is_same_v<decltype(result), ExpectedT<int, ConstructTracker<1>>>, "Bad map(&&) type");
-        CHECK(result.value_or_exit(VCPKG_LINE_INFO) == 42);
+        CHECK(result.value() == 42);
     }
 
     value.check_nothing();

--- a/src/vcpkg-test/manifests.cpp
+++ b/src/vcpkg-test/manifests.cpp
@@ -819,7 +819,7 @@ TEST_CASE ("manifest embed configuration", "[manifests]")
     REQUIRE(pgh.core_paragraph->dependencies[2].constraint ==
             DependencyConstraint{VersionConstraintKind::Minimum, "2018-09-01", 0});
 
-    auto config = Json::parse(raw_config, "<test config>").value_or_exit(VCPKG_LINE_INFO).value;
+    auto config = Json::parse(raw_config, "<test config>").value().value;
     REQUIRE(config.is_object());
     auto config_obj = config.object(VCPKG_LINE_INFO);
     REQUIRE(pgh.core_paragraph->vcpkg_configuration.has_value());

--- a/src/vcpkg-test/registries.cpp
+++ b/src/vcpkg-test/registries.cpp
@@ -45,7 +45,7 @@ namespace
     }
 
     // test functions which parse string literals, so no concerns about failure
-    Json::Value parse_json(StringView sv) { return Json::parse(sv).value_or_exit(VCPKG_LINE_INFO).value; }
+    Json::Value parse_json(StringView sv) { return Json::parse(sv).value().value; }
 }
 
 TEST_CASE ("registry_set_selects_registry", "[registries]")

--- a/src/vcpkg-test/spdx.cpp
+++ b/src/vcpkg-test/spdx.cpp
@@ -157,9 +157,9 @@ TEST_CASE ("spdx maximum serialization", "[spdx]")
     }
   ]
 })json")
-                        .value_or_exit(VCPKG_LINE_INFO);
+                        .value();
 
-    auto doc = Json::parse(sbom).value_or_exit(VCPKG_LINE_INFO);
+    auto doc = Json::parse(sbom).value();
     Test::check_json_eq(expected.value, doc.value);
 }
 
@@ -285,9 +285,9 @@ TEST_CASE ("spdx minimum serialization", "[spdx]")
     }
   ]
 })json")
-                        .value_or_exit(VCPKG_LINE_INFO);
+                        .value();
 
-    auto doc = Json::parse(sbom).value_or_exit(VCPKG_LINE_INFO);
+    auto doc = Json::parse(sbom).value();
     Test::check_json_eq(expected.value, doc.value);
 }
 
@@ -311,14 +311,14 @@ TEST_CASE ("spdx concat resources", "[spdx]")
   "relationships": [ "r1", "r2", "r3" ],
   "files": [ "f1", "f2", "f3" ]
 })json")
-                    .value_or_exit(VCPKG_LINE_INFO)
+                    .value()
                     .value;
     auto doc2 = Json::parse(R"json(
 {
   "packages": [ "p1", "p2", "p3" ],
   "files": [ "f4", "f5" ]
 })json")
-                    .value_or_exit(VCPKG_LINE_INFO)
+                    .value()
                     .value;
 
     const auto sbom = create_spdx_sbom(ipa, {}, {}, "now+1", "ns", {std::move(doc1), std::move(doc2)});
@@ -385,8 +385,8 @@ TEST_CASE ("spdx concat resources", "[spdx]")
     "f5"
   ]
 })json")
-                        .value_or_exit(VCPKG_LINE_INFO);
+                        .value();
 
-    auto doc = Json::parse(sbom).value_or_exit(VCPKG_LINE_INFO);
+    auto doc = Json::parse(sbom).value();
     Test::check_json_eq(expected.value, doc.value);
 }

--- a/src/vcpkg-test/update.cpp
+++ b/src/vcpkg-test/update.cpp
@@ -23,7 +23,7 @@ TEST_CASE ("find outdated packages basic", "[update]")
     StatusParagraphs status_db(std::move(status_paragraphs));
 
     std::unordered_map<std::string, SourceControlFileAndLocation> map;
-    auto scf = test_parse_control_file({{{"Source", "a"}, {"Version", "0"}}}).value_or_exit(VCPKG_LINE_INFO);
+    auto scf = test_parse_control_file({{{"Source", "a"}, {"Version", "0"}}}).value();
     map.emplace("a", SourceControlFileAndLocation{std::move(scf), ""});
     MapPortFileProvider provider(map);
 
@@ -47,7 +47,7 @@ TEST_CASE ("find outdated packages features", "[update]")
     StatusParagraphs status_db(std::move(status_paragraphs));
 
     std::unordered_map<std::string, SourceControlFileAndLocation> map;
-    auto scf = test_parse_control_file({{{"Source", "a"}, {"Version", "0"}}}).value_or_exit(VCPKG_LINE_INFO);
+    auto scf = test_parse_control_file({{{"Source", "a"}, {"Version", "0"}}}).value();
     map.emplace("a", SourceControlFileAndLocation{std::move(scf), ""});
     MapPortFileProvider provider(map);
 
@@ -73,7 +73,7 @@ TEST_CASE ("find outdated packages features 2", "[update]")
     StatusParagraphs status_db(std::move(status_paragraphs));
 
     std::unordered_map<std::string, SourceControlFileAndLocation> map;
-    auto scf = test_parse_control_file({{{"Source", "a"}, {"Version", "0"}}}).value_or_exit(VCPKG_LINE_INFO);
+    auto scf = test_parse_control_file({{{"Source", "a"}, {"Version", "0"}}}).value();
     map.emplace("a", SourceControlFileAndLocation{std::move(scf), ""});
     MapPortFileProvider provider(map);
 
@@ -94,7 +94,7 @@ TEST_CASE ("find outdated packages none", "[update]")
     StatusParagraphs status_db(std::move(status_paragraphs));
 
     std::unordered_map<std::string, SourceControlFileAndLocation> map;
-    auto scf = test_parse_control_file({{{"Source", "a"}, {"Version", "2"}}}).value_or_exit(VCPKG_LINE_INFO);
+    auto scf = test_parse_control_file({{{"Source", "a"}, {"Version", "2"}}}).value();
     map.emplace("a", SourceControlFileAndLocation{std::move(scf), ""});
     MapPortFileProvider provider(map);
 

--- a/src/vcpkg/base/json.cpp
+++ b/src/vcpkg/base/json.cpp
@@ -1139,7 +1139,7 @@ namespace vcpkg::Json
         {
             Checks::msg_exit_with_message(li, LocalizedString::from_raw(ret.error()->to_string()));
         }
-        return ret.value_or_exit(li);
+        return std::move(ret).value();
     }
 
     ExpectedT<ParsedJson, std::unique_ptr<ParseError>> parse(StringView json, StringView origin)

--- a/src/vcpkg/commands.add-version.cpp
+++ b/src/vcpkg/commands.add-version.cpp
@@ -412,7 +412,7 @@ namespace vcpkg::Commands::AddVersion
                 continue;
             }
 
-            const auto& scf = maybe_scf.value_or_exit(VCPKG_LINE_INFO);
+            const auto& scf = maybe_scf.value();
 
             if (!skip_formatting_check)
             {

--- a/src/vcpkg/commands.add.cpp
+++ b/src/vcpkg/commands.add.cpp
@@ -92,7 +92,7 @@ namespace vcpkg::Commands
                 Checks::exit_fail(VCPKG_LINE_INFO);
             }
 
-            auto& manifest_scf = *maybe_manifest_scf.value_or_exit(VCPKG_LINE_INFO);
+            auto& manifest_scf = *maybe_manifest_scf.value();
             for (const auto& spec : specs)
             {
                 auto dep = Util::find_if(manifest_scf.core_paragraph->dependencies, [&spec](Dependency& dep) {

--- a/src/vcpkg/commands.civerifyversions.cpp
+++ b/src/vcpkg/commands.civerifyversions.cpp
@@ -108,7 +108,7 @@ namespace vcpkg::Commands::CIVerifyVersions
                                 expected_right_tag};
                     }
 
-                    const auto& scf = maybe_scf.value_or_exit(VCPKG_LINE_INFO);
+                    const auto& scf = maybe_scf.value();
                     auto&& git_tree_version = scf->to_schemed_version();
                     if (version_entry.first.version != git_tree_version.version)
                     {
@@ -121,9 +121,7 @@ namespace vcpkg::Commands::CIVerifyVersions
                                 .append_raw('\n')
                                 .append(msgVersionInDeclarationDoesNotMatch, msg::version = git_tree_version.version)
                                 .append_raw('\n')
-                                .append(msgCheckedOutGitSha, msg::commit_sha = version_entry.second)
-                                .append_raw('\n')
-                                .append_raw(maybe_scf.error()->error),
+                                .append(msgCheckedOutGitSha, msg::commit_sha = version_entry.second),
                             expected_right_tag};
                     }
                     version_ok = true;
@@ -155,7 +153,7 @@ namespace vcpkg::Commands::CIVerifyVersions
                     expected_right_tag};
         }
 
-        const auto local_port_version = maybe_scf.value_or_exit(VCPKG_LINE_INFO)->to_schemed_version();
+        const auto local_port_version = maybe_scf.value()->to_schemed_version();
 
         auto versions_end = versions.end();
         auto it =

--- a/src/vcpkg/commands.format-manifest.cpp
+++ b/src/vcpkg/commands.format-manifest.cpp
@@ -36,7 +36,7 @@ namespace
             return nullopt;
         }
 
-        const auto& parsed_json = parsed_json_opt.value_or_exit(VCPKG_LINE_INFO).value;
+        const auto& parsed_json = parsed_json_opt.value().value;
         if (!parsed_json.is_object())
         {
             msg::println_error(msgJsonErrorMustBeAnObject, msg::path = path_string);
@@ -54,7 +54,7 @@ namespace
         }
 
         return ToWrite{
-            std::move(*scf.value_or_exit(VCPKG_LINE_INFO)),
+            std::move(*scf.value()),
             manifest_path,
             manifest_path,
             std::move(contents),
@@ -76,8 +76,7 @@ namespace
                                    .append_raw(paragraphs.error()));
             return {};
         }
-        auto scf_res =
-            SourceControlFile::parse_control_file(control_path, std::move(paragraphs).value_or_exit(VCPKG_LINE_INFO));
+        auto scf_res = SourceControlFile::parse_control_file(control_path, std::move(paragraphs).value());
         if (!scf_res)
         {
             msg::println_error(msgFailedToParseControl, msg::path = control_path);
@@ -86,7 +85,7 @@ namespace
         }
 
         return ToWrite{
-            std::move(*scf_res.value_or_exit(VCPKG_LINE_INFO)),
+            std::move(*scf_res.value()),
             manifest_path,
             control_path,
             std::move(contents),

--- a/src/vcpkg/configuration.cpp
+++ b/src/vcpkg/configuration.cpp
@@ -855,7 +855,7 @@ namespace vcpkg
             return nullopt;
         }
 
-        auto conf_value = std::move(conf).value_or_exit(VCPKG_LINE_INFO).value;
+        auto conf_value = std::move(conf).value().value;
         if (!conf_value.is_object())
         {
             messageSink.println(msgFailedToParseNoTopLevelObj, msg::path = origin);

--- a/src/vcpkg/install.cpp
+++ b/src/vcpkg/install.cpp
@@ -1066,7 +1066,7 @@ namespace vcpkg
                 Checks::exit_fail(VCPKG_LINE_INFO);
             }
 
-            auto manifest_scf = std::move(maybe_manifest_scf).value_or_exit(VCPKG_LINE_INFO);
+            auto manifest_scf = std::move(maybe_manifest_scf).value();
             const auto& manifest_core = *manifest_scf->core_paragraph;
             auto registry_set = paths.make_registry_set();
             manifest_scf

--- a/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/src/vcpkg/vcpkgcmdarguments.cpp
@@ -521,7 +521,10 @@ namespace vcpkg
         auto maybe_vcpkg_recursive_data = get_environment_variable(RECURSIVE_DATA_ENV);
         if (auto vcpkg_recursive_data = maybe_vcpkg_recursive_data.get())
         {
-            auto rec_doc = Json::parse(*vcpkg_recursive_data).value_or_exit(VCPKG_LINE_INFO).value;
+            auto rec_doc = Json::parse(*vcpkg_recursive_data)
+                               .map_error(parse_error_formatter)
+                               .value_or_exit(VCPKG_LINE_INFO)
+                               .value;
             const auto& obj = rec_doc.object(VCPKG_LINE_INFO);
 
             if (auto entry = obj.get(VCPKG_ROOT_ARG_NAME))

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -79,7 +79,7 @@ namespace
                                            LocalizedString::from_raw(manifest_opt.error()->to_string()));
         }
 
-        auto manifest_value = std::move(manifest_opt).value_or_exit(VCPKG_LINE_INFO).value;
+        auto manifest_value = std::move(manifest_opt).value().value;
         if (!manifest_value.is_object())
         {
             msg::println_error(msgFailedToParseNoTopLevelObj, msg::path = manifest_path);


### PR DESCRIPTION
The previous code doesn't clearly distinguish between assertion failures (this object should not be null) and intended fail-with-error. This change adds a new api, `.value()` for handling the assertion case and therefore allows us to tighten the fail-with-error case to require localization.