### PR TITLE
add mips64 target support

### DIFF
--- a/include/vcpkg/base/fwd/system.h
+++ b/include/vcpkg/base/fwd/system.h
@@ -15,5 +15,6 @@ namespace vcpkg
         RISCV64,
         LOONGARCH32,
         LOONGARCH64,
+        MIPS64,
     };
 }

--- a/src/vcpkg-test/system.cpp
+++ b/src/vcpkg-test/system.cpp
@@ -56,6 +56,7 @@ TEST_CASE ("[to_cpu_architecture]", "system")
         {CPUArchitecture::X64, "AmD64"},
         {CPUArchitecture::ARM, "ARM"},
         {CPUArchitecture::ARM64, "ARM64"},
+        {CPUArchitecture::MIPS64, "MIPS64"},
         {nullopt, "ARM6"},
         {nullopt, "AR"},
         {nullopt, "Intel"},
@@ -81,6 +82,7 @@ TEST_CASE ("from_cpu_architecture", "[system]")
         {CPUArchitecture::X64, "x64"},
         {CPUArchitecture::ARM, "arm"},
         {CPUArchitecture::ARM64, "arm64"},
+        {CPUArchitecture::MIPS64, "mips64"},
     };
 
     for (auto&& instance : test_cases)

--- a/src/vcpkg/base/system.cpp
+++ b/src/vcpkg/base/system.cpp
@@ -157,6 +157,7 @@ namespace vcpkg
         if (Strings::case_insensitive_ascii_equals(arch, "riscv64")) return CPUArchitecture::RISCV64;
         if (Strings::case_insensitive_ascii_equals(arch, "loongarch32")) return CPUArchitecture::LOONGARCH32;
         if (Strings::case_insensitive_ascii_equals(arch, "loongarch64")) return CPUArchitecture::LOONGARCH64;
+        if (Strings::case_insensitive_ascii_equals(arch, "mips64")) return CPUArchitecture::MIPS64;
 
         return nullopt;
     }
@@ -176,6 +177,7 @@ namespace vcpkg
             case CPUArchitecture::RISCV64: return "riscv64";
             case CPUArchitecture::LOONGARCH32: return "loongarch32";
             case CPUArchitecture::LOONGARCH64: return "loongarch64";
+            case CPUArchitecture::MIPS64: return "mips64";
             default: Checks::exit_with_message(VCPKG_LINE_INFO, "unexpected vcpkg::CPUArchitecture");
         }
     }
@@ -237,6 +239,8 @@ namespace vcpkg
         return CPUArchitecture::ARM64;
 #elif defined(_M_X64)
         return CPUArchitecture::X64;
+#elif defined(__mips64)
+        return CPUArchitecture::MIPS64;
 #else
 #error "Unknown host architecture"
 #endif // architecture
@@ -277,6 +281,8 @@ namespace vcpkg
         return CPUArchitecture::LOONGARCH32;
 #elif defined(__loongarch64) || defined(__loongarch__) && (__loongarch_grlen == 64)
         return CPUArchitecture::LOONGARCH64;
+#elif defined(__mips64)
+        return CPUArchitecture::MIPS64;
 #else // choose architecture
 #error "Unknown host architecture"
 #endif // choose architecture

--- a/src/vcpkg/platform-expression.cpp
+++ b/src/vcpkg/platform-expression.cpp
@@ -19,6 +19,7 @@ namespace vcpkg::PlatformExpression
         arm32,
         arm64,
         wasm32,
+        mips64,
 
         windows,
         mingw,
@@ -47,6 +48,7 @@ namespace vcpkg::PlatformExpression
             {"arm32", Identifier::arm32},
             {"arm64", Identifier::arm64},
             {"wasm32", Identifier::wasm32},
+            {"mips64", Identifier::mips64},
             {"windows", Identifier::windows},
             {"mingw", Identifier::mingw},
             {"linux", Identifier::linux},

--- a/src/vcpkg/triplet.cpp
+++ b/src/vcpkg/triplet.cpp
@@ -92,6 +92,10 @@ namespace vcpkg
         {
             return CPUArchitecture::LOONGARCH64;
         }
+        if (Strings::starts_with(this->canonical_name(), "mips64-"))
+        {
+            return CPUArchitecture::MIPS64;
+        }
 
         return nullopt;
     }


### PR DESCRIPTION
After making the modifications, I tested fmt, spdlog, bzip2, zlib, openssl, libcurl, cpr, protobuf, qt5-base, and ffmpeg, and they all work correctly.

```bash
$ gcc -dM -E - < /dev/null | grep mips
#define _MIPS_TUNE "mips64r2"
#define __mips_abicalls 1
#define __mips_no_madd4 1
#define __mips_fpr 64
#define __mips__ 1
#define mips 1
#define _MIPS_ARCH "mips64r2"
#define __mips_isa_rev 2
#define __mips64 1
#define _mips 1
#define __mips_hard_float 1
#define __mips 64
```

install spdlog success
```
$ ./vcpkg install spdlog
Computing installation plan...
The following packages will be built and installed:
    spdlog:mips64-linux -> 1.12.0
Detecting compiler hash for triplet mips64-linux...
Restored 0 package(s) from /home/user/.cache/vcpkg/archives in 24.9 us. Use --debug to see more details.
Installing 1/1 spdlog:mips64-linux...
Building spdlog:mips64-linux...
-- Downloading https://ghproxy.com/https://github.com/gabime/spdlog/archive/v1.12.0.tar.gz -> gabime-spdlog-v1.12.0.tar.gz...
-- Extracting source /home/user/vcpkg/downloads/gabime-spdlog-v1.12.0.tar.gz
-- Using source at /home/user/vcpkg/buildtrees/spdlog/src/v1.12.0-7bc8dad862.clean
-- Configuring mips64-linux
-- Building mips64-linux-dbg
-- Building mips64-linux-rel
-- Fixing pkgconfig file: /home/user/vcpkg/packages/spdlog_mips64-linux/lib/pkgconfig/spdlog.pc
-- Fixing pkgconfig file: /home/user/vcpkg/packages/spdlog_mips64-linux/debug/lib/pkgconfig/spdlog.pc
-- Installing: /home/user/vcpkg/packages/spdlog_mips64-linux/share/spdlog/usage
-- Installing: /home/user/vcpkg/packages/spdlog_mips64-linux/share/spdlog/copyright
-- Performing post-build validation
Stored binaries in 1 destinations in 1.3 s.
Elapsed time to handle spdlog:mips64-linux: 44 s
Total install time: 44 s
The package spdlog provides CMake targets:

    find_package(spdlog CONFIG REQUIRED)
    target_link_libraries(main PRIVATE spdlog::spdlog)

    # Or use the header-only version
    find_package(spdlog CONFIG REQUIRED)
    target_link_libraries(main PRIVATE spdlog::spdlog_header_only)
```

install curl success
```
$ ./vcpkg install curl[tool]
Computing installation plan...
The following packages will be built and installed:
    curl[core,non-http,openssl,ssl,tool]:mips64-linux -> 8.3.0
Detecting compiler hash for triplet mips64-linux...
Restored 0 package(s) from /home/user/.cache/vcpkg/archives in 26.2 us. Use --debug to see more details.
Installing 1/1 curl:mips64-linux...
Building curl[core,non-http,openssl,ssl,tool]:mips64-linux...
-- Downloading https://ghproxy.com/https://github.com/curl/curl/archive/curl-8_3_0.tar.gz -> curl-curl-curl-8_3_0.tar.gz...
-- Extracting source /home/user/vcpkg/downloads/curl-curl-curl-8_3_0.tar.gz
-- Applying patch 0002_fix_uwp.patch
-- Applying patch 0005_remove_imp_suffix.patch
-- Applying patch 0012-fix-dependency-idn2.patch
-- Applying patch 0020-fix-pc-file.patch
-- Applying patch 0022-deduplicate-libs.patch
-- Applying patch mbedtls-ws2_32.patch
-- Applying patch export-components.patch
-- Applying patch dependencies.patch
-- Applying patch cmake-config.patch
-- Using source at /home/user/vcpkg/buildtrees/curl/src/curl-8_3_0-8ad1d68a56.clean
-- Configuring mips64-linux
-- Building mips64-linux-dbg
-- Building mips64-linux-rel
-- Fixing pkgconfig file: /home/user/vcpkg/packages/curl_mips64-linux/lib/pkgconfig/libcurl.pc
-- Fixing pkgconfig file: /home/user/vcpkg/packages/curl_mips64-linux/debug/lib/pkgconfig/libcurl.pc
-- Installing: /home/user/vcpkg/packages/curl_mips64-linux/share/curl/vcpkg-cmake-wrapper.cmake
-- Installing: /home/user/vcpkg/packages/curl_mips64-linux/share/curl/usage
-- Performing post-build validation
Stored binaries in 1 destinations in 2.4 s.
Elapsed time to handle curl:mips64-linux: 1.2 min
Total install time: 1.2 min
curl is compatible with built-in CMake targets:

    find_package(CURL REQUIRED)
    target_link_libraries(main PRIVATE CURL::libcurl)
```

install cpr success
```
$ ./vcpkg install cpr
Computing installation plan...
The following packages will be built and installed:
    cpr[core,ssl]:mips64-linux -> 1.10.2+3
Detecting compiler hash for triplet mips64-linux...
Restored 0 package(s) from /home/user/.cache/vcpkg/archives in 24.9 us. Use --debug to see more details.
Installing 1/1 cpr:mips64-linux...
Building cpr[core,ssl]:mips64-linux...
-- Downloading https://ghproxy.com/https://github.com/libcpr/cpr/archive/0445800cd2cace404ac37eb3e78ec5d1431a4f30.tar.gz -> libcpr-cpr-0445800cd2cace404ac37eb3e78ec5d1431a4f30.tar.gz...
-- Extracting source /home/user/vcpkg/downloads/libcpr-cpr-0445800cd2cace404ac37eb3e78ec5d1431a4f30.tar.gz
-- Applying patch 001-cpr-config.patch
-- Applying patch disable_werror.patch
-- Using source at /home/user/vcpkg/buildtrees/cpr/src/d1431a4f30-ceb945674d.clean
-- Configuring mips64-linux
-- Building mips64-linux-dbg
-- Building mips64-linux-rel
-- Installing: /home/user/vcpkg/packages/cpr_mips64-linux/share/cpr/copyright
-- Performing post-build validation
Stored binaries in 1 destinations in 1.8 s.
Elapsed time to handle cpr:mips64-linux: 1.5 min
Total install time: 1.5 min
cpr provides CMake targets:

  # this is heuristically generated, and may not be correct
  find_package(cpr CONFIG REQUIRED)
  target_link_libraries(main PRIVATE cpr::cpr)
```