### PR TITLE
Make it possible to run e2e tests without vcpkg.ps1

### DIFF
--- a/azure-pipelines/end-to-end-tests-dir/bundles.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/bundles.ps1
@@ -4,6 +4,11 @@ if (Test-Path env:VCPKG_DOWNLOADS) {
     Remove-Item env:VCPKG_DOWNLOADS
 }
 
+if ($WithoutPs1) {
+    Write-Host "Skipping tests in bundles.ps1 because -WithoutPs1 was specified"
+    return
+}
+
 if ($IsWindows) {
     $cache_home = $env:LOCALAPPDATA
 } elseif (Test-Path "env:XDG_CACHE_HOME") {

--- a/azure-pipelines/end-to-end-tests-prelude.ps1
+++ b/azure-pipelines/end-to-end-tests-prelude.ps1
@@ -104,7 +104,7 @@ function Run-VcpkgAndCaptureOutput {
         [string[]]$TestArgs
     )
     $thisVcpkg = $VcpkgPs1;
-    if ($ForceExe) {
+    if ($ForceExe -or $WithoutPs1) {
         $thisVcpkg = $VcpkgExe;
     }
 

--- a/azure-pipelines/end-to-end-tests.ps1
+++ b/azure-pipelines/end-to-end-tests.ps1
@@ -30,7 +30,9 @@ Param(
     [Parameter(Mandatory = $false)]
     [string]$VcpkgExe,
     [Parameter(Mandatory = $false, HelpMessage="Run artifacts tests, only usable when vcpkg was built with VCPKG_ARTIFACTS_DEVELOPMENT=ON")]
-    [switch]$RunArtifactsTests
+    [switch]$RunArtifactsTests,
+    [Parameter(Mandatory = $false, HelpMessage="Uses the vcpkg executable instead of the vcpkg.ps1 script")]
+    [switch]$WithoutPs1
 )
 
 $ErrorActionPreference = "Stop"


### PR DESCRIPTION
I want to run the e2e test but with the vcpkg-tool because I don't build vcpkg.ps1 locally. 