### PR TITLE
Turn off autocrlf in format-manifest test.

### DIFF
--- a/azure-pipelines/end-to-end-tests-dir/format-manifest.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/format-manifest.ps1
@@ -21,7 +21,13 @@ $testProjects | % {
 Write-Trace "test re-serializing every manifest"
 $manifestDir = "$TestingRoot/manifest-dir"
 Copy-Item -Path "$env:VCPKG_ROOT/ports" -Destination $manifestDir -recurse -Force -Filter vcpkg.json
-& git init $manifestDir && git -C $manifestDir add . && git -C $manifestDir -c user.name='vcpkg-test' -c user.email='my@example.com' commit -m "baseline"
+git init $manifestDir
+Throw-IfFailed
+git -C $manifestDir config user.name='vcpkg-test' user.email='my@example.com' core.autocrlf=false
+Throw-IfFailed
+git -C $manifestDir add .
+Throw-IfFailed
+git -C $manifestDir commit -m "baseline"
 Throw-IfFailed
 Run-Vcpkg format-manifest --all --x-builtin-ports-root=$manifestDir/ports
 Throw-IfFailed

--- a/azure-pipelines/end-to-end-tests-dir/format-manifest.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/format-manifest.ps1
@@ -23,7 +23,11 @@ $manifestDir = "$TestingRoot/manifest-dir"
 Copy-Item -Path "$env:VCPKG_ROOT/ports" -Destination $manifestDir -recurse -Force -Filter vcpkg.json
 git init $manifestDir
 Throw-IfFailed
-git -C $manifestDir config user.name='vcpkg-test' user.email='my@example.com' core.autocrlf=false
+git -C $manifestDir config user.name vcpkg-test
+Throw-IfFailed
+git -C $manifestDir config user.email my@example.com
+Throw-IfFailed
+git -C $manifestDir config core.autocrlf false
 Throw-IfFailed
 git -C $manifestDir add .
 Throw-IfFailed


### PR DESCRIPTION
Resolves output like

```
2023-05-18T00:52:19.4251966Z warning: in the working copy of '3fd/vcpkg.json', LF will be replaced by CRLF the next time Git touches it
2023-05-18T00:52:19.4372050Z warning: in the working copy of '7zip/vcpkg.json', LF will be replaced by CRLF the next time Git touches it
2023-05-18T00:52:19.4386085Z warning: in the working copy of 'ableton-link/vcpkg.json', LF will be replaced by CRLF the next time Git touches it
2023-05-18T00:52:19.4398373Z warning: in the working copy of 'ableton/vcpkg.json', LF will be replaced by CRLF the next time Git touches it
2023-05-18T00:52:19.4410932Z warning: in the working copy of 'abseil/vcpkg.json', LF will be replaced by CRLF the next time Git touches it
2023-05-18T00:52:19.4422736Z warning: in the working copy of 'absent/vcpkg.json', LF will be replaced by CRLF the next time Git touches it
```

in Actions output. Example: https://github.com/microsoft/vcpkg-tool/actions/runs/5008981073/jobs/8977401326