### PR TITLE
Always use <vcpkg-test/util.h> rather than <catch2/catch.hpp>.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -59,6 +59,8 @@ IncludeCategories:
     Priority: -1
   - Regex: '^<catch2/catch\.hpp>$'
     Priority: 1
+  - Regex: '^<vcpkg-test/util\.h>$'
+    Priority: 1
   - Regex: '^<vcpkg/base/fwd/.*\.h>$'
     Priority: 2
   - Regex: '^<vcpkg/fwd/.*\.h>$'

--- a/include/vcpkg-test/util.h
+++ b/include/vcpkg-test/util.h
@@ -84,6 +84,12 @@ namespace Catch
             return "{\"" + value.first.native() + "\", \"" + value.second.native() + "\"}";
         }
     };
+
+    template<>
+    struct StringMaker<vcpkg::Version>
+    {
+        static const std::string convert(const vcpkg::Version& value) { return value.to_string(); }
+    };
 }
 
 namespace vcpkg

--- a/src/vcpkg-test/archives.cpp
+++ b/src/vcpkg-test/archives.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/archives.h>
 

--- a/src/vcpkg-test/arguments.cpp
+++ b/src/vcpkg-test/arguments.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/strings.h>
 

--- a/src/vcpkg-test/binarycaching.cpp
+++ b/src/vcpkg-test/binarycaching.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/files.h>
 #include <vcpkg/base/xmlserializer.h>
@@ -12,8 +12,6 @@
 #include <vcpkg/vcpkgcmdarguments.h>
 
 #include <string>
-
-#include <vcpkg-test/util.h>
 
 using namespace vcpkg;
 

--- a/src/vcpkg-test/bundlesettings.cpp
+++ b/src/vcpkg-test/bundlesettings.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/format.h>
 #include <vcpkg/base/strings.h>

--- a/src/vcpkg-test/cache.cpp
+++ b/src/vcpkg-test/cache.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/cache.h>
 #include <vcpkg/base/stringview.h>

--- a/src/vcpkg-test/catch.cpp
+++ b/src/vcpkg-test/catch.cpp
@@ -1,5 +1,5 @@
 #define CATCH_CONFIG_RUNNER
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/checks.h>
 #include <vcpkg/base/messages.h>

--- a/src/vcpkg-test/cgroup-parser.cpp
+++ b/src/vcpkg-test/cgroup-parser.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/files.h>
 #include <vcpkg/base/optional.h>

--- a/src/vcpkg-test/chrono.cpp
+++ b/src/vcpkg-test/chrono.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/chrono.h>
 

--- a/src/vcpkg-test/ci-baseline.cpp
+++ b/src/vcpkg-test/ci-baseline.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/checks.h>
 #include <vcpkg/base/parse.h>
@@ -9,8 +9,6 @@
 
 #include <ostream>
 #include <utility>
-
-#include <vcpkg-test/util.h>
 
 using namespace vcpkg;
 

--- a/src/vcpkg-test/cmd-parser.cpp
+++ b/src/vcpkg-test/cmd-parser.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/cmd-parser.h>
 #include <vcpkg/base/files.h>

--- a/src/vcpkg-test/coffilereader.cpp
+++ b/src/vcpkg-test/coffilereader.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/cofffilereader.h>
 

--- a/src/vcpkg-test/commands.dependinfo.cpp
+++ b/src/vcpkg-test/commands.dependinfo.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/commands.depend-info.h>
 #include <vcpkg/vcpkgcmdarguments.h>

--- a/src/vcpkg-test/commands.export.cpp
+++ b/src/vcpkg-test/commands.export.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/export.ifw.h>
 #include <vcpkg/export.prefab.h>

--- a/src/vcpkg-test/commands.extract.cpp
+++ b/src/vcpkg-test/commands.extract.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/files.h>
 
@@ -7,8 +7,6 @@
 #include <vcpkg/vcpkgpaths.h>
 
 #include <limits.h>
-
-#include <vcpkg-test/util.h>
 
 using namespace vcpkg;
 

--- a/src/vcpkg-test/commands.install.cpp
+++ b/src/vcpkg-test/commands.install.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/commands.install.h>
 

--- a/src/vcpkg-test/configmetadata.cpp
+++ b/src/vcpkg-test/configmetadata.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/json.h>
 #include <vcpkg/base/jsonreader.h>
@@ -6,8 +6,6 @@
 
 #include <vcpkg/configuration.h>
 #include <vcpkg/registries.h>
-
-#include <vcpkg-test/util.h>
 
 using namespace vcpkg;
 

--- a/src/vcpkg-test/configparser.cpp
+++ b/src/vcpkg-test/configparser.cpp
@@ -1,10 +1,8 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/util.h>
 
 #include <vcpkg/binarycaching.h>
-
-#include <vcpkg-test/util.h>
 
 using namespace vcpkg;
 

--- a/src/vcpkg-test/dependencies.cpp
+++ b/src/vcpkg-test/dependencies.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/fwd/packagespec.h>
 
@@ -17,7 +17,6 @@
 #include <vector>
 
 #include <vcpkg-test/mockcmakevarprovider.h>
-#include <vcpkg-test/util.h>
 
 using namespace vcpkg;
 

--- a/src/vcpkg-test/dependinfo-graphs.cpp
+++ b/src/vcpkg-test/dependinfo-graphs.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/commands.depend-info.h>
 

--- a/src/vcpkg-test/downloads.cpp
+++ b/src/vcpkg-test/downloads.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/downloads.h>
 #include <vcpkg/base/expected.h>

--- a/src/vcpkg-test/expected.cpp
+++ b/src/vcpkg-test/expected.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/expected.h>
 

--- a/src/vcpkg-test/files.cpp
+++ b/src/vcpkg-test/files.cpp
@@ -1,6 +1,6 @@
 #include <vcpkg/base/system-headers.h>
 
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/files.h>
 #include <vcpkg/base/strings.h>
@@ -8,8 +8,6 @@
 #include <iostream>
 #include <random>
 #include <vector>
-
-#include <vcpkg-test/util.h>
 
 #if !defined(_WIN32)
 #include <sys/stat.h>

--- a/src/vcpkg-test/git.parse.cpp
+++ b/src/vcpkg-test/git.parse.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/git.h>
 

--- a/src/vcpkg-test/hash.cpp
+++ b/src/vcpkg-test/hash.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/hash.h>
 

--- a/src/vcpkg-test/integrate.cpp
+++ b/src/vcpkg-test/integrate.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/commands.install.h>
 

--- a/src/vcpkg-test/json.cpp
+++ b/src/vcpkg-test/json.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/files.h>
 #include <vcpkg/base/json.h>

--- a/src/vcpkg-test/manifests.cpp
+++ b/src/vcpkg-test/manifests.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/fwd/message_sinks.h>
 
@@ -9,8 +9,6 @@
 #include <vcpkg/sourceparagraph.h>
 #include <vcpkg/vcpkgcmdarguments.h>
 #include <vcpkg/vcpkgpaths.h>
-
-#include <vcpkg-test/util.h>
 
 using namespace vcpkg;
 using namespace vcpkg::Paragraphs;

--- a/src/vcpkg-test/messages.cpp
+++ b/src/vcpkg-test/messages.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/json.h>
 #include <vcpkg/base/setup-messages.h>

--- a/src/vcpkg-test/metrics.cpp
+++ b/src/vcpkg-test/metrics.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/metrics.h>
 

--- a/src/vcpkg-test/new.cpp
+++ b/src/vcpkg-test/new.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/json.h>
 

--- a/src/vcpkg-test/optional.cpp
+++ b/src/vcpkg-test/optional.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/lineinfo.h>
 #include <vcpkg/base/optional.h>

--- a/src/vcpkg-test/paragraph.cpp
+++ b/src/vcpkg-test/paragraph.cpp
@@ -1,10 +1,8 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/strings.h>
 
 #include <vcpkg/paragraphs.h>
-
-#include <vcpkg-test/util.h>
 
 namespace Strings = vcpkg::Strings;
 using vcpkg::Paragraph;

--- a/src/vcpkg-test/plan.cpp
+++ b/src/vcpkg-test/plan.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/graphs.h>
 
@@ -12,7 +12,6 @@
 #include <vector>
 
 #include <vcpkg-test/mockcmakevarprovider.h>
-#include <vcpkg-test/util.h>
 
 using namespace vcpkg;
 

--- a/src/vcpkg-test/registries.cpp
+++ b/src/vcpkg-test/registries.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/jsonreader.h>
 #include <vcpkg/base/strings.h>

--- a/src/vcpkg-test/spdx.cpp
+++ b/src/vcpkg-test/spdx.cpp
@@ -1,7 +1,7 @@
+#include <vcpkg-test/util.h>
+
 #include <vcpkg/dependencies.h>
 #include <vcpkg/spdx.h>
-
-#include <vcpkg-test/util.h>
 
 using namespace vcpkg;
 

--- a/src/vcpkg-test/specifier.cpp
+++ b/src/vcpkg-test/specifier.cpp
@@ -1,10 +1,8 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/util.h>
 
 #include <vcpkg/packagespec.h>
-
-#include <vcpkg-test/util.h>
 
 using namespace vcpkg;
 

--- a/src/vcpkg-test/statusparagraphs.cpp
+++ b/src/vcpkg-test/statusparagraphs.cpp
@@ -1,11 +1,9 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/util.h>
 
 #include <vcpkg/paragraphs.h>
 #include <vcpkg/statusparagraphs.h>
-
-#include <vcpkg-test/util.h>
 
 using namespace vcpkg;
 using namespace vcpkg::Paragraphs;

--- a/src/vcpkg-test/strings.cpp
+++ b/src/vcpkg-test/strings.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/api-stable-format.h>
 #include <vcpkg/base/expected.h>

--- a/src/vcpkg-test/stringview.cpp
+++ b/src/vcpkg-test/stringview.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/stringview.h>
 

--- a/src/vcpkg-test/system.cpp
+++ b/src/vcpkg-test/system.cpp
@@ -1,6 +1,6 @@
 #include <vcpkg/base/system-headers.h>
 
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/optional.h>
 #include <vcpkg/base/strings.h>

--- a/src/vcpkg-test/system.mac.cpp
+++ b/src/vcpkg-test/system.mac.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/span.h>
 #include <vcpkg/base/stringview.h>

--- a/src/vcpkg-test/system.process.cpp
+++ b/src/vcpkg-test/system.process.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/strings.h>
 #include <vcpkg/base/system.process.h>

--- a/src/vcpkg-test/tools.cpp
+++ b/src/vcpkg-test/tools.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/expected.h>
 
@@ -6,8 +6,6 @@
 #include <vcpkg/tools.test.h>
 
 #include <array>
-
-#include <vcpkg-test/util.h>
 
 using namespace vcpkg;
 

--- a/src/vcpkg-test/uint128.cpp
+++ b/src/vcpkg-test/uint128.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/uint128.h>
 

--- a/src/vcpkg-test/update.cpp
+++ b/src/vcpkg-test/update.cpp
@@ -1,12 +1,10 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/sortedvector.h>
 
 #include <vcpkg/commands.update.h>
 #include <vcpkg/portfileprovider.h>
 #include <vcpkg/statusparagraphs.h>
-
-#include <vcpkg-test/util.h>
 
 using namespace vcpkg;
 using namespace vcpkg::Test;

--- a/src/vcpkg-test/util-tests.cpp
+++ b/src/vcpkg-test/util-tests.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/util.h>
 

--- a/src/vcpkg-test/util.cpp
+++ b/src/vcpkg-test/util.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/base/checks.h>
 #include <vcpkg/base/system.h>
@@ -14,8 +14,6 @@
 #include <numeric>
 #include <set>
 #include <vector>
-
-#include <vcpkg-test/util.h>
 
 namespace vcpkg::Test
 {

--- a/src/vcpkg-test/versionplan.cpp
+++ b/src/vcpkg-test/versionplan.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/dependencies.h>
 #include <vcpkg/paragraphparser.h>
@@ -6,7 +6,6 @@
 #include <vcpkg/sourceparagraph.h>
 
 #include <vcpkg-test/mockcmakevarprovider.h>
-#include <vcpkg-test/util.h>
 
 using namespace vcpkg;
 

--- a/src/vcpkg-test/xunitwriter.cpp
+++ b/src/vcpkg-test/xunitwriter.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <vcpkg-test/util.h>
 
 #include <vcpkg/commands.build.h>
 #include <vcpkg/xunitwriter.h>


### PR DESCRIPTION
This ensures the `StringMaker`s in `util.h` are always available for better console output on check failure.