### PR TITLE
Fix edit to only list builtin ports 

### DIFF
--- a/include/vcpkg/paragraphs.h
+++ b/include/vcpkg/paragraphs.h
@@ -38,21 +38,6 @@ namespace vcpkg::Paragraphs
         std::vector<std::unique_ptr<ParseControlErrorInfo>> errors;
     };
 
-    // this allows one to pass this around as an overload set to stuff like `Util::fmap`,
-    // as opposed to making it a function
-    constexpr struct
-    {
-        const std::string& operator()(const SourceControlFileAndLocation* loc) const
-        {
-            return (*this)(*loc->source_control_file);
-        }
-        const std::string& operator()(const SourceControlFileAndLocation& loc) const
-        {
-            return (*this)(*loc.source_control_file);
-        }
-        const std::string& operator()(const SourceControlFile& scf) const { return scf.core_paragraph->name; }
-    } get_name_of_control_file;
-
     LoadResults try_load_all_registry_ports(const ReadOnlyFilesystem& fs, const RegistrySet& registries);
 
     std::vector<SourceControlFileAndLocation> load_all_registry_ports(const ReadOnlyFilesystem& fs,

--- a/src/vcpkg/commands.edit.cpp
+++ b/src/vcpkg/commands.edit.cpp
@@ -90,10 +90,9 @@ namespace vcpkg::Commands::Edit
 
     static std::vector<std::string> valid_arguments(const VcpkgPaths& paths)
     {
-        auto registry_set = paths.make_registry_set();
-        auto sources_and_errors = Paragraphs::try_load_all_registry_ports(paths.get_filesystem(), *registry_set);
-
-        return Util::fmap(sources_and_errors.paragraphs, Paragraphs::get_name_of_control_file);
+        return Util::fmap(
+            paths.get_filesystem().get_directories_non_recursive(paths.builtin_ports_directory(), IgnoreErrors{}),
+            [](const Path& p) { return p.filename().to_string(); });
     }
 
     static constexpr std::array<CommandSwitch, 2> EDIT_SWITCHES = {


### PR DESCRIPTION
rather than trying to look in the registry set for its autocomplete.

The edit command doesn't understand registries, and certainly has no reason to actually parse all the registries' ports.