### PR TITLE
Add <numeric> to util.cpp for std::iota

### DIFF
--- a/src/vcpkg-test/util.cpp
+++ b/src/vcpkg-test/util.cpp
@@ -11,6 +11,7 @@
 
 #include <iostream>
 #include <memory>
+#include <numeric>
 #include <set>
 #include <vector>
 


### PR DESCRIPTION
Fix vcpkg issue: https://github.com/microsoft/vcpkg/issues/31454, add `include <numeric>` to `util.cpp` for `std::iota`.

```
vcpkg-test/util.cpp(278): error C2039: 'iota': is not a member of 'std'
vcpkg-test/util.cpp(278): error C3861: 'iota': identifier not found
```