### PR TITLE
Use posix definition of a line

### DIFF
--- a/include/vcpkg/base/strings.h
+++ b/include/vcpkg/base/strings.h
@@ -256,8 +256,11 @@ namespace vcpkg::Strings
         template<class Fn>
         void on_end(Fn cb)
         {
-            cb(StringView{previous_partial_line});
-            previous_partial_line.clear();
+            if (!previous_partial_line.empty())
+            {
+                cb(StringView{previous_partial_line});
+                previous_partial_line.clear();
+            }
             last_was_cr = false;
         }
 

--- a/src/vcpkg-test/files.cpp
+++ b/src/vcpkg-test/files.cpp
@@ -954,10 +954,10 @@ TEST_CASE ("LinesCollector", "[files]")
 {
     using Strings::LinesCollector;
     LinesCollector lc;
-    CHECK(lc.extract() == std::vector<std::string>{""});
+    CHECK(lc.extract() == std::vector<std::string>{});
     lc.on_data({"a\nb\r\nc\rd\r\r\n\ne\n\rx", 16});
     CHECK(lc.extract() == std::vector<std::string>{"a", "b", "c", "d", "", "", "e", "", "x"});
-    CHECK(lc.extract() == std::vector<std::string>{""});
+    CHECK(lc.extract() == std::vector<std::string>{});
     lc.on_data({"hello ", 6});
     lc.on_data({"there ", 6});
     lc.on_data({"world", 5});
@@ -966,7 +966,7 @@ TEST_CASE ("LinesCollector", "[files]")
     lc.on_data({"\r\nworld", 7});
     CHECK(lc.extract() == std::vector<std::string>{"", "hello ", "", "world"});
     lc.on_data({"\r\n\r\n\r\n", 6});
-    CHECK(lc.extract() == std::vector<std::string>{"", "", "", ""});
+    CHECK(lc.extract() == std::vector<std::string>{"", "", ""});
     lc.on_data({"a", 1});
     lc.on_data({"b\nc", 3});
     lc.on_data({"d", 1});
@@ -975,11 +975,11 @@ TEST_CASE ("LinesCollector", "[files]")
     lc.on_data({"\nb", 2});
     CHECK(lc.extract() == std::vector<std::string>{"a", "b"});
     lc.on_data({"a\r", 2});
-    CHECK(lc.extract() == std::vector<std::string>{"a", ""});
+    CHECK(lc.extract() == std::vector<std::string>{"a"});
     lc.on_data({"\n", 1});
-    CHECK(lc.extract() == std::vector<std::string>{"", ""});
+    CHECK(lc.extract() == std::vector<std::string>{""});
     lc.on_data({"\rabc\n", 5});
-    CHECK(lc.extract() == std::vector<std::string>{"", "abc", ""});
+    CHECK(lc.extract() == std::vector<std::string>{"", "abc"});
 }
 
 TEST_CASE ("find_file_recursively_up", "[files]")


### PR DESCRIPTION
From https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206 
> A sequence of zero or more non- <newline> characters plus a terminating <newline> character.

We should also accept the line that ends with `eof`. 

Main motivation: `fs.write_lines(path, fs.read_lines(path))` should result in the same file. Currently a new line is added.
input -> current / new lines -> current / new output:
\<empty file> -> "" / ∅ -> "\n" / \<empty file> 
"Hello\n" -> "Hello", "" / "Hello" -> "Hello\n\n" / "Hello\n"
"test\nHello" -> "test", "Hello" -> "test\nHello\n" / "test\nHello\n"