### PR TITLE
Add <numeric> to strings.cpp for std::iota

### DIFF
--- a/src/vcpkg-test/strings.cpp
+++ b/src/vcpkg-test/strings.cpp
@@ -7,6 +7,7 @@
 
 #include <stdint.h>
 
+#include <numeric>
 #include <string>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
Add `numeric` include for `std::iota`. This currently makes the following pipeline fail on Windows (Azure):

https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=681447&view=logs&jobId=a70f640f-cc53-5cd3-6cdc-236a1aa90802