### PR TITLE
Add loongarch64 support

### DIFF
--- a/include/vcpkg/base/cofffilereader.h
+++ b/include/vcpkg/base/cofffilereader.h
@@ -324,6 +324,8 @@ namespace vcpkg
         THUMB = 0x1c2,         // Thumb
         WCEMIPSV2 = 0x169,     // MIPS little-endian WCE v2
         LLVM_BITCODE = 0x4342, // LLVM bitcode https://www.llvm.org/docs/BitCodeFormat.html#llvm-ir-magic-number
+        LOONGARCH32 = 0x6232,  // LoongArch 32-bit processor family
+        LOONGARCH64 = 0x6264,  // LoongArch 64-bit processor family
     };
 
     enum class PEType

--- a/include/vcpkg/base/fwd/system.h
+++ b/include/vcpkg/base/fwd/system.h
@@ -13,5 +13,7 @@ namespace vcpkg
         PPC64LE,
         RISCV32,
         RISCV64,
+        LOONGARCH32,
+        LOONGARCH64,
     };
 }

--- a/src/vcpkg/base/system.cpp
+++ b/src/vcpkg/base/system.cpp
@@ -155,6 +155,8 @@ namespace vcpkg
         if (Strings::case_insensitive_ascii_equals(arch, "ppc64le")) return CPUArchitecture::PPC64LE;
         if (Strings::case_insensitive_ascii_equals(arch, "riscv32")) return CPUArchitecture::RISCV32;
         if (Strings::case_insensitive_ascii_equals(arch, "riscv64")) return CPUArchitecture::RISCV64;
+        if (Strings::case_insensitive_ascii_equals(arch, "loongarch32")) return CPUArchitecture::LOONGARCH32;
+        if (Strings::case_insensitive_ascii_equals(arch, "loongarch64")) return CPUArchitecture::LOONGARCH64;
 
         return nullopt;
     }
@@ -172,6 +174,8 @@ namespace vcpkg
             case CPUArchitecture::PPC64LE: return "ppc64le";
             case CPUArchitecture::RISCV32: return "riscv32";
             case CPUArchitecture::RISCV64: return "riscv64";
+            case CPUArchitecture::LOONGARCH32: return "loongarch32";
+            case CPUArchitecture::LOONGARCH64: return "loongarch64";
             default: Checks::exit_with_message(VCPKG_LINE_INFO, "unexpected vcpkg::CPUArchitecture");
         }
     }
@@ -269,6 +273,10 @@ namespace vcpkg
         return CPUArchitecture::RISCV32;
 #elif defined(__riscv) && defined(__riscv_xlen) && (__riscv_xlen == 64)
         return CPUArchitecture::RISCV64;
+#elif defined(__loongarch32) || defined(__loongarch__) && (__loongarch_grlen == 32)
+        return CPUArchitecture::LOONGARCH32;
+#elif defined(__loongarch64) || defined(__loongarch__) && (__loongarch_grlen == 64)
+        return CPUArchitecture::LOONGARCH64;
 #else // choose architecture
 #error "Unknown host architecture"
 #endif // choose architecture

--- a/src/vcpkg/postbuildlint.cpp
+++ b/src/vcpkg/postbuildlint.cpp
@@ -575,6 +575,8 @@ namespace vcpkg
             case MachineType::THUMB: return "thumb";
             case MachineType::WCEMIPSV2: return "mips-le-wce-v2";
             case MachineType::LLVM_BITCODE: return "llvm-bitcode";
+            case MachineType::LOONGARCH32: return "loongarch32";
+            case MachineType::LOONGARCH64: return "loongarch64";
             default: return fmt::format("unknown-{}", static_cast<uint16_t>(machine_type));
         }
     }

--- a/src/vcpkg/triplet.cpp
+++ b/src/vcpkg/triplet.cpp
@@ -84,6 +84,14 @@ namespace vcpkg
         {
             return CPUArchitecture::RISCV64;
         }
+        if (Strings::starts_with(this->canonical_name(), "loongarch32-"))
+        {
+            return CPUArchitecture::LOONGARCH32;
+        }
+        if (Strings::starts_with(this->canonical_name(), "loongarch64-"))
+        {
+            return CPUArchitecture::LOONGARCH64;
+        }
 
         return nullopt;
     }


### PR DESCRIPTION
This PR allows using vcpkg on LoongArch machines (loongarch32/64). Tested with Gentoo Linux 2.14 (loongarch64 GNU/Linux / Loongson-3A5000-HV-7A2000-1w-V0.1-EVB)

Tested ports:
```
vcpkg list
7zip:loongarch64-linux                            22.01#1             Library for archiving file with a high compressi...
bzip2:loongarch64-linux                           1.0.8#4             bzip2 is a freely available, patent free, high-q...
bzip2[tool]:loongarch64-linux                                         Builds bzip2 executable
curl:loongarch64-linux                            8.2.0               A library for transferring data with URLs
curl[non-http]:loongarch64-linux                                      Enables protocols beyond HTTP/HTTPS/HTTP2
curl[openssl]:loongarch64-linux                                       SSL support (OpenSSL)
curl[ssl]:loongarch64-linux                                           Default SSL backend
cxxopts:loongarch64-linux                         3.1.1               This is a lightweight C++ option parser library,...
fmt:loongarch64-linux                             10.0.0              Formatting library for C++. It can be used as a ...
magic-enum:loongarch64-linux                      0.9.2               Header-only C++17 library provides static reflec...
openssl:loongarch64-linux                         3.1.1#1             OpenSSL is an open source project that provides ...
vcpkg-cmake-config:loongarch64-linux              2022-02-06#1        
vcpkg-cmake-get-vars:loongarch64-linux            2023-03-02          
vcpkg-cmake:loongarch64-linux                     2023-05-04          
yasm:loongarch64-linux                            1.3.0#5             Yasm is a complete rewrite of the NASM assembler...
yasm[tools]:loongarch64-linux                                         Build yasm tools
zlib:loongarch64-linux                            1.2.13              A compression library

```