### PR TITLE
Fix typo in CMakePresets.json

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -148,7 +148,7 @@
             "vendor": {
                 "microsoft.com/VisualStudioSettings/CMake/1.0": {
                     "hostOS": [
-                        "MacOS"
+                        "macOS"
                     ]
                 }
             }


### PR DESCRIPTION
There is a typo in macos-ci preset. the hostOs should be one of `macOS`, `Windows`, `Linux`. But the original CMakePresets.json turns out to be `MacOS`, which should be `macOS`. This fixes CMakePresets.json validation.

On vscode a error message turns out:
```
[presetController] Unsupported presets detected in ***/vcpkg-tool/CMakePresets.json. Support is limited to features defined by version 4.
[presetController]  >> /configurePresets/16/vendor/microsoft.com~1VisualStudioSettings~1CMake~11.0/hostOS: should be equal to one of the allowed values
[presetController]  >> /configurePresets/16/vendor/microsoft.com~1VisualStudioSettings~1CMake~11.0/hostOS: should be array
[presetController]  >> /configurePresets/16/vendor/microsoft.com~1VisualStudioSettings~1CMake~11.0/hostOS: should match some schema in anyOf
[presetController] Unknown properties and macros can be ignored by using the 'cmake.allowUnsupportedPresetsVersions' setting.
```

After fixing this typo, the error is solved.

See also [CMakePresets.json and CMakeUserPresets.json Microsoft vendor maps](https://learn.microsoft.com/en-us/cpp/build/cmake-presets-json-reference?view=msvc-170)