### PR TITLE
Cleanup: `T&`, `std::move`, `ref_t emplace_back(...)`

### DIFF
--- a/src/vcpkg/archives.cpp
+++ b/src/vcpkg/archives.cpp
@@ -16,7 +16,7 @@ namespace
 #if defined(_WIN32)
     void win32_extract_nupkg(const ToolCache& tools, MessageSink& status_sink, const Path& archive, const Path& to_path)
     {
-        const auto nuget_exe = tools.get_tool_path(Tools::NUGET, status_sink);
+        const auto& nuget_exe = tools.get_tool_path(Tools::NUGET, status_sink);
 
         const auto stem = archive.stem();
 

--- a/src/vcpkg/base/json.cpp
+++ b/src/vcpkg/base/json.cpp
@@ -318,8 +318,7 @@ namespace vcpkg::Json
     Value& Array::push_back(std::string&& value) { return this->push_back(Json::Value::string(std::move(value))); }
     Value& Array::push_back(Value&& value)
     {
-        underlying_.push_back(std::move(value));
-        return underlying_.back();
+        return underlying_.emplace_back(std::move(value));
     }
     Object& Array::push_back(Object&& obj) { return push_back(Value::object(std::move(obj))).object(VCPKG_LINE_INFO); }
     Array& Array::push_back(Array&& arr) { return push_back(Value::array(std::move(arr))).array(VCPKG_LINE_INFO); }
@@ -349,8 +348,7 @@ namespace vcpkg::Json
                                 fmt::format("attempted to insert duplicate key {} into JSON object", key));
         }
 
-        underlying_.emplace_back(key.to_string(), std::move(value));
-        return underlying_.back().second;
+        return underlying_.emplace_back(key.to_string(), std::move(value)).second;
     }
     Value& Object::insert(StringView key, const Value& value)
     {
@@ -360,8 +358,7 @@ namespace vcpkg::Json
                                 fmt::format("attempted to insert duplicate key {} into JSON object", key));
         }
 
-        underlying_.emplace_back(key.to_string(), value);
-        return underlying_.back().second;
+        return underlying_.emplace_back(key.to_string(), value).second;
     }
     Array& Object::insert(StringView key, Array&& value)
     {
@@ -394,8 +391,7 @@ namespace vcpkg::Json
         }
         else
         {
-            underlying_.emplace_back(key, std::move(value));
-            return underlying_.back().second;
+            return underlying_.emplace_back(key, std::move(value)).second;
         }
     }
     Value& Object::insert_or_replace(StringView key, const Value& value)
@@ -408,8 +404,7 @@ namespace vcpkg::Json
         }
         else
         {
-            underlying_.emplace_back(key, value);
-            return underlying_.back().second;
+            return underlying_.emplace_back(key, value).second;
         }
     }
     Array& Object::insert_or_replace(StringView key, Array&& value)

--- a/src/vcpkg/base/json.cpp
+++ b/src/vcpkg/base/json.cpp
@@ -316,10 +316,7 @@ namespace vcpkg::Json
     // } struct Value
     // struct Array {
     Value& Array::push_back(std::string&& value) { return this->push_back(Json::Value::string(std::move(value))); }
-    Value& Array::push_back(Value&& value)
-    {
-        return underlying_.emplace_back(std::move(value));
-    }
+    Value& Array::push_back(Value&& value) { return underlying_.emplace_back(std::move(value)); }
     Object& Array::push_back(Object&& obj) { return push_back(Value::object(std::move(obj))).object(VCPKG_LINE_INFO); }
     Array& Array::push_back(Array&& arr) { return push_back(Value::array(std::move(arr))).array(VCPKG_LINE_INFO); }
     Value& Array::insert_before(iterator it, Value&& value)

--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -580,7 +580,7 @@ namespace vcpkg
                 }
                 else
                 {
-                    env_strings.push_back(var);
+                    env_strings.push_back(std::move(var));
                 }
             }
         }

--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -589,7 +589,7 @@ namespace vcpkg
 
         for (auto&& env_string : env_strings)
         {
-            const Optional<std::string> value = get_environment_variable(env_string.c_str());
+            const Optional<std::string> value = get_environment_variable(env_string);
             const auto v = value.get();
             if (!v || v->empty()) continue;
 

--- a/src/vcpkg/commands.ci-verify-versions.cpp
+++ b/src/vcpkg/commands.ci-verify-versions.cpp
@@ -285,7 +285,7 @@ namespace vcpkg::Commands::CIVerifyVersions
                 continue;
             }
 
-            auto git_tree = git_tree_it->second;
+            auto& git_tree = git_tree_it->second;
             auto control_path = port_path / "CONTROL";
             auto manifest_path = port_path / "vcpkg.json";
             auto manifest_exists = fs.exists(manifest_path, IgnoreErrors{});

--- a/src/vcpkg/commands.edit.cpp
+++ b/src/vcpkg/commands.edit.cpp
@@ -253,7 +253,7 @@ namespace vcpkg::Commands::Edit
             Checks::exit_fail(VCPKG_LINE_INFO);
         }
 
-        const Path env_editor = *it;
+        const Path& env_editor = *it;
         const std::vector<std::string> arguments = create_editor_arguments(paths, options, ports);
         const auto args_as_string = Strings::join(" ", arguments);
         auto cmd_line = Command(env_editor).raw_arg(args_as_string).string_arg("-n");

--- a/src/vcpkg/commands.edit.cpp
+++ b/src/vcpkg/commands.edit.cpp
@@ -170,10 +170,14 @@ namespace vcpkg::Commands::Edit
         }
 
         std::vector<Path> candidate_paths;
-        auto maybe_editor_path = get_environment_variable("EDITOR");
-        if (const std::string* editor_path = maybe_editor_path.get())
+
+        // Scope to prevent use of moved-from variable
         {
-            candidate_paths.emplace_back(*editor_path);
+            auto maybe_editor_path = get_environment_variable("EDITOR");
+            if (std::string* editor_path = maybe_editor_path.get())
+            {
+                candidate_paths.emplace_back(std::move(*editor_path));
+            }
         }
 
 #ifdef _WIN32

--- a/src/vcpkg/commands.env.cpp
+++ b/src/vcpkg/commands.env.cpp
@@ -96,7 +96,7 @@ namespace vcpkg::Commands::Env
         {
             if (auto e = get_environment_variable(passthrough))
             {
-                extra_env.emplace(passthrough, e.value_or_exit(VCPKG_LINE_INFO));
+                extra_env.emplace(passthrough, std::move(e.value_or_exit(VCPKG_LINE_INFO)));
             }
         }
 

--- a/src/vcpkg/commands.install.cpp
+++ b/src/vcpkg/commands.install.cpp
@@ -289,9 +289,7 @@ namespace vcpkg
         std::vector<StatusParagraph> features_spghs;
         for (auto&& feature : bcf.features)
         {
-            features_spghs.emplace_back();
-
-            StatusParagraph& feature_paragraph = features_spghs.back();
+            StatusParagraph& feature_paragraph = features_spghs.emplace_back();
             feature_paragraph.package = feature;
             feature_paragraph.want = Want::INSTALL;
             feature_paragraph.state = InstallState::HALF_INSTALLED;
@@ -571,8 +569,7 @@ namespace vcpkg
 
         for (auto&& action : action_plan.already_installed)
         {
-            results.emplace_back(action);
-            results.back().build_result.emplace(
+            results.emplace_back(action).build_result.emplace(
                 perform_install_plan_action(args, paths, action, status_db, binary_cache, build_logs_recorder));
         }
 

--- a/src/vcpkg/commands.integrate.cpp
+++ b/src/vcpkg/commands.integrate.cpp
@@ -438,7 +438,7 @@ namespace vcpkg::Commands::Integrate
             msg::println_error(msg::format(msgCommandFailed, msg::command_line = TITLE)
                                    .append_raw('\n')
                                    .append_raw(script_path.generic_u8string()));
-            get_global_metrics_collector().track_string(StringMetric::Title, TITLE.to_string());
+            get_global_metrics_collector().track_string(StringMetric::Title, TITLE);
         }
 
         Checks::exit_with_code(VCPKG_LINE_INFO, rc);

--- a/src/vcpkg/paragraphs.cpp
+++ b/src/vcpkg/paragraphs.cpp
@@ -284,8 +284,7 @@ namespace vcpkg::Paragraphs
             skip_whitespace();
             while (!at_eof())
             {
-                paragraphs.emplace_back();
-                get_paragraph(paragraphs.back());
+                get_paragraph(paragraphs.emplace_back());
                 match_while(is_lineend);
             }
             if (get_error()) return LocalizedString::from_raw(get_error()->to_string());

--- a/src/vcpkg/versions.cpp
+++ b/src/vcpkg/versions.cpp
@@ -321,8 +321,7 @@ namespace vcpkg
         // (\.(0|[1-9][0-9]*))*
         while (*cur == '.')
         {
-            ret.identifiers.push_back(0);
-            cur = parse_skip_number(cur + 1, &ret.identifiers.back());
+            cur = parse_skip_number(cur + 1, &ret.identifiers.emplace_back(0));
             if (!cur)
             {
                 return format_invalid_date_version(version);


### PR DESCRIPTION
- Fix more cases of unneeded copies due to missing &
- Prefer move over copy
- Cosmetic change: Prove that C++17's `reference_type emplace_back()` actually works

https://en.cppreference.com/w/cpp/compiler_support/17#C.2B.2B17_library_features
Search for [P0084R2](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0084r2.pdf).