### PR TITLE
--x-cmake-args: Only imply editable if a variable is being set

### DIFF
--- a/src/vcpkg/commands.install.cpp
+++ b/src/vcpkg/commands.install.cpp
@@ -977,8 +977,9 @@ namespace vcpkg
         return ret;
     }
 
-    static bool cmake_args_sets_variable(const VcpkgCmdArguments& args) {
-        return Util::any_of(args.cmake_args, [](auto &s){ return Strings::starts_with(s, "-D"); });
+    static bool cmake_args_sets_variable(const VcpkgCmdArguments& args)
+    {
+        return Util::any_of(args.cmake_args, [](auto& s) { return Strings::starts_with(s, "-D"); });
     }
 
     void command_install_and_exit(const VcpkgCmdArguments& args,
@@ -995,7 +996,8 @@ namespace vcpkg
         const bool only_downloads = Util::Sets::contains(options.switches, (OPTION_ONLY_DOWNLOADS));
         const bool no_build_missing = Util::Sets::contains(options.switches, OPTION_ONLY_BINARYCACHING);
         const bool is_recursive = Util::Sets::contains(options.switches, (OPTION_RECURSE));
-        const bool is_editable = Util::Sets::contains(options.switches, (OPTION_EDITABLE)) || cmake_args_sets_variable(args);
+        const bool is_editable =
+            Util::Sets::contains(options.switches, (OPTION_EDITABLE)) || cmake_args_sets_variable(args);
         const bool use_aria2 = Util::Sets::contains(options.switches, (OPTION_USE_ARIA2));
         const bool clean_after_build = Util::Sets::contains(options.switches, (OPTION_CLEAN_AFTER_BUILD));
         const bool clean_buildtrees_after_build =

--- a/src/vcpkg/commands.install.cpp
+++ b/src/vcpkg/commands.install.cpp
@@ -978,7 +978,7 @@ namespace vcpkg
     }
 
     bool cmake_args_sets_variable(const VcpkgCmdArguments& args) {
-        return Utils::any_of(args, [](auto &s){ return Strings::starts_with(s, "-D"); });
+        return Util::any_of(args.cmake_args, [](auto &s){ return Strings::starts_with(s, "-D"); });
     }
 
     void command_install_and_exit(const VcpkgCmdArguments& args,

--- a/src/vcpkg/commands.install.cpp
+++ b/src/vcpkg/commands.install.cpp
@@ -977,6 +977,13 @@ namespace vcpkg
         return ret;
     }
 
+    bool cmake_args_sets_variable(const VcpkgCmdArguments& args) {
+        auto sets_variable = [] (std::string_view str) {
+            return (str.find("-D") == 0); // starts_with is c++20
+        };
+        return std::any_of(args.cmake_args.cbegin(), args.cmake_args.cend(),sets_variable);
+    }
+
     void command_install_and_exit(const VcpkgCmdArguments& args,
                                   const VcpkgPaths& paths,
                                   Triplet default_triplet,
@@ -991,7 +998,7 @@ namespace vcpkg
         const bool only_downloads = Util::Sets::contains(options.switches, (OPTION_ONLY_DOWNLOADS));
         const bool no_build_missing = Util::Sets::contains(options.switches, OPTION_ONLY_BINARYCACHING);
         const bool is_recursive = Util::Sets::contains(options.switches, (OPTION_RECURSE));
-        const bool is_editable = Util::Sets::contains(options.switches, (OPTION_EDITABLE)) || !args.cmake_args.empty();
+        const bool is_editable = Util::Sets::contains(options.switches, (OPTION_EDITABLE)) || cmake_args_sets_variable(args);
         const bool use_aria2 = Util::Sets::contains(options.switches, (OPTION_USE_ARIA2));
         const bool clean_after_build = Util::Sets::contains(options.switches, (OPTION_CLEAN_AFTER_BUILD));
         const bool clean_buildtrees_after_build =

--- a/src/vcpkg/commands.install.cpp
+++ b/src/vcpkg/commands.install.cpp
@@ -977,7 +977,7 @@ namespace vcpkg
         return ret;
     }
 
-    bool cmake_args_sets_variable(const VcpkgCmdArguments& args) {
+    static bool cmake_args_sets_variable(const VcpkgCmdArguments& args) {
         return Util::any_of(args.cmake_args, [](auto &s){ return Strings::starts_with(s, "-D"); });
     }
 

--- a/src/vcpkg/commands.install.cpp
+++ b/src/vcpkg/commands.install.cpp
@@ -978,10 +978,7 @@ namespace vcpkg
     }
 
     bool cmake_args_sets_variable(const VcpkgCmdArguments& args) {
-        auto sets_variable = [] (std::string_view str) {
-            return (str.find("-D") == 0); // starts_with is c++20
-        };
-        return std::any_of(args.cmake_args.cbegin(), args.cmake_args.cend(),sets_variable);
+        return Utils::any_of(args, [](auto &s){ return Strings::starts_with(s, "-D"); });
     }
 
     void command_install_and_exit(const VcpkgCmdArguments& args,


### PR DESCRIPTION
Allows stuff like --trace etc. be used in manifest mode. Don't see a reason to add extra commands for all possible cmake options to vcpkg if it can be passed via --x-cmake-args.