### PR TITLE
Telemetry: defend against parent process loops

### DIFF
--- a/include/vcpkg/base/system.process.h
+++ b/include/vcpkg/base/system.process.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <vcpkg/base/fwd/files.h>
 #include <vcpkg/base/fwd/optional.h>
 #include <vcpkg/base/fwd/system.process.h>
-#include <vcpkg/base/fwd/files.h>
 
 #include <vcpkg/base/expected.h>
 #include <vcpkg/base/path.h>

--- a/include/vcpkg/base/system.process.h
+++ b/include/vcpkg/base/system.process.h
@@ -2,6 +2,7 @@
 
 #include <vcpkg/base/fwd/optional.h>
 #include <vcpkg/base/fwd/system.process.h>
+#include <vcpkg/base/fwd/files.h>
 
 #include <vcpkg/base/expected.h>
 #include <vcpkg/base/path.h>
@@ -167,7 +168,7 @@ namespace vcpkg
         std::string executable_name;
     };
 
-    Optional<ProcessStat> try_parse_process_stat_file(StringView text, StringView origin);
+    Optional<ProcessStat> try_parse_process_stat_file(const FileContents& contents);
     void get_parent_process_list(std::vector<std::string>& ret);
 
     bool succeeded(const ExpectedL<int>& maybe_exit) noexcept;

--- a/src/vcpkg-test/cgroup-parser.cpp
+++ b/src/vcpkg-test/cgroup-parser.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch.hpp>
 
+#include <vcpkg/base/files.h>
 #include <vcpkg/base/optional.h>
 #include <vcpkg/base/stringview.h>
 #include <vcpkg/base/system.process.h>
@@ -74,7 +75,7 @@ TEST_CASE ("parse proc/pid/stat file", "[cgroup-parser]")
         std::string contents =
             R"(4281 (cpptools-srv) S 4099 1676 1676 0 -1 1077936384 51165 303 472 0 81 25 0 0 20 0 10 0 829158 4924583936 39830 18446744073709551615 4194304 14147733 140725993620736 0 0 0 0 16781312 16386 0 0 0 17 1 0 0 5 0 0 16247120 16519160 29999104 140725993622792 140725993622920 140725993622920 140725993627556 0)";
 
-        auto maybe_stat = try_parse_process_stat_file(contents, "test");
+        auto maybe_stat = try_parse_process_stat_file({contents, "test"});
         REQUIRE(maybe_stat.has_value());
         auto stat = maybe_stat.value_or_exit(VCPKG_LINE_INFO);
         CHECK(stat.ppid == 4099);
@@ -86,7 +87,7 @@ TEST_CASE ("parse proc/pid/stat file", "[cgroup-parser]")
         std::string contents =
             R"(4281 () S 4099 1676 1676 0 -1 1077936384 51165 303 472 0 81 25 0 0 20 0 10 0 829158 4924583936 39830 18446744073709551615 4194304 14147733 140725993620736 0 0 0 0 16781312 16386 0 0 0 17 1 0 0 5 0 0 16247120 16519160 29999104 140725993622792 140725993622920 140725993622920 140725993627556 0)";
 
-        auto maybe_stat = try_parse_process_stat_file(contents, "test");
+        auto maybe_stat = try_parse_process_stat_file({contents, "test"});
         REQUIRE(maybe_stat.has_value());
         auto stat = maybe_stat.value_or_exit(VCPKG_LINE_INFO);
         CHECK(stat.ppid == 4099);
@@ -98,7 +99,7 @@ TEST_CASE ("parse proc/pid/stat file", "[cgroup-parser]")
         std::string contents =
             R"(4281 (<(' '<)(> ' ')>) S 4099 1676 1676 0 -1 1077936384 51165 303 472 0 81 25 0 0 20 0 10 0 829158 4924583936 39830 18446744073709551615 4194304 14147733 140725993620736 0 0 0 0 16781312 16386 0 0 0 17 1 0 0 5 0 0 16247120 16519160 29999104 140725993622792 140725993622920 140725993622920 140725993627556 0)";
 
-        auto maybe_stat = try_parse_process_stat_file(contents, "test");
+        auto maybe_stat = try_parse_process_stat_file({contents, "test"});
         REQUIRE(maybe_stat.has_value());
         auto stat = maybe_stat.value_or_exit(VCPKG_LINE_INFO);
         CHECK(stat.ppid == 4099);
@@ -110,7 +111,7 @@ TEST_CASE ("parse proc/pid/stat file", "[cgroup-parser]")
         std::string contents =
             R"(4281 (0123456789abcdef) S 4099 1676 1676 0 -1 1077936384 51165 303 472 0 81 25 0 0 20 0 10 0 829158 4924583936 39830 18446744073709551615 4194304 14147733 140725993620736 0 0 0 0 16781312 16386 0 0 0 17 1 0 0 5 0 0 16247120 16519160 29999104 140725993622792 140725993622920 140725993622920 140725993627556 0)";
 
-        auto maybe_stat = try_parse_process_stat_file(contents, "test");
+        auto maybe_stat = try_parse_process_stat_file({contents, "test"});
         REQUIRE(maybe_stat.has_value());
         auto stat = maybe_stat.value_or_exit(VCPKG_LINE_INFO);
         CHECK(stat.ppid == 4099);
@@ -122,7 +123,7 @@ TEST_CASE ("parse proc/pid/stat file", "[cgroup-parser]")
         std::string contents =
             R"(4281 (()()()()()()()()) S 4099 1676 1676 0 -1 1077936384 51165 303 472 0 81 25 0 0 20 0 10 0 829158 4924583936 39830 18446744073709551615 4194304 14147733 140725993620736 0 0 0 0 16781312 16386 0 0 0 17 1 0 0 5 0 0 16247120 16519160 29999104 140725993622792 140725993622920 140725993622920 140725993627556 0)";
 
-        auto maybe_stat = try_parse_process_stat_file(contents, "test");
+        auto maybe_stat = try_parse_process_stat_file({contents, "test"});
         REQUIRE(maybe_stat.has_value());
         auto stat = maybe_stat.value_or_exit(VCPKG_LINE_INFO);
         CHECK(stat.ppid == 4099);
@@ -134,7 +135,7 @@ TEST_CASE ("parse proc/pid/stat file", "[cgroup-parser]")
         std::string contents =
             R"(4281 (0123456789abcdefg) S 4099 1676 1676 0 -1 1077936384 51165 303 472 0 81 25 0 0 20 0 10 0 829158 4924583936 39830 18446744073709551615 4194304 14147733 140725993620736 0 0 0 0 16781312 16386 0 0 0 17 1 0 0 5 0 0 16247120 16519160 29999104 140725993622792 140725993622920 140725993622920 140725993627556 0)";
 
-        auto maybe_stat = try_parse_process_stat_file(contents, "test");
+        auto maybe_stat = try_parse_process_stat_file({contents, "test"});
         REQUIRE(!maybe_stat.has_value());
     }
 }

--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -296,7 +296,8 @@ namespace vcpkg
     }
 } // namespace vcpkg
 
-namespace {
+namespace
+{
 #if defined(_WIN32)
     struct ToolHelpProcessSnapshot
     {
@@ -314,14 +315,17 @@ namespace {
 
         BOOL Process32First(PPROCESSENTRY32W entry) const noexcept { return Process32FirstW(snapshot, entry); }
         BOOL Process32Next(PPROCESSENTRY32W entry) const noexcept { return Process32NextW(snapshot, entry); }
+
     private:
         HANDLE snapshot;
     };
 #elif defined(__linux__)
-    Optional<ProcessStat> try_get_process_stat_by_pid(int pid) {
+    Optional<ProcessStat> try_get_process_stat_by_pid(int pid)
+    {
         auto filepath = fmt::format("/proc/{}/stat", pid);
         auto maybe_contents = real_filesystem.try_read_contents(filepath);
-        if (auto contents = maybe_contents.get()) {
+        if (auto contents = maybe_contents.get())
+        {
             return try_parse_process_stat_file(*contents);
         }
 
@@ -330,7 +334,8 @@ namespace {
 #endif // ^^^ __linux__
 } // unnamed namespace
 
-namespace vcpkg {
+namespace vcpkg
+{
     void get_parent_process_list(std::vector<std::string>& ret)
     {
         ret.clear();
@@ -360,7 +365,7 @@ namespace vcpkg {
         } // destroy snapshot
 
         // Find hierarchy of current process
-        
+
         for (DWORD next_parent = GetCurrentProcessId();;)
         {
             if (Util::Sets::contains(seen_pids, next_parent))
@@ -382,9 +387,12 @@ namespace vcpkg {
 #elif defined(__linux__)
         std::set<int> seen_pids;
         auto maybe_vcpkg_stat = try_get_process_stat_by_pid(getpid());
-        if (auto vcpkg_stat = maybe_vcpkg_stat.get()) {
-            for (auto next_parent = vcpkg_stat->ppid; next_parent != 0;) {
-                if (Util::Sets::contains(seen_pids, next_parent)) {
+        if (auto vcpkg_stat = maybe_vcpkg_stat.get())
+        {
+            for (auto next_parent = vcpkg_stat->ppid; next_parent != 0;)
+            {
+                if (Util::Sets::contains(seen_pids, next_parent))
+                {
                     // parent graph loops, for example if a parent terminates and the PID is reused by a child launch
                     break;
                 }
@@ -395,7 +403,9 @@ namespace vcpkg {
                 {
                     ret.push_back(next_parent_stat->executable_name);
                     next_parent = next_parent_stat->ppid;
-                } else {
+                }
+                else
+                {
                     break;
                 }
             }


### PR DESCRIPTION
This is psychic debugging as to why we occasionally have OOM recently. Example: https://github.com/microsoft/vcpkg/pull/31770/checks?check_run_id=14302512642