### PR TITLE
Use git read-tree rather than git archive + untar to extract trees.

### DIFF
--- a/include/vcpkg/vcpkgpaths.h
+++ b/include/vcpkg/vcpkgpaths.h
@@ -138,7 +138,8 @@ namespace vcpkg
         ExpectedL<std::string> git_show_from_remote_registry(StringView hash, const Path& relative_path_to_file) const;
         ExpectedL<std::string> git_find_object_id_for_remote_registry_path(StringView hash,
                                                                            const Path& relative_path_to_file) const;
-        ExpectedL<Path> git_checkout_object_from_remote_registry(StringView tree) const;
+        ExpectedL<Unit> git_read_tree(const Path& destination, StringView tree, const Path& dot_git_dir) const;
+        ExpectedL<Path> git_extract_tree_from_remote_registry(StringView tree) const;
 
         Optional<const ManifestAndPath&> get_manifest() const;
         bool manifest_mode_enabled() const;

--- a/src/vcpkg/registries.cpp
+++ b/src/vcpkg/registries.cpp
@@ -242,7 +242,7 @@ namespace
                                                     .append_raw('\n')
                                                     .append_raw(maybe_tree.error()));
                 }
-                auto maybe_path = m_paths.git_checkout_object_from_remote_registry(*maybe_tree.get());
+                auto maybe_path = m_paths.git_extract_tree_from_remote_registry(*maybe_tree.get());
                 if (!maybe_path)
                 {
                     msg::println_error(msgFailedToCheckoutRepo, msg::package_name = m_repo);
@@ -275,7 +275,7 @@ namespace
                     // This could be caused by git gc or otherwise -- fall back to full fetch
                     return {get_versions_tree_path(), false};
                 }
-                auto maybe_path = m_paths.git_checkout_object_from_remote_registry(*maybe_tree.get());
+                auto maybe_path = m_paths.git_extract_tree_from_remote_registry(*maybe_tree.get());
                 if (!maybe_path)
                 {
                     // This could be caused by git gc or otherwise -- fall back to full fetch
@@ -952,7 +952,7 @@ namespace
         }
 
         const auto& git_tree = git_trees[it - port_versions.begin()];
-        return parent.m_paths.git_checkout_object_from_remote_registry(git_tree).map(
+        return parent.m_paths.git_extract_tree_from_remote_registry(git_tree).map(
             [this, &git_tree](Path&& p) -> PathAndLocation {
                 return {
                     std::move(p),


### PR DESCRIPTION
Helps work on https://github.com/microsoft/vcpkg/issues/31133 : Reduces `vcpkg find port zlib` with a blank git trees cache to around 2 minutes from 4.5 minutes on my 12900HX laptop.

Implements https://stackoverflow.com/questions/72521247/how-do-i-extract-a-tree-ish-to-a-directory
