### PR TITLE
Fix search-by-name commands broken by wildcard packages feature.

### DIFF
--- a/include/vcpkg/registries.h
+++ b/include/vcpkg/registries.h
@@ -80,6 +80,11 @@ namespace vcpkg
         // appends the names of the ports to the out parameter
         // may result in duplicated port names; make sure to Util::sort_unique_erase at the end
         virtual void append_all_port_names(std::vector<std::string>& port_names) const = 0;
+        
+        // appends the names of the ports to the out parameter if this can be known without
+        // network access.
+        // returns true if names were appended, otherwise returns false.
+        virtual bool try_append_all_port_names_no_network(std::vector<std::string>& port_names) const = 0;
 
         virtual ExpectedL<Version> get_baseline_version(StringView port_name) const = 0;
 
@@ -138,6 +143,9 @@ namespace vcpkg
 
         // Returns a sorted vector of all reachable port names in this set.
         std::vector<std::string> get_all_reachable_port_names() const;
+
+        // Returns a sorted vector of all reachable port names we can provably determine without touching the network.
+        std::vector<std::string> get_all_known_reachable_port_names_no_network() const;
 
     private:
         std::unique_ptr<RegistryImplementation> default_registry_;

--- a/include/vcpkg/registries.h
+++ b/include/vcpkg/registries.h
@@ -80,7 +80,7 @@ namespace vcpkg
         // appends the names of the ports to the out parameter
         // may result in duplicated port names; make sure to Util::sort_unique_erase at the end
         virtual void append_all_port_names(std::vector<std::string>& port_names) const = 0;
-        
+
         // appends the names of the ports to the out parameter if this can be known without
         // network access.
         // returns true if names were appended, otherwise returns false.

--- a/include/vcpkg/registries.h
+++ b/include/vcpkg/registries.h
@@ -89,16 +89,16 @@ namespace vcpkg
     struct Registry
     {
         // requires: static_cast<bool>(implementation)
-        Registry(std::vector<std::string>&& packages, std::unique_ptr<RegistryImplementation>&& implementation);
+        Registry(std::vector<std::string>&& patterns, std::unique_ptr<RegistryImplementation>&& implementation);
 
         Registry(std::vector<std::string>&&, std::nullptr_t) = delete;
 
-        // always ordered lexicographically
-        View<std::string> packages() const { return packages_; }
+        // always ordered lexicographically; note the JSON name is "packages"
+        View<std::string> patterns() const { return patterns_; }
         const RegistryImplementation& implementation() const { return *implementation_; }
 
     private:
-        std::vector<std::string> packages_;
+        std::vector<std::string> patterns_;
         std::unique_ptr<RegistryImplementation> implementation_;
     };
 
@@ -160,5 +160,9 @@ namespace vcpkg
     ExpectedL<std::map<std::string, Version, std::less<>>> get_builtin_baseline(const VcpkgPaths& paths);
 
     bool is_git_commit_sha(StringView sv);
-    size_t package_match_prefix(StringView name, StringView pattern);
+
+    // Returns the effective match length of the package pattern `pattern` against `name`.
+    // No match is 0, exact match is SIZE_MAX, wildcard match is the length of the pattern.
+    // Note that the * is included in the match size to distinguish from 0 == no match.
+    size_t package_pattern_match(StringView name, StringView pattern);
 }

--- a/include/vcpkg/registries.h
+++ b/include/vcpkg/registries.h
@@ -79,7 +79,7 @@ namespace vcpkg
 
         // appends the names of the ports to the out parameter
         // may result in duplicated port names; make sure to Util::sort_unique_erase at the end
-        virtual void get_all_port_names(std::vector<std::string>& port_names) const = 0;
+        virtual void append_all_port_names(std::vector<std::string>& port_names) const = 0;
 
         virtual ExpectedL<Version> get_baseline_version(StringView port_name) const = 0;
 
@@ -97,8 +97,6 @@ namespace vcpkg
         View<std::string> packages() const { return packages_; }
         const RegistryImplementation& implementation() const { return *implementation_; }
 
-        friend RegistrySet; // for experimental_set_builtin_registry_baseline
-
     private:
         std::vector<std::string> packages_;
         std::unique_ptr<RegistryImplementation> implementation_;
@@ -112,8 +110,8 @@ namespace vcpkg
     // configuration fields.
     struct RegistrySet
     {
-        RegistrySet(std::unique_ptr<RegistryImplementation>&& x, std::vector<Registry>&& y)
-            : default_registry_(std::move(x)), registries_(std::move(y))
+        RegistrySet(std::unique_ptr<RegistryImplementation>&& default_registry, std::vector<Registry>&& registries)
+            : default_registry_(std::move(default_registry)), registries_(std::move(registries))
         {
         }
 

--- a/include/vcpkg/registries.h
+++ b/include/vcpkg/registries.h
@@ -136,6 +136,9 @@ namespace vcpkg
         // for checking against the registry feature flag.
         bool has_modifications() const;
 
+        // Returns a sorted vector of all reachable port names in this set.
+        std::vector<std::string> get_all_reachable_port_names() const;
+
     private:
         std::unique_ptr<RegistryImplementation> default_registry_;
         std::vector<Registry> registries_;

--- a/src/vcpkg-test/registries.cpp
+++ b/src/vcpkg-test/registries.cpp
@@ -17,9 +17,16 @@ namespace
 
         std::unique_ptr<RegistryEntry> get_port_entry(StringView) const override { return nullptr; }
 
-        void append_all_port_names(std::vector<std::string>&) const override { }
+        void append_all_port_names(std::vector<std::string>& port_names) const override
+        {
+            port_names.insert(port_names.end(), all_port_names.begin(), all_port_names.end());
+        }
 
-        bool try_append_all_port_names_no_network(std::vector<std::string>&) const override { return true; }
+        bool try_append_all_port_names_no_network(std::vector<std::string>& port_names) const override
+        {
+            port_names.insert(port_names.end(), no_network_port_names.begin(), no_network_port_names.end());
+            return !no_network_port_names.empty();
+        }
 
         ExpectedL<Version> get_baseline_version(StringView) const override
         {
@@ -27,13 +34,30 @@ namespace
         }
 
         int number;
+        std::vector<std::string> all_port_names;
+        std::vector<std::string> no_network_port_names;
 
-        TestRegistryImplementation(int n) : number(n) { }
+        TestRegistryImplementation(int n) : number(n), all_port_names(), no_network_port_names() { }
+        TestRegistryImplementation(int n,
+                                   std::vector<std::string>&& all_port_names,
+                                   std::vector<std::string>&& no_network_port_names)
+            : number(n), all_port_names(all_port_names), no_network_port_names(no_network_port_names)
+        {
+        }
     };
 
-    Registry make_registry(int n, std::vector<std::string>&& port_names)
+    Registry make_registry(int n, std::vector<std::string>&& patterns)
     {
-        return {std::move(port_names), std::make_unique<TestRegistryImplementation>(n)};
+        return {std::move(patterns), std::make_unique<TestRegistryImplementation>(n)};
+    }
+
+    Registry make_registry(int n,
+                           std::vector<std::string>&& patterns,
+                           std::vector<std::string>&& known_no_network,
+                           std::vector<std::string>&& known_network)
+    {
+        return {std::move(patterns),
+                std::make_unique<TestRegistryImplementation>(n, std::move(known_no_network), std::move(known_network))};
     }
 
     int get_tri_num(const RegistryImplementation& r)
@@ -713,5 +737,59 @@ TEST_CASE ("filesystem_version_db_parsing", "[registries]")
     )json");
         CHECK(r.visit(test_json, *filesystem_version_db).value_or_exit(VCPKG_LINE_INFO).empty());
         CHECK(!r.errors().empty());
+    }
+}
+
+TEST_CASE ("get_all_port_names", "[registries]")
+{
+    std::vector<Registry> registries;
+    // no network 0 known ports, unrelated and example are not selected
+    registries.emplace_back(make_registry(1,
+                                          {"hello", "world", "abc*", "notpresent"},
+                                          {"hello", "world", "unrelated", "example", "abcdefg", "abc", "abcde"},
+                                          {}));
+    // no network has some known ports
+    registries.emplace_back(
+        make_registry(2,
+                      {"two*"},
+                      {"hello", "world", "unrelated", "twoRegistry", "abcdefgXXX", "abcXXX", "abcdeXXX"},
+                      {"old", "ports", "abcdefgsuper", "twoOld"}));
+
+    SECTION ("with default registry")
+    {
+        RegistrySet with_default_registry{std::make_unique<TestRegistryImplementation>(
+                                              1,
+                                              std::vector<std::string>{"aDefault", "bDefault", "cDefault"},
+                                              std::vector<std::string>{"aDefaultOld", "bDefaultOld", "cDefaultOld"}),
+                                          std::move(registries)};
+
+        // All the known ports from the default registry
+        // hello, world, abcdefg, abc, abcde from the first registry
+        // twoRegistry from the second registry
+        CHECK(with_default_registry.get_all_reachable_port_names() ==
+              std::vector<std::string>{
+                  "aDefault", "abc", "abcde", "abcdefg", "bDefault", "cDefault", "hello", "twoRegistry", "world"});
+
+        // All the old ports from the default registry
+        // hello, world, notpresent from the first registry (since network was unknown)
+        // twoOld from the second registry
+        CHECK(with_default_registry.get_all_known_reachable_port_names_no_network() ==
+              std::vector<std::string>{
+                  "aDefaultOld", "bDefaultOld", "cDefaultOld", "hello", "notpresent", "twoOld", "world"});
+    }
+
+    SECTION ("without default registry")
+    {
+        RegistrySet without_default_registry{nullptr, std::move(registries)};
+
+        // hello, world, abcdefg, abc, abcde from the first registry
+        // twoRegistry from the second registry
+        CHECK(without_default_registry.get_all_reachable_port_names() ==
+              std::vector<std::string>{"abc", "abcde", "abcdefg", "hello", "twoRegistry", "world"});
+
+        // hello, world, notpresent from the first registry
+        // twoOld from the second registry
+        CHECK(without_default_registry.get_all_known_reachable_port_names_no_network() ==
+              std::vector<std::string>{"hello", "notpresent", "twoOld", "world"});
     }
 }

--- a/src/vcpkg-test/registries.cpp
+++ b/src/vcpkg-test/registries.cpp
@@ -19,6 +19,8 @@ namespace
 
         void append_all_port_names(std::vector<std::string>&) const override { }
 
+        bool try_append_all_port_names_no_network(std::vector<std::string>&) const override { return true; }
+
         ExpectedL<Version> get_baseline_version(StringView) const override
         {
             return LocalizedString::from_raw("error");

--- a/src/vcpkg-test/registries.cpp
+++ b/src/vcpkg-test/registries.cpp
@@ -17,7 +17,7 @@ namespace
 
         std::unique_ptr<RegistryEntry> get_port_entry(StringView) const override { return nullptr; }
 
-        void get_all_port_names(std::vector<std::string>&) const override { }
+        void append_all_port_names(std::vector<std::string>&) const override { }
 
         ExpectedL<Version> get_baseline_version(StringView) const override
         {

--- a/src/vcpkg-test/registries.cpp
+++ b/src/vcpkg-test/registries.cpp
@@ -138,19 +138,19 @@ TEST_CASE ("check valid package patterns", "[registries]")
 
 TEST_CASE ("calculate prefix priority", "[registries]")
 {
-    CHECK(package_match_prefix("boost", "*") == 1);
-    CHECK(package_match_prefix("boost", "b*") == 2);
-    CHECK(package_match_prefix("boost", "boost*") == 6);
-    CHECK(package_match_prefix("boost", "boost") == SIZE_MAX);
+    CHECK(package_pattern_match("boost", "*") == 1);
+    CHECK(package_pattern_match("boost", "b*") == 2);
+    CHECK(package_pattern_match("boost", "boost*") == 6);
+    CHECK(package_pattern_match("boost", "boost") == SIZE_MAX);
 
-    CHECK(package_match_prefix("", "") == SIZE_MAX);
-    CHECK(package_match_prefix("", "*") == 1);
-    CHECK(package_match_prefix("", "a") == 0);
-    CHECK(package_match_prefix("boost", "") == 0);
-    CHECK(package_match_prefix("boost", "c*") == 0);
-    CHECK(package_match_prefix("boost", "*c") == 0);
-    CHECK(package_match_prefix("boost", "c**") == 0);
-    CHECK(package_match_prefix("boost", "c*a") == 0);
+    CHECK(package_pattern_match("", "") == SIZE_MAX);
+    CHECK(package_pattern_match("", "*") == 1);
+    CHECK(package_pattern_match("", "a") == 0);
+    CHECK(package_pattern_match("boost", "") == 0);
+    CHECK(package_pattern_match("boost", "c*") == 0);
+    CHECK(package_pattern_match("boost", "*c") == 0);
+    CHECK(package_pattern_match("boost", "c**") == 0);
+    CHECK(package_pattern_match("boost", "c*a") == 0);
 }
 
 TEST_CASE ("select highest priority registry", "[registries]")

--- a/src/vcpkg/commands.install.cpp
+++ b/src/vcpkg/commands.install.cpp
@@ -648,23 +648,9 @@ namespace vcpkg
         {OPTION_MANIFEST_FEATURE, []() { return msg::format(msgHelpTxtOptManifestFeature); }},
     }};
 
-    static std::vector<std::string> get_all_port_names(const VcpkgPaths& paths)
+    static std::vector<std::string> get_all_reachable_port_names(const VcpkgPaths& paths)
     {
-        const auto registries = paths.make_registry_set();
-
-        std::vector<std::string> ret;
-        for (const auto& registry : registries->registries())
-        {
-            const auto packages = registry.packages();
-            ret.insert(ret.end(), packages.begin(), packages.end());
-        }
-        if (auto registry = registries->default_registry())
-        {
-            registry->append_all_port_names(ret);
-        }
-
-        Util::sort_unique_erase(ret);
-        return ret;
+        return paths.make_registry_set()->get_all_reachable_port_names();
     }
 
     const CommandStructure Install::COMMAND_STRUCTURE = {
@@ -672,7 +658,7 @@ namespace vcpkg
         0,
         SIZE_MAX,
         {INSTALL_SWITCHES, INSTALL_SETTINGS, INSTALL_MULTISETTINGS},
-        &get_all_port_names,
+        &get_all_reachable_port_names,
     };
 
     // This command structure must share "critical" values (switches, number of arguments). It exists only to provide a

--- a/src/vcpkg/commands.install.cpp
+++ b/src/vcpkg/commands.install.cpp
@@ -648,9 +648,9 @@ namespace vcpkg
         {OPTION_MANIFEST_FEATURE, []() { return msg::format(msgHelpTxtOptManifestFeature); }},
     }};
 
-    static std::vector<std::string> get_all_reachable_port_names(const VcpkgPaths& paths)
+    static std::vector<std::string> get_all_known_reachable_port_names_no_network(const VcpkgPaths& paths)
     {
-        return paths.make_registry_set()->get_all_reachable_port_names();
+        return paths.make_registry_set()->get_all_known_reachable_port_names_no_network();
     }
 
     const CommandStructure Install::COMMAND_STRUCTURE = {
@@ -658,7 +658,7 @@ namespace vcpkg
         0,
         SIZE_MAX,
         {INSTALL_SWITCHES, INSTALL_SETTINGS, INSTALL_MULTISETTINGS},
-        &get_all_reachable_port_names,
+        &get_all_known_reachable_port_names_no_network,
     };
 
     // This command structure must share "critical" values (switches, number of arguments). It exists only to provide a

--- a/src/vcpkg/commands.install.cpp
+++ b/src/vcpkg/commands.install.cpp
@@ -660,7 +660,7 @@ namespace vcpkg
         }
         if (auto registry = registries->default_registry())
         {
-            registry->get_all_port_names(ret);
+            registry->append_all_port_names(ret);
         }
 
         Util::sort_unique_erase(ret);

--- a/src/vcpkg/paragraphs.cpp
+++ b/src/vcpkg/paragraphs.cpp
@@ -505,21 +505,7 @@ namespace vcpkg::Paragraphs
     LoadResults try_load_all_registry_ports(const ReadOnlyFilesystem& fs, const RegistrySet& registries)
     {
         LoadResults ret;
-
-        std::vector<std::string> ports;
-
-        for (const auto& registry : registries.registries())
-        {
-            const auto packages = registry.packages();
-            ports.insert(end(ports), begin(packages), end(packages));
-        }
-        if (auto registry = registries.default_registry())
-        {
-            registry->append_all_port_names(ports);
-        }
-
-        Util::sort_unique_erase(ports);
-
+        std::vector<std::string> ports = registries.get_all_reachable_port_names();
         for (const auto& port_name : ports)
         {
             auto impl = registries.registry_for_port(port_name);

--- a/src/vcpkg/paragraphs.cpp
+++ b/src/vcpkg/paragraphs.cpp
@@ -515,7 +515,7 @@ namespace vcpkg::Paragraphs
         }
         if (auto registry = registries.default_registry())
         {
-            registry->get_all_port_names(ports);
+            registry->append_all_port_names(ports);
         }
 
         Util::sort_unique_erase(ports);

--- a/src/vcpkg/registries.cpp
+++ b/src/vcpkg/registries.cpp
@@ -1186,24 +1186,24 @@ namespace vcpkg
         return candidates[0];
     }
 
+    // Note that the * is included in the match so that 0 means no match
     size_t package_match_prefix(StringView name, StringView prefix)
     {
-        if (name == prefix)
-        {
-            // exact match is like matching "infinity" prefix
-            return SIZE_MAX;
-        }
-
-        // Note that the * is included in the match so that 0 means no match
         const auto prefix_size = prefix.size();
-        if (prefix_size != 0)
+        const auto maybe_star_index = prefix_size - 1;
+        if (prefix_size != 0 && prefix[maybe_star_index] == '*')
         {
-            const auto star_index = prefix_size - 1;
-            if (prefix[star_index] == '*' && name.size() >= star_index &&
-                name.substr(0, star_index) == prefix.substr(0, star_index))
+            // prefix is a wildcard
+            if (name.size() >= maybe_star_index &&
+                std::equal(prefix.begin(), prefix.end() - 1, name.begin()))
             {
                 return prefix_size;
             }
+        }
+        else if (name == prefix)
+        {
+            // exact match is like matching "infinity" prefix
+            return SIZE_MAX;
         }
 
         return 0;

--- a/src/vcpkg/registries.cpp
+++ b/src/vcpkg/registries.cpp
@@ -1258,6 +1258,23 @@ namespace vcpkg
     }
     bool RegistrySet::has_modifications() const { return !registries_.empty() || !is_default_builtin_registry(); }
 
+    std::vector<std::string> RegistrySet::get_all_reachable_port_names() const
+    {
+        std::vector<std::string> result;
+        for (const auto& registry : registries())
+        {
+            const auto packages = registry.packages();
+            result.insert(result.end(), packages.begin(), packages.end());
+        }
+        if (auto registry = default_registry())
+        {
+            registry->append_all_port_names(result);
+        }
+
+        Util::sort_unique_erase(result);
+        return result;
+    }
+
     ExpectedL<std::vector<std::pair<SchemedVersion, std::string>>> get_builtin_versions(const VcpkgPaths& paths,
                                                                                         StringView port_name)
     {

--- a/src/vcpkg/registries.cpp
+++ b/src/vcpkg/registries.cpp
@@ -1380,9 +1380,10 @@ namespace vcpkg
         return load_versions_file(
                    paths.get_filesystem(), VersionDbType::Git, paths.builtin_registry_versions, port_name)
             .map([&](std::vector<VersionDbEntry>&& versions) {
-                return Util::fmap(versions, [](const VersionDbEntry& entry) -> auto {
-                    return std::make_pair(SchemedVersion{entry.scheme, entry.version}, entry.git_tree);
-                });
+                return Util::fmap(
+                    versions, [](const VersionDbEntry& entry) -> auto{
+                        return std::make_pair(SchemedVersion{entry.scheme, entry.version}, entry.git_tree);
+                    });
             });
     }
 

--- a/src/vcpkg/registries.cpp
+++ b/src/vcpkg/registries.cpp
@@ -212,7 +212,7 @@ namespace
 
         std::unique_ptr<RegistryEntry> get_port_entry(StringView) const override;
 
-        void get_all_port_names(std::vector<std::string>&) const override;
+        void append_all_port_names(std::vector<std::string>&) const override;
 
         ExpectedL<Version> get_baseline_version(StringView) const override;
 
@@ -370,7 +370,7 @@ namespace
 
         std::unique_ptr<RegistryEntry> get_port_entry(StringView port_name) const override;
 
-        void get_all_port_names(std::vector<std::string>&) const override;
+        void append_all_port_names(std::vector<std::string>&) const override;
 
         ExpectedL<Version> get_baseline_version(StringView port_name) const override;
 
@@ -407,7 +407,7 @@ namespace
 
         std::unique_ptr<RegistryEntry> get_port_entry(StringView port_name) const override;
 
-        void get_all_port_names(std::vector<std::string>&) const override;
+        void append_all_port_names(std::vector<std::string>&) const override;
 
         ExpectedL<Version> get_baseline_version(StringView port_name) const override;
 
@@ -436,7 +436,7 @@ namespace
             Checks::msg_exit_with_error(VCPKG_LINE_INFO, msgErrorRequireBaseline);
         }
 
-        void get_all_port_names(std::vector<std::string>&) const override
+        void append_all_port_names(std::vector<std::string>&) const override
         {
             Checks::msg_exit_with_error(VCPKG_LINE_INFO, msgErrorRequireBaseline);
         }
@@ -461,7 +461,7 @@ namespace
 
         std::unique_ptr<RegistryEntry> get_port_entry(StringView) const override;
 
-        void get_all_port_names(std::vector<std::string>&) const override;
+        void append_all_port_names(std::vector<std::string>&) const override;
 
         ExpectedL<Version> get_baseline_version(StringView) const override;
 
@@ -610,7 +610,7 @@ namespace
         return LocalizedString::from_raw(ParseControlErrorInfo::format_errors({&maybe_scf.error(), 1}));
     }
 
-    void BuiltinFilesRegistry::get_all_port_names(std::vector<std::string>& out) const
+    void BuiltinFilesRegistry::append_all_port_names(std::vector<std::string>& out) const
     {
         std::error_code ec;
         auto port_directories = m_fs.get_directories_non_recursive(m_builtin_ports_directory, VCPKG_LINE_INFO);
@@ -680,7 +680,7 @@ namespace
         return msg::format(msg::msgErrorMessage).append(msgPortNotInBaseline, msg::package_name = port_name);
     }
 
-    void BuiltinGitRegistry::get_all_port_names(std::vector<std::string>& out) const
+    void BuiltinGitRegistry::append_all_port_names(std::vector<std::string>& out) const
     {
         const auto& fs = m_paths.get_filesystem();
 
@@ -689,7 +689,7 @@ namespace
             load_all_port_names_from_registry_versions(out, fs, m_paths.builtin_registry_versions);
         }
 
-        m_files_impl->get_all_port_names(out);
+        m_files_impl->append_all_port_names(out);
     }
     // } BuiltinGitRegistry::RegistryImplementation
 
@@ -747,7 +747,7 @@ namespace
         return res;
     }
 
-    void FilesystemRegistry::get_all_port_names(std::vector<std::string>& out) const
+    void FilesystemRegistry::append_all_port_names(std::vector<std::string>& out) const
     {
         load_all_port_names_from_registry_versions(out, m_fs, m_path / registry_versions_dir_name);
     }
@@ -860,7 +860,7 @@ namespace
         return msg::format(msg::msgErrorMessage).append(msgPortNotInBaseline, msg::package_name = port_name);
     }
 
-    void GitRegistry::get_all_port_names(std::vector<std::string>& out) const
+    void GitRegistry::append_all_port_names(std::vector<std::string>& out) const
     {
         auto versions_path = get_stale_versions_tree_path();
         load_all_port_names_from_registry_versions(out, m_paths.get_filesystem(), versions_path.p);


### PR DESCRIPTION
This fixes a bug I discovered while implementing the `git mktree` stuff.

Commands that tried to get all port names considered the ports declaration in registries to be the literal list of ports available in that registry, even though we added wildcards that make that not true any longer.

Moreover, when we do autocomplete operations, we need to make sure we never hit the network.

Before / broken:
* Searching for 'be' can't find any ports starting with this
* autocomplete suggests package names with *s in them which clearly aren't packages

<details>

```console
PS C:\Dev\test> type .\vcpkg-configuration.json
{
  "default-registry": null,
  "registries": [
    {
      "kind": "git",
      "baseline": "156b8935542c119471a8b8d702bc42146a8f0e4c",
      "repository": "https://github.com/microsoft/vcpkg",
      "packages": ["be*", "zlib"]
    }
  ]
}
PS C:\Dev\test> ..\vcpkg\vcpkg.exe search be
Fetching registry information from https://github.com/microsoft/vcpkg (HEAD)...
The result may be outdated. Run `git pull` to get the latest results.
If your port is not listed, please open an issue at and/or consider making a pull request.    -  https://github.com/Microsoft/vcpkg/issues
PS C:\Dev\test> ..\vcpkg\vcpkg.exe search zlib
Fetching registry information from https://github.com/microsoft/vcpkg (HEAD)...
zlib                     1.2.13           A compression library
The result may be outdated. Run `git pull` to get the latest results.
If your port is not listed, please open an issue at and/or consider making a pull request.    -  https://github.com/Microsoft/vcpkg/issues
PS C:\Dev\test> ..\vcpkg\vcpkg.exe autocomplete install be
be*
be*:arm-android
be*:arm-ios
be*:arm-linux
be*:arm-linux-release
be*:arm-mingw-dynamic
be*:arm-mingw-static
be*:arm-neon-android
be*:arm-uwp
be*:arm-uwp-static-md
be*:arm-windows
be*:arm-windows-static
be*:arm64-android
be*:arm64-ios
be*:arm64-linux
be*:arm64-linux-release
be*:arm64-mingw-dynamic
be*:arm64-mingw-static
be*:arm64-osx
be*:arm64-osx-dynamic
be*:arm64-osx-release
be*:arm64-uwp
be*:arm64-uwp-static-md
be*:arm64-windows
be*:arm64-windows-static
be*:arm64-windows-static-md
be*:arm64-windows-static-release
be*:arm64ec-windows
be*:armv6-android
be*:ppc64le-linux
be*:ppc64le-linux-release
be*:riscv32-linux
be*:riscv32-linux-release
be*:riscv64-linux
be*:riscv64-linux-release
be*:s390x-linux
be*:s390x-linux-release
be*:wasm32-emscripten
be*:x64-android
be*:x64-freebsd
be*:x64-ios
be*:x64-linux
be*:x64-linux-dynamic
be*:x64-linux-release
be*:x64-mingw-dynamic
be*:x64-mingw-static
be*:x64-openbsd
be*:x64-osx
be*:x64-osx-dynamic
be*:x64-osx-release
be*:x64-uwp
be*:x64-uwp-static-md
be*:x64-windows
be*:x64-windows-release
be*:x64-windows-static
be*:x64-windows-static-md
be*:x64-windows-static-release
be*:x64-xbox-scarlett
be*:x64-xbox-scarlett-static
be*:x64-xbox-xboxone
be*:x64-xbox-xboxone-static
be*:x86-android
be*:x86-freebsd
be*:x86-ios
be*:x86-linux
be*:x86-mingw-dynamic
be*:x86-mingw-static
be*:x86-uwp
be*:x86-uwp-static-md
be*:x86-windows
be*:x86-windows-static
be*:x86-windows-static-md
be*:x86-windows-v120
PS C:\Dev\test>
```

</details>

After / fixed:

<details>

```console
PS C:\Dev\test> C:\Dev\vcpkg-tool\out\build\Win-x64-Debug-WithArtifacts\vcpkg.exe search be
Fetching registry information from https://github.com/microsoft/vcpkg (HEAD)...
beast                    0#2              HTTP/1 and WebSocket, header-only using Boost.Asio and C++11
behaviortree-cpp         4.1.1            Behavior Trees Library in C++.
benchmark                1.8.2            A library to support the benchmarking of functions, similar to unit-tests.
bento4                   1.6.0-639#1      Bento4 is a C++ class library and tools designed to read and write ISO-MP4...
berkeleydb               4.8.30#9         BDB - A high-performance embedded database for key/value data.
bext-di                  1.2.0#1          C++14 Dependency Injection Library.
bext-sml                 1.1.5            Your scalable C++14 one header only State Machine Library with no dependen...
bext-ut                  1.1.9#2          UT: C++20 μ(micro)/Unit Testing Framework
bext-wintls              0.9.5            Native Windows TLS stream wrapper for use with boost::asio
The result may be outdated. Run `git pull` to get the latest results.
If your port is not listed, please open an issue at and/or consider making a pull request.    -  https://github.com/Microsoft/vcpkg/issues
PS C:\Dev\test> C:\Dev\vcpkg-tool\out\build\Win-x64-Debug-WithArtifacts\vcpkg.exe search zlib
Fetching registry information from https://github.com/microsoft/vcpkg (HEAD)...
zlib                     1.2.13           A compression library
The result may be outdated. Run `git pull` to get the latest results.
If your port is not listed, please open an issue at and/or consider making a pull request.    -  https://github.com/Microsoft/vcpkg/issues
PS C:\Dev\test> C:\Dev\vcpkg-tool\out\build\Win-x64-Debug-WithArtifacts\vcpkg.exe autocomplete install zl
zlib
zlib:arm-android
zlib:arm-ios
zlib:arm-linux
zlib:arm-linux-release
zlib:arm-mingw-dynamic
zlib:arm-mingw-static
zlib:arm-neon-android
zlib:arm-uwp
zlib:arm-uwp-static-md
zlib:arm-windows
zlib:arm-windows-static
zlib:arm64-android
zlib:arm64-ios
zlib:arm64-linux
zlib:arm64-linux-release
zlib:arm64-mingw-dynamic
zlib:arm64-mingw-static
zlib:arm64-osx
zlib:arm64-osx-dynamic
zlib:arm64-osx-release
zlib:arm64-uwp
zlib:arm64-uwp-static-md
zlib:arm64-windows
zlib:arm64-windows-static
zlib:arm64-windows-static-md
zlib:arm64-windows-static-release
zlib:arm64ec-windows
zlib:armv6-android
zlib:ppc64le-linux
zlib:ppc64le-linux-release
zlib:riscv32-linux
zlib:riscv32-linux-release
zlib:riscv64-linux
zlib:riscv64-linux-release
zlib:s390x-linux
zlib:s390x-linux-release
zlib:wasm32-emscripten
zlib:x64-android
zlib:x64-freebsd
zlib:x64-ios
zlib:x64-linux
zlib:x64-linux-dynamic
zlib:x64-linux-release
zlib:x64-mingw-dynamic
zlib:x64-mingw-static
zlib:x64-openbsd
zlib:x64-osx
zlib:x64-osx-dynamic
zlib:x64-osx-release
zlib:x64-uwp
zlib:x64-uwp-static-md
zlib:x64-windows
zlib:x64-windows-release
zlib:x64-windows-static
zlib:x64-windows-static-md
zlib:x64-windows-static-release
zlib:x64-xbox-scarlett
zlib:x64-xbox-scarlett-static
zlib:x64-xbox-xboxone
zlib:x64-xbox-xboxone-static
zlib:x86-android
zlib:x86-freebsd
zlib:x86-ios
zlib:x86-linux
zlib:x86-mingw-dynamic
zlib:x86-mingw-static
zlib:x86-uwp
zlib:x86-uwp-static-md
zlib:x86-windows
zlib:x86-windows-static
zlib:x86-windows-static-md
zlib:x86-windows-v120
PS C:\Dev\test> C:\Dev\vcpkg-tool\out\build\Win-x64-Debug-WithArtifacts\vcpkg.exe autocomplete install bl
PS C:\Dev\test>
```

</details>