### PR TITLE
Add build policy to allow DLLs in the lib directory if they are used …

### DIFF
--- a/include/vcpkg/fwd/build.h
+++ b/include/vcpkg/fwd/build.h
@@ -95,6 +95,7 @@ namespace vcpkg
     enum class BuildPolicy
     {
         EMPTY_PACKAGE,
+        DLLS_AS_PLUGINS,
         DLLS_WITHOUT_LIBS,
         DLLS_WITHOUT_EXPORTS,
         DLLS_IN_STATIC_LIBRARY,

--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -207,6 +207,7 @@ namespace vcpkg
     static constexpr StringLiteral NAME_DLLS_WITHOUT_LIBS = "PolicyDLLsWithoutLIBs";
     static constexpr StringLiteral NAME_DLLS_WITHOUT_EXPORTS = "PolicyDLLsWithoutExports";
     static constexpr StringLiteral NAME_DLLS_IN_STATIC_LIBRARY = "PolicyDLLsInStaticLibrary";
+    static constexpr StringLiteral NAME_DLLS_AS_PLUGINS = "PolicyDLLsAsPlugins";
     static constexpr StringLiteral NAME_MISMATCHED_NUMBER_OF_BINARIES = "PolicyMismatchedNumberOfBinaries";
     static constexpr StringLiteral NAME_ONLY_RELEASE_CRT = "PolicyOnlyReleaseCRT";
     static constexpr StringLiteral NAME_EMPTY_INCLUDE_FOLDER = "PolicyEmptyIncludeFolder";
@@ -238,6 +239,7 @@ namespace vcpkg
             case BuildPolicy::DLLS_WITHOUT_LIBS: return NAME_DLLS_WITHOUT_LIBS;
             case BuildPolicy::DLLS_WITHOUT_EXPORTS: return NAME_DLLS_WITHOUT_EXPORTS;
             case BuildPolicy::DLLS_IN_STATIC_LIBRARY: return NAME_DLLS_IN_STATIC_LIBRARY;
+            case BuildPolicy::DLLS_AS_PLUGINS: return NAME_DLLS_AS_PLUGINS;
             case BuildPolicy::MISMATCHED_NUMBER_OF_BINARIES: return NAME_MISMATCHED_NUMBER_OF_BINARIES;
             case BuildPolicy::ONLY_RELEASE_CRT: return NAME_ONLY_RELEASE_CRT;
             case BuildPolicy::EMPTY_INCLUDE_FOLDER: return NAME_EMPTY_INCLUDE_FOLDER;
@@ -260,6 +262,7 @@ namespace vcpkg
             case BuildPolicy::DLLS_WITHOUT_LIBS: return "VCPKG_POLICY_DLLS_WITHOUT_LIBS";
             case BuildPolicy::DLLS_WITHOUT_EXPORTS: return "VCPKG_POLICY_DLLS_WITHOUT_EXPORTS";
             case BuildPolicy::DLLS_IN_STATIC_LIBRARY: return "VCPKG_POLICY_DLLS_IN_STATIC_LIBRARY";
+            case BuildPolicy::DLLS_AS_PLUGINS: return "VCPKG_POLICY_DLLS_AS_PLUGINS";
             case BuildPolicy::MISMATCHED_NUMBER_OF_BINARIES: return "VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES";
             case BuildPolicy::ONLY_RELEASE_CRT: return "VCPKG_POLICY_ONLY_RELEASE_CRT";
             case BuildPolicy::EMPTY_INCLUDE_FOLDER: return "VCPKG_POLICY_EMPTY_INCLUDE_FOLDER";

--- a/src/vcpkg/postbuildlint.cpp
+++ b/src/vcpkg/postbuildlint.cpp
@@ -334,8 +334,13 @@ namespace vcpkg
         return LintStatus::SUCCESS;
     }
 
-    static LintStatus check_for_dlls_in_lib_dir(const Filesystem& fs, const Path& package_dir, MessageSink& msg_sink)
+    static LintStatus check_for_dlls_in_lib_dir(const Filesystem& fs,
+                                                const BuildPolicies& policies,
+                                                const Path& package_dir,
+                                                MessageSink& msg_sink)
     {
+        if (policies.is_enabled(BuildPolicy::DLLS_AS_PLUGINS)) return LintStatus::SUCCESS;
+
         std::vector<Path> dlls = fs.get_regular_files_recursive(package_dir / "lib", IgnoreErrors{});
         Util::erase_remove_if(dlls, NotExtensionCaseInsensitive{".dll"});
 
@@ -1321,8 +1326,8 @@ namespace vcpkg
         error_count += check_folder_lib_cmake(fs, package_dir, spec, msg_sink);
         error_count += check_for_misplaced_cmake_files(fs, package_dir, spec, msg_sink);
         error_count += check_folder_debug_lib_cmake(fs, package_dir, spec, msg_sink);
-        error_count += check_for_dlls_in_lib_dir(fs, package_dir, msg_sink);
-        error_count += check_for_dlls_in_lib_dir(fs, package_dir / "debug", msg_sink);
+        error_count += check_for_dlls_in_lib_dir(fs, build_info.policies, package_dir, msg_sink);
+        error_count += check_for_dlls_in_lib_dir(fs, build_info.policies, package_dir / "debug", msg_sink);
         error_count += check_for_copyright_file(fs, spec, paths, msg_sink);
         error_count += check_for_exes(fs, package_dir, msg_sink);
         error_count += check_for_exes(fs, package_dir / "debug", msg_sink);


### PR DESCRIPTION
…as plugins.

Some libraries/programs, notably GStreamer typically keep the plugins in the lib folder of the install root. GStreamer also uses the .dll extension for these plugins.

https://gstreamer.freedesktop.org/documentation/installing/on-windows.html?gi-language=c#download-and-install-gstreamer-binaries