### PR TITLE
Assorted small improvements.

### DIFF
--- a/include/vcpkg/base/strings.h
+++ b/include/vcpkg/base/strings.h
@@ -43,54 +43,36 @@ namespace vcpkg::Strings::details
 
 namespace vcpkg::Strings
 {
-#if __cpp_fold_expressions >= 201603L
     template<class... Args>
     std::string& append(std::string& into, const Args&... args)
     {
-        (void)(details::append_internal(into, args), ...);
+        (void)((details::append_internal(into, args), 0) || ... || 0);
         return into;
     }
-#else
-    inline std::string& append(std::string& into) { return into; }
-    template<class Arg, class... Args>
-    std::string& append(std::string& into, const Arg& arg, const Args&... args)
-    {
-        details::append_internal(into, arg);
-        return ::vcpkg::Strings::append(into, args...);
-    }
-#endif
 
     template<class... Args>
     [[nodiscard]] std::string concat(const Args&... args)
     {
-        std::string ret;
-#if __cpp_fold_expressions >= 201603L
-        (void)(details::append_internal(ret, args), ...);
-#else
-        ::vcpkg::Strings::append(ret, args...);
-#endif
-        return ret;
+        std::string into;
+        (void)((details::append_internal(into, args), 0) || ... || 0);
+        return into;
     }
 
     template<class... Args>
-    [[nodiscard]] std::string concat(std::string&& first, const Args&... args)
+    [[nodiscard]] std::string concat(std::string&& into, const Args&... args)
     {
-#if __cpp_fold_expressions >= 201603L
-        (void)(details::append_internal(first, args), ...);
-#else
-        ::vcpkg::Strings::append(first, args...);
-#endif
-        return std::move(first);
+        (void)((details::append_internal(into, args), 0) || ... || 0);
+        return std::move(into);
     }
 
     template<class... Args, class = void>
-    std::string concat_or_view(const Args&... args)
+    [[nodiscard]] std::string concat_or_view(Args&&... args)
     {
-        return Strings::concat(args...);
+        return Strings::concat(static_cast<Args&&>(args)...);
     }
 
     template<class T, class = std::enable_if_t<std::is_convertible_v<T, StringView>>>
-    StringView concat_or_view(const T& v)
+    [[nodiscard]] StringView concat_or_view(const T& v)
     {
         return v;
     }

--- a/include/vcpkg/base/strings.h
+++ b/include/vcpkg/base/strings.h
@@ -156,7 +156,6 @@ namespace vcpkg::Strings
         return join(delimiter, std::begin(v), std::end(v), details::identity_transformer);
     }
 
-    [[nodiscard]] std::string replace_all(const char* s, StringView search, StringView rep);
     [[nodiscard]] std::string replace_all(StringView s, StringView search, StringView rep);
     [[nodiscard]] std::string replace_all(std::string&& s, StringView search, StringView rep);
 

--- a/include/vcpkg/base/strings.h
+++ b/include/vcpkg/base/strings.h
@@ -30,39 +30,56 @@ namespace vcpkg::Strings::details
     {
         to_string(into, t);
     }
+
+    static constexpr struct IdentityTransformer
+    {
+        template<class T>
+        T&& operator()(T&& t) const noexcept
+        {
+            return static_cast<T&&>(t);
+        }
+    } identity_transformer;
 }
 
 namespace vcpkg::Strings
 {
-    constexpr struct
-    {
-        char operator()(char c) const noexcept { return (c < 'A' || c > 'Z') ? c : c - 'A' + 'a'; }
-    } tolower_char;
-
-    constexpr struct
-    {
-        bool operator()(char a, char b) const noexcept { return tolower_char(a) == tolower_char(b); }
-    } icase_eq;
-
+#if __cpp_fold_expressions >= 201603L
     template<class... Args>
     std::string& append(std::string& into, const Args&... args)
     {
         (void)(details::append_internal(into, args), ...);
         return into;
     }
+#else
+    inline std::string& append(std::string& into) { return into; }
+    template<class Arg, class... Args>
+    std::string& append(std::string& into, const Arg& arg, const Args&... args)
+    {
+        details::append_internal(into, arg);
+        return ::vcpkg::Strings::append(into, args...);
+    }
+#endif
 
     template<class... Args>
     [[nodiscard]] std::string concat(const Args&... args)
     {
         std::string ret;
+#if __cpp_fold_expressions >= 201603L
         (void)(details::append_internal(ret, args), ...);
+#else
+        ::vcpkg::Strings::append(ret, args...);
+#endif
         return ret;
     }
 
     template<class... Args>
     [[nodiscard]] std::string concat(std::string&& first, const Args&... args)
     {
+#if __cpp_fold_expressions >= 201603L
         (void)(details::append_internal(first, args), ...);
+#else
+        ::vcpkg::Strings::append(first, args...);
+#endif
         return std::move(first);
     }
 
@@ -91,11 +108,10 @@ namespace vcpkg::Strings
     bool case_insensitive_ascii_contains(StringView s, StringView pattern);
     bool case_insensitive_ascii_equals(StringView left, StringView right);
 
-    void ascii_to_lowercase(char* first, char* last);
-    std::string ascii_to_lowercase(const std::string& s);
-    std::string ascii_to_lowercase(std::string&& s);
-
-    std::string ascii_to_uppercase(std::string&& s);
+    void inplace_ascii_to_lowercase(char* first, char* last);
+    void inplace_ascii_to_lowercase(std::string& s);
+    [[nodiscard]] std::string ascii_to_lowercase(std::string s);
+    [[nodiscard]] std::string ascii_to_uppercase(std::string s);
 
     bool case_insensitive_ascii_starts_with(StringView s, StringView pattern);
     bool case_insensitive_ascii_ends_with(StringView s, StringView pattern);
@@ -103,53 +119,41 @@ namespace vcpkg::Strings
     bool starts_with(StringView s, StringView pattern);
 
     template<class InputIterator, class Transformer>
-    std::string join(StringLiteral delimiter, InputIterator first, InputIterator last, Transformer transformer)
+    [[nodiscard]] std::string join(StringLiteral delimiter,
+                                   InputIterator first,
+                                   InputIterator last,
+                                   Transformer transformer)
     {
-        if (first == last)
-        {
-            return std::string();
-        }
-
         std::string output;
-        append(output, transformer(*first));
-        for (++first; first != last; ++first)
+        if (first != last)
         {
-            output.append(delimiter.data(), delimiter.size());
-            append(output, transformer(*first));
+            Strings::append(output, transformer(*first));
+            for (++first; first != last; ++first)
+            {
+                output.append(delimiter.data(), delimiter.size());
+                Strings::append(output, transformer(*first));
+            }
         }
 
         return output;
     }
 
     template<class Container, class Transformer>
-    std::string join(StringLiteral delimiter, const Container& v, Transformer transformer)
+    [[nodiscard]] std::string join(StringLiteral delimiter, const Container& v, Transformer transformer)
     {
         return join(delimiter, std::begin(v), std::end(v), transformer);
     }
 
     template<class InputIterator>
-    std::string join(StringLiteral delimiter, InputIterator first, InputIterator last)
+    [[nodiscard]] std::string join(StringLiteral delimiter, InputIterator first, InputIterator last)
     {
-        if (first == last)
-        {
-            return std::string();
-        }
-
-        std::string output;
-        append(output, *first);
-        for (++first; first != last; ++first)
-        {
-            output.append(delimiter.data(), delimiter.size());
-            append(output, *first);
-        }
-
-        return output;
+        return join(delimiter, first, last, details::identity_transformer);
     }
 
     template<class Container>
-    std::string join(StringLiteral delimiter, const Container& v)
+    [[nodiscard]] std::string join(StringLiteral delimiter, const Container& v)
     {
-        return join(delimiter, std::begin(v), std::end(v));
+        return join(delimiter, std::begin(v), std::end(v), details::identity_transformer);
     }
 
     [[nodiscard]] std::string replace_all(const char* s, StringView search, StringView rep);
@@ -162,21 +166,25 @@ namespace vcpkg::Strings
 
     void inplace_trim(std::string& s);
 
-    StringView trim(StringView sv);
+    [[nodiscard]] StringView trim(StringView sv);
 
     void inplace_trim_all_and_remove_whitespace_strings(std::vector<std::string>& strings);
 
-    std::vector<std::string> split(StringView s, const char delimiter);
+    [[nodiscard]] std::vector<std::string> split(StringView s, const char delimiter);
 
-    std::vector<std::string> split_paths(StringView s);
+    [[nodiscard]] std::vector<std::string> split_paths(StringView s);
 
     const char* find_first_of(StringView searched, StringView candidates);
 
-    std::vector<StringView> find_all_enclosed(StringView input, StringView left_delim, StringView right_delim);
+    [[nodiscard]] std::vector<StringView> find_all_enclosed(StringView input,
+                                                            StringView left_delim,
+                                                            StringView right_delim);
 
-    StringView find_exactly_one_enclosed(StringView input, StringView left_tag, StringView right_tag);
+    [[nodiscard]] StringView find_exactly_one_enclosed(StringView input, StringView left_tag, StringView right_tag);
 
-    Optional<StringView> find_at_most_one_enclosed(StringView input, StringView left_tag, StringView right_tag);
+    [[nodiscard]] Optional<StringView> find_at_most_one_enclosed(StringView input,
+                                                                 StringView left_tag,
+                                                                 StringView right_tag);
 
     bool contains_any_ignoring_c_comments(const std::string& source, View<StringView> to_find);
 
@@ -184,10 +192,10 @@ namespace vcpkg::Strings
 
     bool contains_any(StringView source, View<StringView> to_find);
 
-    bool equals(StringView a, StringView b);
+    [[nodiscard]] bool equals(StringView a, StringView b);
 
     template<class T>
-    std::string serialize(const T& t)
+    [[nodiscard]] std::string serialize(const T& t)
     {
         std::string ret;
         serialize(t, ret);
@@ -219,10 +227,10 @@ namespace vcpkg::Strings
     bool contains(StringView haystack, char needle);
 
     // base 32 encoding, following IETF RFC 4648
-    std::string b32_encode(std::uint64_t x) noexcept;
+    [[nodiscard]] std::string b32_encode(std::uint64_t x) noexcept;
 
     // percent encoding, following IETF RFC 3986
-    std::string percent_encode(StringView sv) noexcept;
+    [[nodiscard]] std::string percent_encode(StringView sv) noexcept;
 
     // Implements https://en.wikipedia.org/wiki/Levenshtein_distance with a "give-up" clause for large strings
     // Guarantees 0 for equal strings and nonzero for inequal strings.

--- a/include/vcpkg/binaryparagraph.h
+++ b/include/vcpkg/binaryparagraph.h
@@ -16,11 +16,8 @@ namespace vcpkg
         BinaryParagraph(const SourceParagraph& spgh,
                         Triplet triplet,
                         const std::string& abi_tag,
-                        const std::vector<FeatureSpec>& deps);
-        BinaryParagraph(const SourceParagraph& spgh,
-                        const FeatureParagraph& fpgh,
-                        Triplet triplet,
-                        const std::vector<FeatureSpec>& deps);
+                        std::vector<PackageSpec> deps);
+        BinaryParagraph(const PackageSpec& spec, const FeatureParagraph& fpgh, std::vector<PackageSpec> deps);
 
         void canonicalize();
 

--- a/src/vcpkg-test/strings.cpp
+++ b/src/vcpkg-test/strings.cpp
@@ -155,7 +155,7 @@ TEST_CASE ("edit distance", "[strings]")
 
 TEST_CASE ("replace_all", "[strings]")
 {
-    REQUIRE(vcpkg::Strings::replace_all("literal", "ter", "x") == "lixal");
+    REQUIRE(vcpkg::Strings::replace_all(vcpkg::StringView("literal"), "ter", "x") == "lixal");
 }
 
 TEST_CASE ("inplace_replace_all", "[strings]")

--- a/src/vcpkg/base/json.cpp
+++ b/src/vcpkg/base/json.cpp
@@ -1177,16 +1177,20 @@ namespace vcpkg::Json
 
             void append_unicode_escape(char16_t code_unit) const
             {
-                buffer.append("\\u");
-
                 // AFAIK, there's no standard way of doing this?
                 constexpr const char hex_digit[16] = {
                     '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
 
-                buffer.push_back(hex_digit[(code_unit >> 12) & 0x0F]);
-                buffer.push_back(hex_digit[(code_unit >> 8) & 0x0F]);
-                buffer.push_back(hex_digit[(code_unit >> 4) & 0x0F]);
-                buffer.push_back(hex_digit[(code_unit >> 0) & 0x0F]);
+                const char seq[6] = {
+                    '\\',
+                    'u',
+                    hex_digit[(code_unit >> 12) & 0x0F],
+                    hex_digit[(code_unit >> 8) & 0x0F],
+                    hex_digit[(code_unit >> 4) & 0x0F],
+                    hex_digit[(code_unit >> 0) & 0x0F],
+                };
+
+                buffer.append(seq, 6);
             }
 
             // taken from the ECMAScript 2020 standard, 24.5.2.2: Runtime Semantics: QuoteJSONString

--- a/src/vcpkg/base/strings.cpp
+++ b/src/vcpkg/base/strings.cpp
@@ -25,10 +25,6 @@ namespace vcpkg::Strings::details
     void append_internal(std::string& into, const char* v) { into.append(v); }
     void append_internal(std::string& into, const std::string& s) { into.append(s); }
     void append_internal(std::string& into, StringView s) { into.append(s.begin(), s.end()); }
-    void append_internal(std::string& into, LineInfo ln)
-    {
-        fmt::format_to(std::back_inserter(into), "{}:{}:", ln.file_name, ln.line_number);
-    }
 }
 
 vcpkg::ExpectedL<std::string> vcpkg::details::api_stable_format_impl(StringView sv,

--- a/src/vcpkg/base/strings.cpp
+++ b/src/vcpkg/base/strings.cpp
@@ -218,11 +218,6 @@ bool Strings::starts_with(StringView s, StringView pattern)
     return std::equal(s.begin(), s.begin() + pattern.size(), pattern.begin(), pattern.end());
 }
 
-std::string Strings::replace_all(const char* s, StringView search, StringView rep)
-{
-    return Strings::replace_all(std::string(s), search, rep);
-}
-
 std::string Strings::replace_all(StringView s, StringView search, StringView rep)
 {
     std::string ret = s.to_string();

--- a/src/vcpkg/base/strings.cpp
+++ b/src/vcpkg/base/strings.cpp
@@ -149,15 +149,6 @@ void Strings::to_utf8(std::string& output, const wchar_t* w, size_t size_in_char
 std::string Strings::to_utf8(const std::wstring& ws) { return to_utf8(ws.data(), ws.size()); }
 #endif
 
-std::string Strings::escape_string(std::string&& s, char char_to_escape, char escape_char)
-{
-    // Replace '\' with '\\' or '`' with '``'
-    auto ret = Strings::replace_all(std::move(s), {&escape_char, 1}, std::string{escape_char, escape_char});
-    // Replace '"' with '\"' or '`"'
-    ret = Strings::replace_all(std::move(ret), {&char_to_escape, 1}, std::string{escape_char, char_to_escape});
-    return ret;
-}
-
 const char* Strings::case_insensitive_ascii_search(StringView s, StringView pattern)
 {
     return std::search(s.begin(), s.end(), pattern.begin(), pattern.end(), icase_eq);
@@ -252,11 +243,10 @@ void Strings::inplace_replace_all(std::string& s, char search, char rep) noexcep
     std::replace(s.begin(), s.end(), search, rep);
 }
 
-std::string Strings::trim(std::string&& s)
+void Strings::inplace_trim(std::string& s)
 {
     s.erase(std::find_if_not(s.rbegin(), s.rend(), details::is_space).base(), s.end());
     s.erase(s.begin(), std::find_if_not(s.begin(), s.end(), details::is_space));
-    return std::move(s);
 }
 
 StringView Strings::trim(StringView sv)
@@ -266,14 +256,14 @@ StringView Strings::trim(StringView sv)
     return StringView(first, last);
 }
 
-void Strings::trim_all_and_remove_whitespace_strings(std::vector<std::string>* strings)
+void Strings::inplace_trim_all_and_remove_whitespace_strings(std::vector<std::string>& strings)
 {
-    for (std::string& s : *strings)
+    for (std::string& s : strings)
     {
-        s = trim(std::move(s));
+        inplace_trim(s);
     }
 
-    Util::erase_remove_if(*strings, [](const std::string& s) { return s.empty(); });
+    Util::erase_remove_if(strings, [](const std::string& s) { return s.empty(); });
 }
 
 std::vector<std::string> Strings::split(StringView s, const char delimiter)

--- a/src/vcpkg/binaryparagraph.cpp
+++ b/src/vcpkg/binaryparagraph.cpp
@@ -111,10 +111,9 @@ namespace vcpkg
         , maintainers(spgh.maintainers)
         , feature()
         , default_features(spgh.default_features)
-        , dependencies()
+        , dependencies(Util::fmap(deps, [](const FeatureSpec& spec) { return spec.spec(); }))
         , abi(abi_tag)
     {
-        this->dependencies = Util::fmap(deps, [](const FeatureSpec& spec) { return spec.spec(); });
         canonicalize();
     }
 
@@ -129,10 +128,9 @@ namespace vcpkg
         , maintainers()
         , feature(fpgh.name)
         , default_features()
-        , dependencies()
+        , dependencies(Util::fmap(deps, [](const FeatureSpec& spec) { return spec.spec(); }))
         , abi()
     {
-        this->dependencies = Util::fmap(deps, [](const FeatureSpec& spec) { return spec.spec(); });
         canonicalize();
     }
 
@@ -146,7 +144,7 @@ namespace vcpkg
 
         for (auto& maintainer : this->maintainers)
         {
-            maintainer = Strings::trim(std::move(maintainer));
+            Strings::inplace_trim(maintainer);
         }
         if (all_empty(this->maintainers))
         {
@@ -155,7 +153,7 @@ namespace vcpkg
 
         for (auto& desc : this->description)
         {
-            desc = Strings::trim(std::move(desc));
+            Strings::inplace_trim(desc);
         }
         if (all_empty(this->description))
         {

--- a/src/vcpkg/binaryparagraph.cpp
+++ b/src/vcpkg/binaryparagraph.cpp
@@ -103,7 +103,7 @@ namespace vcpkg
     BinaryParagraph::BinaryParagraph(const SourceParagraph& spgh,
                                      Triplet triplet,
                                      const std::string& abi_tag,
-                                     const std::vector<FeatureSpec>& deps)
+                                     std::vector<PackageSpec> deps)
         : spec(spgh.name, triplet)
         , version(spgh.raw_version)
         , port_version(spgh.port_version)
@@ -111,24 +111,23 @@ namespace vcpkg
         , maintainers(spgh.maintainers)
         , feature()
         , default_features(spgh.default_features)
-        , dependencies(Util::fmap(deps, [](const FeatureSpec& spec) { return spec.spec(); }))
+        , dependencies(std::move(deps))
         , abi(abi_tag)
     {
         canonicalize();
     }
 
-    BinaryParagraph::BinaryParagraph(const SourceParagraph& spgh,
+    BinaryParagraph::BinaryParagraph(const PackageSpec& spec,
                                      const FeatureParagraph& fpgh,
-                                     Triplet triplet,
-                                     const std ::vector<FeatureSpec>& deps)
-        : spec(spgh.name, triplet)
+                                     std::vector<PackageSpec> deps)
+        : spec(spec)
         , version()
         , port_version()
         , description(fpgh.description)
         , maintainers()
         , feature(fpgh.name)
         , default_features()
-        , dependencies(Util::fmap(deps, [](const FeatureSpec& spec) { return spec.spec(); }))
+        , dependencies(std::move(deps))
         , abi()
     {
         canonicalize();

--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -1507,7 +1507,7 @@ namespace vcpkg
             paths.get_filesystem().read_contents(build_result.stdoutlog.value_or_exit(VCPKG_LINE_INFO),
                                                  VCPKG_LINE_INFO),
             "\n```\n",
-            Strings::join("\n", Util::fmap(build_result.error_logs, create_log_details)),
+            Strings::join("\n", build_result.error_logs, create_log_details),
             "\n\n**Additional context**\n\n",
             manifest);
     }

--- a/src/vcpkg/build.cpp
+++ b/src/vcpkg/build.cpp
@@ -626,8 +626,11 @@ namespace vcpkg
         {
             find_itr = action.feature_dependencies.find(feature);
             Checks::check_exit(VCPKG_LINE_INFO, find_itr != action.feature_dependencies.end());
-            const auto& fpgh = scfl.source_control_file->find_feature(feature).value_or_exit(VCPKG_LINE_INFO);
-            bcf->features.emplace_back(action.spec, fpgh, fspecs_to_pspecs(find_itr->second));
+            auto maybe_fpgh = scfl.source_control_file->find_feature(feature);
+            if (auto fpgh = maybe_fpgh.get())
+            {
+                bcf->features.emplace_back(action.spec, *fpgh, fspecs_to_pspecs(find_itr->second));
+            }
         }
         return bcf;
     }

--- a/src/vcpkg/commands.ci.cpp
+++ b/src/vcpkg/commands.ci.cpp
@@ -404,16 +404,14 @@ namespace vcpkg::Commands::CI
         auto& var_provider = *var_provider_storage;
 
         const ElapsedTimer timer;
-        std::vector<std::string> all_port_names =
-            Util::fmap(provider.load_all_control_files(), Paragraphs::get_name_of_control_file);
         // Install the default features for every package
-        std::vector<FullPackageSpec> all_default_full_specs;
-        all_default_full_specs.reserve(all_port_names.size());
-        for (auto&& port_name : all_port_names)
-        {
-            all_default_full_specs.emplace_back(PackageSpec{std::move(port_name), target_triplet},
-                                                InternalFeatureSet{"core", "default"});
-        }
+        const std::vector<FullPackageSpec> all_default_full_specs =
+            Util::fmap(provider.load_all_control_files(), [target_triplet](auto* scfl) {
+                return FullPackageSpec{
+                    PackageSpec{scfl->source_control_file->core_paragraph->name, target_triplet},
+                    InternalFeatureSet{"core", "default"},
+                };
+            });
 
         CreateInstallPlanOptions serialize_options(host_triplet, UnsupportedPortAction::Warn);
 

--- a/src/vcpkg/commands.ci.cpp
+++ b/src/vcpkg/commands.ci.cpp
@@ -405,13 +405,13 @@ namespace vcpkg::Commands::CI
 
         const ElapsedTimer timer;
         // Install the default features for every package
-        const std::vector<FullPackageSpec> all_default_full_specs =
-            Util::fmap(provider.load_all_control_files(), [target_triplet](auto* scfl) {
-                return FullPackageSpec{
-                    PackageSpec{scfl->source_control_file->core_paragraph->name, target_triplet},
-                    InternalFeatureSet{"core", "default"},
-                };
-            });
+        std::vector<FullPackageSpec> all_default_full_specs;
+        for (auto scfl : provider.load_all_control_files())
+        {
+            all_default_full_specs.emplace_back(
+                PackageSpec{scfl->source_control_file->core_paragraph->name, target_triplet},
+                InternalFeatureSet{"core", "default"});
+        }
 
         CreateInstallPlanOptions serialize_options(host_triplet, UnsupportedPortAction::Warn);
 

--- a/src/vcpkg/commands.integrate.cpp
+++ b/src/vcpkg/commands.integrate.cpp
@@ -186,7 +186,7 @@ namespace vcpkg::Commands::Integrate
                                                    const std::string& nuget_id,
                                                    const std::string& nupkg_version)
     {
-        static constexpr auto CONTENT_TEMPLATE = R"(
+        static constexpr StringLiteral CONTENT_TEMPLATE = R"(
 <package>
     <metadata>
         <id>@NUGET_ID@</id>

--- a/src/vcpkg/commands.xdownload.cpp
+++ b/src/vcpkg/commands.xdownload.cpp
@@ -82,7 +82,7 @@ namespace vcpkg::Commands::X_Download
             {
                 Checks::msg_exit_with_error(VCPKG_LINE_INFO, msgImproperShaLength, msg::value = *p);
             }
-            Strings::ascii_to_lowercase(p->data(), p->data() + p->size());
+            Strings::inplace_ascii_to_lowercase(p->data(), p->data() + p->size());
         }
 
         return sha;

--- a/src/vcpkg/export.chocolatey.cpp
+++ b/src/vcpkg/export.chocolatey.cpp
@@ -16,7 +16,8 @@ namespace vcpkg::Export::Chocolatey
     static std::string create_nuspec_dependencies(const BinaryParagraph& binary_paragraph,
                                                   const std::map<PackageSpec, std::string>& packages_version)
     {
-        static constexpr auto CONTENT_TEMPLATE = R"(<dependency id="@PACKAGE_ID@" version="[@PACKAGE_VERSION@]" />)";
+        static constexpr StringLiteral CONTENT_TEMPLATE =
+            R"(<dependency id="@PACKAGE_ID@" version="[@PACKAGE_VERSION@]" />)";
 
         std::string nuspec_dependencies;
         for (const auto& depend : binary_paragraph.dependencies)
@@ -38,7 +39,7 @@ namespace vcpkg::Export::Chocolatey
                                                    const std::map<PackageSpec, std::string>& packages_version,
                                                    const Options& chocolatey_options)
     {
-        static constexpr auto CONTENT_TEMPLATE = R"(<?xml version="1.0" encoding="utf-8"?>
+        static constexpr StringLiteral CONTENT_TEMPLATE = R"(<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>@PACKAGE_ID@</id>
@@ -79,7 +80,7 @@ namespace vcpkg::Export::Chocolatey
 
     static std::string create_chocolatey_install_contents()
     {
-        static constexpr auto CONTENT_TEMPLATE = R"###(
+        static constexpr StringLiteral CONTENT_TEMPLATE = R"###(
 $ErrorActionPreference = 'Stop';
 
 $packageName= $env:ChocolateyPackageName
@@ -92,12 +93,12 @@ $whereToInstallCache = Join-Path $rootDir 'install.txt'
 Set-Content -Path $whereToInstallCache -Value $whereToInstall
 Copy-Item $installedDir -destination $whereToInstall -recurse -force
 )###";
-        return CONTENT_TEMPLATE;
+        return CONTENT_TEMPLATE.to_string();
     }
 
     static std::string create_chocolatey_uninstall_contents(const BinaryParagraph& binary_paragraph)
     {
-        static constexpr auto CONTENT_TEMPLATE = R"###(
+        static constexpr StringLiteral CONTENT_TEMPLATE = R"###(
 $ErrorActionPreference = 'Stop';
 
 $packageName= $env:ChocolateyPackageName

--- a/src/vcpkg/export.prefab.cpp
+++ b/src/vcpkg/export.prefab.cpp
@@ -569,7 +569,7 @@ namespace vcpkg::Export::Prefab
                         ab.ndk = version.major();
 
                         Debug::print(fmt::format("Found module {} {}", module_name, ab.abi));
-                        module_name = Strings::trim(std::move(module_name));
+                        Strings::inplace_trim(module_name);
 
                         if (Strings::starts_with(module_name, "lib"))
                         {

--- a/src/vcpkg/input.cpp
+++ b/src/vcpkg/input.cpp
@@ -48,7 +48,6 @@ namespace vcpkg
                                                     const LocalizedString& example_text,
                                                     const VcpkgPaths& paths)
     {
-        Strings::ascii_to_lowercase(full_package_spec_as_string);
         auto expected_spec = parse_qualified_specifier(full_package_spec_as_string)
                                  .then(&ParsedQualifiedSpecifier::to_full_spec,
                                        default_triplet,

--- a/src/vcpkg/sourceparagraph.cpp
+++ b/src/vcpkg/sourceparagraph.cpp
@@ -166,7 +166,9 @@ namespace vcpkg
     static void trim_all(std::vector<std::string>& arr)
     {
         for (auto& el : arr)
+        {
             Strings::inplace_trim(el);
+        }
     }
 
     namespace

--- a/src/vcpkg/sourceparagraph.cpp
+++ b/src/vcpkg/sourceparagraph.cpp
@@ -166,9 +166,7 @@ namespace vcpkg
     static void trim_all(std::vector<std::string>& arr)
     {
         for (auto& el : arr)
-        {
-            el = Strings::trim(std::move(el));
-        }
+            Strings::inplace_trim(el);
     }
 
     namespace

--- a/src/vcpkg/triplet.cpp
+++ b/src/vcpkg/triplet.cpp
@@ -33,7 +33,7 @@ namespace vcpkg
     Triplet Triplet::from_canonical_name(std::string triplet_as_string)
     {
         static std::unordered_set<TripletInstance> g_triplet_instances;
-        Strings::ascii_to_lowercase(triplet_as_string.data(), triplet_as_string.data() + triplet_as_string.size());
+        Strings::inplace_ascii_to_lowercase(triplet_as_string);
         const auto p = g_triplet_instances.emplace(std::move(triplet_as_string));
         return &*p.first;
     }

--- a/src/vcpkg/vcpkglib.cpp
+++ b/src/vcpkg/vcpkglib.cpp
@@ -205,7 +205,7 @@ namespace vcpkg
             const auto listfile_path = installed.listfile_path(pgh->package);
             std::vector<std::string> installed_files_of_current_pgh =
                 fs.read_lines(listfile_path).value_or_exit(VCPKG_LINE_INFO);
-            Strings::trim_all_and_remove_whitespace_strings(&installed_files_of_current_pgh);
+            Strings::inplace_trim_all_and_remove_whitespace_strings(installed_files_of_current_pgh);
             upgrade_to_slash_terminated_sorted_format(fs, &installed_files_of_current_pgh, listfile_path);
 
             // Remove the directories

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -921,7 +921,8 @@ namespace vcpkg
         auto cmd = git_cmd_builder(this->root / ".git", this->root);
         cmd.string_arg("rev-parse").string_arg("HEAD");
         return flatten_out(cmd_execute_and_capture_output(cmd), Tools::GIT).map([](std::string&& output) {
-            return Strings::trim(std::move(output));
+            Strings::inplace_trim(output);
+            return std::move(output);
         });
     }
 
@@ -1204,7 +1205,8 @@ namespace vcpkg
                                     .string_arg(revision);
 
         return flatten_out(cmd_execute_and_capture_output(git_rev_parse), Tools::GIT).map([](std::string&& output) {
-            return Strings::trim(std::move(output));
+            Strings::inplace_trim(output);
+            return std::move(output);
         });
     }
     ExpectedL<Path> VcpkgPaths::git_checkout_object_from_remote_registry(StringView object) const


### PR DESCRIPTION
- Remove unneeded specialization of append_internal
- Instead of recursive templates, use pack expansion
- Remove unused Strings::escape_string
- Remove no-op transformer in Strings::join
- Don't require pointer parameter to trim_all_and_remove_whitespace_strings -- rename as "inplace" for consistency
- Fuse some loops