### PR TITLE
Correct schema for version overrides to show that they accept a schemed version

### DIFF
--- a/docs/vcpkg-schema-definitions.schema.json
+++ b/docs/vcpkg-schema-definitions.schema.json
@@ -645,6 +645,31 @@
       },
       "else": false
     },
+    "has-one-version": {
+      "type": "object",
+      "oneOf": [
+        {
+          "required": [
+            "version-string"
+          ]
+        },
+        {
+          "required": [
+            "version"
+          ]
+        },
+        {
+          "required": [
+            "version-semver"
+          ]
+        },
+        {
+          "required": [
+            "version-date"
+          ]
+        }
+      ]
+    },
     "has-zero-or-one-version": {
       "type": "object",
       "oneOf": [
@@ -729,27 +754,50 @@
     },
     "override": {
       "description": "A version override.",
-      "type": "object",
-      "properties": {
-        "name": {
-          "$ref": "#/definitions/identifier"
+      "allOf": [
+        {
+          "type": "object",
+          "$comment": "The regexes below have (#\\d+)? added to the end as overrides allow putting the port-version inline",
+          "properties": {
+              "name": {
+                "$ref": "#/definitions/identifier"
+              },
+            "version-string": {
+              "description": "Text used to identify an arbitrary version",
+              "type": "string",
+              "pattern": "^[^#]+(#\\d+)?$"
+            },
+            "version": {
+              "description": "A relaxed version string (1.2.3.4...)",
+              "type": "string",
+              "pattern": "^\\d+(\\.\\d+)*(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?(#\\d+)?$"
+            },
+            "version-date": {
+              "description": "A date version string (e.g. 2020-01-20)",
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(\\.\\d+)*(#\\d+)?$"
+            },
+            "version-semver": {
+              "description": "A semantic version string. See https://semver.org/",
+              "type": "string",
+              "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?(#\\d+)?$"
+            },
+            "port-version": {
+              "$ref": "#/definitions/port-version"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "patternProperties": {
+            "^\\$": {}
+          },
+          "additionalProperties": false
         },
-        "version": {
-          "type": "string",
-          "pattern": "^[^#]+(#\\d+)?$"
-        },
-        "port-version": {
-          "$ref": "#/definitions/port-version"
+        {
+          "$ref": "#/definitions/has-one-version"
         }
-      },
-      "required": [
-        "name",
-        "version"
-      ],
-      "patternProperties": {
-        "^\\$": {}
-      },
-      "additionalProperties": false
+      ]
     },
     "port-name": {
       "type": "string",


### PR DESCRIPTION
This is what the product does, see tests:

https://github.com/microsoft/vcpkg-tool/blob/785af0d180135ea93077c364445e879eb75dd1b4/src/vcpkg-test/manifests.cpp#L335-L433