### PR TITLE
Fix edit command.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -530,6 +530,12 @@ set_property(TARGET closes-stdout PROPERTY PDB_NAME "closes-stdout${VCPKG_PDB_SU
 set(READS_STDIN_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/reads-stdin.c")
 add_executable(reads-stdin ${READS_STDIN_SOURCES} "${CMAKE_CURRENT_SOURCE_DIR}/src/vcpkg.manifest")
 set_property(TARGET reads-stdin PROPERTY PDB_NAME "reads-stdin${VCPKG_PDB_SUFFIX}")
+
+# === Target: test-editor ===
+
+set(TEST_EDITOR_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/test-editor.c")
+add_executable(test-editor ${TEST_EDITOR_SOURCES} "${CMAKE_CURRENT_SOURCE_DIR}/src/vcpkg.manifest")
+set_property(TARGET test-editor PROPERTY PDB_NAME "test-editor${VCPKG_PDB_SUFFIX}")
 endif()
 
 # === Target: format ===
@@ -554,6 +560,7 @@ if(CLANG_FORMAT)
         COMMAND "${CLANG_FORMAT}" -i -verbose ${CLOSES_STDIN_SOURCES}
         COMMAND "${CLANG_FORMAT}" -i -verbose ${CLOSES_STDOUT_SOURCES}
         COMMAND "${CLANG_FORMAT}" -i -verbose ${READS_STDIN_SOURCES}
+        COMMAND "${CLANG_FORMAT}" -i -verbose ${TEST_EDITOR_SOURCES}
     )
 endif()
 

--- a/azure-pipelines/end-to-end-tests-dir/edit.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/edit.ps1
@@ -1,0 +1,33 @@
+. $PSScriptRoot/../end-to-end-tests-prelude.ps1
+
+$expected = "$env:VCPKG_ROOT/ports/zlib`n$env:VCPKG_ROOT/ports/zlib/portfile.cmake`n-n"
+$expected = $expected.Replace('\', '/')
+
+Refresh-TestRoot
+
+$buildDir = (Get-Item $VcpkgExe).Directory
+$tempFilePath = "$TestingRoot/result.txt"
+
+$env:VCPKG_TEST_OUTPUT = $tempFilePath
+$editor = "$buildDir/test-editor"
+if ($IsWindows) {
+	$editor += '.exe'
+}
+
+Write-Host "Using editor $editor"
+$env:EDITOR = $editor
+try {
+	Run-Vcpkg edit zlib
+	Throw-IfFailed
+
+	$result = Get-Content -LiteralPath $tempFilePath -Raw
+} finally {
+	Remove-Item env:VCPKG_TEST_OUTPUT
+	Remove-Item env:EDITOR
+}
+
+$result = $result.Trim().Replace('\', '/')
+
+if ($result -ne $expected) {
+	throw 'Did not edit the expected directory.'
+}

--- a/src/test-editor.c
+++ b/src/test-editor.c
@@ -1,0 +1,43 @@
+#define _CRT_SECURE_NO_WARNINGS
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, const char* argv[])
+{
+    const char* path;
+    FILE* f;
+    if (argc != 4)
+    {
+        puts("bad arg count");
+        return 1;
+    }
+
+    path = getenv("VCPKG_TEST_OUTPUT");
+    if (!path)
+    {
+        puts("bad env var");
+        return 1;
+    }
+
+    f = fopen(path, "wb");
+    if (!f)
+    {
+        puts("bad open");
+        return 1;
+    }
+
+    for (size_t idx = 1; idx < 4; ++idx)
+    {
+        if (fputs(argv[idx], f) < 0)
+        {
+            puts("bad write");
+        }
+    
+        if (fputs("\n", f) < 0)
+        {
+            puts("bad write newline");
+        }
+    }
+
+    fclose(f);
+}

--- a/src/test-editor.c
+++ b/src/test-editor.c
@@ -32,7 +32,7 @@ int main(int argc, const char* argv[])
         {
             puts("bad write");
         }
-    
+
         if (fputs("\n", f) < 0)
         {
             puts("bad write newline");

--- a/src/test-editor.c
+++ b/src/test-editor.c
@@ -21,7 +21,7 @@ int main(int argc, const char* argv[])
         return 1;
     }
 
-    for (size_t idx = 1; idx < argc; ++idx)
+    for (int idx = 1; idx < argc; ++idx)
     {
         if (fputs(argv[idx], f) < 0)
         {

--- a/src/test-editor.c
+++ b/src/test-editor.c
@@ -6,11 +6,6 @@ int main(int argc, const char* argv[])
 {
     const char* path;
     FILE* f;
-    if (argc != 4)
-    {
-        puts("bad arg count");
-        return 1;
-    }
 
     path = getenv("VCPKG_TEST_OUTPUT");
     if (!path)
@@ -26,7 +21,7 @@ int main(int argc, const char* argv[])
         return 1;
     }
 
-    for (size_t idx = 1; idx < 4; ++idx)
+    for (size_t idx = 1; idx < argc; ++idx)
     {
         if (fputs(argv[idx], f) < 0)
         {


### PR DESCRIPTION
Fix edit command I broke in https://github.com/microsoft/vcpkg-tool/commit/81c8bedf74dd27b9c00b25e787256d98464e85d0

`PROC_THREAD_ATTRIBUTE_HANDLE_LIST` rejects a list of length `0`. Instead, just pass false to bInheritHandles in the CreateProcess call.