### PR TITLE
vcpkg new / validate name

### DIFF
--- a/src/vcpkg/commands.new.cpp
+++ b/src/vcpkg/commands.new.cpp
@@ -1,5 +1,6 @@
 #include <vcpkg/base/checks.h>
 #include <vcpkg/base/files.h>
+#include <vcpkg/base/jsonreader.h>
 #include <vcpkg/base/util.h>
 
 #include <vcpkg/commands.new.h>
@@ -52,18 +53,6 @@ namespace vcpkg
         nullptr,
     };
 
-    static bool isValidName(const std::string& name)
-    {
-        for (char ch : name)
-        {
-            if (!(std::islower(ch) || ch == '-'))
-            {
-                return false;
-            }
-        }
-        return true;
-    }
-
     ExpectedL<Json::Object> build_prototype_manifest(const std::string* name,
                                                      const std::string* version,
                                                      bool option_application,
@@ -89,7 +78,7 @@ namespace vcpkg
                 return msg::format_error(msgNewNameCannotBeEmpty);
             }
 
-            if (!isValidName(*name))
+            if (!Json::IdentifierDeserializer::is_ident(*name))
             {
                 return msg::format_error(msgParseIdentifierError,
                                          msg::value = *name,

--- a/src/vcpkg/commands.new.cpp
+++ b/src/vcpkg/commands.new.cpp
@@ -52,7 +52,7 @@ namespace vcpkg
         nullptr,
     };
 
-    bool isValidName(const std::string& name)
+    static bool isValidName(const std::string& name)
     {
         for (char ch : name)
         {
@@ -91,7 +91,9 @@ namespace vcpkg
 
             if (!isValidName(*name))
             {
-                return msg::format_error(msgParseIdentifierError, msg::value = *name, msg::url = "https://learn.microsoft.com/vcpkg/commands/new");
+                return msg::format_error(msgParseIdentifierError,
+                                         msg::value = *name,
+                                         msg::url = "https://learn.microsoft.com/vcpkg/commands/new");
             }
 
             manifest.insert("name", *name);

--- a/src/vcpkg/commands.new.cpp
+++ b/src/vcpkg/commands.new.cpp
@@ -52,6 +52,18 @@ namespace vcpkg
         nullptr,
     };
 
+    bool isValidName(const std::string& name)
+    {
+        for (char ch : name)
+        {
+            if (!(std::islower(ch) || ch == '-'))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
     ExpectedL<Json::Object> build_prototype_manifest(const std::string* name,
                                                      const std::string* version,
                                                      bool option_application,
@@ -75,6 +87,11 @@ namespace vcpkg
             if (name->empty())
             {
                 return msg::format_error(msgNewNameCannotBeEmpty);
+            }
+
+            if (!isValidName(*name))
+            {
+                return msg::format_error(msgParseIdentifierError, msg::value = *name, msg::url = "https://learn.microsoft.com/vcpkg/commands/new");
             }
 
             manifest.insert("name", *name);


### PR DESCRIPTION
vcpkg new should validate name as an identifier. 

Before:

```
vcpkg new --name HelloWorld --version 1.0
```

After:

```
vcpkg new --name HelloWorld --version 1.0

error: "HelloWorld" is not a valid identifier. Identifiers must be lowercase alphanumeric+hypens and not reserved (see https://learn.microsoft.com/vcpkg/commands/new for more information)
```