### PR TITLE
Extract BasicAction/PackageAction in preparation for splitting action types

### DIFF
--- a/include/vcpkg/base/messages.h
+++ b/include/vcpkg/base/messages.h
@@ -86,6 +86,12 @@ namespace vcpkg
 
         LocalizedString& append_raw(char c);
         LocalizedString& append_raw(StringView s);
+        template<class T, class = decltype(std::declval<const T&>().to_string(std::declval<std::string&>()))>
+        LocalizedString& append_raw(const T& s)
+        {
+            s.to_string(m_data);
+            return *this;
+        }
         LocalizedString& append(const LocalizedString& s);
         template<VCPKG_DECL_MSG_TEMPLATE>
         LocalizedString& append(VCPKG_DECL_MSG_ARGS)

--- a/include/vcpkg/dependencies.h
+++ b/include/vcpkg/dependencies.h
@@ -99,11 +99,6 @@ namespace vcpkg
 
     struct RemovePlanAction : BasicAction
     {
-        RemovePlanAction(const RemovePlanAction&) = delete;
-        RemovePlanAction(RemovePlanAction&&) = default;
-        RemovePlanAction& operator=(const RemovePlanAction&) = delete;
-        RemovePlanAction& operator=(RemovePlanAction&&) = default;
-
         RemovePlanAction(const PackageSpec& spec, const RemovePlanType& plan_type, const RequestType& request_type);
 
         RemovePlanType plan_type;
@@ -195,5 +190,13 @@ namespace vcpkg
                                                         Triplet host_triplet,
                                                         UnsupportedPortAction unsupported_port_action);
 
-    void print_plan(const ActionPlan& action_plan, const bool is_recursive = true, const Path& builtin_ports_dir = {});
+    struct FormattedPlan
+    {
+        bool has_removals = false;
+        LocalizedString text;
+    };
+
+    FormattedPlan format_plan(const ActionPlan& action_plan, const Path& builtin_ports_dir);
+
+    void print_plan(const ActionPlan& action_plan, const bool is_recursive, const Path& builtin_ports_dir);
 }

--- a/include/vcpkg/dependencies.h
+++ b/include/vcpkg/dependencies.h
@@ -29,7 +29,7 @@ namespace vcpkg
         AUTO_SELECTED
     };
 
-    std::string to_output_string(RequestType request_type, StringView s);
+    [[nodiscard]] StringLiteral request_type_indent(RequestType request_type);
 
     enum class InstallPlanType
     {
@@ -48,13 +48,6 @@ namespace vcpkg
 
     struct PackageAction : BasicAction
     {
-        PackageAction(PackageSpec spec, std::vector<PackageSpec> package_dependencies, InternalFeatureSet feature_list)
-            : BasicAction{std::move(spec)}
-            , package_dependencies(std::move(package_dependencies))
-            , feature_list(std::move(feature_list))
-        {
-        }
-
         std::string displayname() const;
 
         std::vector<PackageSpec> package_dependencies;
@@ -81,6 +74,7 @@ namespace vcpkg
         bool has_package_abi() const;
         Optional<const std::string&> package_abi() const;
         const PreBuildInfo& pre_build_info(LineInfo li) const;
+        Version version() const;
 
         Optional<const SourceControlFileAndLocation&> source_control_file_and_location;
         Optional<InstalledPackageView> installed_package;

--- a/include/vcpkg/packagespec.h
+++ b/include/vcpkg/packagespec.h
@@ -96,6 +96,8 @@ namespace vcpkg
     struct InternalFeatureSet : std::vector<std::string>
     {
         using std::vector<std::string>::vector;
+
+        bool empty_or_only_core() const;
     };
 
     InternalFeatureSet internalize_feature_list(View<std::string> fs, ImplicitDefault id);

--- a/include/vcpkg/statusparagraph.h
+++ b/include/vcpkg/statusparagraph.h
@@ -62,6 +62,7 @@ namespace vcpkg
         std::vector<PackageSpec> dependencies() const;
         std::map<std::string, std::vector<FeatureSpec>> feature_dependencies() const;
         InternalFeatureSet feature_list() const;
+        Version version() const;
 
         std::vector<StatusParagraph> all_status_paragraphs() const;
 

--- a/include/vcpkg/statusparagraph.h
+++ b/include/vcpkg/statusparagraph.h
@@ -61,6 +61,7 @@ namespace vcpkg
         const PackageSpec& spec() const { return core->package.spec; }
         std::vector<PackageSpec> dependencies() const;
         std::map<std::string, std::vector<FeatureSpec>> feature_dependencies() const;
+        InternalFeatureSet feature_list() const;
 
         std::vector<StatusParagraph> all_status_paragraphs() const;
 

--- a/src/vcpkg-test/binarycaching.cpp
+++ b/src/vcpkg-test/binarycaching.cpp
@@ -462,9 +462,12 @@ Description: a spiffy compression library wrapper
     auto maybe_scf = SourceControlFile::parse_control_file("", std::move(*pghs.get()));
     REQUIRE(maybe_scf.has_value());
     SourceControlFileAndLocation scfl{std::move(*maybe_scf.get()), Path()};
-    plan.install_actions.emplace_back();
-    plan.install_actions[0].spec = PackageSpec("zlib", Test::X64_ANDROID);
-    plan.install_actions[0].source_control_file_and_location = scfl;
+    plan.install_actions.emplace_back(PackageSpec("zlib", Test::X64_ANDROID),
+                                      scfl,
+                                      RequestType::USER_REQUESTED,
+                                      Test::ARM64_WINDOWS,
+                                      std::map<std::string, std::vector<FeatureSpec>>{},
+                                      std::vector<LocalizedString>{});
     plan.install_actions[0].abi_info = AbiInfo{};
     plan.install_actions[0].abi_info.get()->package_abi = "packageabi";
 
@@ -485,9 +488,12 @@ Description: a spiffy compression library wrapper
     auto maybe_scf2 = SourceControlFile::parse_control_file("", std::move(*pghs2.get()));
     REQUIRE(maybe_scf2.has_value());
     SourceControlFileAndLocation scfl2{std::move(*maybe_scf2.get()), Path()};
-    plan.install_actions.emplace_back();
-    plan.install_actions[1].spec = PackageSpec("zlib2", Test::X64_ANDROID);
-    plan.install_actions[1].source_control_file_and_location = scfl2;
+    plan.install_actions.emplace_back(PackageSpec("zlib2", Test::X64_ANDROID),
+                                      scfl2,
+                                      RequestType::USER_REQUESTED,
+                                      Test::ARM64_WINDOWS,
+                                      std::map<std::string, std::vector<FeatureSpec>>{},
+                                      std::vector<LocalizedString>{});
     plan.install_actions[1].abi_info = AbiInfo{};
     plan.install_actions[1].abi_info.get()->package_abi = "packageabi2";
 

--- a/src/vcpkg-test/dependencies.cpp
+++ b/src/vcpkg-test/dependencies.cpp
@@ -2211,3 +2211,119 @@ TEST_CASE ("respect supports expressions of features", "[versionplan]")
         CHECK_FALSE(install_plan.has_value());
     }
 }
+
+TEST_CASE ("formatting plan 1", "[dependencies]")
+{
+    std::vector<std::unique_ptr<StatusParagraph>> status_paragraphs;
+    status_paragraphs.push_back(vcpkg::Test::make_status_pgh("d"));
+    status_paragraphs.push_back(vcpkg::Test::make_status_pgh("e"));
+    StatusParagraphs status_db(std::move(status_paragraphs));
+
+    MockVersionedPortfileProvider vp;
+    auto& scfl_a = vp.emplace("a", {"1", 0});
+    auto& scfl_b = vp.emplace("b", {"1", 0});
+    auto& scfl_c = vp.emplace("c", {"1", 0});
+    auto& scfl_f = vp.emplace("f", {"1", 0});
+
+    const RemovePlanAction remove_b({"b", Test::X64_OSX}, RemovePlanType::REMOVE, RequestType::USER_REQUESTED);
+    const RemovePlanAction remove_a({"a", Test::X64_OSX}, RemovePlanType::NOT_INSTALLED, RequestType::USER_REQUESTED);
+    const RemovePlanAction remove_c({"c", Test::X64_OSX}, RemovePlanType::REMOVE, RequestType::AUTO_SELECTED);
+    InstallPlanAction install_a({"a", Test::X64_OSX}, scfl_a, RequestType::AUTO_SELECTED, Test::X64_ANDROID, {}, {});
+    InstallPlanAction install_b(
+        {"b", Test::X64_OSX}, scfl_b, RequestType::AUTO_SELECTED, Test::X64_ANDROID, {{"1", {}}}, {});
+    InstallPlanAction install_c({"c", Test::X64_OSX}, scfl_c, RequestType::USER_REQUESTED, Test::X64_ANDROID, {}, {});
+    InstallPlanAction install_f({"f", Test::X64_OSX}, scfl_f, RequestType::USER_REQUESTED, Test::X64_ANDROID, {}, {});
+    install_f.plan_type = InstallPlanType::EXCLUDED;
+
+    InstallPlanAction already_installed_d(
+        status_db.get_installed_package_view({"d", Test::X86_WINDOWS}).value_or_exit(VCPKG_LINE_INFO),
+        RequestType::AUTO_SELECTED);
+    InstallPlanAction already_installed_e(
+        status_db.get_installed_package_view({"e", Test::X86_WINDOWS}).value_or_exit(VCPKG_LINE_INFO),
+        RequestType::USER_REQUESTED);
+
+    ActionPlan plan;
+    {
+        auto formatted = format_plan(plan, "/builtin");
+        CHECK_FALSE(formatted.has_removals);
+        CHECK(formatted.text == "All requested packages are currently installed.\n");
+    }
+
+    plan.remove_actions.push_back(remove_b);
+    {
+        auto formatted = format_plan(plan, "/builtin");
+        CHECK(formatted.has_removals);
+        CHECK(formatted.text == "The following packages will be removed:\n"
+                                "    b:x64-osx\n");
+    }
+
+    plan.remove_actions.push_back(remove_a);
+    {
+        auto formatted = format_plan(plan, "/builtin");
+        CHECK(formatted.text == "The following packages will be removed:\n"
+                                "    a:x64-osx\n"
+                                "    b:x64-osx\n");
+    }
+
+    plan.install_actions.push_back(std::move(install_c));
+    {
+        auto formatted = format_plan(plan, "/builtin");
+        CHECK(formatted.text == "The following packages will be removed:\n"
+                                "    a:x64-osx\n"
+                                "    b:x64-osx\n"
+                                "The following packages will be built and installed:\n"
+                                "    c:x64-osx -> 1 -- c\n");
+    }
+
+    plan.remove_actions.push_back(remove_c);
+    {
+        auto formatted = format_plan(plan, "c");
+        CHECK(formatted.text == "The following packages will be removed:\n"
+                                "    a:x64-osx\n"
+                                "    b:x64-osx\n"
+                                "The following packages will be rebuilt:\n"
+                                "    c:x64-osx -> 1\n");
+    }
+
+    plan.install_actions.push_back(std::move(install_b));
+    {
+        auto formatted = format_plan(plan, "c");
+        CHECK(formatted.text == "The following packages will be removed:\n"
+                                "    a:x64-osx\n"
+                                "The following packages will be rebuilt:\n"
+                                "  * b[1]:x64-osx -> 1 -- b\n"
+                                "    c:x64-osx -> 1\n"
+                                "Additional packages (*) will be modified to complete this operation.\n");
+    }
+
+    plan.install_actions.push_back(std::move(install_a));
+    plan.already_installed.push_back(std::move(already_installed_d));
+    plan.already_installed.push_back(std::move(already_installed_e));
+    {
+        auto formatted = format_plan(plan, "b");
+        CHECK(formatted.has_removals);
+        CHECK(formatted.text == "The following packages are already installed:\n"
+                                "  * d:x86-windows -> 1\n"
+                                "    e:x86-windows -> 1\n"
+                                "The following packages will be rebuilt:\n"
+                                "  * a:x64-osx -> 1 -- a\n"
+                                "  * b[1]:x64-osx -> 1\n"
+                                "    c:x64-osx -> 1 -- c\n"
+                                "Additional packages (*) will be modified to complete this operation.\n");
+    }
+
+    plan.install_actions.push_back(std::move(install_f));
+    {
+        auto formatted = format_plan(plan, "b");
+        CHECK(formatted.text == "The following packages are excluded:\n"
+                                "    f:x64-osx -> 1 -- f\n"
+                                "The following packages are already installed:\n"
+                                "  * d:x86-windows -> 1\n"
+                                "    e:x86-windows -> 1\n"
+                                "The following packages will be rebuilt:\n"
+                                "  * a:x64-osx -> 1 -- a\n"
+                                "  * b[1]:x64-osx -> 1\n"
+                                "    c:x64-osx -> 1 -- c\n"
+                                "Additional packages (*) will be modified to complete this operation.\n");
+    }
+}

--- a/src/vcpkg/dependencies.cpp
+++ b/src/vcpkg/dependencies.cpp
@@ -431,8 +431,12 @@ namespace vcpkg
     {
         std::set<PackageSpec> specs;
         for (auto&& p : dependencies)
+        {
             for (auto&& q : p.second)
+            {
                 specs.insert(q.spec());
+            }
+        }
         specs.erase(self);
         return {specs.begin(), specs.end()};
     }
@@ -441,7 +445,9 @@ namespace vcpkg
     {
         InternalFeatureSet ret;
         for (auto&& d : fdeps)
+        {
             ret.push_back(d.first);
+        }
         return ret;
     }
 
@@ -507,11 +513,17 @@ namespace vcpkg
     Version InstallPlanAction::version() const
     {
         if (auto scfl = source_control_file_and_location.get())
+        {
             return scfl->to_version();
+        }
         else if (auto ipv = installed_package.get())
+        {
             return ipv->version();
+        }
         else
+        {
             Checks::unreachable(VCPKG_LINE_INFO);
+        }
     }
 
     RemovePlanAction::RemovePlanAction(const PackageSpec& spec,

--- a/src/vcpkg/dependencies.cpp
+++ b/src/vcpkg/dependencies.cpp
@@ -451,7 +451,7 @@ namespace vcpkg
                                          Triplet host_triplet,
                                          std::map<std::string, std::vector<FeatureSpec>>&& dependencies,
                                          std::vector<LocalizedString>&& build_failure_messages)
-        : PackageAction{spec, fdeps_to_pdeps(spec, dependencies), fdeps_to_feature_list(dependencies)}
+        : PackageAction{{spec}, fdeps_to_pdeps(spec, dependencies), fdeps_to_feature_list(dependencies)}
         , source_control_file_and_location(scfl)
         , plan_type(InstallPlanType::BUILD_AND_INSTALL)
         , request_type(request_type)
@@ -463,7 +463,7 @@ namespace vcpkg
     }
 
     InstallPlanAction::InstallPlanAction(InstalledPackageView&& ipv, const RequestType& request_type)
-        : PackageAction{ipv.spec(), ipv.dependencies(), ipv.feature_list()}
+        : PackageAction{{ipv.spec()}, ipv.dependencies(), ipv.feature_list()}
         , installed_package(std::move(ipv))
         , plan_type(InstallPlanType::ALREADY_INSTALLED)
         , request_type(request_type)

--- a/src/vcpkg/export.cpp
+++ b/src/vcpkg/export.cpp
@@ -102,20 +102,20 @@ namespace vcpkg::Export
 
             std::vector<const ExportPlanAction*> cont = it->second;
             std::sort(cont.begin(), cont.end(), &ExportPlanAction::compare_by_name);
-            const std::string as_string = Strings::join("\n", cont, [](const ExportPlanAction* p) {
-                return to_output_string(p->request_type, p->spec.to_string());
-            });
+            LocalizedString msg;
+            if (plan_type == ExportPlanType::ALREADY_BUILT)
+                msg = msg::format(msgExportingAlreadyBuiltPackages);
+            else if (plan_type == ExportPlanType::NOT_BUILT)
+                msg = msg::format(msgPackagesToInstall);
+            else
+                Checks::unreachable(VCPKG_LINE_INFO);
 
-            switch (plan_type)
+            msg.append_raw('\n');
+            for (auto&& action : cont)
             {
-                case ExportPlanType::ALREADY_BUILT:
-                    msg::println(msg::format(msgExportingAlreadyBuiltPackages).append_raw("\n" + as_string));
-                    continue;
-                case ExportPlanType::NOT_BUILT:
-                    msg::println(msg::format(msgPackagesToInstall).append_raw("\n" + as_string));
-                    continue;
-                default: Checks::unreachable(VCPKG_LINE_INFO);
+                msg.append_raw(request_type_indent(action->request_type)).append_raw(action->spec).append_raw('\n');
             }
+            msg::print(msg);
         }
     }
 

--- a/src/vcpkg/export.cpp
+++ b/src/vcpkg/export.cpp
@@ -103,7 +103,7 @@ namespace vcpkg::Export
             std::vector<const ExportPlanAction*> cont = it->second;
             std::sort(cont.begin(), cont.end(), &ExportPlanAction::compare_by_name);
             const std::string as_string = Strings::join("\n", cont, [](const ExportPlanAction* p) {
-                return to_output_string(p->request_type, p->spec.to_string(), default_build_package_options);
+                return to_output_string(p->request_type, p->spec.to_string());
             });
 
             switch (plan_type)

--- a/src/vcpkg/packagespec.cpp
+++ b/src/vcpkg/packagespec.cpp
@@ -43,6 +43,8 @@ namespace vcpkg
         return fmt::format("{}[{}]", package_name, feature_name);
     }
 
+    bool InternalFeatureSet::empty_or_only_core() const { return empty() || (size() == 1 && *begin() == "core"); }
+
     InternalFeatureSet internalize_feature_list(View<std::string> fs, ImplicitDefault id)
     {
         InternalFeatureSet ret;

--- a/src/vcpkg/remove.cpp
+++ b/src/vcpkg/remove.cpp
@@ -117,11 +117,17 @@ namespace vcpkg::Remove
 
             LocalizedString msg;
             if (plan_type == RemovePlanType::NOT_INSTALLED)
+            {
                 msg = msg::format(msgFollowingPackagesNotInstalled).append_raw('\n');
+            }
             else if (plan_type == RemovePlanType::REMOVE)
+            {
                 msg = msg::format(msgPackagesToRemove).append_raw('\n');
+            }
             else
+            {
                 Checks::unreachable(VCPKG_LINE_INFO);
+            }
 
             std::vector<const RemovePlanAction*> cont = it->second;
             std::sort(cont.begin(), cont.end(), &RemovePlanAction::compare_by_name);

--- a/src/vcpkg/remove.cpp
+++ b/src/vcpkg/remove.cpp
@@ -115,22 +115,21 @@ namespace vcpkg::Remove
                 continue;
             }
 
+            LocalizedString msg;
+            if (plan_type == RemovePlanType::NOT_INSTALLED)
+                msg = msg::format(msgFollowingPackagesNotInstalled).append_raw('\n');
+            else if (plan_type == RemovePlanType::REMOVE)
+                msg = msg::format(msgPackagesToRemove).append_raw('\n');
+            else
+                Checks::unreachable(VCPKG_LINE_INFO);
+
             std::vector<const RemovePlanAction*> cont = it->second;
             std::sort(cont.begin(), cont.end(), &RemovePlanAction::compare_by_name);
-            const std::string as_string = Strings::join("\n", cont, [](const RemovePlanAction* p) {
-                return to_output_string(p->request_type, p->spec.to_string());
-            });
-
-            switch (plan_type)
+            for (auto p : cont)
             {
-                case RemovePlanType::NOT_INSTALLED:
-                    msg::println(msg::format(msgFollowingPackagesNotInstalled).append_raw(as_string));
-                    continue;
-                case RemovePlanType::REMOVE:
-                    msg::println(msg::format(msgPackagesToRemove).append_raw('\n').append_raw(as_string));
-                    continue;
-                default: Checks::unreachable(VCPKG_LINE_INFO);
+                msg.append_raw(request_type_indent(p->request_type)).append_raw(p->spec).append_raw('\n');
             }
+            msg::print(msg);
         }
     }
 

--- a/src/vcpkg/statusparagraph.cpp
+++ b/src/vcpkg/statusparagraph.cpp
@@ -96,6 +96,17 @@ namespace vcpkg
         return deps;
     }
 
+    InternalFeatureSet InstalledPackageView::feature_list() const
+    {
+        InternalFeatureSet ret;
+        ret.emplace_back("core");
+        for (const auto& f : features)
+        {
+            ret.emplace_back(f->package.feature);
+        }
+        return ret;
+    }
+
     std::vector<PackageSpec> InstalledPackageView::dependencies() const
     {
         // accumulate all features in installed dependencies

--- a/src/vcpkg/statusparagraph.cpp
+++ b/src/vcpkg/statusparagraph.cpp
@@ -106,6 +106,7 @@ namespace vcpkg
         }
         return ret;
     }
+    Version InstalledPackageView::version() const { return {core->package.version, core->package.port_version}; }
 
     std::vector<PackageSpec> InstalledPackageView::dependencies() const
     {


### PR DESCRIPTION
This PR is a reduced set of changes from https://github.com/microsoft/vcpkg-tool/pull/1022.

- Simplify `to_output_string()` implementations
- Extract `PackageAction`, which can be shared between `AlreadyInstalledAction` (future) and `InstallPlanAction`
- Extract `BasicAction`, which is shared amongst all action types. This alllows deduplication of `XYZAction::compare_by_name`.
- Remove default constructors from some action types (w/tweaking tests)