### PR TITLE
Installation from packages to installed: Hard link files instead of copy

### DIFF
--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -2979,7 +2979,7 @@ namespace vcpkg
 #if defined(_WIN32)
             stdfs::create_hard_link(to_stdfs_path(to), to_stdfs_path(from), ec);
 #else  // ^^^ _WIN32 // !_WIN32 vvv
-            if (::link(from.c_str(), to.c_str()) == 0)
+            if (::link(to.c_str(), from.c_str()) == 0)
             {
                 ec.clear();
             }

--- a/src/vcpkg/commands.install.cpp
+++ b/src/vcpkg/commands.install.cpp
@@ -124,7 +124,7 @@ namespace vcpkg
                         {
                             Debug::println("Install from packages to installed: Fallback to copy "
                                            "instead creating hard links because of: ",
-                                           ec);
+                                           ec.message());
                             use_hard_link = false;
                         }
                     }

--- a/src/vcpkg/commands.install.cpp
+++ b/src/vcpkg/commands.install.cpp
@@ -93,6 +93,7 @@ namespace vcpkg
             const auto suffix = file.generic_u8string().substr(prefix_length + 1);
             const auto target = destination / suffix;
 
+            bool use_hard_link = true;
             auto this_output = Strings::concat(destination_subdirectory, "/", suffix);
             switch (status)
             {
@@ -116,7 +117,6 @@ namespace vcpkg
                         msg::println_warning(msgOverwritingFile, msg::path = target);
                         fs.remove_all(target, IgnoreErrors{});
                     }
-                    static bool use_hard_link = true;
                     if (use_hard_link)
                     {
                         fs.create_hard_link(file, target, ec);

--- a/src/vcpkg/commands.install.cpp
+++ b/src/vcpkg/commands.install.cpp
@@ -122,6 +122,9 @@ namespace vcpkg
                         fs.create_hard_link(file, target, ec);
                         if (ec)
                         {
+                            Debug::println("Install from packages to installed: Fallback to copy "
+                                           "instead creating hard links because of: ",
+                                           ec);
                             use_hard_link = false;
                         }
                     }

--- a/src/vcpkg/commands.install.cpp
+++ b/src/vcpkg/commands.install.cpp
@@ -114,9 +114,22 @@ namespace vcpkg
                     if (fs.exists(target, IgnoreErrors{}))
                     {
                         msg::println_warning(msgOverwritingFile, msg::path = target);
+                        fs.remove_all(target, IgnoreErrors{});
+                    }
+                    static bool use_hard_link = true;
+                    if (use_hard_link)
+                    {
+                        fs.create_hard_link(file, target, ec);
+                        if (ec)
+                        {
+                            use_hard_link = false;
+                        }
+                    }
+                    if (!use_hard_link)
+                    {
+                        fs.copy_file(file, target, CopyOptions::overwrite_existing, ec);
                     }
 
-                    fs.copy_file(file, target, CopyOptions::overwrite_existing, ec);
                     if (ec)
                     {
                         msg::println_error(msgInstallFailed, msg::path = target, msg::error_msg = ec.message());


### PR DESCRIPTION
Current situation: 
If a package gets installed, all files are copied from the packages folder to the installed dir. 

Current problem: 
Duplicating files consumes a lot of unnecessary disk space. It also results in unnecessary read and write operations on the hard disk.

Solution:
Instead of copying the file, create a hard link. If a hard link is not possible (for example if the two folders are on different disks), copy the file. 

Concerns:
If a file on windows is opened without the `FILE_SHARE_DELETE` flag, a file is an executable that is executed or a loaded dll, the file can not be deleted even it would only reduce the hard link count by 1 without deleting the file finally. If this would be the case for a file in the installed dir vcpkg could not delete the packages folder and build new packages. 
=> This is not a problem because if a package A gets build, it must be uninstalled first. So vcpkg would then fail to uninstall package A, which is already the current behavior. 