### PR TITLE
Search for absolute paths in parallel

### DIFF
--- a/include/vcpkg/base/parallel-algorithms.h
+++ b/include/vcpkg/base/parallel-algorithms.h
@@ -8,6 +8,27 @@
 
 namespace vcpkg
 {
+    template<class F>
+    inline void execute_in_parallel(size_t work_count, F&& work)
+    {
+        const size_t thread_count = static_cast<size_t>(get_concurrency());
+        const size_t num_threads = std::max(static_cast<size_t>(1), std::min(thread_count, work_count));
+
+        std::vector<std::future<void>> workers;
+        workers.reserve(num_threads - 1);
+
+        for (size_t i = 0; i < num_threads - 1; ++i)
+        {
+            workers.emplace_back(std::async(std::launch::async, [&work]() { work(); }));
+        }
+        work();
+
+        for (auto&& w : workers)
+        {
+            w.get();
+        }
+    }
+
     template<class It, class F>
     void parallel_for_each(It begin, size_t work_count, F&& cb)
     {
@@ -21,30 +42,38 @@ namespace vcpkg
             return;
         }
 
-        const size_t thread_count = static_cast<size_t>(get_concurrency());
-        const size_t num_threads = std::max(static_cast<size_t>(1), std::min(thread_count, work_count));
-
-        std::vector<std::future<void>> workers;
-        workers.reserve(num_threads - 1);
-
         std::atomic_size_t next{0};
-        auto work = [&]() {
+
+        execute_in_parallel(work_count, [&]() {
             size_t i;
             while (i = next.fetch_add(1, std::memory_order_relaxed), i < work_count)
             {
                 cb(*(begin + i));
             }
-        };
+        });
+    }
 
-        for (size_t i = 0; i < num_threads - 1; ++i)
+    template<class InIt, class OutIt, class F>
+    void parallel_transform(InIt begin, size_t work_count, OutIt out_begin, F&& cb)
+    {
+        if (work_count == 0)
         {
-            workers.emplace_back(std::async(std::launch::async, [&work]() { work(); }));
+            return;
         }
-        work();
+        if (work_count == 1)
+        {
+            *out_begin = cb(*begin);
+            return;
+        }
 
-        for (auto&& w : workers)
-        {
-            w.get();
-        }
+        std::atomic_size_t next{0};
+
+        execute_in_parallel(work_count, [&]() {
+            size_t i;
+            while (i = next.fetch_add(1, std::memory_order_relaxed), i < work_count)
+            {
+                *(out_begin + i) = cb(*(begin + i));
+            }
+        });
     }
 }

--- a/include/vcpkg/base/parallel-algorithms.h
+++ b/include/vcpkg/base/parallel-algorithms.h
@@ -9,7 +9,7 @@
 namespace vcpkg
 {
     template<class F>
-    inline void execute_in_parallel(size_t work_count, F&& work)
+    inline void execute_in_parallel(size_t work_count, F&& work) noexcept
     {
         const size_t thread_count = static_cast<size_t>(get_concurrency());
         const size_t num_threads = std::max(static_cast<size_t>(1), std::min(thread_count, work_count));
@@ -19,7 +19,7 @@ namespace vcpkg
 
         for (size_t i = 0; i < num_threads - 1; ++i)
         {
-            workers.emplace_back(std::async(std::launch::async, [&work]() { work(); }));
+            workers.emplace_back(std::async(std::launch::async | std::launch::deferred, [&work]() { work(); }));
         }
         work();
 
@@ -29,8 +29,8 @@ namespace vcpkg
         }
     }
 
-    template<class It, class F>
-    void parallel_for_each(It begin, size_t work_count, F&& cb)
+    template<class RanIt, class F>
+    void parallel_for_each_n(RanIt begin, size_t work_count, F cb) noexcept
     {
         if (work_count == 0)
         {
@@ -45,16 +45,19 @@ namespace vcpkg
         std::atomic_size_t next{0};
 
         execute_in_parallel(work_count, [&]() {
-            size_t i;
-            while (i = next.fetch_add(1, std::memory_order_relaxed), i < work_count)
+            size_t i = 0;
+            while (i < work_count)
             {
-                cb(*(begin + i));
+                if (next.compare_exchange_weak(i, i + 1, std::memory_order_relaxed))
+                {
+                    cb(*(begin + i));
+                }
             }
         });
     }
 
-    template<class InIt, class OutIt, class F>
-    void parallel_transform(InIt begin, size_t work_count, OutIt out_begin, F&& cb)
+    template<class RanItSource, class RanItTarget, class F>
+    void parallel_transform(RanItSource begin, size_t work_count, RanItTarget out_begin, F&& cb) noexcept
     {
         if (work_count == 0)
         {
@@ -69,10 +72,13 @@ namespace vcpkg
         std::atomic_size_t next{0};
 
         execute_in_parallel(work_count, [&]() {
-            size_t i;
-            while (i = next.fetch_add(1, std::memory_order_relaxed), i < work_count)
+            size_t i = 0;
+            while (i < work_count)
             {
-                *(out_begin + i) = cb(*(begin + i));
+                if (next.compare_exchange_weak(i, i + 1, std::memory_order_relaxed))
+                {
+                    *(out_begin + i) = cb(*(begin + i));
+                }
             }
         });
     }

--- a/include/vcpkg/base/parallel-algorithms.h
+++ b/include/vcpkg/base/parallel-algorithms.h
@@ -1,0 +1,66 @@
+#pragma once
+
+// At this time only MSVC supports parallel algorithms by default
+// Gcc needs tbb as a runtime dependency
+// Clang doesn't support parallel algorithms at all
+
+#if defined(_MSC_VER)
+#include <algorithm>
+#include <execution>
+#include <mutex>
+
+#define vcpkg_parallel_for_each(BEGIN, END, CB) std::for_each(std::execution::par, BEGIN, END, CB)
+#define vcpkg_par_unseq_for_each(BEGIN, END, CB) std::for_each(std::execution::par_unseq, BEGIN, END, CB)
+
+#else
+#include <atomic>
+#include <future>
+#include <vector>
+
+namespace vcpkg
+{
+    template<class It, class F>
+    void parallel_for_each(It begin, It end, F&& cb)
+    {
+        if (begin == end)
+        {
+            return;
+        }
+        if (begin + 1 == end)
+        {
+            return cb(std::move(*begin));
+        }
+
+        const auto thread_count = std::thread::hardware_concurrency() * 2;
+        const ptrdiff_t work_count = std::distance(begin, end);
+        const auto num_threads = static_cast<size_t>(
+            std::max(static_cast<ptrdiff_t>(1), std::min(static_cast<ptrdiff_t>(thread_count), work_count)));
+
+        std::vector<std::future<void>> workers;
+        workers.reserve(num_threads);
+
+        std::atomic_size_t next{0};
+        auto work = [&]() {
+            size_t i;
+            while (i = next.fetch_add(1, std::memory_order_relaxed), i < static_cast<size_t>(work_count))
+            {
+                cb(std::move(*(begin + i)));
+            }
+        };
+
+        for (size_t i = 0; i < num_threads - 1; ++i)
+        {
+            workers.emplace_back(std::async(std::launch::async, work));
+        }
+        work();
+
+        for (auto&& w : workers)
+        {
+            w.get();
+        }
+    }
+}
+
+#define vcpkg_parallel_for_each(BEGIN, END, CB) ::vcpkg::parallel_for_each(BEGIN, END, CB)
+#define vcpkg_par_unseq_for_each(BEGIN, END, CB) vcpkg_parallel_for_each(BEGIN, END, CB)
+#endif

--- a/include/vcpkg/base/parallel-algorithms.h
+++ b/include/vcpkg/base/parallel-algorithms.h
@@ -36,7 +36,7 @@ namespace vcpkg
         const auto num_threads = static_cast<size_t>(
             std::max(static_cast<ptrdiff_t>(1), std::min(static_cast<ptrdiff_t>(thread_count), work_count)));
 
-        std::vector<std::future<void>> workers;
+        std::vector<std::thread> workers;
         workers.reserve(num_threads);
 
         std::atomic_size_t next{0};
@@ -50,13 +50,13 @@ namespace vcpkg
 
         for (size_t i = 0; i < num_threads - 1; ++i)
         {
-            workers.emplace_back(std::async(std::launch::async, work));
+            workers.emplace_back(work);
         }
         work();
 
         for (auto&& w : workers)
         {
-            w.get();
+            w.join();
         }
     }
 }

--- a/include/vcpkg/base/parallel-algorithms.h
+++ b/include/vcpkg/base/parallel-algorithms.h
@@ -1,18 +1,7 @@
 #pragma once
 
-// At this time only MSVC supports parallel algorithms by default
-// Gcc needs tbb as a runtime dependency
-// Clang doesn't support parallel algorithms at all
+#include <vcpkg/base/system.h>
 
-#if defined(_MSC_VER)
-#include <algorithm>
-#include <execution>
-#include <mutex>
-
-#define vcpkg_parallel_for_each(BEGIN, END, CB) std::for_each(std::execution::par, BEGIN, END, CB)
-#define vcpkg_par_unseq_for_each(BEGIN, END, CB) std::for_each(std::execution::par_unseq, BEGIN, END, CB)
-
-#else
 #include <atomic>
 #include <future>
 #include <vector>
@@ -20,47 +9,42 @@
 namespace vcpkg
 {
     template<class It, class F>
-    void parallel_for_each(It begin, It end, F&& cb)
+    void parallel_for_each(It begin, size_t work_count, F&& cb)
     {
-        if (begin == end)
+        if (work_count == 0)
         {
             return;
         }
-        if (begin + 1 == end)
+        if (work_count == 1)
         {
-            return cb(std::move(*begin));
+            cb(*begin);
+            return;
         }
 
-        const auto thread_count = std::thread::hardware_concurrency() * 2;
-        const ptrdiff_t work_count = std::distance(begin, end);
-        const auto num_threads = static_cast<size_t>(
-            std::max(static_cast<ptrdiff_t>(1), std::min(static_cast<ptrdiff_t>(thread_count), work_count)));
+        const size_t thread_count = static_cast<size_t>(get_concurrency());
+        const size_t num_threads = std::max(static_cast<size_t>(1), std::min(thread_count, work_count));
 
-        std::vector<std::thread> workers;
-        workers.reserve(num_threads);
+        std::vector<std::future<void>> workers;
+        workers.reserve(num_threads - 1);
 
         std::atomic_size_t next{0};
         auto work = [&]() {
             size_t i;
-            while (i = next.fetch_add(1, std::memory_order_relaxed), i < static_cast<size_t>(work_count))
+            while (i = next.fetch_add(1, std::memory_order_relaxed), i < work_count)
             {
-                cb(std::move(*(begin + i)));
+                cb(*(begin + i));
             }
         };
 
         for (size_t i = 0; i < num_threads - 1; ++i)
         {
-            workers.emplace_back(work);
+            workers.emplace_back(std::async(std::launch::async, [&work]() { work(); }));
         }
         work();
 
         for (auto&& w : workers)
         {
-            w.join();
+            w.get();
         }
     }
 }
-
-#define vcpkg_parallel_for_each(BEGIN, END, CB) ::vcpkg::parallel_for_each(BEGIN, END, CB)
-#define vcpkg_par_unseq_for_each(BEGIN, END, CB) vcpkg_parallel_for_each(BEGIN, END, CB)
-#endif

--- a/src/vcpkg/postbuildlint.cpp
+++ b/src/vcpkg/postbuildlint.cpp
@@ -1284,15 +1284,14 @@ namespace vcpkg
         std::vector<Path> failing_files;
         std::mutex mtx;
         auto files = fs.get_regular_files_recursive(dir, IgnoreErrors{});
-        auto work = [&](auto&& file) {
+
+        parallel_for_each(files.begin(), files.size(), [&](const Path& file) {
             if (file_contains_absolute_paths(fs, file, stringview_paths))
             {
                 std::lock_guard lock{mtx};
-                failing_files.push_back(std::move(file));
+                failing_files.push_back(file);
             }
-        };
-
-        vcpkg_parallel_for_each(files.begin(), files.end(), work);
+        });
 
         if (failing_files.empty())
         {

--- a/src/vcpkg/postbuildlint.cpp
+++ b/src/vcpkg/postbuildlint.cpp
@@ -1285,7 +1285,7 @@ namespace vcpkg
         std::mutex mtx;
         auto files = fs.get_regular_files_recursive(dir, IgnoreErrors{});
 
-        parallel_for_each(files.begin(), files.size(), [&](const Path& file) {
+        parallel_for_each_n(files.begin(), files.size(), [&](const Path& file) {
             if (file_contains_absolute_paths(fs, file, stringview_paths))
             {
                 std::lock_guard lock{mtx};

--- a/src/vcpkg/postbuildlint.cpp
+++ b/src/vcpkg/postbuildlint.cpp
@@ -1292,7 +1292,7 @@ namespace vcpkg
             }
         };
 
-        vcpkg_par_unseq_for_each(files.begin(), files.end(), work);
+        vcpkg_parallel_for_each(files.begin(), files.end(), work);
 
         if (failing_files.empty())
         {


### PR DESCRIPTION
In #694 I proposed the use of parallel for_each for some use cases. The problem was that it was possible that the program is exited during a loop iteration.
Here I checked that functions inside the loop don't exit.

I observed that checking for absolute paths is the post build check that needs by far the longest time. This check opens almoast every non-binary file that a port installed and searches for absolute paths. This results in linear complexity. If a file isn't too big, parsing doesn't take that long but it adds up if there are multiple header files. Using parallel for_each as proposed here can therefore lead to significant speedup. The speedup increases with number and size of installed header files. I observed ~3x speedup for nlohmann-json:x64-windows (release build).

Note that `file_contains_absolute_paths` does nothing if the file is a binary. However, I considered the number of binaries low in comparison to the number of header files so I think we don't waste that much if we had a few no-op iterations.