### PR TITLE
'integrate install' needs to be run twice.

### DIFF
--- a/src/vcpkg/commands.integrate.cpp
+++ b/src/vcpkg/commands.integrate.cpp
@@ -312,8 +312,9 @@ namespace vcpkg::Commands::Integrate
                 default: Checks::unreachable(VCPKG_LINE_INFO);
             }
 
-            Checks::msg_exit_with_error(
-                VCPKG_LINE_INFO, msgSystemTargetsInstallFailed, msg::path = SYSTEM_WIDE_TARGETS_FILE);
+            Checks::msg_check_exit(VCPKG_LINE_INFO,
+                                   fs.exists(SYSTEM_WIDE_TARGETS_FILE, IgnoreErrors{}),
+                                   msgSystemTargetsInstallFailed, msg::path = SYSTEM_WIDE_TARGETS_FILE);
         }
     }
 #endif

--- a/src/vcpkg/commands.integrate.cpp
+++ b/src/vcpkg/commands.integrate.cpp
@@ -314,7 +314,8 @@ namespace vcpkg::Commands::Integrate
 
             Checks::msg_check_exit(VCPKG_LINE_INFO,
                                    fs.exists(SYSTEM_WIDE_TARGETS_FILE, IgnoreErrors{}),
-                                   msgSystemTargetsInstallFailed, msg::path = SYSTEM_WIDE_TARGETS_FILE);
+                                   msgSystemTargetsInstallFailed,
+                                   msg::path = SYSTEM_WIDE_TARGETS_FILE);
         }
     }
 #endif


### PR DESCRIPTION
When running for the first time (file _C:\Program Files (x86)\MSBuild\\...\vcpkg.system.props_ doesn't exist), the `integrate install` command must be executed twice.

```
> .\vcpkg.exe integrate install
failed to install system targets file to C:\Program Files (x86)\MSBuild/Microsoft.Cpp/v4.0/V140/ImportBefore/Default/vcpkg.system.props

> .\vcpkg.exe integrate install
Applied user-wide integration for this vcpkg root.
...
```

Yet _vcpkg.system.props_ was correctly installed on the first try. The error message is incorrect. This appears to be a regression caused by #937. The final exit check in  `integrate_install_msbuild14()` should be conditional.