### PR TITLE
Simplify CMake Android detection.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -407,12 +407,9 @@ elseif(NOT MSVC)
     target_compile_options(vcpkglib PRIVATE -include "${CMAKE_CURRENT_SOURCE_DIR}/include/pch.h")
 endif()
 
-if(ANDROID)
-    if((CMAKE_SYSTEM_NAME STREQUAL "Android" AND CMAKE_SYSTEM_VERSION LESS "28") 
-       OR CMAKE_SYSTEM_NAME STREQUAL "Linux")
-        # pkg install libandroid-spawn
-        target_link_libraries(vcpkglib PRIVATE android-spawn)
-    endif()
+if(ANDROID AND CMAKE_SYSTEM_VERSION LESS "28")
+    # pkg install libandroid-spawn
+    target_link_libraries(vcpkglib PRIVATE android-spawn)
 endif()
 
 if(MINGW)


### PR DESCRIPTION
Hi, sorry to bother again. This is just a minor issue, but
`if(ANDROID)` is equal to `if(CMAKE_SYSTEM_NAME STREQUAL "Android")`
https://cmake.org/cmake/help/v3.26/variable/ANDROID.html

and `CMAKE_SYSTEM_NAME STREQUAL "Linux"` is unnecessary.
