### PR TITLE
VcpkgCmdArguments: empty arguments should be discarded

### DIFF
--- a/src/vcpkg-test/cmd-parser.cpp
+++ b/src/vcpkg-test/cmd-parser.cpp
@@ -1180,6 +1180,13 @@ TEST_CASE ("inverted switches", "[cmd_parser]")
         CHECK(uut.get_errors().empty());
         CHECK(uut.get_remaining_args() == std::vector<std::string>{"--z-x-no-switch"});
     }
+
+    {
+        CmdParser uut{std::vector<std::string>{""}};
+        CHECK(uut.consume_remaining_args().empty());
+        CHECK(uut.get_errors().empty());
+        CHECK(uut.get_remaining_args().empty());
+    }
 }
 
 TEST_CASE ("Options do not return consumed args", "[cmd_parser]")

--- a/src/vcpkg/base/cmd-parser.cpp
+++ b/src/vcpkg/base/cmd-parser.cpp
@@ -782,7 +782,9 @@ namespace vcpkg
                 else
                 {
                     if (!argument_strings[idx].empty())
+                    {
                         results.emplace_back(argument_strings[idx]);
+                    }
                 }
             }
         }

--- a/src/vcpkg/base/cmd-parser.cpp
+++ b/src/vcpkg/base/cmd-parser.cpp
@@ -781,7 +781,8 @@ namespace vcpkg
                 }
                 else
                 {
-                    results.emplace_back(argument_strings[idx]);
+                    if (!argument_strings[idx].empty())
+                        results.emplace_back(argument_strings[idx]);
                 }
             }
         }


### PR DESCRIPTION
When using latest (`64dc5d0`) vcpkg-tool with a cmake based project using the vcpkg's toolchain (e.g. vcpkg.cmake), I hit the error `msgErrorIndividualPackagesUnsupported` in install.cpp, since the cmake script can potentially pass in an empty argument when launching `vcpkg`, which happens at https://github.com/microsoft/vcpkg/blob/master/scripts/buildsystems/vcpkg.cmake#L522.

For more details the error I got is, and it is a regression that does not happen with latest official release (which is older):
```
-- Running vcpkg install
error: In manifest mode, `vcpkg install` does not support individual package arguments.
To install additional packages, edit vcpkg.json and then run `vcpkg install` without any package arguments.
See https://learn.microsoft.com/vcpkg/users/manifests for more information.
```



Another option is to drop the double quotes from the vcpkg.cmake, or perhaps it makes sense to have both fixes altogether. This PR does not contain this second option.

