### PR TITLE
Fix handling of z- switches.

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -95,7 +95,7 @@
       ]
     },
     {
-      "name": "x64-Debug-Official-2023-03-14",
+      "name": "x64-Debug-Official-2023-03-28",
       "generator": "Ninja",
       "configurationType": "Debug",
       "inheritEnvironments": [ "msvc_x64_x64" ],
@@ -112,17 +112,17 @@
         },
         {
           "name": "VCPKG_BASE_VERSION",
-          "value": "2023-03-14",
+          "value": "2023-03-28",
           "type": "STRING"
         },
         {
           "name": "VCPKG_STANDALONE_BUNDLE_SHA",
-          "value": "32024d3d703aaa5961e8072ab883537a858885c501223530285926f919bad67003d40ba35686eb9d24673c4b030bb289a82d515c7bdf9931e9249d873b2b2abd",
+          "value": "bdf19a9e602f237d3906321a13e883f72e8804e0bbbd4369b6fca3acdd98238371445c8cab2e7a155cf56db43a2f1e30060c71eaf4e3cb55d892d100a312ada5",
           "type": "STRING"
         },
         {
           "name": "VCPKG_CE_SHA",
-          "value": "fb2c2f568b563a88d2ebf2b29ced491e8109134529c477629e5e1dde89f52bf8a60d9b5ce8285f260cc94b7c100704128d3724bbda523edb57233dbda5a2c02a",
+          "value": "ffae1cb2fee518aba585a45f5e25c4eedf6218126821ae75808b9575b0c9d9b096ddb28475979a9c1a5ce217d920a91e1b510433a9f5a0ab5c4a44f6ff82a210",
           "type": "STRING"
         },
         {

--- a/src/vcpkg/base/cmd-parser.cpp
+++ b/src/vcpkg/base/cmd-parser.cpp
@@ -1007,6 +1007,7 @@ namespace vcpkg
             msg::write_unlocalized_text_to_stdout(Color::error, error.append_raw("\n"));
         }
 
+        example.append_raw('\n');
         append_options_table(example);
         msg::println(Color::none, example);
         Checks::exit_with_code(VCPKG_LINE_INFO, 1);

--- a/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/src/vcpkg/vcpkgcmdarguments.cpp
@@ -77,6 +77,11 @@ namespace
                 name.erase(0, 2);
                 tag = StabilityTag::Experimental;
             }
+            else if (Strings::starts_with(name, "z-"))
+            {
+                name.erase(0, 2);
+                tag = StabilityTag::ImplementationDetail;
+            }
 
             if (switch_.helpmsg)
             {
@@ -105,6 +110,11 @@ namespace
                     name.erase(0, 2);
                     tag = StabilityTag::Experimental;
                 }
+                else if (Strings::starts_with(name, "z-"))
+                {
+                    name.erase(0, 2);
+                    tag = StabilityTag::ImplementationDetail;
+                }
 
                 if (option.helpmsg)
                 {
@@ -131,6 +141,11 @@ namespace
             {
                 name.erase(0, 2);
                 tag = StabilityTag::Experimental;
+            }
+            else if (Strings::starts_with(name, "z-"))
+            {
+                name.erase(0, 2);
+                tag = StabilityTag::ImplementationDetail;
             }
 
             std::vector<std::string> maybe_parse_result;


### PR DESCRIPTION
This was discovered in smoke testing of the artifacts feature. Artifacts was unable to download anything because it passes `--z-machine-readable-progress` which failed with:

```
PS C:\Dev\vcpkg-tool> C:\Users\bion\.vcpkg\vcpkg.exe x-download c:\Users\bion\.vcpkg\downloads\vcpkg.ce.default-registry.zip --z-machine-readable-progress --skip-sha512 --url=https://aka.ms/vcpkg-ce-default
error: unexpected switch: --z-machine-readable-progress
example:
    vcpkg x-download <filepath> [--sha512=]<sha512> [--url=https://...]...
example:
    vcpkg x-download <filepath> --skip-sha512 [--url=https://...]...Options:
  --x-asset-sources=...           Add sources for asset caching. See 'vcpkg help assetcaching'.
  --binarysource=...              Add sources for binary caching. See 'vcpkg help binarycaching'.
  --x-buildtrees-root=...         (Experimental) Specify the buildtrees root directory.
  --downloads-root=...            Specify the downloads root directory.
                                  (default: VCPKG_DOWNLOADS)
  --header=...                    Additional header to use when fetching from URLs
  --host-triplet=...              Specify the host architecture triplet. See 'vcpkg help triplet'.
                                  (default: 'VCPKG_DEFAULT_HOST_TRIPLET')
  --x-install-root=...            (Experimental) Specify the install root directory.
  --overlay-ports=...             Specify directories to be used when searching for ports.
                                  (also: 'VCPKG_OVERLAY_PORTS')
  --overlay-triplets=...          Specifiy directories containing triplets files.
                                  (also: 'VCPKG_OVERLAY_TRIPLETS')
  --x-packages-root=...           (Experimental) Specify the packages root directory.
  --sha512=...                    The hash of the file to be downloaded
  --skip-sha512                   Do not check the SHA512 of the downloaded file
  --store                         Indicates the file should be stored instead of fetched
  --triplet=...                   Specify the target architecture triplet. See 'vcpkg help triplet'.
                                  (default: 'VCPKG_DEFAULT_TRIPLET')
  --url=...                       URL to download and store if missing from cache
  --vcpkg-root=...                Specify the vcpkg root directory.
                                  (default: 'VCPKG_ROOT')

PS C:\Dev\vcpkg-tool>
```