### PR TITLE
Add base64.h, Makefile, Makefile.am, and Makefile.in to the banned header list.

### DIFF
--- a/src/vcpkg/postbuildlint.cpp
+++ b/src/vcpkg/postbuildlint.cpp
@@ -161,6 +161,9 @@ namespace vcpkg
             "local.h",
             "slice.h",
             "platform.h",
+            "base64.h",
+            "Makefile.am",
+            "Makefile.in",
         };
         static constexpr Span<const StringLiteral> restricted_lists[] = {
             restricted_sys_filenames, restricted_crt_filenames, restricted_general_filenames};

--- a/src/vcpkg/postbuildlint.cpp
+++ b/src/vcpkg/postbuildlint.cpp
@@ -164,6 +164,7 @@ namespace vcpkg
             "base64.h",
             "Makefile.am",
             "Makefile.in",
+            "Makefile",
         };
         static constexpr Span<const StringLiteral> restricted_lists[] = {
             restricted_sys_filenames, restricted_crt_filenames, restricted_general_filenames};


### PR DESCRIPTION
Resolves https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1901356

See also https://github.com/microsoft/vcpkg/pull/34481