### PR TITLE
[dependencygraph] Fix "command line too long" when sending to GitHub's dependency-graph API

### DIFF
--- a/include/vcpkg/base/downloads.h
+++ b/include/vcpkg/base/downloads.h
@@ -36,7 +36,8 @@ namespace vcpkg
                                     View<std::pair<std::string, Path>> url_pairs,
                                     View<std::string> headers);
 
-    bool send_snapshot_to_api(const std::string& github_token,
+    bool send_snapshot_to_api(const Filesystem& fs,
+                              const std::string& github_token,
                               const std::string& github_repository,
                               const Json::Object& snapshot);
     ExpectedL<int> put_file(const ReadOnlyFilesystem&,

--- a/src/vcpkg/commands.set-installed.cpp
+++ b/src/vcpkg/commands.set-installed.cpp
@@ -193,7 +193,7 @@ namespace vcpkg::Commands::SetInstalled
             bool s = false;
             if (snapshot.has_value() && args.github_token.has_value() && args.github_repository.has_value())
             {
-                s = send_snapshot_to_api(*args.github_token.get(), *args.github_repository.get(), *snapshot.get());
+                s = send_snapshot_to_api(fs, *args.github_token.get(), *args.github_repository.get(), *snapshot.get());
                 if (s)
                 {
                     msg::println(msgDependencyGraphSuccess);


### PR DESCRIPTION
We started to use the `dependencygraph` internally. It worked for some of our repositories, but for some other, it failed with no message, even when using `--debug`:

```shell
" 2>&1) # last line of the popen call
[DEBUG] 
Dependency graph submission failed.
```

To understand the issue, I tried running the command `curl` directly (in a GitHub workflow) and I got `curl: Argument list too long`, which hinted that maybe we were hitting a limit on the `command` length with `popen`. I made the modifications I suggest in this pull request, and this indeed resolve the issue:

```shell
[DEBUG] 1288: popen( curl -w "\\nfcfad8a3-bb68-4a54-ad00-dab1ff671ed2%{http_code}" -X POST -H "Accept: application/vnd.github+json" -H "Authorization: ***" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/<A_REPOSITORY>/dependency-graph/snapshots -d @/tmp/vcpkg/dependency_snapshot_9f868846-cd35-4af6-a062-2cd4a5d6b152.json 2>&1)
[DEBUG]   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
[DEBUG]                                  Dload  Upload   Total   Spent    Left  Speed
[DEBUG] 
[DEBUG]   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
[DEBUG] 100  126k  100   227  100  126k    540   300k --:--:-- --:--:-- --:--:--  301k
[DEBUG] {
[DEBUG]   "id": <AN_ID>,
[DEBUG]   "created_at": "2023-07-31T20:54:53.465Z",
[DEBUG]   "result": "ACCEPTED",
[DEBUG]   "message": "The snapshot was accepted, but it is not for the default branch. It will not update dependency results for the repository."
[DEBUG] }
[DEBUG] 
[DEBUG] 1288: cmd_execute_and_stream_data() returned 0
```