### PR TITLE
Restore LSP on PortfileProvider infrastructure.

### DIFF
--- a/include/vcpkg/portfileprovider.h
+++ b/include/vcpkg/portfileprovider.h
@@ -13,7 +13,7 @@ namespace vcpkg
 {
     struct PortFileProvider
     {
-        virtual ~PortFileProvider() = default;
+        virtual ~PortFileProvider();
         virtual ExpectedL<const SourceControlFileAndLocation&> get_control_file(const std::string& src_name) const = 0;
         virtual std::vector<const SourceControlFileAndLocation*> load_all_control_files() const = 0;
     };
@@ -33,23 +33,31 @@ namespace vcpkg
     struct IVersionedPortfileProvider
     {
         virtual View<Version> get_port_versions(StringView port_name) const = 0;
-        virtual ~IVersionedPortfileProvider() = default;
+        virtual ~IVersionedPortfileProvider();
 
         virtual ExpectedL<const SourceControlFileAndLocation&> get_control_file(
             const VersionSpec& version_spec) const = 0;
+    };
+
+    struct IFullVersionedPortfileProvider : IVersionedPortfileProvider
+    {
         virtual void load_all_control_files(std::map<std::string, const SourceControlFileAndLocation*>& out) const = 0;
     };
 
     struct IBaselineProvider
     {
         virtual ExpectedL<Version> get_baseline_version(StringView port_name) const = 0;
-        virtual ~IBaselineProvider() = default;
+        virtual ~IBaselineProvider();
     };
 
     struct IOverlayProvider
     {
-        virtual ~IOverlayProvider() = default;
+        virtual ~IOverlayProvider();
         virtual Optional<const SourceControlFileAndLocation&> get_control_file(StringView port_name) const = 0;
+    };
+
+    struct IFullOverlayProvider : IOverlayProvider
+    {
         virtual void load_all_control_files(std::map<std::string, const SourceControlFileAndLocation*>& out) const = 0;
     };
 
@@ -57,22 +65,22 @@ namespace vcpkg
     {
         explicit PathsPortFileProvider(const ReadOnlyFilesystem& fs,
                                        const RegistrySet& registry_set,
-                                       std::unique_ptr<IOverlayProvider>&& overlay);
+                                       std::unique_ptr<IFullOverlayProvider>&& overlay);
         ExpectedL<const SourceControlFileAndLocation&> get_control_file(const std::string& src_name) const override;
         std::vector<const SourceControlFileAndLocation*> load_all_control_files() const override;
 
     private:
         std::unique_ptr<IBaselineProvider> m_baseline;
-        std::unique_ptr<IVersionedPortfileProvider> m_versioned;
-        std::unique_ptr<IOverlayProvider> m_overlay;
+        std::unique_ptr<IFullVersionedPortfileProvider> m_versioned;
+        std::unique_ptr<IFullOverlayProvider> m_overlay;
     };
 
     std::unique_ptr<IBaselineProvider> make_baseline_provider(const RegistrySet& registry_set);
-    std::unique_ptr<IVersionedPortfileProvider> make_versioned_portfile_provider(const ReadOnlyFilesystem& fs,
-                                                                                 const RegistrySet& registry_set);
-    std::unique_ptr<IOverlayProvider> make_overlay_provider(const ReadOnlyFilesystem& fs,
-                                                            const Path& original_cwd,
-                                                            View<std::string> overlay_ports);
+    std::unique_ptr<IFullVersionedPortfileProvider> make_versioned_portfile_provider(const ReadOnlyFilesystem& fs,
+                                                                                     const RegistrySet& registry_set);
+    std::unique_ptr<IFullOverlayProvider> make_overlay_provider(const ReadOnlyFilesystem& fs,
+                                                                const Path& original_cwd,
+                                                                View<std::string> overlay_ports);
     std::unique_ptr<IOverlayProvider> make_manifest_provider(const ReadOnlyFilesystem& fs,
                                                              const Path& original_cwd,
                                                              View<std::string> overlay_ports,

--- a/src/vcpkg-test/dependencies.cpp
+++ b/src/vcpkg-test/dependencies.cpp
@@ -82,11 +82,6 @@ struct MockVersionedPortfileProvider : IVersionedPortfileProvider
 
         return it2->second;
     }
-
-    virtual void load_all_control_files(std::map<std::string, const SourceControlFileAndLocation*>&) const override
-    {
-        Checks::unreachable(VCPKG_LINE_INFO);
-    }
 };
 
 struct CoreDependency : Dependency
@@ -211,11 +206,6 @@ struct MockOverlayProvider : IOverlayProvider
     }
 
     SourceControlFileAndLocation& emplace(const std::string& name) { return emplace(name, {"1", 0}); }
-
-    virtual void load_all_control_files(std::map<std::string, const SourceControlFileAndLocation*>&) const override
-    {
-        Checks::unreachable(VCPKG_LINE_INFO);
-    }
 
 private:
     std::map<std::string, SourceControlFileAndLocation, std::less<>> mappings;

--- a/src/vcpkg/portfileprovider.cpp
+++ b/src/vcpkg/portfileprovider.cpp
@@ -37,6 +37,8 @@ namespace
 
 namespace vcpkg
 {
+    PortFileProvider::~PortFileProvider() = default;
+
     MapPortFileProvider::MapPortFileProvider(const std::unordered_map<std::string, SourceControlFileAndLocation>& map)
         : ports(map)
     {
@@ -54,9 +56,15 @@ namespace vcpkg
         return Util::fmap(ports, [](auto&& kvpair) -> const SourceControlFileAndLocation* { return &kvpair.second; });
     }
 
+    IVersionedPortfileProvider::~IVersionedPortfileProvider() = default;
+
+    IBaselineProvider::~IBaselineProvider() = default;
+
+    IOverlayProvider::~IOverlayProvider() = default;
+
     PathsPortFileProvider::PathsPortFileProvider(const ReadOnlyFilesystem& fs,
                                                  const RegistrySet& registry_set,
-                                                 std::unique_ptr<IOverlayProvider>&& overlay)
+                                                 std::unique_ptr<IFullOverlayProvider>&& overlay)
         : m_baseline(make_baseline_provider(registry_set))
         , m_versioned(make_versioned_portfile_provider(fs, registry_set))
         , m_overlay(std::move(overlay))
@@ -118,7 +126,7 @@ namespace vcpkg
             mutable std::map<std::string, ExpectedL<Version>, std::less<>> m_baseline_cache;
         };
 
-        struct VersionedPortfileProviderImpl : IVersionedPortfileProvider
+        struct VersionedPortfileProviderImpl : IFullVersionedPortfileProvider
         {
             VersionedPortfileProviderImpl(const ReadOnlyFilesystem& fs, const RegistrySet& rset)
                 : m_fs(fs), m_registry_set(rset)
@@ -248,7 +256,7 @@ namespace vcpkg
             mutable std::map<std::string, ExpectedL<std::unique_ptr<RegistryEntry>>, std::less<>> m_entry_cache;
         };
 
-        struct OverlayProviderImpl : IOverlayProvider
+        struct OverlayProviderImpl : IFullOverlayProvider
         {
             OverlayProviderImpl(const ReadOnlyFilesystem& fs, const Path& original_cwd, View<std::string> overlay_ports)
                 : m_fs(fs), m_overlay_ports(Util::fmap(overlay_ports, [&original_cwd](const std::string& s) -> Path {
@@ -389,7 +397,7 @@ namespace vcpkg
             mutable std::map<std::string, Optional<SourceControlFileAndLocation>, std::less<>> m_overlay_cache;
         };
 
-        struct ManifestProviderImpl : IOverlayProvider
+        struct ManifestProviderImpl : IFullOverlayProvider
         {
             ManifestProviderImpl(const ReadOnlyFilesystem& fs,
                                  const Path& original_cwd,
@@ -431,15 +439,15 @@ namespace vcpkg
         return std::make_unique<BaselineProviderImpl>(registry_set);
     }
 
-    std::unique_ptr<IVersionedPortfileProvider> make_versioned_portfile_provider(const ReadOnlyFilesystem& fs,
-                                                                                 const RegistrySet& registry_set)
+    std::unique_ptr<IFullVersionedPortfileProvider> make_versioned_portfile_provider(const ReadOnlyFilesystem& fs,
+                                                                                     const RegistrySet& registry_set)
     {
         return std::make_unique<VersionedPortfileProviderImpl>(fs, registry_set);
     }
 
-    std::unique_ptr<IOverlayProvider> make_overlay_provider(const ReadOnlyFilesystem& fs,
-                                                            const Path& original_cwd,
-                                                            View<std::string> overlay_ports)
+    std::unique_ptr<IFullOverlayProvider> make_overlay_provider(const ReadOnlyFilesystem& fs,
+                                                                const Path& original_cwd,
+                                                                View<std::string> overlay_ports)
     {
         return std::make_unique<OverlayProviderImpl>(fs, original_cwd, overlay_ports);
     }


### PR DESCRIPTION
Tests don't want to provide "load all" operations, so the interface they speak shouldn't have them.