### PR TITLE
Expose vcpkglib's Threads dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,8 +396,8 @@ target_link_libraries(vcpkglib
     PUBLIC
         fmt::fmt
         cmakerc::locales
-    PRIVATE
         Threads::Threads
+    PRIVATE
         ${CPP_ATOMIC_LIBRARY}
 )
 


### PR DESCRIPTION
The vcpkglib target generates a precompiled header, which later during the build process is consumed by the vcpkg-target target.

However, vcpkglib is compiled with threading support, while vcpkg-test is not, causing the PCH being rejected.

Enforce multithreadened target mode to all vcpkglib consumers by marking its' Threads::Threads dependency public

Fixes: microsoft/vcpkg#30863