### PR TITLE
x-update-baseline should not make overlay-triplet paths absolute

### DIFF
--- a/azure-pipelines/end-to-end-tests-dir/overlays.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/overlays.ps1
@@ -35,9 +35,9 @@ $overlayTripletsBeforeUpdate = Get-Content "$manifestRoot/vcpkg-configuration.js
 Run-Vcpkg x-update-baseline --x-manifest-root=$manifestRoot
 $overlayTripletsAfterUpdate = Get-Content "$manifestRoot/vcpkg-configuration.json" | ConvertFrom-Json
 
-$sortedBeforeUpdate = ($overlayTripletsBeforeUpdate."overlay-triplets" | Sort-Object) -join ""
-$sortedAfterUpdate = ($overlayTripletsAfterUpdate."overlay-triplets" | Sort-Object) -join ""
+$pathsBeforeUpdate = $overlayTripletsBeforeUpdate."overlay-triplets" -join ""
+$pathsAfterUpdate = $overlayTripletsAfterUpdate."overlay-triplets"  -join ""
 
-if ($sortedBeforeUpdate -ne $sortedAfterUpdate) {
+if ($pathsBeforeUpdate -ne $pathsAfterUpdate) {
 	Throw "Overlay triplets paths changed after x-update-baseline"
 }

--- a/azure-pipelines/end-to-end-tests-dir/overlays.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/overlays.ps1
@@ -34,4 +34,10 @@ $manifestRoot = "$e2eProjects/overlays-project-with-config"
 $overlayTripletsBeforeUpdate = Get-Content "$manifestRoot/vcpkg-configuration.json" | ConvertFrom-Json
 Run-Vcpkg x-update-baseline --x-manifest-root=$manifestRoot
 $overlayTripletsAfterUpdate = Get-Content "$manifestRoot/vcpkg-configuration.json" | ConvertFrom-Json
-Throw-IfNotEqual $overlayTripletsBeforeUpdate."overlay-triplets" $overlayTripletsAfterUpdate."overlay-triplets"
+
+$sortedBeforeUpdate = ($overlayTripletsBeforeUpdate."overlay-triplets" | Sort-Object) -join ""
+$sortedAfterUpdate = ($overlayTripletsAfterUpdate."overlay-triplets" | Sort-Object) -join ""
+
+if ($sortedBeforeUpdate -ne $sortedAfterUpdate) {
+	Throw "Overlay triplets paths changed after x-update-baseline"
+}

--- a/azure-pipelines/end-to-end-tests-dir/overlays.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/overlays.ps1
@@ -31,13 +31,15 @@ Throw-IfNotFailed
 
 # Test overlay_triplet paths remain relative to the manifest root after x-update-baseline
 $manifestRoot = "$e2eProjects/overlays-project-with-config"
-$overlayTripletsBeforeUpdate = Get-Content "$manifestRoot/vcpkg-configuration.json" | ConvertFrom-Json
+$configurationBefore = Get-Content "$manifestRoot/vcpkg-configuration.json" | ConvertFrom-Json
 Run-Vcpkg x-update-baseline --x-manifest-root=$manifestRoot
-$overlayTripletsAfterUpdate = Get-Content "$manifestRoot/vcpkg-configuration.json" | ConvertFrom-Json
+$configurationAfter = Get-Content "$manifestRoot/vcpkg-configuration.json" | ConvertFrom-Json
 
-$pathsBeforeUpdate = $overlayTripletsBeforeUpdate."overlay-triplets" -join ""
-$pathsAfterUpdate = $overlayTripletsAfterUpdate."overlay-triplets"  -join ""
+$overlaysBefore = $configurationBefore."overlay-triplets"
+$overlaysAfter = $configurationAfter."overlay-triplets"
 
-if ($pathsBeforeUpdate -ne $pathsAfterUpdate) {
+$notEqual = @(Compare-Object $overlaysBefore $overlaysAfter -SyncWindow 0).Length -ne 0
+
+if ($notEqual) {
 	Throw "Overlay triplets paths changed after x-update-baseline"
 }

--- a/azure-pipelines/end-to-end-tests-dir/overlays.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/overlays.ps1
@@ -28,3 +28,10 @@ Run-Vcpkg install --x-manifest-root=$manifestRoot `
     --overlay-triplets=$manifestRoot/my-triplets `
     --x-install-root=$installRoot
 Throw-IfNotFailed
+
+# Test overlay_triplet paths remain relative to the manifest root after x-update-baseline
+$manifestRoot = "$e2eProjects/overlays-project-with-config"
+$overlayTripletsBeforeUpdate = Get-Content "$manifestRoot/vcpkg-configuration.json" | ConvertFrom-Json
+Run-Vcpkg x-update-baseline --x-manifest-root=$manifestRoot
+$overlayTripletsAfterUpdate = Get-Content "$manifestRoot/vcpkg-configuration.json" | ConvertFrom-Json
+Throw-IfNotEqual $overlayTripletsBeforeUpdate."overlay-triplets" $overlayTripletsAfterUpdate."overlay-triplets"

--- a/src/vcpkg/commands.update-baseline.cpp
+++ b/src/vcpkg/commands.update-baseline.cpp
@@ -64,6 +64,7 @@ namespace vcpkg::Commands
         const bool dry_run = Util::Sets::contains(options.switches, OPTION_DRY_RUN);
 
         auto configuration = paths.get_configuration();
+
         const bool has_manifest = paths.get_manifest().has_value();
         auto manifest = has_manifest ? *paths.get_manifest().get() : ManifestAndPath{};
 

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -662,17 +662,18 @@ namespace vcpkg
                 return (m_pimpl->m_config.directory / overlay_path).native();
             };
 
+            std::vector<std::string> overlay_triplet_paths;
+            std::vector<std::string> overlay_port_paths;
+
             if (!m_pimpl->m_config.directory.empty())
             {
                 auto& config = m_pimpl->m_config.config;
-                Util::transform(config.overlay_ports, resolve_relative_to_config);
-                Util::transform(config.overlay_triplets, resolve_relative_to_config);
+                overlay_triplet_paths = Util::fmap(config.overlay_triplets, resolve_relative_to_config);
+                overlay_port_paths = Util::fmap(config.overlay_ports, resolve_relative_to_config);
             }
 
-            overlay_ports =
-                merge_overlays(args.cli_overlay_ports, m_pimpl->m_config.config.overlay_ports, args.env_overlay_ports);
-            overlay_triplets = merge_overlays(
-                args.cli_overlay_triplets, m_pimpl->m_config.config.overlay_triplets, args.env_overlay_triplets);
+            overlay_ports = merge_overlays(args.cli_overlay_ports, overlay_port_paths, args.env_overlay_ports);
+            overlay_triplets = merge_overlays(args.cli_overlay_triplets, overlay_triplet_paths, args.env_overlay_triplets);
         }
 
         for (const std::string& triplet : this->overlay_triplets)

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -673,7 +673,8 @@ namespace vcpkg
             }
 
             overlay_ports = merge_overlays(args.cli_overlay_ports, overlay_port_paths, args.env_overlay_ports);
-            overlay_triplets = merge_overlays(args.cli_overlay_triplets, overlay_triplet_paths, args.env_overlay_triplets);
+            overlay_triplets =
+                merge_overlays(args.cli_overlay_triplets, overlay_triplet_paths, args.env_overlay_triplets);
         }
 
         for (const std::string& triplet : this->overlay_triplets)


### PR DESCRIPTION
This PR fixes a bug where the command `x-update-baseline` makes overlay-triplet paths absolute in vcpkg-configuration.json.


