### PR TITLE
Fix binary caching for 'upgrade'd packages

### DIFF
--- a/include/vcpkg/commands.install.h
+++ b/include/vcpkg/commands.install.h
@@ -92,6 +92,8 @@ namespace vcpkg
                                      const Filesystem& fs,
                                      const InstalledPaths& installed);
 
+        void preclear_packages(const VcpkgPaths& paths, const ActionPlan& action_plan);
+
         InstallSummary execute_plan(const VcpkgCmdArguments& args,
                                     const ActionPlan& action_plan,
                                     const KeepGoing keep_going,

--- a/src/vcpkg/commands.ci.cpp
+++ b/src/vcpkg/commands.ci.cpp
@@ -514,6 +514,7 @@ namespace vcpkg::Commands::CI
             {
                 msg::println_warning(msgCISkipInstallation, msg::list = Strings::join(", ", already_installed));
             }
+            Install::preclear_packages(paths, action_plan);
             binary_cache.fetch(action_plan.install_actions);
             auto summary = Install::execute_plan(
                 args, action_plan, KeepGoing::YES, paths, status_db, binary_cache, build_logs_recorder);

--- a/src/vcpkg/commands.install.cpp
+++ b/src/vcpkg/commands.install.cpp
@@ -285,7 +285,7 @@ namespace vcpkg
         const InstallDir install_dir =
             InstallDir::from_destination_root(paths.installed(), triplet, bcf.core_paragraph);
 
-        install_package_and_write_listfile(fs, paths.package_dir(bcf.core_paragraph.spec), install_dir);
+        install_package_and_write_listfile(fs, package_dir, install_dir);
 
         source_paragraph.state = InstallState::INSTALLED;
         write_update(fs, installed, source_paragraph);
@@ -524,7 +524,7 @@ namespace vcpkg
 
         for (auto&& action : action_plan.install_actions)
         {
-            fs.remove_all(paths.package_dir(action.spec), VCPKG_LINE_INFO);
+            fs.remove_all(action.package_dir.value_or_exit(VCPKG_LINE_INFO), VCPKG_LINE_INFO);
         }
     }
 

--- a/src/vcpkg/commands.remove.cpp
+++ b/src/vcpkg/commands.remove.cpp
@@ -288,7 +288,7 @@ namespace vcpkg::Remove
         {
             for (auto&& action : plan.not_installed)
             {
-                fs.remove_all(paths.packages() / action.spec.dir(), VCPKG_LINE_INFO);
+                fs.remove_all(paths.package_dir(action.spec), VCPKG_LINE_INFO);
             }
         }
 
@@ -302,7 +302,7 @@ namespace vcpkg::Remove
             remove_package(fs, paths.installed(), action.spec, status_db);
             if (purge == Purge::YES)
             {
-                fs.remove_all(paths.packages() / action.spec.dir(), VCPKG_LINE_INFO);
+                fs.remove_all(paths.package_dir(action.spec), VCPKG_LINE_INFO);
             }
         }
 

--- a/src/vcpkg/commands.set-installed.cpp
+++ b/src/vcpkg/commands.set-installed.cpp
@@ -131,6 +131,7 @@ namespace vcpkg::Commands::SetInstalled
         paths.flush_lockfile();
 
         track_install_plan(action_plan);
+        Install::preclear_packages(paths, action_plan);
 
         auto binary_cache = only_downloads ? BinaryCache(paths.get_filesystem())
                                            : BinaryCache::make(args, paths, stdout_sink).value_or_exit(VCPKG_LINE_INFO);

--- a/src/vcpkg/postbuildlint.cpp
+++ b/src/vcpkg/postbuildlint.cpp
@@ -354,7 +354,7 @@ namespace vcpkg
                                                const VcpkgPaths& paths,
                                                MessageSink& msg_sink)
     {
-        const auto packages_dir = paths.packages() / spec.dir();
+        const auto packages_dir = paths.package_dir(spec);
         const auto copyright_file = packages_dir / "share" / spec.name() / "copyright";
 
         switch (fs.status(copyright_file, IgnoreErrors{}))


### PR DESCRIPTION
@autoantwort reports in https://github.com/microsoft/vcpkg-tool/pull/1057/files#r1210842149 that we fail to account for upgraded packages in the new binary caching strategy because we blow away the extracted bits on the remove package action.

```
PS C:\Dev\vcpkg> .\vcpkg x-set-installed 'sqlite3' && .\vcpkg x-set-installed 'sqlite3[dbstat]'
warning: Starting with the September 2023 release, the default triplet for vcpkg libraries will change from x86-windows to the detected host triplet (x64-windows). To resolve this message, add --triplet x86-windows to keep the same behavior.
Detecting compiler hash for triplet x64-windows...
Detecting compiler hash for triplet x86-windows...
The following packages will be removed:
    boost-array:x64-windows
    boost-assert:x64-windows
    boost-bind:x64-windows
    boost-concept-check:x64-windows
    boost-config:x64-windows
    boost-core:x64-windows
    boost-preprocessor:x64-windows
    boost-static-assert:x64-windows
    boost-throw-exception:x64-windows
    boost-type-traits:x64-windows
    boost-uninstall:x64-windows
    boost-vcpkg-helpers:x64-windows
The following packages will be built and installed:
    sqlite3:x86-windows -> 3.40.1#3
  * vcpkg-cmake:x64-windows -> 2023-05-04
  * vcpkg-cmake-config:x64-windows -> 2022-02-06#1
Additional packages (*) will be modified to complete this operation.
Restored 0 package(s) from C:\Users\bion\AppData\Local\vcpkg\archives in 768 us. Use --debug to see more details.
Removing 1/15 boost-concept-check:x64-windows
Elapsed time to handle boost-concept-check:x64-windows: 8.31 ms
Removing 2/15 boost-type-traits:x64-windows
Elapsed time to handle boost-type-traits:x64-windows: 30.8 ms
Removing 3/15 boost-preprocessor:x64-windows
Elapsed time to handle boost-preprocessor:x64-windows: 48.2 ms
Removing 4/15 boost-bind:x64-windows
Elapsed time to handle boost-bind:x64-windows: 4.85 ms
Removing 5/15 boost-array:x64-windows
Elapsed time to handle boost-array:x64-windows: 2.78 ms
Removing 6/15 boost-core:x64-windows
Elapsed time to handle boost-core:x64-windows: 9.83 ms
Removing 7/15 boost-throw-exception:x64-windows
Elapsed time to handle boost-throw-exception:x64-windows: 3.23 ms
Removing 8/15 boost-static-assert:x64-windows
Elapsed time to handle boost-static-assert:x64-windows: 3.41 ms
Removing 9/15 boost-assert:x64-windows
Elapsed time to handle boost-assert:x64-windows: 3.53 ms
Removing 10/15 boost-config:x64-windows
Elapsed time to handle boost-config:x64-windows: 63.8 ms
Removing 11/15 boost-vcpkg-helpers:x64-windows
Elapsed time to handle boost-vcpkg-helpers:x64-windows: 3.05 ms
Removing 12/15 boost-uninstall:x64-windows
Elapsed time to handle boost-uninstall:x64-windows: 2.54 ms
Installing 13/15 vcpkg-cmake:x64-windows...
Building vcpkg-cmake:x64-windows...
-- Installing: C:/Dev/vcpkg/packages/vcpkg-cmake_x64-windows/share/vcpkg-cmake/vcpkg_cmake_configure.cmake
-- Installing: C:/Dev/vcpkg/packages/vcpkg-cmake_x64-windows/share/vcpkg-cmake/vcpkg_cmake_build.cmake
-- Installing: C:/Dev/vcpkg/packages/vcpkg-cmake_x64-windows/share/vcpkg-cmake/vcpkg_cmake_install.cmake
-- Installing: C:/Dev/vcpkg/packages/vcpkg-cmake_x64-windows/share/vcpkg-cmake/vcpkg-port-config.cmake
-- Installing: C:/Dev/vcpkg/packages/vcpkg-cmake_x64-windows/share/vcpkg-cmake/copyright
-- Performing post-build validation
Stored binaries in 1 destinations in 37 ms.
Elapsed time to handle vcpkg-cmake:x64-windows: 104 ms
Installing 14/15 vcpkg-cmake-config:x64-windows...
Building vcpkg-cmake-config:x64-windows...
-- Installing: C:/Dev/vcpkg/packages/vcpkg-cmake-config_x64-windows/share/vcpkg-cmake-config/vcpkg_cmake_config_fixup.cmake
-- Installing: C:/Dev/vcpkg/packages/vcpkg-cmake-config_x64-windows/share/vcpkg-cmake-config/vcpkg-port-config.cmake
-- Installing: C:/Dev/vcpkg/packages/vcpkg-cmake-config_x64-windows/share/vcpkg-cmake-config/copyright
-- Performing post-build validation
Stored binaries in 1 destinations in 29.6 ms.
Elapsed time to handle vcpkg-cmake-config:x64-windows: 86.5 ms
Installing 15/15 sqlite3:x86-windows...
Building sqlite3:x86-windows...
-- Using cached sqlite-amalgamation-3400100.zip.
-- Extracting source C:/Dev/vcpkg-downloads/sqlite-amalgamation-3400100.zip
-- Applying patch fix-arm-uwp.patch
-- Applying patch add-config-include.patch
-- Using source at C:/Dev/vcpkg/buildtrees/sqlite3/src/on-3400100-8430f9f010.clean
-- Configuring x86-windows
-- Building x86-windows-dbg
-- Building x86-windows-rel
-- Fixing pkgconfig file: C:/Dev/vcpkg/packages/sqlite3_x86-windows/lib/pkgconfig/sqlite3.pc
-- Downloading https://mirror.msys2.org/mingw/i686/mingw-w64-i686-pkg-config-0.29.2-3-any.pkg.tar.zst;https://repo.msys2.org/mingw/i686/mingw-w64-i686-pkg-config-0.29.2-3-any.pkg.tar.zst;https://repo.msys2.org/mingw/i686/mingw-w64-i686-pkg-config-0.29.2-3-any.pkg.tar.zst;https://repo.msys2.org/mingw/i686/mingw-w64-i686-pkg-config-0.29.2-3-any.pkg.tar.zst;https://repo.msys2.org/mingw/i686/mingw-w64-i686-pkg-config-0.29.2-3-any.pkg.tar.zst;https://repo.msys2.org/mingw/i686/mingw-w64-i686-pkg-config-0.29.2-3-any.pkg.tar.zst -> mingw-w64-i686-pkg-config-0.29.2-3-any.pkg.tar.zst...
-- Downloading https://mirror.msys2.org/mingw/i686/mingw-w64-i686-libwinpthread-git-9.0.0.6373.5be8fcd83-1-any.pkg.tar.zst;https://repo.msys2.org/mingw/i686/mingw-w64-i686-libwinpthread-git-9.0.0.6373.5be8fcd83-1-any.pkg.tar.zst;https://repo.msys2.org/mingw/i686/mingw-w64-i686-libwinpthread-git-9.0.0.6373.5be8fcd83-1-any.pkg.tar.zst;https://repo.msys2.org/mingw/i686/mingw-w64-i686-libwinpthread-git-9.0.0.6373.5be8fcd83-1-any.pkg.tar.zst;https://repo.msys2.org/mingw/i686/mingw-w64-i686-libwinpthread-git-9.0.0.6373.5be8fcd83-1-any.pkg.tar.zst;https://repo.msys2.org/mingw/i686/mingw-w64-i686-libwinpthread-git-9.0.0.6373.5be8fcd83-1-any.pkg.tar.zst -> mingw-w64-i686-libwinpthread-git-9.0.0.6373.5be8fcd83-1-any.pkg.tar.zst...
-- Downloading https://mirror.msys2.org/msys/x86_64/msys2-runtime-3.4.6-1-x86_64.pkg.tar.zst;https://repo.msys2.org/msys/x86_64/msys2-runtime-3.4.6-1-x86_64.pkg.tar.zst;https://mirror.yandex.ru/mirrors/msys2/msys/x86_64/msys2-runtime-3.4.6-1-x86_64.pkg.tar.zst;https://mirrors.tuna.tsinghua.edu.cn/msys2/msys/x86_64/msys2-runtime-3.4.6-1-x86_64.pkg.tar.zst;https://mirrors.ustc.edu.cn/msys2/msys/x86_64/msys2-runtime-3.4.6-1-x86_64.pkg.tar.zst;https://mirror.selfnet.de/msys2/msys/x86_64/msys2-runtime-3.4.6-1-x86_64.pkg.tar.zst -> msys2-msys2-runtime-3.4.6-1-x86_64.pkg.tar.zst...
-- Using msys root at C:/Dev/vcpkg-downloads/tools/msys2/5b9374e6ec2c4e17
-- Fixing pkgconfig file: C:/Dev/vcpkg/packages/sqlite3_x86-windows/debug/lib/pkgconfig/sqlite3.pc
-- Installing: C:/Dev/vcpkg/packages/sqlite3_x86-windows/share/sqlite3/usage
-- Performing post-build validation
Stored binaries in 1 destinations in 358 ms.
Elapsed time to handle sqlite3:x86-windows: 14 s
Total install time: 14 s
sqlite3 provides pkgconfig bindings.
sqlite3 provides CMake targets:

    find_package(unofficial-sqlite3 CONFIG REQUIRED)
    target_link_libraries(main PRIVATE unofficial::sqlite3::sqlite3)

warning: Starting with the September 2023 release, the default triplet for vcpkg libraries will change from x86-windows to the detected host triplet (x64-windows). To resolve this message, add --triplet x86-windows to keep the same behavior.
Detecting compiler hash for triplet x64-windows...
Detecting compiler hash for triplet x86-windows...
The following packages will be rebuilt:
    sqlite3[core,dbstat]:x86-windows -> 3.40.1#3
Restored 0 package(s) from C:\Users\bion\AppData\Local\vcpkg\archives in 78.9 us. Use --debug to see more details.
Removing 1/2 sqlite3:x86-windows
Elapsed time to handle sqlite3:x86-windows: 9.11 ms
Installing 2/2 sqlite3:x86-windows...
Building sqlite3[core,dbstat]:x86-windows...
-- Using cached sqlite-amalgamation-3400100.zip.
-- Extracting source C:/Dev/vcpkg-downloads/sqlite-amalgamation-3400100.zip
-- Applying patch fix-arm-uwp.patch
-- Applying patch add-config-include.patch
-- Using source at C:/Dev/vcpkg/buildtrees/sqlite3/src/on-3400100-8430f9f010.clean
-- Configuring x86-windows
-- Building x86-windows-dbg
-- Building x86-windows-rel
-- Fixing pkgconfig file: C:/Dev/vcpkg/packages/sqlite3_x86-windows/lib/pkgconfig/sqlite3.pc
-- Using cached mingw-w64-i686-pkg-config-0.29.2-3-any.pkg.tar.zst.
-- Using cached mingw-w64-i686-libwinpthread-git-9.0.0.6373.5be8fcd83-1-any.pkg.tar.zst.
-- Using cached msys2-msys2-runtime-3.4.6-1-x86_64.pkg.tar.zst.
-- Using msys root at C:/Dev/vcpkg-downloads/tools/msys2/5b9374e6ec2c4e17
-- Fixing pkgconfig file: C:/Dev/vcpkg/packages/sqlite3_x86-windows/debug/lib/pkgconfig/sqlite3.pc
-- Installing: C:/Dev/vcpkg/packages/sqlite3_x86-windows/share/sqlite3/usage
-- Performing post-build validation
Stored binaries in 1 destinations in 438 ms.
Elapsed time to handle sqlite3:x86-windows: 7.8 s
Total install time: 7.8 s
sqlite3 provides pkgconfig bindings.
sqlite3 provides CMake targets:

    find_package(unofficial-sqlite3 CONFIG REQUIRED)
    target_link_libraries(main PRIVATE unofficial::sqlite3::sqlite3)

PS C:\Dev\vcpkg> .\vcpkg x-set-installed 'sqlite3' && .\vcpkg x-set-installed 'sqlite3[dbstat]'
warning: Starting with the September 2023 release, the default triplet for vcpkg libraries will change from x86-windows to the detected host triplet (x64-windows). To resolve this message, add --triplet x86-windows to keep the same behavior.
Detecting compiler hash for triplet x64-windows...
Detecting compiler hash for triplet x86-windows...
The following packages will be rebuilt:
    sqlite3:x86-windows -> 3.40.1#3
Restored 1 package(s) from C:\Users\bion\AppData\Local\vcpkg\archives in 90.5 ms. Use --debug to see more details.
Removing 1/2 sqlite3:x86-windows
Elapsed time to handle sqlite3:x86-windows: 20 ms
Installing 2/2 sqlite3:x86-windows...
no such file or directory
PS C:\Dev\vcpkg>
```