### PR TITLE
Return a non-zero exit code on error

### DIFF
--- a/vcpkg-artifacts/main.ts
+++ b/vcpkg-artifacts/main.ts
@@ -98,7 +98,7 @@ async function main() {
     error(e);
 
     await session.writeTelemetry();
-    return process.exit(result ? 0 : 1);
+    return process.exit(1);
   } finally {
     await session.writeTelemetry();
   }


### PR DESCRIPTION
Commands such as `vcpkg activate` now exit with an exit code of `1` if the command method throws an exception. Previously, the exit code was always `0`.