### PR TITLE
Introduce --x-cmake-debug and --x-cmake-configure-debug

### DIFF
--- a/include/vcpkg/fwd/vcpkgcmdarguments.h
+++ b/include/vcpkg/fwd/vcpkgcmdarguments.h
@@ -11,4 +11,5 @@ namespace vcpkg
     struct HelpTableFormatter;
     struct VcpkgCmdArguments;
     struct FeatureFlagSettings;
+    struct PortApplicableSetting;
 }

--- a/include/vcpkg/vcpkgcmdarguments.h
+++ b/include/vcpkg/vcpkgcmdarguments.h
@@ -164,6 +164,11 @@ namespace vcpkg
         constexpr static StringLiteral CMAKE_SCRIPT_ARG = "cmake-args";
         std::vector<std::string> cmake_args;
 
+        constexpr static StringLiteral CMAKE_DEBUGGING_ARG = "cmake-debug";
+        std::vector<std::string> cmake_debug;
+        constexpr static StringLiteral CMAKE_CONFIGURE_DEBUGGING_ARG = "cmake-configure-debug";
+        std::vector<std::string> cmake_configure_debug;
+
         constexpr static StringLiteral EXACT_ABI_TOOLS_VERSIONS_SWITCH = "abi-tools-use-exact-versions";
         Optional<bool> exact_abi_tools_versions;
 

--- a/include/vcpkg/vcpkgcmdarguments.h
+++ b/include/vcpkg/vcpkgcmdarguments.h
@@ -80,6 +80,21 @@ namespace vcpkg
         bool dependency_graph;
     };
 
+    struct PortApplicableSetting
+    {
+        std::string value;
+
+        PortApplicableSetting(StringView setting);
+        PortApplicableSetting(const PortApplicableSetting&);
+        PortApplicableSetting(PortApplicableSetting&&);
+        PortApplicableSetting& operator=(const PortApplicableSetting&);
+        PortApplicableSetting& operator=(PortApplicableSetting&&);
+        bool is_port_affected(StringView port_name) const noexcept;
+
+    private:
+        std::vector<std::string> affected_ports;
+    };
+
     struct VcpkgCmdArguments
     {
         static VcpkgCmdArguments create_from_command_line(const ILineReader& fs,
@@ -161,13 +176,13 @@ namespace vcpkg
         constexpr static StringLiteral GITHUB_REPOSITORY_OWNER_ID = "GITHUB_REPOSITORY_OWNER_ID";
         Optional<std::string> github_repository_owner_id;
 
+        constexpr static StringLiteral CMAKE_DEBUGGING_ARG = "cmake-debug";
+        Optional<PortApplicableSetting> cmake_debug;
+        constexpr static StringLiteral CMAKE_CONFIGURE_DEBUGGING_ARG = "cmake-configure-debug";
+        Optional<PortApplicableSetting> cmake_configure_debug;
+
         constexpr static StringLiteral CMAKE_SCRIPT_ARG = "cmake-args";
         std::vector<std::string> cmake_args;
-
-        constexpr static StringLiteral CMAKE_DEBUGGING_ARG = "cmake-debug";
-        std::vector<std::string> cmake_debug;
-        constexpr static StringLiteral CMAKE_CONFIGURE_DEBUGGING_ARG = "cmake-configure-debug";
-        std::vector<std::string> cmake_configure_debug;
 
         constexpr static StringLiteral EXACT_ABI_TOOLS_VERSIONS_SWITCH = "abi-tools-use-exact-versions";
         Optional<bool> exact_abi_tools_versions;

--- a/src/vcpkg-test/arguments.cpp
+++ b/src/vcpkg-test/arguments.cpp
@@ -160,3 +160,24 @@ TEST_CASE ("Feature flag off", "[arguments]")
     auto v = VcpkgCmdArguments::create_from_arg_sequence(t.data(), t.data() + t.size());
     CHECK(!v.versions_enabled());
 }
+
+TEST_CASE ("CMake debugger flags", "[arguments]")
+{
+    std::vector<std::string> t = {"--x-cmake-debug",
+                                  "\\\\.\\pipe\\tespipe;zlib;bar;baz",
+                                  "--x-cmake-configure-debug",
+                                  "\\\\.\\pipe\\configure-pipe"};
+    auto v = VcpkgCmdArguments::create_from_arg_sequence(t.data(), t.data() + t.size());
+    auto& cmake_debug = v.cmake_debug.value_or_exit(VCPKG_LINE_INFO);
+    REQUIRE(cmake_debug.value == "\\\\.\\pipe\\tespipe");
+    REQUIRE(!cmake_debug.is_port_affected("7zip"));
+    REQUIRE(cmake_debug.is_port_affected("zlib"));
+    REQUIRE(cmake_debug.is_port_affected("bar"));
+    REQUIRE(cmake_debug.is_port_affected("baz"));
+    REQUIRE(!cmake_debug.is_port_affected("bazz"));
+
+    auto& cmake_configure_debug = v.cmake_configure_debug.value_or_exit(VCPKG_LINE_INFO);
+    REQUIRE(cmake_configure_debug.value == "\\\\.\\pipe\\configure-pipe");
+    REQUIRE(cmake_configure_debug.is_port_affected("7zip"));
+    REQUIRE(cmake_configure_debug.is_port_affected("zlib"));
+}

--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -37,8 +37,6 @@
 #include <vcpkg/vcpkglib.h>
 #include <vcpkg/vcpkgpaths.h>
 
-#include <algorithm>
-
 using namespace vcpkg;
 
 namespace
@@ -780,26 +778,21 @@ namespace vcpkg
             variables.emplace_back("ARIA2", paths.get_tool_exe(Tools::ARIA2, stdout_sink));
         }
 
-        if (!args.cmake_debug.empty())
+        if (auto cmake_debug = args.cmake_debug.get())
         {
-            if (args.cmake_debug.size() == 1 ||
-                std::find(args.cmake_debug.begin(), args.cmake_debug.end(), scf.core_paragraph->name) !=
-                    args.cmake_debug.end())
+            if (cmake_debug->is_port_affected(scf.core_paragraph->name))
             {
                 variables.emplace_back("--debugger");
-                variables.emplace_back(fmt::format("--debugger-pipe={}", *args.cmake_debug.begin()));
+                variables.emplace_back(fmt::format("--debugger-pipe={}", cmake_debug->value));
             }
         }
 
-        if (!args.cmake_configure_debug.empty())
+        if (auto cmake_configure_debug = args.cmake_configure_debug.get())
         {
-            if (args.cmake_configure_debug.size() == 1 ||
-                std::find(args.cmake_configure_debug.begin(),
-                          args.cmake_configure_debug.end(),
-                          scf.core_paragraph->name) != args.cmake_configure_debug.end())
+            if (cmake_configure_debug->is_port_affected(scf.core_paragraph->name))
             {
                 variables.emplace_back(fmt::format("-DVCPKG_CMAKE_CONFIGURE_OPTIONS=--debugger;--debugger-pipe={}",
-                                                   *args.cmake_configure_debug.begin()));
+                                                   cmake_configure_debug->value));
             }
         }
 

--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -37,6 +37,8 @@
 #include <vcpkg/vcpkglib.h>
 #include <vcpkg/vcpkgpaths.h>
 
+#include <algorithm>
+
 using namespace vcpkg;
 
 namespace
@@ -776,6 +778,29 @@ namespace vcpkg
         if (action.build_options.download_tool == DownloadTool::ARIA2)
         {
             variables.emplace_back("ARIA2", paths.get_tool_exe(Tools::ARIA2, stdout_sink));
+        }
+
+        if (!args.cmake_debug.empty())
+        {
+            if (args.cmake_debug.size() == 1 ||
+                std::find(args.cmake_debug.begin(), args.cmake_debug.end(), scf.core_paragraph->name) !=
+                    args.cmake_debug.end())
+            {
+                variables.emplace_back("--debugger");
+                variables.emplace_back(fmt::format("--debugger-pipe={}", *args.cmake_debug.begin()));
+            }
+        }
+
+        if (!args.cmake_configure_debug.empty())
+        {
+            if (args.cmake_configure_debug.size() == 1 ||
+                std::find(args.cmake_configure_debug.begin(),
+                          args.cmake_configure_debug.end(),
+                          scf.core_paragraph->name) != args.cmake_configure_debug.end())
+            {
+                variables.emplace_back(fmt::format("-DVCPKG_CMAKE_CONFIGURE_OPTIONS=--debugger;--debugger-pipe={}",
+                                                   *args.cmake_configure_debug.begin()));
+            }
         }
 
         for (const auto& cmake_arg : args.cmake_args)

--- a/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/src/vcpkg/vcpkgcmdarguments.cpp
@@ -304,6 +304,9 @@ namespace vcpkg
         args.parser.parse_multi_option(
             BINARY_SOURCES_ARG, StabilityTag::Standard, args.cli_binary_sources, msg::format(msgBinarySourcesArg));
         args.parser.parse_multi_option(CMAKE_SCRIPT_ARG, StabilityTag::Standard, args.cmake_args);
+        args.parser.parse_multi_option(CMAKE_DEBUGGING_ARG, StabilityTag::Experimental, args.cmake_debug);
+        args.parser.parse_multi_option(
+            CMAKE_CONFIGURE_DEBUGGING_ARG, StabilityTag::Experimental, args.cmake_configure_debug);
 
         std::vector<std::string> feature_flags;
         args.parser.parse_multi_option(FEATURE_FLAGS_ARG, StabilityTag::Standard, feature_flags);
@@ -804,5 +807,7 @@ namespace vcpkg
     constexpr StringLiteral VcpkgCmdArguments::VERSIONS_FEATURE;
 
     constexpr StringLiteral VcpkgCmdArguments::CMAKE_SCRIPT_ARG;
+    constexpr StringLiteral VcpkgCmdArguments::CMAKE_DEBUGGING_ARG;
+    constexpr StringLiteral VcpkgCmdArguments::CMAKE_CONFIGURE_DEBUGGING_ARG;
     constexpr StringLiteral VcpkgCmdArguments::EXACT_ABI_TOOLS_VERSIONS_SWITCH;
 }


### PR DESCRIPTION
Debug with e.g. 

`./vcpkg.exe install zlib --x-cmake-debug \\.\pipe\tespipe;zlib`
for portfile debugging
`./vcpkg.exe install zlib --x-cmake-configure-debug \\.\pipe\tespipe;zlib`
for debugging cmake configure of the port

(In Git bash `\` needs to be escaped to `\\`)

or more general
`./vcpkg.exe install zlib --x-cmake(-configure)-debug <valid_pipe_name>(;semicolon_seperated_list_of_ports_to_debug)`
for debugging cmake configure of the port

Requires external cmake debugger to attach to the opened pipe to continue execution (which is why I did not write tests for it since it would at least require two seperate process started at the right time to test this.). 

Docs PR https://github.com/microsoft/vcpkg-docs/pull/143