### PR TITLE
Update fmt to 10.1.0

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -17,9 +17,9 @@
         "Type": "other",
         "other": {
           "name": "fmt",
-          "version": "10.0.0",
-          "downloadUrl": "https://github.com/fmtlib/fmt/archive/refs/tags/10.0.0.tar.gz",
-          "hash": "6188508d74ca1ed75bf6441b152c07ca83971d3104b37f33784a7b55dfcc614d6243e77e0a14220018586fdb86207cc033eece834e7acd5e0907ed4c97403f3b"
+          "version": "10.1.0",
+          "downloadUrl": "https://github.com/fmtlib/fmt/archive/refs/tags/10.1.0.tar.gz",
+          "hash": "69a7b8584f828528e3bb4b87153449e96df29bd740adcd42a2e3d50ae4a270c80a5eb2c3057337048be5b978094d8bb73bec3378e3b6370748de2b063dd0aa4b"
         }
       },
       "DevelopmentDependency": false,

--- a/cmake/Findfmt.cmake
+++ b/cmake/Findfmt.cmake
@@ -9,7 +9,7 @@ if("$CACHE{VCPKG_FMT_URL}" MATCHES "^https://github.com/fmtlib/fmt/archive/refs/
     unset(VCPKG_FMT_URL CACHE) # Fix upgrade
 endif()
 if(NOT VCPKG_FMT_URL)
-    set(VCPKG_FMT_URL "https://github.com/fmtlib/fmt/archive/refs/tags/10.0.0.tar.gz")
+    set(VCPKG_FMT_URL "https://github.com/fmtlib/fmt/archive/refs/tags/10.1.0.tar.gz")
 endif()
 
 if(POLICY CMP0135)
@@ -33,7 +33,7 @@ include(FetchContent)
 FetchContent_Declare(
     fmt
     URL "${VCPKG_FMT_URL}"
-    URL_HASH "SHA512=6188508d74ca1ed75bf6441b152c07ca83971d3104b37f33784a7b55dfcc614d6243e77e0a14220018586fdb86207cc033eece834e7acd5e0907ed4c97403f3b"
+    URL_HASH "SHA512=69a7b8584f828528e3bb4b87153449e96df29bd740adcd42a2e3d50ae4a270c80a5eb2c3057337048be5b978094d8bb73bec3378e3b6370748de2b063dd0aa4b"
 )
 
 if(NOT fmt_FIND_REQUIRED)

--- a/include/vcpkg/base/messages.h
+++ b/include/vcpkg/base/messages.h
@@ -143,7 +143,7 @@ namespace vcpkg::msg
             return detail::format_message_by_index_to(s, index, fmt::make_format_args(args...));
         }
     }
-    
+
     template<class... Tags, class... Types>
     LocalizedString format(MessageT<Tags...> m, TagArg<identity_t<Tags>, Types>... args)
     {

--- a/include/vcpkg/base/messages.h
+++ b/include/vcpkg/base/messages.h
@@ -128,15 +128,31 @@ VCPKG_FORMAT_AS(vcpkg::LocalizedString, vcpkg::StringView);
 
 namespace vcpkg::msg
 {
+    namespace detail
+    {
+        template<class... FmtArgs>
+        LocalizedString format_impl(std::size_t index, FmtArgs&&... args)
+        {
+            // no forward to intentionally make an lvalue here
+            return detail::format_message_by_index(index, fmt::make_format_args(args...));
+        }
+        template<class... FmtArgs>
+        void format_to_impl(LocalizedString& s, std::size_t index, FmtArgs&&... args)
+        {
+            // no forward to intentionally make an lvalue here
+            return detail::format_message_by_index_to(s, index, fmt::make_format_args(args...));
+        }
+    }
+    
     template<class... Tags, class... Types>
     LocalizedString format(MessageT<Tags...> m, TagArg<identity_t<Tags>, Types>... args)
     {
-        return detail::format_message_by_index(m.index, fmt::make_format_args(args.arg()...));
+        return detail::format_impl(m.index, args.arg()...);
     }
     template<class... Tags, class... Types>
     void format_to(LocalizedString& s, MessageT<Tags...> m, TagArg<identity_t<Tags>, Types>... args)
     {
-        return detail::format_message_by_index_to(s, m.index, fmt::make_format_args(args.arg()...));
+        return detail::format_to_impl(s, m.index, args.arg()...);
     }
 
     inline void println() { msg::write_unlocalized_text_to_stdout(Color::none, "\n"); }


### PR DESCRIPTION
The fmt library has pushed a breaking change in its minor version 10.1.0.

Cause of the build error with fmt 10.1.0: https://github.com/fmtlib/fmt/commit/8f18e72df576ebfbd088a57a5c6cae8d4d0fc3dc

Even though this code was safe, the changes to improve safety broke `vcpkg::msg::format`. My Solution is to simply store all arguments in `args` in a tuple then unpack it in `fmt::make_format_args` using an index sequence.

This changes makes it compatible with fmt 10.1.0, and upgrades the library.