### PR TITLE
Improve integrate install for non-admin users.

### DIFF
--- a/src/vcpkg/commands.integrate.cpp
+++ b/src/vcpkg/commands.integrate.cpp
@@ -327,14 +327,14 @@ namespace vcpkg::Commands::Integrate
         fs.write_contents(user_configuration_home / vcpkg_path_txt, paths.root.generic_u8string(), VCPKG_LINE_INFO);
 
 #if defined(_WIN32)
-        integrate_install_msbuild14(fs);
-
         fs.write_contents(user_configuration_home / vcpkg_user_props,
                           create_appdata_shortcut(paths.buildsystems_msbuild_props),
                           VCPKG_LINE_INFO);
         fs.write_contents(user_configuration_home / vcpkg_user_targets,
                           create_appdata_shortcut(paths.buildsystems_msbuild_targets),
                           VCPKG_LINE_INFO);
+
+        integrate_install_msbuild14(fs);
 #endif
         msg::println(Color::success, msgAppliedUserIntegration);
 


### PR DESCRIPTION
Change the order of operations in `integrate install`.

Currently, MSBuild14 is configured first. This can be a problem because MSBuild14 files are deployed under _C:\Program Files (x86)\MSBuild_. In many environments, this folder is not user-writable. In essence, this means that `integrate install` must be run with elevated privileges, otherwise the command is aborted almost immediately.

On the other hand, vcpkg integration for subsequent versions (MSBuild15+) only need access to `%LOCALAPPDATA%`, which is user-writable and likely to succeed.

With this change, `integrate install` still exits with an error for non-admin user, but at least results in a working integration for anyone targeting VS2017 and later.

Another approach would be to simply log failures in `integrate_install_msbuild14` as warnings and let the command continue.