### PR TITLE
Clean up NoTtyProgressRenderer timeout on error

### DIFF
--- a/vcpkg-artifacts/cli/artifacts.ts
+++ b/vcpkg-artifacts/cli/artifacts.ts
@@ -219,6 +219,12 @@ class NoTtyProgressRenderer implements Partial<ProgressRenderer> {
     }
   }
 
+  stop(): void {
+    if (this.#downloadTimeoutId) {
+      clearTimeout(this.#downloadTimeoutId);
+    }
+  }
+
   unpackArchiveStart(archiveUri: Uri) {
     this.channels.message(i`Unpacking ${archiveUri.fsPath}...`);
   }


### PR DESCRIPTION
The `acquireArtifacts` function calls stop on the ProgressRenderer when there is an error. Previously, stop was not implemented on the NoTtyProgressRenderer. This meant the progress continued to be reported after the download had failed.