### PR TITLE
Ci: also output "Regression: marked as fail but not supported" when there are no other errors

### DIFF
--- a/src/vcpkg/commands.ci.cpp
+++ b/src/vcpkg/commands.ci.cpp
@@ -274,7 +274,7 @@ namespace
                            const LocalizedString& not_supported_regressions,
                            bool allow_unexpected_passing)
     {
-        bool has_error = false;
+        bool has_error = !not_supported_regressions.empty();
         LocalizedString output = msg::format(msgCiBaselineRegressionHeader);
         output.append_raw('\n');
         output.append(not_supported_regressions);


### PR DESCRIPTION
Detected because I got [this](https://github.com/microsoft/vcpkg/pull/34702#issuecomment-1778369624) comment a ci was green. 