### PR TITLE
Keep LocationAndRegistry an aggregate in c++20

### DIFF
--- a/src/vcpkg/configuration.cpp
+++ b/src/vcpkg/configuration.cpp
@@ -532,8 +532,6 @@ namespace
         {
             StringView location;
             StringView registry;
-
-            LocationAndRegistry() = default;
         };
 
         // handle warnings from package pattern declarations


### PR DESCRIPTION
Aggregates can no longer have user-declared constructors in C++20, but this type relies on aggregate initialization.