### PR TITLE
Rearrange declarations and definitions to reduce needed includes.

### DIFF
--- a/include/vcpkg/base/file_sink.h
+++ b/include/vcpkg/base/file_sink.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <vcpkg/base/files.h>
+#include <vcpkg/base/message_sinks.h>
+
+namespace vcpkg
+{
+    struct FileSink : MessageSink
+    {
+        Path m_log_file;
+        WriteFilePointer m_out_file;
+
+        FileSink(Filesystem& fs, StringView log_file, Append append_to_file)
+            : m_log_file(log_file), m_out_file(fs.open_for_write(m_log_file, append_to_file, VCPKG_LINE_INFO))
+        {
+        }
+        void print(Color c, StringView sv) override;
+    };
+}

--- a/include/vcpkg/base/files.h
+++ b/include/vcpkg/base/files.h
@@ -9,7 +9,7 @@
 #include <vcpkg/base/file-contents.h>
 #include <vcpkg/base/lineinfo.h>
 #include <vcpkg/base/messages.h>
-#include <vcpkg/base/pragmas.h>
+#include <vcpkg/base/path.h>
 #include <vcpkg/base/stringview.h>
 
 #include <stdio.h>
@@ -21,12 +21,6 @@
 #include <system_error>
 #include <utility>
 #include <vector>
-
-#if defined(_WIN32)
-#define VCPKG_PREFERRED_SEPARATOR "\\"
-#else // ^^^ _WIN32 / !_WIN32 vvv
-#define VCPKG_PREFERRED_SEPARATOR "/"
-#endif // _WIN32
 
 namespace vcpkg
 {
@@ -43,61 +37,6 @@ namespace vcpkg
 
     private:
         std::error_code ec;
-    };
-
-    struct Path
-    {
-        Path();
-        Path(const Path&);
-        Path(Path&&);
-        Path& operator=(const Path&);
-        Path& operator=(Path&&);
-
-        Path(const StringView sv);
-        Path(const std::string& s);
-        Path(std::string&& s);
-        Path(const char* s);
-        Path(const char* first, size_t size);
-
-        const std::string& native() const& noexcept;
-        std::string&& native() && noexcept;
-        operator StringView() const noexcept;
-
-        const char* c_str() const noexcept;
-
-        std::string generic_u8string() const;
-
-        bool empty() const noexcept;
-
-        Path operator/(StringView sv) const&;
-        Path operator/(StringView sv) &&;
-        Path operator+(StringView sv) const&;
-        Path operator+(StringView sv) &&;
-
-        Path& operator/=(StringView sv);
-        Path& operator+=(StringView sv);
-
-        void replace_filename(StringView sv);
-        void remove_filename();
-        void make_preferred();
-        void clear();
-        Path lexically_normal() const;
-
-        // Sets *this to parent_path, returns whether anything was removed
-        bool make_parent_path();
-
-        StringView parent_path() const;
-        StringView filename() const;
-        StringView extension() const;
-        StringView stem() const;
-
-        bool is_absolute() const;
-        bool is_relative() const;
-
-        friend const char* to_printf_arg(const Path& p) noexcept;
-
-    private:
-        std::string m_str;
     };
 
     bool is_symlink(FileType s);

--- a/include/vcpkg/base/fwd/files.h
+++ b/include/vcpkg/base/fwd/files.h
@@ -1,5 +1,11 @@
 #pragma once
 
+#if defined(_WIN32)
+#define VCPKG_PREFERRED_SEPARATOR "\\"
+#else // ^^^ _WIN32 / !_WIN32 vvv
+#define VCPKG_PREFERRED_SEPARATOR "/"
+#endif // _WIN32
+
 namespace vcpkg
 {
     enum class CopyOptions

--- a/include/vcpkg/base/git.h
+++ b/include/vcpkg/base/git.h
@@ -3,7 +3,7 @@
 #include <vcpkg/base/fwd/git.h>
 
 #include <vcpkg/base/expected.h>
-#include <vcpkg/base/files.h>
+#include <vcpkg/base/path.h>
 #include <vcpkg/base/stringview.h>
 
 #include <set>

--- a/include/vcpkg/base/jsonreader.h
+++ b/include/vcpkg/base/jsonreader.h
@@ -3,9 +3,9 @@
 #include <vcpkg/base/fwd/json.h>
 
 #include <vcpkg/base/chrono.h>
-#include <vcpkg/base/files.h>
 #include <vcpkg/base/json.h>
 #include <vcpkg/base/optional.h>
+#include <vcpkg/base/path.h>
 #include <vcpkg/base/span.h>
 #include <vcpkg/base/stringview.h>
 
@@ -349,32 +349,5 @@ namespace vcpkg::Json
         virtual LocalizedString type_name() const override;
         virtual Optional<std::string> visit_string(Json::Reader&, StringView sv) const override;
         static const PackageNameDeserializer instance;
-    };
-
-    /// <summary>
-    /// A registry package pattern (e.g.: boost*) and the in-file location where it was declared.
-    /// </summary>
-    struct PackagePatternDeclaration
-    {
-        std::string pattern;
-        std::string location;
-    };
-
-    /// <summary>
-    /// Deserializes a list of package names and patterns along with their respective in-file declaration locations.
-    /// </summary>
-    struct PackagePatternDeserializer final : Json::IDeserializer<PackagePatternDeclaration>
-    {
-        virtual LocalizedString type_name() const override;
-        virtual Optional<PackagePatternDeclaration> visit_string(Json::Reader&, StringView sv) const override;
-
-        static bool is_package_pattern(StringView sv);
-        static const PackagePatternDeserializer instance;
-    };
-
-    struct PackagePatternArrayDeserializer final : Json::ArrayDeserializer<PackagePatternDeserializer>
-    {
-        virtual LocalizedString type_name() const override;
-        static const PackagePatternArrayDeserializer instance;
     };
 }

--- a/include/vcpkg/base/message_sinks.h
+++ b/include/vcpkg/base/message_sinks.h
@@ -2,7 +2,6 @@
 
 #include <vcpkg/base/fwd/message_sinks.h>
 
-#include <vcpkg/base/files.h>
 #include <vcpkg/base/messages.h>
 
 namespace vcpkg
@@ -69,17 +68,6 @@ namespace vcpkg
         ~MessageSink() = default;
     };
 
-    struct FileSink : MessageSink
-    {
-        Path m_log_file;
-        WriteFilePointer m_out_file;
-
-        FileSink(Filesystem& fs, StringView log_file, Append append_to_file)
-            : m_log_file(log_file), m_out_file(fs.open_for_write(m_log_file, append_to_file, VCPKG_LINE_INFO))
-        {
-        }
-        void print(Color c, StringView sv) override;
-    };
     struct CombiningSink : MessageSink
     {
         MessageSink& m_first;

--- a/include/vcpkg/base/parse.h
+++ b/include/vcpkg/base/parse.h
@@ -79,6 +79,7 @@ namespace vcpkg
 
         static constexpr bool is_whitespace(char32_t ch) { return ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n'; }
         static constexpr bool is_lower_alpha(char32_t ch) { return ch >= 'a' && ch <= 'z'; }
+        static constexpr bool is_lower_digit(char ch) { return is_lower_alpha(ch) || is_ascii_digit(ch); }
         static constexpr bool is_upper_alpha(char32_t ch) { return ch >= 'A' && ch <= 'Z'; }
         static constexpr bool is_icase_alpha(char32_t ch) { return is_lower_alpha(ch) || is_upper_alpha(ch); }
         static constexpr bool is_ascii_digit(char32_t ch) { return ch >= '0' && ch <= '9'; }

--- a/include/vcpkg/base/path.h
+++ b/include/vcpkg/base/path.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <vcpkg/base/stringview.h>
+
+#include <string>
+
+namespace vcpkg
+{
+    struct Path
+    {
+        Path();
+        Path(const Path&);
+        Path(Path&&);
+        Path& operator=(const Path&);
+        Path& operator=(Path&&);
+
+        Path(const StringView sv);
+        Path(const std::string& s);
+        Path(std::string&& s);
+        Path(const char* s);
+        Path(const char* first, size_t size);
+
+        const std::string& native() const& noexcept;
+        std::string&& native() && noexcept;
+        operator StringView() const noexcept;
+
+        const char* c_str() const noexcept;
+
+        std::string generic_u8string() const;
+
+        bool empty() const noexcept;
+
+        Path operator/(StringView sv) const&;
+        Path operator/(StringView sv) &&;
+        Path operator+(StringView sv) const&;
+        Path operator+(StringView sv) &&;
+
+        Path& operator/=(StringView sv);
+        Path& operator+=(StringView sv);
+
+        void replace_filename(StringView sv);
+        void remove_filename();
+        void make_preferred();
+        void clear();
+        Path lexically_normal() const;
+
+        // Sets *this to parent_path, returns whether anything was removed
+        bool make_parent_path();
+
+        StringView parent_path() const;
+        StringView filename() const;
+        StringView extension() const;
+        StringView stem() const;
+
+        bool is_absolute() const;
+        bool is_relative() const;
+
+        friend const char* to_printf_arg(const Path& p) noexcept;
+
+    private:
+        std::string m_str;
+    };
+}

--- a/include/vcpkg/base/system.h
+++ b/include/vcpkg/base/system.h
@@ -1,12 +1,15 @@
 #pragma once
 
+#include <vcpkg/base/fwd/files.h>
 #include <vcpkg/base/fwd/system.h>
 
 #include <vcpkg/base/expected.h>
-#include <vcpkg/base/files.h>
 #include <vcpkg/base/messages.h>
 #include <vcpkg/base/optional.h>
 #include <vcpkg/base/stringview.h>
+
+#include <string>
+#include <vector>
 
 namespace vcpkg
 {

--- a/include/vcpkg/base/system.process.h
+++ b/include/vcpkg/base/system.process.h
@@ -3,7 +3,7 @@
 #include <vcpkg/base/fwd/system.process.h>
 
 #include <vcpkg/base/expected.h>
-#include <vcpkg/base/files.h>
+#include <vcpkg/base/path.h>
 #include <vcpkg/base/span.h>
 #include <vcpkg/base/stringview.h>
 

--- a/include/vcpkg/base/unicode.h
+++ b/include/vcpkg/base/unicode.h
@@ -29,8 +29,6 @@ namespace vcpkg::Unicode
         UnexpectedEof = 6,
     };
 
-    const std::error_category& utf8_category() noexcept;
-
     Utf8CodeUnitKind utf8_code_unit_kind(unsigned char code_unit) noexcept;
 
     constexpr int utf8_code_unit_count(Utf8CodeUnitKind kind) noexcept { return static_cast<int>(kind); }
@@ -103,11 +101,6 @@ namespace vcpkg::Unicode
     }
 
     char32_t utf16_surrogates_to_code_point(char32_t leading, char32_t trailing);
-
-    inline std::error_code make_error_code(utf8_errc err) noexcept
-    {
-        return std::error_code(static_cast<int>(err), utf8_category());
-    }
 
     /*
         There are two ways to parse utf-8: we could allow unpaired surrogates (as in [wtf-8]) -- this is important
@@ -188,12 +181,4 @@ namespace vcpkg::Unicode
     constexpr bool operator==(Utf8Decoder::sentinel s, const Utf8Decoder& d) { return d == s; }
     constexpr bool operator!=(const Utf8Decoder& d, Utf8Decoder::sentinel) { return !d.is_eof(); }
     constexpr bool operator!=(Utf8Decoder::sentinel s, const Utf8Decoder& d) { return d != s; }
-}
-
-namespace std
-{
-    template<>
-    struct is_error_code_enum<vcpkg::Unicode::utf8_errc> : std::true_type
-    {
-    };
 }

--- a/include/vcpkg/binarycaching.h
+++ b/include/vcpkg/binarycaching.h
@@ -8,7 +8,7 @@
 
 #include <vcpkg/base/downloads.h>
 #include <vcpkg/base/expected.h>
-#include <vcpkg/base/files.h>
+#include <vcpkg/base/path.h>
 
 #include <vcpkg/packagespec.h>
 

--- a/include/vcpkg/configuration.h
+++ b/include/vcpkg/configuration.h
@@ -5,14 +5,23 @@
 #include <vcpkg/fwd/configuration.h>
 #include <vcpkg/fwd/vcpkgcmdarguments.h>
 
-#include <vcpkg/base/files.h>
 #include <vcpkg/base/json.h>
 #include <vcpkg/base/optional.h>
+#include <vcpkg/base/path.h>
 
 #include <vcpkg/registries.h>
 
 namespace vcpkg
 {
+    /// <summary>
+    /// A registry package pattern (e.g.: boost*) and the in-file location where it was declared.
+    /// </summary>
+    struct PackagePatternDeclaration
+    {
+        std::string pattern;
+        std::string location;
+    };
+
     struct RegistryConfig
     {
         // Missing kind means "null"
@@ -24,7 +33,7 @@ namespace vcpkg
         Optional<std::string> reference;
         Optional<std::string> repo;
         Optional<std::vector<std::string>> packages;
-        Optional<std::vector<Json::PackagePatternDeclaration>> package_declarations;
+        Optional<std::vector<PackagePatternDeclaration>> package_declarations;
 
         Json::Value serialize() const;
 
@@ -87,4 +96,7 @@ namespace vcpkg
                                                 vcpkg::MessageSink& messageSink);
 
     std::vector<std::string> find_unknown_fields(const Configuration& config);
+
+    // Exposed for testing
+    bool is_package_pattern(StringView sv);
 }

--- a/include/vcpkg/installedpaths.h
+++ b/include/vcpkg/installedpaths.h
@@ -2,7 +2,7 @@
 
 #include <vcpkg/fwd/binaryparagraph.h>
 
-#include <vcpkg/base/files.h>
+#include <vcpkg/base/path.h>
 
 #include <vcpkg/packagespec.h>
 #include <vcpkg/triplet.h>

--- a/include/vcpkg/packagespec.h
+++ b/include/vcpkg/packagespec.h
@@ -6,13 +6,11 @@
 #include <vcpkg/fwd/packagespec.h>
 
 #include <vcpkg/base/expected.h>
-#include <vcpkg/base/json.h>
 #include <vcpkg/base/optional.h>
 #include <vcpkg/base/span.h>
 
 #include <vcpkg/platform-expression.h>
 #include <vcpkg/triplet.h>
-#include <vcpkg/versions.h>
 
 namespace vcpkg
 {
@@ -112,10 +110,11 @@ namespace vcpkg
         InternalFeatureSet features;
 
         FullPackageSpec() = default;
-        explicit FullPackageSpec(PackageSpec spec, InternalFeatureSet features)
+        FullPackageSpec(PackageSpec spec, InternalFeatureSet features)
             : package_spec(std::move(spec)), features(std::move(features))
         {
         }
+        FullPackageSpec(PackageSpec spec, View<std::string> features, ImplicitDefault id);
 
         /// Splats into individual FeatureSpec's
         void expand_fspecs_to(std::vector<FeatureSpec>& oFut) const;
@@ -125,51 +124,6 @@ namespace vcpkg
             return l.package_spec == r.package_spec && l.features == r.features;
         }
         friend bool operator!=(const FullPackageSpec& l, const FullPackageSpec& r) { return !(l == r); }
-    };
-
-    struct DependencyConstraint
-    {
-        VersionConstraintKind type = VersionConstraintKind::None;
-        std::string value;
-        int port_version = 0;
-
-        friend bool operator==(const DependencyConstraint& lhs, const DependencyConstraint& rhs);
-        friend bool operator!=(const DependencyConstraint& lhs, const DependencyConstraint& rhs)
-        {
-            return !(lhs == rhs);
-        }
-
-        Optional<Version> try_get_minimum_version() const;
-    };
-
-    struct Dependency
-    {
-        std::string name;
-        std::vector<std::string> features;
-        PlatformExpression::Expr platform;
-        DependencyConstraint constraint;
-        bool host = false;
-
-        Json::Object extra_info;
-
-        /// @param id adds "default" if "core" not present.
-        FullPackageSpec to_full_spec(Triplet target, Triplet host, ImplicitDefault id) const;
-
-        friend bool operator==(const Dependency& lhs, const Dependency& rhs);
-        friend bool operator!=(const Dependency& lhs, const Dependency& rhs) { return !(lhs == rhs); }
-    };
-
-    struct DependencyOverride
-    {
-        std::string name;
-        std::string version;
-        int port_version = 0;
-        VersionScheme version_scheme = VersionScheme::String;
-
-        Json::Object extra_info;
-
-        friend bool operator==(const DependencyOverride& lhs, const DependencyOverride& rhs);
-        friend bool operator!=(const DependencyOverride& lhs, const DependencyOverride& rhs) { return !(lhs == rhs); }
     };
 
     struct ParsedQualifiedSpecifier

--- a/include/vcpkg/paragraphparser.h
+++ b/include/vcpkg/paragraphparser.h
@@ -75,7 +75,4 @@ namespace vcpkg
     ExpectedL<std::vector<ParsedQualifiedSpecifier>> parse_qualified_specifier_list(const std::string& str,
                                                                                     StringView origin = "<unknown>",
                                                                                     TextRowCol textrowcol = {});
-    ExpectedL<std::vector<Dependency>> parse_dependencies_list(const std::string& str,
-                                                               StringView origin = "<unknown>",
-                                                               TextRowCol textrowcol = {});
 }

--- a/include/vcpkg/registries.h
+++ b/include/vcpkg/registries.h
@@ -7,6 +7,7 @@
 #include <vcpkg/fwd/registries.h>
 #include <vcpkg/fwd/vcpkgpaths.h>
 
+#include <vcpkg/base/path.h>
 #include <vcpkg/base/span.h>
 #include <vcpkg/base/stringview.h>
 
@@ -158,27 +159,5 @@ namespace vcpkg
     ExpectedL<std::map<std::string, Version, std::less<>>> get_builtin_baseline(const VcpkgPaths& paths);
 
     bool is_git_commit_sha(StringView sv);
-
-    struct VersionDbEntry
-    {
-        Version version;
-        VersionScheme scheme = VersionScheme::String;
-
-        // only one of these may be non-empty
-        std::string git_tree;
-        Path p;
-    };
-
-    // VersionDbType::Git => VersionDbEntry.git_tree is filled
-    // VersionDbType::Filesystem => VersionDbEntry.path is filled
-    enum class VersionDbType
-    {
-        Git,
-        Filesystem,
-    };
-
-    std::unique_ptr<Json::IDeserializer<std::vector<VersionDbEntry>>> make_version_db_deserializer(VersionDbType type,
-                                                                                                   const Path& root);
-
     size_t package_match_prefix(StringView name, StringView pattern);
 }

--- a/include/vcpkg/registries.h
+++ b/include/vcpkg/registries.h
@@ -7,7 +7,6 @@
 #include <vcpkg/fwd/registries.h>
 #include <vcpkg/fwd/vcpkgpaths.h>
 
-#include <vcpkg/base/jsonreader.h>
 #include <vcpkg/base/span.h>
 #include <vcpkg/base/stringview.h>
 
@@ -178,31 +177,8 @@ namespace vcpkg
         Filesystem,
     };
 
-    struct VersionDbEntryDeserializer final : Json::IDeserializer<VersionDbEntry>
-    {
-        static constexpr StringLiteral GIT_TREE = "git-tree";
-        static constexpr StringLiteral PATH = "path";
-
-        LocalizedString type_name() const override;
-        View<StringView> valid_fields() const override;
-        Optional<VersionDbEntry> visit_object(Json::Reader& r, const Json::Object& obj) const override;
-        VersionDbEntryDeserializer(VersionDbType type, const Path& root) : type(type), registry_root(root) { }
-
-    private:
-        VersionDbType type;
-        Path registry_root;
-    };
-
-    struct VersionDbEntryArrayDeserializer final : Json::IDeserializer<std::vector<VersionDbEntry>>
-    {
-        virtual LocalizedString type_name() const override;
-        virtual Optional<std::vector<VersionDbEntry>> visit_array(Json::Reader& r,
-                                                                  const Json::Array& arr) const override;
-        VersionDbEntryArrayDeserializer(VersionDbType type, const Path& root) : underlying{type, root} { }
-
-    private:
-        VersionDbEntryDeserializer underlying;
-    };
+    std::unique_ptr<Json::IDeserializer<std::vector<VersionDbEntry>>> make_version_db_deserializer(VersionDbType type,
+                                                                                                   const Path& root);
 
     size_t package_match_prefix(StringView name, StringView pattern);
 }

--- a/include/vcpkg/registries.private.h
+++ b/include/vcpkg/registries.private.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <vcpkg/base/jsonreader.h>
+#include <vcpkg/base/path.h>
+
+#include <vcpkg/versions.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace vcpkg
+{
+
+    struct VersionDbEntry
+    {
+        Version version;
+        VersionScheme scheme = VersionScheme::String;
+
+        // only one of these may be non-empty
+        std::string git_tree;
+        Path p;
+    };
+
+    // VersionDbType::Git => VersionDbEntry.git_tree is filled
+    // VersionDbType::Filesystem => VersionDbEntry.path is filled
+    enum class VersionDbType
+    {
+        Git,
+        Filesystem,
+    };
+
+    std::unique_ptr<Json::IDeserializer<std::vector<VersionDbEntry>>> make_version_db_deserializer(VersionDbType type,
+                                                                                                   const Path& root);
+}

--- a/include/vcpkg/sourceparagraph.h
+++ b/include/vcpkg/sourceparagraph.h
@@ -4,8 +4,8 @@
 #include <vcpkg/fwd/vcpkgcmdarguments.h>
 
 #include <vcpkg/base/expected.h>
-#include <vcpkg/base/files.h>
 #include <vcpkg/base/json.h>
+#include <vcpkg/base/path.h>
 #include <vcpkg/base/span.h>
 
 #include <vcpkg/packagespec.h>
@@ -19,6 +19,51 @@ namespace vcpkg
     {
         Json::Object manifest;
         Path path;
+    };
+
+    struct DependencyConstraint
+    {
+        VersionConstraintKind type = VersionConstraintKind::None;
+        std::string value;
+        int port_version = 0;
+
+        friend bool operator==(const DependencyConstraint& lhs, const DependencyConstraint& rhs);
+        friend bool operator!=(const DependencyConstraint& lhs, const DependencyConstraint& rhs)
+        {
+            return !(lhs == rhs);
+        }
+
+        Optional<Version> try_get_minimum_version() const;
+    };
+
+    struct Dependency
+    {
+        std::string name;
+        std::vector<std::string> features;
+        PlatformExpression::Expr platform;
+        DependencyConstraint constraint;
+        bool host = false;
+
+        Json::Object extra_info;
+
+        /// @param id adds "default" if "core" not present.
+        FullPackageSpec to_full_spec(Triplet target, Triplet host, ImplicitDefault id) const;
+
+        friend bool operator==(const Dependency& lhs, const Dependency& rhs);
+        friend bool operator!=(const Dependency& lhs, const Dependency& rhs) { return !(lhs == rhs); }
+    };
+
+    struct DependencyOverride
+    {
+        std::string name;
+        std::string version;
+        int port_version = 0;
+        VersionScheme version_scheme = VersionScheme::String;
+
+        Json::Object extra_info;
+
+        friend bool operator==(const DependencyOverride& lhs, const DependencyOverride& rhs);
+        friend bool operator!=(const DependencyOverride& lhs, const DependencyOverride& rhs) { return !(lhs == rhs); }
     };
 
     std::vector<FullPackageSpec> filter_dependencies(const std::vector<Dependency>& deps,
@@ -149,4 +194,9 @@ namespace vcpkg
     }
 
     std::string parse_spdx_license_expression(StringView sv, ParseMessages& messages);
+
+    // Exposed for testing
+    ExpectedL<std::vector<Dependency>> parse_dependencies_list(const std::string& str,
+                                                               StringView origin = "<unknown>",
+                                                               TextRowCol textrowcol = {});
 }

--- a/include/vcpkg/tools.test.h
+++ b/include/vcpkg/tools.test.h
@@ -4,7 +4,7 @@
 #include <vcpkg/base/fwd/optional.h>
 #include <vcpkg/base/fwd/stringview.h>
 
-#include <vcpkg/base/files.h>
+#include <vcpkg/base/path.h>
 
 #include <array>
 #include <string>

--- a/include/vcpkg/vcpkgpaths.h
+++ b/include/vcpkg/vcpkgpaths.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vcpkg/base/fwd/downloads.h>
+#include <vcpkg/base/fwd/files.h>
 #include <vcpkg/base/fwd/git.h>
 #include <vcpkg/base/fwd/system.process.h>
 
@@ -15,9 +16,8 @@
 #include <vcpkg/fwd/vcpkgcmdarguments.h>
 #include <vcpkg/fwd/vcpkgpaths.h>
 
-#include <vcpkg/base/files.h>
 #include <vcpkg/base/optional.h>
-#include <vcpkg/base/stringview.h>
+#include <vcpkg/base/path.h>
 
 #include <vcpkg/triplet.h>
 

--- a/src/vcpkg-test/registries.cpp
+++ b/src/vcpkg-test/registries.cpp
@@ -87,7 +87,6 @@ TEST_CASE ("registry_set_selects_registry", "[registries]")
 TEST_CASE ("check valid package patterns", "[registries]")
 {
     using ID = Json::IdentifierDeserializer;
-    using PD = Json::PackagePatternDeserializer;
 
     // test identifiers
     CHECK(ID::is_ident("co"));
@@ -123,17 +122,17 @@ TEST_CASE ("check valid package patterns", "[registries]")
     CHECK(!ID::is_ident("---"));
 
     // accept prefixes
-    CHECK(PD::is_package_pattern("*"));
-    CHECK(PD::is_package_pattern("b*"));
-    CHECK(PD::is_package_pattern("boost*"));
-    CHECK(PD::is_package_pattern("boost-*"));
+    CHECK(is_package_pattern("*"));
+    CHECK(is_package_pattern("b*"));
+    CHECK(is_package_pattern("boost*"));
+    CHECK(is_package_pattern("boost-*"));
 
     // reject invalid patterns
-    CHECK(!PD::is_package_pattern("*a"));
-    CHECK(!PD::is_package_pattern("a*a"));
-    CHECK(!PD::is_package_pattern("a**"));
-    CHECK(!PD::is_package_pattern("a+"));
-    CHECK(!PD::is_package_pattern("a?"));
+    CHECK(!is_package_pattern("*a"));
+    CHECK(!is_package_pattern("a*a"));
+    CHECK(!is_package_pattern("a**"));
+    CHECK(!is_package_pattern("a+"));
+    CHECK(!is_package_pattern("a?"));
 }
 
 TEST_CASE ("calculate prefix priority", "[registries]")
@@ -509,7 +508,7 @@ TEST_CASE ("registries ignored patterns warning", "[registries]")
 
 TEST_CASE ("git_version_db_parsing", "[registries]")
 {
-    VersionDbEntryArrayDeserializer filesystem_version_db{VersionDbType::Git, "a/b"};
+    auto filesystem_version_db = make_version_db_deserializer(VersionDbType::Git, "a/b");
     Json::Reader r;
     auto test_json = parse_json(R"json(
 [
@@ -531,7 +530,7 @@ TEST_CASE ("git_version_db_parsing", "[registries]")
 ]
 )json");
 
-    auto results_opt = r.visit(test_json, filesystem_version_db);
+    auto results_opt = r.visit(test_json, *filesystem_version_db);
     auto& results = results_opt.value_or_exit(VCPKG_LINE_INFO);
     CHECK(results[0].version == Version{"2021-06-26", 0});
     CHECK(results[0].git_tree == "9b07f8a38bbc4d13f8411921e6734753e15f8d50");
@@ -544,7 +543,7 @@ TEST_CASE ("git_version_db_parsing", "[registries]")
 
 TEST_CASE ("filesystem_version_db_parsing", "[registries]")
 {
-    VersionDbEntryArrayDeserializer filesystem_version_db{VersionDbType::Filesystem, "a/b"};
+    auto filesystem_version_db = make_version_db_deserializer(VersionDbType::Filesystem, "a/b");
 
     {
         Json::Reader r;
@@ -567,7 +566,7 @@ TEST_CASE ("filesystem_version_db_parsing", "[registries]")
     }
 ]
     )json");
-        auto results_opt = r.visit(test_json, filesystem_version_db);
+        auto results_opt = r.visit(test_json, *filesystem_version_db);
         auto& results = results_opt.value_or_exit(VCPKG_LINE_INFO);
         CHECK(results[0].version == Version{"puppies", 0});
         CHECK(results[0].p == "a/b" VCPKG_PREFERRED_SEPARATOR "c/d");
@@ -589,7 +588,7 @@ TEST_CASE ("filesystem_version_db_parsing", "[registries]")
     }
 ]
     )json");
-        CHECK(r.visit(test_json, filesystem_version_db).value_or_exit(VCPKG_LINE_INFO).empty());
+        CHECK(r.visit(test_json, *filesystem_version_db).value_or_exit(VCPKG_LINE_INFO).empty());
         CHECK(!r.errors().empty());
     }
 
@@ -604,7 +603,7 @@ TEST_CASE ("filesystem_version_db_parsing", "[registries]")
     }
 ]
     )json");
-        CHECK(r.visit(test_json, filesystem_version_db).value_or_exit(VCPKG_LINE_INFO).empty());
+        CHECK(r.visit(test_json, *filesystem_version_db).value_or_exit(VCPKG_LINE_INFO).empty());
         CHECK(!r.errors().empty());
     }
 
@@ -619,7 +618,7 @@ TEST_CASE ("filesystem_version_db_parsing", "[registries]")
     }
 ]
     )json");
-        CHECK(r.visit(test_json, filesystem_version_db).value_or_exit(VCPKG_LINE_INFO).empty());
+        CHECK(r.visit(test_json, *filesystem_version_db).value_or_exit(VCPKG_LINE_INFO).empty());
         CHECK(!r.errors().empty());
     }
 
@@ -634,7 +633,7 @@ TEST_CASE ("filesystem_version_db_parsing", "[registries]")
     }
 ]
     )json");
-        CHECK(r.visit(test_json, filesystem_version_db).value_or_exit(VCPKG_LINE_INFO).empty());
+        CHECK(r.visit(test_json, *filesystem_version_db).value_or_exit(VCPKG_LINE_INFO).empty());
         CHECK(!r.errors().empty());
     }
 
@@ -649,7 +648,7 @@ TEST_CASE ("filesystem_version_db_parsing", "[registries]")
     }
 ]
     )json");
-        CHECK(r.visit(test_json, filesystem_version_db).value_or_exit(VCPKG_LINE_INFO).empty());
+        CHECK(r.visit(test_json, *filesystem_version_db).value_or_exit(VCPKG_LINE_INFO).empty());
         CHECK(!r.errors().empty());
     }
 
@@ -664,7 +663,7 @@ TEST_CASE ("filesystem_version_db_parsing", "[registries]")
     }
 ]
     )json");
-        CHECK(r.visit(test_json, filesystem_version_db).value_or_exit(VCPKG_LINE_INFO).empty());
+        CHECK(r.visit(test_json, *filesystem_version_db).value_or_exit(VCPKG_LINE_INFO).empty());
         CHECK(!r.errors().empty());
     }
 
@@ -679,7 +678,7 @@ TEST_CASE ("filesystem_version_db_parsing", "[registries]")
     }
 ]
     )json");
-        CHECK(r.visit(test_json, filesystem_version_db).value_or_exit(VCPKG_LINE_INFO).empty());
+        CHECK(r.visit(test_json, *filesystem_version_db).value_or_exit(VCPKG_LINE_INFO).empty());
         CHECK(!r.errors().empty());
     }
 
@@ -694,7 +693,7 @@ TEST_CASE ("filesystem_version_db_parsing", "[registries]")
     }
 ]
     )json");
-        CHECK(r.visit(test_json, filesystem_version_db).value_or_exit(VCPKG_LINE_INFO).empty());
+        CHECK(r.visit(test_json, *filesystem_version_db).value_or_exit(VCPKG_LINE_INFO).empty());
         CHECK(!r.errors().empty());
     }
 
@@ -709,7 +708,7 @@ TEST_CASE ("filesystem_version_db_parsing", "[registries]")
     }
 ]
     )json");
-        CHECK(r.visit(test_json, filesystem_version_db).value_or_exit(VCPKG_LINE_INFO).empty());
+        CHECK(r.visit(test_json, *filesystem_version_db).value_or_exit(VCPKG_LINE_INFO).empty());
         CHECK(!r.errors().empty());
     }
 }

--- a/src/vcpkg-test/registries.cpp
+++ b/src/vcpkg-test/registries.cpp
@@ -5,6 +5,7 @@
 
 #include <vcpkg/configuration.h>
 #include <vcpkg/registries.h>
+#include <vcpkg/registries.private.h>
 
 using namespace vcpkg;
 

--- a/src/vcpkg/archives.cpp
+++ b/src/vcpkg/archives.cpp
@@ -1,3 +1,4 @@
+#include <vcpkg/base/files.h>
 #include <vcpkg/base/parse.h>
 #include <vcpkg/base/system.debug.h>
 #include <vcpkg/base/system.h>

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -1,8 +1,8 @@
 #include <vcpkg/base/api-stable-format.h>
 #include <vcpkg/base/cache.h>
 #include <vcpkg/base/downloads.h>
+#include <vcpkg/base/files.h>
 #include <vcpkg/base/hash.h>
-#include <vcpkg/base/json.h>
 #include <vcpkg/base/message_sinks.h>
 #include <vcpkg/base/parse.h>
 #include <vcpkg/base/strings.h>

--- a/src/vcpkg/base/message_sinks.cpp
+++ b/src/vcpkg/base/message_sinks.cpp
@@ -1,3 +1,4 @@
+#include <vcpkg/base/file_sink.h>
 #include <vcpkg/base/message_sinks.h>
 
 namespace

--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -2,6 +2,7 @@
 
 #include <vcpkg/base/checks.h>
 #include <vcpkg/base/chrono.h>
+#include <vcpkg/base/files.h>
 #include <vcpkg/base/strings.h>
 #include <vcpkg/base/system.debug.h>
 #include <vcpkg/base/system.h>

--- a/src/vcpkg/base/unicode.cpp
+++ b/src/vcpkg/base/unicode.cpp
@@ -186,31 +186,19 @@ namespace vcpkg::Unicode
         return res;
     }
 
-    struct Utf8Category : std::error_category
+    static LocalizedString message(utf8_errc condition)
     {
-        const char* name() const noexcept override { return "utf8"; }
-
-        std::string message(int condition) const override
+        switch (condition)
         {
-            switch (static_cast<utf8_errc>(condition))
-            {
-                case utf8_errc::NoError: return msg::format(msgNoError).extract_data();
-                case utf8_errc::InvalidCodeUnit: return msg::format(msgInvalidCodeUnit).extract_data();
-                case utf8_errc::InvalidCodePoint:
-                    return msg::format(msgInvalidCodePoint).append_raw(" (>0x10FFFF)").extract_data();
-                case utf8_errc::PairedSurrogates: return msg::format(msgPairedSurrogatesAreInvalid).extract_data();
-                case utf8_errc::UnexpectedContinue: return msg::format(msgContinueCodeUnitInStart).extract_data();
-                case utf8_errc::UnexpectedStart: return msg::format(msgStartCodeUnitInContinue).extract_data();
-                case utf8_errc::UnexpectedEof: return msg::format(msgEndOfStringInCodeUnit).extract_data();
-                default: Checks::unreachable(VCPKG_LINE_INFO);
-            }
+            case utf8_errc::NoError: return msg::format(msgNoError);
+            case utf8_errc::InvalidCodeUnit: return msg::format(msgInvalidCodeUnit);
+            case utf8_errc::InvalidCodePoint: return msg::format(msgInvalidCodePoint).append_raw(" (>0x10FFFF)");
+            case utf8_errc::PairedSurrogates: return msg::format(msgPairedSurrogatesAreInvalid);
+            case utf8_errc::UnexpectedContinue: return msg::format(msgContinueCodeUnitInStart);
+            case utf8_errc::UnexpectedStart: return msg::format(msgStartCodeUnitInContinue);
+            case utf8_errc::UnexpectedEof: return msg::format(msgEndOfStringInCodeUnit);
+            default: Checks::unreachable(VCPKG_LINE_INFO);
         }
-    };
-
-    const std::error_category& utf8_category() noexcept
-    {
-        static const Utf8Category t;
-        return t;
     }
 
     char const* Utf8Decoder::pointer_to_current() const noexcept
@@ -261,8 +249,8 @@ namespace vcpkg::Unicode
         const auto err = next();
         if (err != utf8_errc::NoError)
         {
-            Checks::msg_exit_with_error(
-                VCPKG_LINE_INFO, msg::format(msgUtf8ConversionFailed).append_raw(std::error_code(err).message()));
+            Checks::msg_exit_with_error(VCPKG_LINE_INFO,
+                                        msg::format(msgUtf8ConversionFailed).append_raw(": ").append(message(err)));
         }
 
         return *this;

--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -1,8 +1,8 @@
 #include <vcpkg/base/cache.h>
 #include <vcpkg/base/checks.h>
 #include <vcpkg/base/chrono.h>
+#include <vcpkg/base/file_sink.h>
 #include <vcpkg/base/hash.h>
-#include <vcpkg/base/json.h>
 #include <vcpkg/base/message_sinks.h>
 #include <vcpkg/base/messages.h>
 #include <vcpkg/base/optional.h>

--- a/src/vcpkg/commands.add.cpp
+++ b/src/vcpkg/commands.add.cpp
@@ -1,6 +1,7 @@
 #include <vcpkg/base/fwd/message_sinks.h>
 
 #include <vcpkg/base/checks.h>
+#include <vcpkg/base/files.h>
 #include <vcpkg/base/hash.h>
 #include <vcpkg/base/messages.h>
 #include <vcpkg/base/strings.h>

--- a/src/vcpkg/commands.edit.cpp
+++ b/src/vcpkg/commands.edit.cpp
@@ -1,3 +1,4 @@
+#include <vcpkg/base/files.h>
 #include <vcpkg/base/strings.h>
 #include <vcpkg/base/system.h>
 #include <vcpkg/base/system.process.h>

--- a/src/vcpkg/commands.hash.cpp
+++ b/src/vcpkg/commands.hash.cpp
@@ -1,3 +1,4 @@
+#include <vcpkg/base/files.h>
 #include <vcpkg/base/hash.h>
 #include <vcpkg/base/util.h>
 

--- a/src/vcpkg/commands.new.cpp
+++ b/src/vcpkg/commands.new.cpp
@@ -1,4 +1,5 @@
 #include <vcpkg/base/checks.h>
+#include <vcpkg/base/files.h>
 #include <vcpkg/base/util.h>
 
 #include <vcpkg/commands.new.h>

--- a/src/vcpkg/commands.portsdiff.cpp
+++ b/src/vcpkg/commands.portsdiff.cpp
@@ -1,4 +1,4 @@
-#include <vcpkg/base/sortedvector.h>
+#include <vcpkg/base/files.h>
 #include <vcpkg/base/system.process.h>
 #include <vcpkg/base/util.h>
 

--- a/src/vcpkg/commands.xdownload.cpp
+++ b/src/vcpkg/commands.xdownload.cpp
@@ -1,6 +1,7 @@
 #include <vcpkg/base/fwd/message_sinks.h>
 
 #include <vcpkg/base/downloads.h>
+#include <vcpkg/base/files.h>
 #include <vcpkg/base/hash.h>
 #include <vcpkg/base/parse.h>
 #include <vcpkg/base/system.debug.h>

--- a/src/vcpkg/configuration.cpp
+++ b/src/vcpkg/configuration.cpp
@@ -13,6 +13,44 @@ namespace
 {
     using namespace vcpkg;
 
+    /// <summary>
+    /// Deserializes a list of package names and patterns along with their respective in-file declaration locations.
+    /// </summary>
+    struct PackagePatternDeserializer final : Json::IDeserializer<PackagePatternDeclaration>
+    {
+        virtual LocalizedString type_name() const override;
+        virtual Optional<PackagePatternDeclaration> visit_string(Json::Reader&, StringView sv) const override;
+
+        static const PackagePatternDeserializer instance;
+    };
+
+    struct PackagePatternArrayDeserializer final : Json::ArrayDeserializer<PackagePatternDeserializer>
+    {
+        virtual LocalizedString type_name() const override;
+        static const PackagePatternArrayDeserializer instance;
+    };
+    LocalizedString PackagePatternDeserializer::type_name() const { return msg::format(msgAPackagePattern); }
+
+    Optional<PackagePatternDeclaration> PackagePatternDeserializer::visit_string(Json::Reader& r, StringView sv) const
+    {
+        if (!is_package_pattern(sv))
+        {
+            r.add_generic_error(
+                type_name(),
+                msg::format(msgParsePackagePatternError, msg::package_name = sv, msg::url = docs::registries_url));
+        }
+
+        return PackagePatternDeclaration{
+            sv.to_string(),
+            r.path(),
+        };
+    }
+
+    const PackagePatternDeserializer PackagePatternDeserializer::instance;
+
+    LocalizedString PackagePatternArrayDeserializer::type_name() const { return msg::format(msgAPackagePatternArray); }
+
+    const PackagePatternArrayDeserializer PackagePatternArrayDeserializer::instance;
     struct RegistryImplementationKindDeserializer : Json::StringDeserializer
     {
         LocalizedString type_name() const override { return msg::format(msgARegistryImplementationKind); }
@@ -295,7 +333,7 @@ namespace
             {
                 auto& declarations = config->package_declarations.emplace();
                 r.required_object_field(
-                    type_name(), obj, PACKAGES, declarations, Json::PackagePatternArrayDeserializer::instance);
+                    type_name(), obj, PACKAGES, declarations, PackagePatternArrayDeserializer::instance);
                 config->packages.emplace(Util::fmap(declarations, [](auto&& decl) { return decl.pattern; }));
             }
         }
@@ -1031,5 +1069,62 @@ namespace vcpkg
         std::vector<std::string> out;
         find_unknown_fields_impl(config.ce_metadata, out, "$");
         return out;
+    }
+
+    bool is_package_pattern(StringView sv)
+    {
+        if (Json::IdentifierDeserializer::is_ident(sv))
+        {
+            return true;
+        }
+
+        /*if (sv == "*")
+        {
+            return true;
+        }*/
+
+        // ([a-z0-9]+(-[a-z0-9]+)*)(\*?)
+        auto cur = sv.begin();
+        const auto last = sv.end();
+        for (;;)
+        {
+            // [a-z0-9]+
+            if (cur == last)
+            {
+                return false;
+            }
+
+            if (!ParserBase::is_lower_digit(*cur))
+            {
+                if (*cur != '*')
+                {
+                    return false;
+                }
+
+                return ++cur == last;
+            }
+
+            do
+            {
+                ++cur;
+                if (cur == last)
+                {
+                    return true;
+                }
+            } while (ParserBase::is_lower_digit(*cur));
+
+            switch (*cur)
+            {
+                case '-':
+                    // repeat outer [a-z0-9]+ again to match -[a-z0-9]+
+                    ++cur;
+                    continue;
+                case '*':
+                    // match last optional *
+                    ++cur;
+                    return cur == last;
+                default: return false;
+            }
+        }
     }
 }

--- a/src/vcpkg/configure-environment.cpp
+++ b/src/vcpkg/configure-environment.cpp
@@ -2,6 +2,7 @@
 
 #include <vcpkg/base/checks.h>
 #include <vcpkg/base/downloads.h>
+#include <vcpkg/base/files.h>
 #include <vcpkg/base/json.h>
 #include <vcpkg/base/setup-messages.h>
 #include <vcpkg/base/system.debug.h>

--- a/src/vcpkg/portfileprovider.cpp
+++ b/src/vcpkg/portfileprovider.cpp
@@ -1,4 +1,4 @@
-#include <vcpkg/base/json.h>
+#include <vcpkg/base/files.h>
 #include <vcpkg/base/messages.h>
 #include <vcpkg/base/system.debug.h>
 

--- a/src/vcpkg/registries.cpp
+++ b/src/vcpkg/registries.cpp
@@ -10,6 +10,7 @@
 #include <vcpkg/metrics.h>
 #include <vcpkg/paragraphs.h>
 #include <vcpkg/registries.h>
+#include <vcpkg/registries.private.h>
 #include <vcpkg/sourceparagraph.h>
 #include <vcpkg/vcpkgcmdarguments.h>
 #include <vcpkg/vcpkgpaths.h>

--- a/src/vcpkg/registries.cpp
+++ b/src/vcpkg/registries.cpp
@@ -1,5 +1,6 @@
 #include <vcpkg/base/cache.h>
 #include <vcpkg/base/delayed-init.h>
+#include <vcpkg/base/files.h>
 #include <vcpkg/base/json.h>
 #include <vcpkg/base/jsonreader.h>
 #include <vcpkg/base/messages.h>
@@ -20,6 +21,151 @@
 namespace
 {
     using namespace vcpkg;
+
+    struct GitTreeStringDeserializer : Json::StringDeserializer
+    {
+        LocalizedString type_name() const override { return msg::format(msgAGitObjectSha); }
+
+        static const GitTreeStringDeserializer instance;
+    };
+    const GitTreeStringDeserializer GitTreeStringDeserializer::instance;
+
+    struct RegistryPathStringDeserializer : Json::StringDeserializer
+    {
+        LocalizedString type_name() const override { return msg::format(msgARegistryPath); }
+
+        static const RegistryPathStringDeserializer instance;
+    };
+    const RegistryPathStringDeserializer RegistryPathStringDeserializer::instance;
+
+    struct VersionDbEntryDeserializer final : Json::IDeserializer<VersionDbEntry>
+    {
+        static constexpr StringLiteral GIT_TREE = "git-tree";
+        static constexpr StringLiteral PATH = "path";
+
+        LocalizedString type_name() const override;
+        View<StringView> valid_fields() const override;
+        Optional<VersionDbEntry> visit_object(Json::Reader& r, const Json::Object& obj) const override;
+        VersionDbEntryDeserializer(VersionDbType type, const Path& root) : type(type), registry_root(root) { }
+
+    private:
+        VersionDbType type;
+        Path registry_root;
+    };
+    constexpr StringLiteral VersionDbEntryDeserializer::GIT_TREE;
+    constexpr StringLiteral VersionDbEntryDeserializer::PATH;
+    LocalizedString VersionDbEntryDeserializer::type_name() const { return msg::format(msgAVersionDatabaseEntry); }
+    View<StringView> VersionDbEntryDeserializer::valid_fields() const
+    {
+        static constexpr StringView u_git[] = {GIT_TREE};
+        static constexpr StringView u_path[] = {PATH};
+        static const auto t_git = vcpkg::Util::Vectors::concat<StringView>(schemed_deserializer_fields(), u_git);
+        static const auto t_path = vcpkg::Util::Vectors::concat<StringView>(schemed_deserializer_fields(), u_path);
+
+        return type == VersionDbType::Git ? t_git : t_path;
+    }
+
+    Optional<VersionDbEntry> VersionDbEntryDeserializer::visit_object(Json::Reader& r, const Json::Object& obj) const
+    {
+        VersionDbEntry ret;
+
+        auto schemed_version = visit_required_schemed_deserializer(type_name(), r, obj);
+        ret.scheme = schemed_version.scheme;
+        ret.version = std::move(schemed_version.version);
+        switch (type)
+        {
+            case VersionDbType::Git:
+            {
+                r.required_object_field(type_name(), obj, GIT_TREE, ret.git_tree, GitTreeStringDeserializer::instance);
+                break;
+            }
+            case VersionDbType::Filesystem:
+            {
+                std::string path_res;
+                r.required_object_field(type_name(), obj, PATH, path_res, RegistryPathStringDeserializer::instance);
+                if (!Strings::starts_with(path_res, "$/"))
+                {
+                    r.add_generic_error(msg::format(msgARegistryPath),
+                                        msg::format(msgARegistryPathMustStartWithDollar));
+                    return nullopt;
+                }
+
+                if (Strings::contains(path_res, '\\') || Strings::contains(path_res, "//"))
+                {
+                    r.add_generic_error(msg::format(msgARegistryPath),
+                                        msg::format(msgARegistryPathMustBeDelimitedWithForwardSlashes));
+                    return nullopt;
+                }
+
+                auto first = path_res.begin();
+                const auto last = path_res.end();
+                for (std::string::iterator candidate;; first = candidate)
+                {
+                    candidate = std::find(first, last, '/');
+                    if (candidate == last)
+                    {
+                        break;
+                    }
+
+                    ++candidate;
+                    if (candidate == last)
+                    {
+                        break;
+                    }
+
+                    if (*candidate != '.')
+                    {
+                        continue;
+                    }
+
+                    ++candidate;
+                    if (candidate == last || *candidate == '/')
+                    {
+                        r.add_generic_error(msg::format(msgARegistryPath),
+                                            msg::format(msgARegistryPathMustNotHaveDots));
+                        return nullopt;
+                    }
+
+                    if (*candidate != '.')
+                    {
+                        first = candidate;
+                        continue;
+                    }
+
+                    ++candidate;
+                    if (candidate == last || *candidate == '/')
+                    {
+                        r.add_generic_error(msg::format(msgARegistryPath),
+                                            msg::format(msgARegistryPathMustNotHaveDots));
+                        return nullopt;
+                    }
+                }
+
+                ret.p = registry_root / StringView{path_res}.substr(2);
+                break;
+            }
+        }
+
+        return ret;
+    }
+
+    struct VersionDbEntryArrayDeserializer final : Json::IDeserializer<std::vector<VersionDbEntry>>
+    {
+        virtual LocalizedString type_name() const override;
+        virtual Optional<std::vector<VersionDbEntry>> visit_array(Json::Reader& r,
+                                                                  const Json::Array& arr) const override;
+        VersionDbEntryArrayDeserializer(VersionDbType type, const Path& root) : underlying{type, root} { }
+
+    private:
+        VersionDbEntryDeserializer underlying;
+    };
+    LocalizedString VersionDbEntryArrayDeserializer::type_name() const { return msg::format(msgAnArrayOfVersions); }
+
+    Optional<std::vector<VersionDbEntry>> VersionDbEntryArrayDeserializer::visit_array(Json::Reader& r,
+                                                                                       const Json::Array& arr) const
+    {
+        return r.array_elements(arr, underlying);
+    }
 
     using Baseline = std::map<std::string, Version, std::less<>>;
 
@@ -983,133 +1129,10 @@ namespace
 
         return parse_baseline_versions(contents, baseline, baseline_path);
     }
-
-    struct GitTreeStringDeserializer : Json::StringDeserializer
-    {
-        LocalizedString type_name() const override { return msg::format(msgAGitObjectSha); }
-
-        static const GitTreeStringDeserializer instance;
-    };
-
-    const GitTreeStringDeserializer GitTreeStringDeserializer::instance;
-
-    struct RegistryPathStringDeserializer : Json::StringDeserializer
-    {
-        LocalizedString type_name() const override { return msg::format(msgARegistryPath); }
-
-        static const RegistryPathStringDeserializer instance;
-    };
-
-    const RegistryPathStringDeserializer RegistryPathStringDeserializer::instance;
 }
 
 namespace vcpkg
 {
-    constexpr StringLiteral VersionDbEntryDeserializer::GIT_TREE;
-    constexpr StringLiteral VersionDbEntryDeserializer::PATH;
-    LocalizedString VersionDbEntryDeserializer::type_name() const { return msg::format(msgAVersionDatabaseEntry); }
-    View<StringView> VersionDbEntryDeserializer::valid_fields() const
-    {
-        static constexpr StringView u_git[] = {GIT_TREE};
-        static constexpr StringView u_path[] = {PATH};
-        static const auto t_git = vcpkg::Util::Vectors::concat<StringView>(schemed_deserializer_fields(), u_git);
-        static const auto t_path = vcpkg::Util::Vectors::concat<StringView>(schemed_deserializer_fields(), u_path);
-
-        return type == VersionDbType::Git ? t_git : t_path;
-    }
-
-    Optional<VersionDbEntry> VersionDbEntryDeserializer::visit_object(Json::Reader& r, const Json::Object& obj) const
-    {
-        VersionDbEntry ret;
-
-        auto schemed_version = visit_required_schemed_deserializer(type_name(), r, obj);
-        ret.scheme = schemed_version.scheme;
-        ret.version = std::move(schemed_version.version);
-        switch (type)
-        {
-            case VersionDbType::Git:
-            {
-                r.required_object_field(type_name(), obj, GIT_TREE, ret.git_tree, GitTreeStringDeserializer::instance);
-                break;
-            }
-            case VersionDbType::Filesystem:
-            {
-                std::string path_res;
-                r.required_object_field(type_name(), obj, PATH, path_res, RegistryPathStringDeserializer::instance);
-                if (!Strings::starts_with(path_res, "$/"))
-                {
-                    r.add_generic_error(msg::format(msgARegistryPath),
-                                        msg::format(msgARegistryPathMustStartWithDollar));
-                    return nullopt;
-                }
-
-                if (Strings::contains(path_res, '\\') || Strings::contains(path_res, "//"))
-                {
-                    r.add_generic_error(msg::format(msgARegistryPath),
-                                        msg::format(msgARegistryPathMustBeDelimitedWithForwardSlashes));
-                    return nullopt;
-                }
-
-                auto first = path_res.begin();
-                const auto last = path_res.end();
-                for (std::string::iterator candidate;; first = candidate)
-                {
-                    candidate = std::find(first, last, '/');
-                    if (candidate == last)
-                    {
-                        break;
-                    }
-
-                    ++candidate;
-                    if (candidate == last)
-                    {
-                        break;
-                    }
-
-                    if (*candidate != '.')
-                    {
-                        continue;
-                    }
-
-                    ++candidate;
-                    if (candidate == last || *candidate == '/')
-                    {
-                        r.add_generic_error(msg::format(msgARegistryPath),
-                                            msg::format(msgARegistryPathMustNotHaveDots));
-                        return nullopt;
-                    }
-
-                    if (*candidate != '.')
-                    {
-                        first = candidate;
-                        continue;
-                    }
-
-                    ++candidate;
-                    if (candidate == last || *candidate == '/')
-                    {
-                        r.add_generic_error(msg::format(msgARegistryPath),
-                                            msg::format(msgARegistryPathMustNotHaveDots));
-                        return nullopt;
-                    }
-                }
-
-                ret.p = registry_root / StringView{path_res}.substr(2);
-                break;
-            }
-        }
-
-        return ret;
-    }
-
-    LocalizedString VersionDbEntryArrayDeserializer::type_name() const { return msg::format(msgAnArrayOfVersions); }
-
-    Optional<std::vector<VersionDbEntry>> VersionDbEntryArrayDeserializer::visit_array(Json::Reader& r,
-                                                                                       const Json::Array& arr) const
-    {
-        return r.array_elements(arr, underlying);
-    }
-
     LockFile::Entry LockFile::get_or_fetch(const VcpkgPaths& paths, StringView repo, StringView reference)
     {
         auto range = lockdata.equal_range(repo);
@@ -1305,5 +1328,11 @@ namespace vcpkg
                                                                      std::string baseline)
     {
         return std::make_unique<FilesystemRegistry>(fs, std::move(path), std::move(baseline));
+    }
+
+    std::unique_ptr<Json::IDeserializer<std::vector<VersionDbEntry>>> make_version_db_deserializer(VersionDbType type,
+                                                                                                   const Path& root)
+    {
+        return std::make_unique<VersionDbEntryArrayDeserializer>(type, root);
     }
 }

--- a/src/vcpkg/sourceparagraph.cpp
+++ b/src/vcpkg/sourceparagraph.cpp
@@ -19,6 +19,55 @@
 
 namespace vcpkg
 {
+
+    bool operator==(const DependencyConstraint& lhs, const DependencyConstraint& rhs)
+    {
+        if (lhs.type != rhs.type) return false;
+        if (lhs.value != rhs.value) return false;
+        return lhs.port_version == rhs.port_version;
+    }
+
+    Optional<Version> DependencyConstraint::try_get_minimum_version() const
+    {
+        if (type == VersionConstraintKind::None)
+        {
+            return nullopt;
+        }
+
+        return Version{
+            value,
+            port_version,
+        };
+    }
+
+    FullPackageSpec Dependency::to_full_spec(Triplet target, Triplet host_triplet, ImplicitDefault id) const
+    {
+        return FullPackageSpec{{name, host ? host_triplet : target}, features, id};
+    }
+
+    bool operator==(const Dependency& lhs, const Dependency& rhs)
+    {
+        if (lhs.name != rhs.name) return false;
+        if (lhs.features != rhs.features) return false;
+        if (!structurally_equal(lhs.platform, rhs.platform)) return false;
+        if (lhs.extra_info != rhs.extra_info) return false;
+        if (lhs.constraint != rhs.constraint) return false;
+        if (lhs.host != rhs.host) return false;
+
+        return true;
+    }
+    bool operator!=(const Dependency& lhs, const Dependency& rhs);
+
+    bool operator==(const DependencyOverride& lhs, const DependencyOverride& rhs)
+    {
+        if (lhs.version_scheme != rhs.version_scheme) return false;
+        if (lhs.port_version != rhs.port_version) return false;
+        if (lhs.name != rhs.name) return false;
+        if (lhs.version != rhs.version) return false;
+        return lhs.extra_info == rhs.extra_info;
+    }
+    bool operator!=(const DependencyOverride& lhs, const DependencyOverride& rhs);
+
     struct UrlDeserializer : Json::StringDeserializer
     {
         LocalizedString type_name() const override { return msg::format(msgAUrl); }


### PR DESCRIPTION
1. Pull out `Path` from `files.h` since many other headers simply want to declare structs containing `Path`.
2. Remove vestigial uses of `error_category` and `error_code` from Unicode handler
3. Move PackagePattern parsing into configuration.h (the only consumer)
4. Move Dependency and Constraints into sourceparagraph.h (packagespec no longer needs json)
5. Hide VersionDbEntryDeserializer / VersionDbEntryArrayDeserializer because users of Registry shouldn't need to know the intimate details of parsing & deserializing json
6. Promote `is_lower_digit` to a general parsing classifier
7. Pull out `FileSink` from `message_sinks.h` because that caused broad-spectrum coupling to `files.h`

~Depends on #983 -- do not review this PR until that one has been merged.~