### PR TITLE
Use different search algorithm in `Strings::contains_any`

### DIFF
--- a/include/vcpkg/base/strings.h
+++ b/include/vcpkg/base/strings.h
@@ -183,8 +183,7 @@ namespace vcpkg::Strings
 
     bool contains_any_ignoring_hash_comments(StringView source, View<boyer_moore_horspool_searcher> to_find);
 
-    // Note: It makes sense to call this function only if source is long
-    bool contains_any(StringView source, View<boyer_moore_horspool_searcher> to_find);
+    bool long_string_contains_any(StringView source, View<boyer_moore_horspool_searcher> to_find);
 
     [[nodiscard]] bool equals(StringView a, StringView b);
 

--- a/include/vcpkg/base/strings.h
+++ b/include/vcpkg/base/strings.h
@@ -14,6 +14,10 @@
 #include <algorithm>
 #include <vector>
 
+#ifdef __APPLE__
+#include <experimental/functional>
+#endif
+
 namespace vcpkg::Strings::details
 {
     void append_internal(std::string& into, char c);
@@ -43,6 +47,12 @@ namespace vcpkg::Strings::details
 
 namespace vcpkg::Strings
 {
+#ifdef __APPLE__
+    using boyer_moore_horspool_searcher = std::experimental::boyer_moore_horspool_searcher<std::string::const_iterator>;
+#else
+    using boyer_moore_horspool_searcher = std::boyer_moore_horspool_searcher<std::string::const_iterator>;
+#endif
+
     template<class... Args>
     std::string& append(std::string& into, const Args&... args)
     {
@@ -169,11 +179,12 @@ namespace vcpkg::Strings
                                                                  StringView left_tag,
                                                                  StringView right_tag);
 
-    bool contains_any_ignoring_c_comments(const std::string& source, View<StringView> to_find);
+    bool contains_any_ignoring_c_comments(const std::string& source, View<boyer_moore_horspool_searcher> to_find);
 
-    bool contains_any_ignoring_hash_comments(StringView source, View<StringView> to_find);
+    bool contains_any_ignoring_hash_comments(StringView source, View<boyer_moore_horspool_searcher> to_find);
 
-    bool contains_any(StringView source, View<StringView> to_find);
+    // Note: It makes sense to call this function only if source is long
+    bool contains_any(StringView source, View<boyer_moore_horspool_searcher> to_find);
 
     [[nodiscard]] bool equals(StringView a, StringView b);
 

--- a/src/vcpkg-test/strings.cpp
+++ b/src/vcpkg-test/strings.cpp
@@ -72,7 +72,12 @@ TEST_CASE ("find_first_of", "[strings]")
 TEST_CASE ("contains_any_ignoring_c_comments", "[strings]")
 {
     using vcpkg::Strings::contains_any_ignoring_c_comments;
-    vcpkg::StringView to_find[] = {"abc", "wer"};
+    std::string a = "abc";
+    std::string b = "wer";
+
+    vcpkg::Strings::boyer_moore_horspool_searcher to_find[] = {
+        vcpkg::Strings::boyer_moore_horspool_searcher(a.begin(), a.end()),
+        vcpkg::Strings::boyer_moore_horspool_searcher(b.begin(), b.end())};
     REQUIRE(contains_any_ignoring_c_comments(R"(abc)", to_find));
     REQUIRE(contains_any_ignoring_c_comments(R"("abc")", to_find));
     REQUIRE_FALSE(contains_any_ignoring_c_comments(R"("" //abc)", to_find));
@@ -127,7 +132,12 @@ TEST_CASE ("contains_any_ignoring_c_comments", "[strings]")
 TEST_CASE ("contains_any_ignoring_hash_comments", "[strings]")
 {
     using vcpkg::Strings::contains_any_ignoring_hash_comments;
-    vcpkg::StringView to_find[] = {"abc", "wer"};
+    std::string a = "abc";
+    std::string b = "wer";
+
+    vcpkg::Strings::boyer_moore_horspool_searcher to_find[] = {
+        vcpkg::Strings::boyer_moore_horspool_searcher(a.begin(), a.end()),
+        vcpkg::Strings::boyer_moore_horspool_searcher(b.begin(), b.end())};
     REQUIRE(contains_any_ignoring_hash_comments("abc", to_find));
     REQUIRE(contains_any_ignoring_hash_comments("wer", to_find));
     REQUIRE(contains_any_ignoring_hash_comments("wer # test", to_find));

--- a/src/vcpkg/base/strings.cpp
+++ b/src/vcpkg/base/strings.cpp
@@ -476,7 +476,7 @@ bool Strings::contains_any(StringView source, View<StringView> to_find)
 {
     for (const auto& subject : to_find)
     {
-        auto found =std::search(
+        auto found = std::search(
             source.begin(), source.end(), std::boyer_moore_horspool_searcher(subject.begin(), subject.end()));
         if (found != source.end())
         {

--- a/src/vcpkg/base/strings.cpp
+++ b/src/vcpkg/base/strings.cpp
@@ -476,8 +476,8 @@ bool Strings::contains_any(StringView source, View<StringView> to_find)
 {
     for (const auto& subject : to_find)
     {
-        auto found =
-            std::search(source.begin(), source.end(), std::boyer_moore_horspool_searcher(subject.begin(), subject.end()));
+        auto found =std::search(
+            source.begin(), source.end(), std::boyer_moore_horspool_searcher(subject.begin(), subject.end()));
         if (found != source.end())
         {
             return true;

--- a/src/vcpkg/base/strings.cpp
+++ b/src/vcpkg/base/strings.cpp
@@ -15,6 +15,10 @@
 #include <string>
 #include <vector>
 
+#ifdef __APPLE__
+#include <experimental/functional>
+#endif
+
 #include <fmt/compile.h>
 
 using namespace vcpkg;
@@ -473,20 +477,21 @@ bool Strings::contains_any_ignoring_hash_comments(StringView source, View<String
 
 bool Strings::contains_any(StringView source, View<StringView> to_find)
 {
-#ifdef __APPLE__
-    return Util::any_of(to_find, [=](StringView s) { return Strings::contains(source, s); });
-#else
     for (const auto& subject : to_find)
     {
         auto found = std::search(
-            source.begin(), source.end(), std::boyer_moore_horspool_searcher(subject.begin(), subject.end()));
+            source.begin(), source.end(),
+#ifdef __APPLE__
+            std::experimental::boyer_moore_horspool_searcher(subject.begin(), subject.end()));
+#else
+            std::boyer_moore_horspool_searcher(subject.begin(), subject.end()));
+#endif
         if (found != source.end())
         {
             return true;
         }
     }
     return false;
-#endif
 }
 
 bool Strings::equals(StringView a, StringView b)

--- a/src/vcpkg/base/strings.cpp
+++ b/src/vcpkg/base/strings.cpp
@@ -11,6 +11,7 @@
 #include <stdarg.h>
 
 #include <algorithm>
+#include <functional>
 #include <iterator>
 #include <string>
 #include <vector>

--- a/src/vcpkg/base/strings.cpp
+++ b/src/vcpkg/base/strings.cpp
@@ -11,7 +11,6 @@
 #include <stdarg.h>
 
 #include <algorithm>
-#include <functional>
 #include <iterator>
 #include <string>
 #include <vector>
@@ -474,6 +473,9 @@ bool Strings::contains_any_ignoring_hash_comments(StringView source, View<String
 
 bool Strings::contains_any(StringView source, View<StringView> to_find)
 {
+#ifdef __APPLE__
+    return Util::any_of(to_find, [=](StringView s) { return Strings::contains(source, s); });
+#else
     for (const auto& subject : to_find)
     {
         auto found = std::search(
@@ -484,6 +486,7 @@ bool Strings::contains_any(StringView source, View<StringView> to_find)
         }
     }
     return false;
+#endif
 }
 
 bool Strings::equals(StringView a, StringView b)

--- a/src/vcpkg/base/strings.cpp
+++ b/src/vcpkg/base/strings.cpp
@@ -15,10 +15,6 @@
 #include <string>
 #include <vector>
 
-#ifdef __APPLE__
-#include <experimental/functional>
-#endif
-
 #include <fmt/compile.h>
 
 using namespace vcpkg;
@@ -384,7 +380,8 @@ Optional<StringView> Strings::find_at_most_one_enclosed(StringView input, String
     return result.front();
 }
 
-bool vcpkg::Strings::contains_any_ignoring_c_comments(const std::string& source, View<StringView> to_find)
+bool vcpkg::Strings::contains_any_ignoring_c_comments(const std::string& source,
+                                                      View<boyer_moore_horspool_searcher> to_find)
 {
     std::string::size_type offset = 0;
     std::string::size_type no_comment_offset = 0;
@@ -448,7 +445,7 @@ bool vcpkg::Strings::contains_any_ignoring_c_comments(const std::string& source,
     return false;
 }
 
-bool Strings::contains_any_ignoring_hash_comments(StringView source, View<StringView> to_find)
+bool Strings::contains_any_ignoring_hash_comments(StringView source, View<boyer_moore_horspool_searcher> to_find)
 {
     auto first = source.data();
     auto block_start = first;
@@ -475,17 +472,11 @@ bool Strings::contains_any_ignoring_hash_comments(StringView source, View<String
     return Strings::contains_any(StringView{block_start, last}, to_find);
 }
 
-bool Strings::contains_any(StringView source, View<StringView> to_find)
+bool Strings::contains_any(StringView source, View<boyer_moore_horspool_searcher> to_find)
 {
-#ifdef __APPLE__
-    using std::experimental::boyer_moore_horspool_searcher;
-#else
-    using std::boyer_moore_horspool_searcher;
-#endif
     for (const auto& subject : to_find)
     {
-        auto found =
-            std::search(source.begin(), source.end(), boyer_moore_horspool_searcher(subject.begin(), subject.end()));
+        auto found = std::search(source.begin(), source.end(), subject);
         if (found != source.end())
         {
             return true;

--- a/src/vcpkg/base/strings.cpp
+++ b/src/vcpkg/base/strings.cpp
@@ -391,14 +391,14 @@ bool vcpkg::Strings::contains_any_ignoring_c_comments(const std::string& source,
         auto start = source.find_first_of("/\"", no_comment_offset);
         if (start == std::string::npos || start + 1 == source.size() || no_comment_offset == std::string::npos)
         {
-            return Strings::contains_any(StringView(source).substr(offset), to_find);
+            return Strings::long_string_contains_any(StringView(source).substr(offset), to_find);
         }
 
         if (source[start] == '/')
         {
             if (source[start + 1] == '/' || source[start + 1] == '*')
             {
-                if (Strings::contains_any(StringView(source).substr(offset, start - offset), to_find))
+                if (Strings::long_string_contains_any(StringView(source).substr(offset, start - offset), to_find))
                 {
                     return true;
                 }
@@ -454,7 +454,7 @@ bool Strings::contains_any_ignoring_hash_comments(StringView source, View<boyer_
     {
         if (*first == '#')
         {
-            if (Strings::contains_any(StringView{block_start, first}, to_find))
+            if (Strings::long_string_contains_any(StringView{block_start, first}, to_find))
             {
                 return true;
             }
@@ -469,10 +469,10 @@ bool Strings::contains_any_ignoring_hash_comments(StringView source, View<boyer_
         }
     }
 
-    return Strings::contains_any(StringView{block_start, last}, to_find);
+    return Strings::long_string_contains_any(StringView{block_start, last}, to_find);
 }
 
-bool Strings::contains_any(StringView source, View<boyer_moore_horspool_searcher> to_find)
+bool Strings::long_string_contains_any(StringView source, View<boyer_moore_horspool_searcher> to_find)
 {
     for (const auto& subject : to_find)
     {

--- a/src/vcpkg/base/strings.cpp
+++ b/src/vcpkg/base/strings.cpp
@@ -477,15 +477,15 @@ bool Strings::contains_any_ignoring_hash_comments(StringView source, View<String
 
 bool Strings::contains_any(StringView source, View<StringView> to_find)
 {
+#ifdef __APPLE__
+    using std::experimental::boyer_moore_horspool_searcher;
+#else
+    using std::boyer_moore_horspool_searcher;
+#endif
     for (const auto& subject : to_find)
     {
         auto found = std::search(
-            source.begin(), source.end(),
-#ifdef __APPLE__
-            std::experimental::boyer_moore_horspool_searcher(subject.begin(), subject.end()));
-#else
-            std::boyer_moore_horspool_searcher(subject.begin(), subject.end()));
-#endif
+            source.begin(), source.end(), boyer_moore_horspool_searcher(subject.begin(), subject.end()));
         if (found != source.end())
         {
             return true;

--- a/src/vcpkg/base/strings.cpp
+++ b/src/vcpkg/base/strings.cpp
@@ -473,7 +473,16 @@ bool Strings::contains_any_ignoring_hash_comments(StringView source, View<String
 
 bool Strings::contains_any(StringView source, View<StringView> to_find)
 {
-    return Util::any_of(to_find, [=](StringView s) { return Strings::contains(source, s); });
+    for (const auto& subject : to_find)
+    {
+        auto found =
+            std::search(source.begin(), source.end(), std::boyer_moore_horspool_searcher(subject.begin(), subject.end()));
+        if (found != source.end())
+        {
+            return true;
+        }
+    }
+    return false;
 }
 
 bool Strings::equals(StringView a, StringView b)

--- a/src/vcpkg/base/strings.cpp
+++ b/src/vcpkg/base/strings.cpp
@@ -484,8 +484,8 @@ bool Strings::contains_any(StringView source, View<StringView> to_find)
 #endif
     for (const auto& subject : to_find)
     {
-        auto found = std::search(
-            source.begin(), source.end(), boyer_moore_horspool_searcher(subject.begin(), subject.end()));
+        auto found =
+            std::search(source.begin(), source.end(), boyer_moore_horspool_searcher(subject.begin(), subject.end()));
         if (found != source.end())
         {
             return true;

--- a/src/vcpkg/postbuildlint.cpp
+++ b/src/vcpkg/postbuildlint.cpp
@@ -1216,28 +1216,27 @@ namespace vcpkg
         return LintStatus::SUCCESS;
     }
 
-    static bool file_contains_absolute_paths(
-        const ReadOnlyFilesystem& fs,
-        const Path& file,
-        const std::vector<Strings::boyer_moore_horspool_searcher>& stringview_paths)
+    static bool file_contains_absolute_paths(const ReadOnlyFilesystem& fs,
+                                             const Path& file,
+                                             View<Strings::boyer_moore_horspool_searcher> searcher_paths)
     {
         const auto extension = file.extension();
         if (extension == ".h" || extension == ".hpp" || extension == ".hxx")
         {
-            return Strings::contains_any_ignoring_c_comments(fs.read_contents(file, IgnoreErrors{}), stringview_paths);
+            return Strings::contains_any_ignoring_c_comments(fs.read_contents(file, IgnoreErrors{}), searcher_paths);
         }
 
         if (extension == ".cfg" || extension == ".ini" || file.filename() == "usage")
         {
             const auto contents = fs.read_contents(file, IgnoreErrors{});
-            return Strings::contains_any(contents, stringview_paths);
+            return Strings::contains_any(contents, searcher_paths);
         }
 
         if (extension == ".py" || extension == ".sh" || extension == ".cmake" || extension == ".pc" ||
             extension == ".conf")
         {
             const auto contents = fs.read_contents(file, IgnoreErrors{});
-            return Strings::contains_any_ignoring_hash_comments(contents, stringview_paths);
+            return Strings::contains_any_ignoring_hash_comments(contents, searcher_paths);
         }
 
         if (extension.empty())
@@ -1251,7 +1250,7 @@ namespace vcpkg
                 Strings::starts_with(StringView(buffer, sizeof(buffer)), "\xEF\xBB\xBF#!") /* ignore byte-order mark */)
             {
                 const auto contents = fs.read_contents(file, IgnoreErrors{});
-                return Strings::contains_any_ignoring_hash_comments(contents, stringview_paths);
+                return Strings::contains_any_ignoring_hash_comments(contents, searcher_paths);
             }
             return false;
         }

--- a/src/vcpkg/postbuildlint.cpp
+++ b/src/vcpkg/postbuildlint.cpp
@@ -1279,7 +1279,9 @@ namespace vcpkg
 
         Util::sort_unique_erase(string_paths);
 
-        const auto stringview_paths = Util::fmap(string_paths, [](std::string& s) { return StringView(s); });
+        const auto stringview_paths = Util::fmap(string_paths, [](std::string& s) {
+            return Strings::boyer_moore_horspool_searcher(s.begin(), s.end());
+        });
 
         std::vector<Path> failing_files;
         std::mutex mtx;

--- a/src/vcpkg/postbuildlint.cpp
+++ b/src/vcpkg/postbuildlint.cpp
@@ -1216,9 +1216,10 @@ namespace vcpkg
         return LintStatus::SUCCESS;
     }
 
-    static bool file_contains_absolute_paths(const ReadOnlyFilesystem& fs,
-                                             const Path& file,
-                                             const std::vector<StringView> stringview_paths)
+    static bool file_contains_absolute_paths(
+        const ReadOnlyFilesystem& fs,
+        const Path& file,
+        const std::vector<Strings::boyer_moore_horspool_searcher>& stringview_paths)
     {
         const auto extension = file.extension();
         if (extension == ".h" || extension == ".hpp" || extension == ".hxx")
@@ -1279,7 +1280,7 @@ namespace vcpkg
 
         Util::sort_unique_erase(string_paths);
 
-        const auto stringview_paths = Util::fmap(string_paths, [](std::string& s) {
+        const auto searcher_paths = Util::fmap(string_paths, [](std::string& s) {
             return Strings::boyer_moore_horspool_searcher(s.begin(), s.end());
         });
 
@@ -1288,7 +1289,7 @@ namespace vcpkg
         auto files = fs.get_regular_files_recursive(dir, IgnoreErrors{});
 
         parallel_for_each_n(files.begin(), files.size(), [&](const Path& file) {
-            if (file_contains_absolute_paths(fs, file, stringview_paths))
+            if (file_contains_absolute_paths(fs, file, searcher_paths))
             {
                 std::lock_guard lock{mtx};
                 failing_files.push_back(file);

--- a/src/vcpkg/postbuildlint.cpp
+++ b/src/vcpkg/postbuildlint.cpp
@@ -1229,7 +1229,7 @@ namespace vcpkg
         if (extension == ".cfg" || extension == ".ini" || file.filename() == "usage")
         {
             const auto contents = fs.read_contents(file, IgnoreErrors{});
-            return Strings::contains_any(contents, searcher_paths);
+            return Strings::long_string_contains_any(contents, searcher_paths);
         }
 
         if (extension == ".py" || extension == ".sh" || extension == ".cmake" || extension == ".pc" ||

--- a/src/vcpkg/postbuildlint.cpp
+++ b/src/vcpkg/postbuildlint.cpp
@@ -1279,9 +1279,8 @@ namespace vcpkg
 
         Util::sort_unique_erase(string_paths);
 
-        const auto searcher_paths = Util::fmap(string_paths, [](std::string& s) {
-            return Strings::boyer_moore_horspool_searcher(s.begin(), s.end());
-        });
+        const auto searcher_paths = Util::fmap(
+            string_paths, [](std::string& s) { return Strings::boyer_moore_horspool_searcher(s.begin(), s.end()); });
 
         std::vector<Path> failing_files;
         std::mutex mtx;


### PR DESCRIPTION
Using `std::boyer_moore_horspool_searcher` results in approx. 3x speedup of `Strings::contains_any()` which is used by `contains_any_ignoring_c_comments()` during post build lint.

Note that this search algorithm is only useful when dealing with long strings: [cppreference](https://en.cppreference.com/w/cpp/utility/functional/boyer_moore_horspool_searcher)