### PR TITLE
Fix github issue body size

### DIFF
--- a/include/vcpkg/commands.build.h
+++ b/include/vcpkg/commands.build.h
@@ -186,6 +186,9 @@ namespace vcpkg
         std::vector<std::string> error_logs;
     };
 
+    void append_log(const Path& path, const std::string& log, int max_size, std::string& out);
+    void append_logs(View<std::pair<Path, std::string>> logs, int max_size, std::string& out);
+
     LocalizedString create_error_message(const ExtendedBuildResult& build_result, const PackageSpec& spec);
 
     std::string create_github_issue(const VcpkgCmdArguments& args,

--- a/include/vcpkg/commands.build.h
+++ b/include/vcpkg/commands.build.h
@@ -194,7 +194,8 @@ namespace vcpkg
     std::string create_github_issue(const VcpkgCmdArguments& args,
                                     const ExtendedBuildResult& build_result,
                                     const VcpkgPaths& paths,
-                                    const InstallPlanAction& action);
+                                    const InstallPlanAction& action,
+                                    bool include_manifest);
 
     ExtendedBuildResult build_package(const VcpkgCmdArguments& args,
                                       const VcpkgPaths& paths,

--- a/include/vcpkg/commands.build.h
+++ b/include/vcpkg/commands.build.h
@@ -186,8 +186,8 @@ namespace vcpkg
         std::vector<std::string> error_logs;
     };
 
-    void append_log(const Path& path, const std::string& log, int max_size, std::string& out);
-    void append_logs(View<std::pair<Path, std::string>> logs, int max_size, std::string& out);
+    void append_log(const Path& path, const std::string& log, size_t max_size, std::string& out);
+    void append_logs(std::vector<std::pair<Path, std::string>>&& logs, size_t max_size, std::string& out);
 
     LocalizedString create_error_message(const ExtendedBuildResult& build_result, const PackageSpec& spec);
 

--- a/include/vcpkg/commands.install.h
+++ b/include/vcpkg/commands.install.h
@@ -102,7 +102,8 @@ namespace vcpkg
                                         const VcpkgPaths& paths,
                                         StatusParagraphs& status_db,
                                         BinaryCache& binary_cache,
-                                        const IBuildLogsRecorder& build_logs_recorder);
+                                        const IBuildLogsRecorder& build_logs_recorder,
+                                        bool include_manifest_in_github_issue = false);
 
     void command_install_and_exit(const VcpkgCmdArguments& args,
                                   const VcpkgPaths& paths,

--- a/include/vcpkg/commands.set-installed.h
+++ b/include/vcpkg/commands.set-installed.h
@@ -41,7 +41,8 @@ namespace vcpkg
                                            Triplet host_triplet,
                                            const KeepGoing keep_going,
                                            const bool only_downloads,
-                                           const PrintUsage print_cmake_usage);
+                                           const PrintUsage print_cmake_usage,
+                                           bool include_manifest_in_github_issue);
     void command_set_installed_and_exit(const VcpkgCmdArguments& args,
                                         const VcpkgPaths& paths,
                                         Triplet default_triplet,

--- a/src/vcpkg-test/issue_body.cpp
+++ b/src/vcpkg-test/issue_body.cpp
@@ -1,0 +1,60 @@
+#include <vcpkg-test/util.h>
+
+#include <vcpkg/base/files.h>
+#include <vcpkg/base/strings.h>
+
+#include <vcpkg/commands.build.h>
+
+namespace
+{
+    const std::string file_content = R"(00 32 byte long line xxxxxxxxxx
+01 32 byte long line xxxxxxxxxx
+02 32 byte long line xxxxxxxxxx
+03 32 byte long line xxxxxxxxxx
+04 32 byte long line xxxxxxxxxx
+05 32 byte long line xxxxxxxxxx
+06 32 byte long line xxxxxxxxxx)";
+
+    const auto expected_body = R"(<details><summary>test 2</summary>
+
+```
+00 32 byte long line xxxxxxxxxx
+...
+Skipped 4 lines
+...
+05 32 byte long line xxxxxxxxxx
+06 32 byte long line xxxxxxxxxx
+```
+</details>)";
+
+    const auto prefix = "<details><summary>test</summary>\n\n```\n";
+    const auto postfix = "\n```\n</details>";
+}
+
+TEST_CASE ("Testing append_log", "[github-issue-body]")
+{
+    using namespace vcpkg;
+    {
+        std::string out;
+        append_log("test", file_content, 100, out);
+        CHECK(out == ""); // Not enough space at all
+        out.clear();
+        append_log("test 2", file_content, file_content.size(), out);
+        CHECK(out == expected_body); // Not enough space
+        out.clear();
+        append_log("test", file_content, file_content.size() + 100, out);
+        CHECK(out == prefix + file_content + postfix); // Enough space
+    }
+}
+
+TEST_CASE ("Testing append_log extra_size", "[github-issue-body]")
+{
+    using namespace vcpkg;
+    {
+        std::string out;
+        std::vector<std::pair<Path, std::string>> logs{
+            {"not_included_1", file_content}, {"test", file_content}, {"test 2", file_content}};
+        append_logs(logs, 500, out);
+        CHECK(out == prefix + file_content + postfix + "\n\n" + expected_body + "\n\n");
+    }
+}

--- a/src/vcpkg-test/issue_body.cpp
+++ b/src/vcpkg-test/issue_body.cpp
@@ -27,8 +27,8 @@ Skipped 4 lines
 ```
 </details>)";
 
-    const auto prefix = "<details><summary>test</summary>\n\n```\n";
-    const auto postfix = "\n```\n</details>";
+    const auto block_prefix = "<details><summary>test</summary>\n\n```\n";
+    const auto block_postfix = "\n```\n</details>";
 }
 
 TEST_CASE ("Testing append_log", "[github-issue-body]")
@@ -43,7 +43,7 @@ TEST_CASE ("Testing append_log", "[github-issue-body]")
         CHECK(out == expected_body); // Not enough space
         out.clear();
         append_log("test", file_content, static_cast<int>(file_content.size() + 100), out);
-        CHECK(out == prefix + file_content + postfix); // Enough space
+        CHECK(out == block_prefix + file_content + block_postfix); // Enough space
     }
 }
 
@@ -55,6 +55,6 @@ TEST_CASE ("Testing append_log extra_size", "[github-issue-body]")
         std::vector<std::pair<Path, std::string>> logs{
             {"not_included_1", file_content}, {"test", file_content}, {"test 2", file_content}};
         append_logs(logs, 500, out);
-        CHECK(out == prefix + file_content + postfix + "\n\n" + expected_body + "\n\n");
+        CHECK(out == block_prefix + file_content + block_postfix + "\n\n" + expected_body + "\n\n");
     }
 }

--- a/src/vcpkg-test/issue_body.cpp
+++ b/src/vcpkg-test/issue_body.cpp
@@ -39,10 +39,10 @@ TEST_CASE ("Testing append_log", "[github-issue-body]")
         append_log("test", file_content, 100, out);
         CHECK(out == ""); // Not enough space at all
         out.clear();
-        append_log("test 2", file_content, file_content.size(), out);
+        append_log("test 2", file_content, static_cast<int>(file_content.size()), out);
         CHECK(out == expected_body); // Not enough space
         out.clear();
-        append_log("test", file_content, file_content.size() + 100, out);
+        append_log("test", file_content, static_cast<int>(file_content.size() + 100), out);
         CHECK(out == prefix + file_content + postfix); // Enough space
     }
 }

--- a/src/vcpkg-test/issue_body.cpp
+++ b/src/vcpkg-test/issue_body.cpp
@@ -25,10 +25,12 @@ Skipped 4 lines
 05 32 byte long line xxxxxxxxxx
 06 32 byte long line xxxxxxxxxx
 ```
-</details>)";
+</details>
+
+)";
 
     const auto block_prefix = "<details><summary>test</summary>\n\n```\n";
-    const auto block_postfix = "\n```\n</details>";
+    const auto block_postfix = "\n```\n</details>\n\n";
 }
 
 TEST_CASE ("Testing append_log", "[github-issue-body]")
@@ -39,7 +41,7 @@ TEST_CASE ("Testing append_log", "[github-issue-body]")
         append_log("test", file_content, 100, out);
         CHECK(out == ""); // Not enough space at all
         out.clear();
-        append_log("test 2", file_content, static_cast<int>(file_content.size()), out);
+        append_log("test 2", file_content, file_content.size(), out);
         CHECK(out == expected_body); // Not enough space
         out.clear();
         append_log("test", file_content, static_cast<int>(file_content.size() + 100), out);
@@ -54,7 +56,16 @@ TEST_CASE ("Testing append_log extra_size", "[github-issue-body]")
         std::string out;
         std::vector<std::pair<Path, std::string>> logs{
             {"not_included_1", file_content}, {"test", file_content}, {"test 2", file_content}};
-        append_logs(logs, 500, out);
-        CHECK(out == block_prefix + file_content + block_postfix + "\n\n" + expected_body + "\n\n");
+        append_logs(std::move(logs), 500, out);
+        CHECK(out == block_prefix + file_content + block_postfix + expected_body);
+    }
+    {
+        using namespace std::string_literals;
+        std::string out;
+        std::vector<std::pair<Path, std::string>> logs{{"test", file_content}, {"test", "smal"}, {"test", "smal"}};
+        // Enough space to output all logs, but if we would output the largest log first, there would be not enough
+        // space for this log if every log get the size total_size/number_of_logs.
+        append_logs(std::move(logs), file_content.size() + 3 * 110, out);
+        CHECK(out == fmt::format("{0}smal{1}{0}smal{1}{0}{2}{1}", block_prefix, block_postfix, file_content));
     }
 }

--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -1557,7 +1557,8 @@ namespace vcpkg
     std::string create_github_issue(const VcpkgCmdArguments& args,
                                     const ExtendedBuildResult& build_result,
                                     const VcpkgPaths& paths,
-                                    const InstallPlanAction& action)
+                                    const InstallPlanAction& action,
+                                    bool include_manifest)
     {
         constexpr int MAX_ISSUE_SIZE = 65536;
         const auto& fs = paths.get_filesystem();
@@ -1594,7 +1595,7 @@ namespace vcpkg
         const auto maybe_manifest = paths.get_manifest();
         if (auto manifest = maybe_manifest.get())
         {
-            if (args.get_command() != "x-set-installed" || manifest->manifest.contains("builtin-baseline"))
+            if (include_manifest || manifest->manifest.contains("builtin-baseline"))
             {
                 fmt::format_to(
                     std::back_inserter(postfix),

--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -1490,7 +1490,7 @@ namespace vcpkg
 
     static void append_log(const Filesystem& fs, const Path& path, int max_size, std::string& out)
     {
-        max_size -= path.native().size() + 80 /* size of all static text */;
+        max_size -= static_cast<int>(path.native().size()) + 80 /* size of all static text */;
         if (max_size < 100)
         {
             return;
@@ -1537,13 +1537,13 @@ namespace vcpkg
     static void append_logs(const Filesystem& fs, const std::vector<std::string>& logs, int max_size, std::string& out)
     {
         int extra_size = 0;
-        max_size -= logs.size() * 2;
-        auto size_per_log = max_size / logs.size();
+        max_size -= static_cast<int>(logs.size()) * 2;
+        auto size_per_log = max_size / static_cast<int>(logs.size());
         for (auto& log : logs)
         {
             const auto old_size = out.size();
             append_log(fs, log, size_per_log + extra_size, out);
-            extra_size += size_per_log - (out.size() - old_size);
+            extra_size += size_per_log - static_cast<int>(out.size() - old_size);
             out += "\n\n";
         }
     }
@@ -1596,7 +1596,7 @@ namespace vcpkg
             }
         }
 
-        int max_body_size = MAX_ISSUE_SIZE - result.size() - postfix.size();
+        int max_body_size = MAX_ISSUE_SIZE - static_cast<int>(result.size()) - static_cast<int>(postfix.size());
         append_logs(fs, build_result.error_logs, max_body_size, result);
 
         result.append(postfix);

--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -1488,7 +1488,7 @@ namespace vcpkg
         return res;
     }
 
-    static void append_log(const Filesystem& fs, const Path& path, int max_size, std::string& out)
+    void append_log(const Path& path, const std::string& log, int max_size, std::string& out)
     {
         StringLiteral details_start = "<details><summary>{}</summary>\n\n```\n";
         StringLiteral skipped_msg = "\n...\nSkipped {} lines\n...";
@@ -1502,21 +1502,18 @@ namespace vcpkg
         fmt::format_to(std::back_inserter(out), details_start.c_str(), path.native());
 
         const auto max_log_length = static_cast<size_t>(max_size);
-        const auto start_block_length = max_log_length * 4 / 12;
-        const auto start_block_max_length = max_log_length * 5 / 12;
-        const auto end_block_length = max_log_length * 7 / 12;
+        const auto start_block_max_length = max_log_length * 1 / 3;
         const auto end_block_max_length = max_log_length - start_block_max_length;
-        auto log = fs.read_contents(path, VCPKG_LINE_INFO);
         if (log.size() > max_log_length)
         {
-            auto first_block_end = log.find_first_of('\n', start_block_length);
-            if (first_block_end == std::string::npos || first_block_end > start_block_max_length)
+            auto first_block_end = log.find_last_of('\n', start_block_max_length);
+            if (first_block_end == std::string::npos)
             {
                 first_block_end = start_block_max_length;
             }
 
-            auto last_block_start = log.find_last_of('\n', log.size() - end_block_length);
-            if (last_block_start == std::string::npos || last_block_start < log.size() - end_block_max_length)
+            auto last_block_start = log.find_first_of('\n', log.size() - end_block_max_length);
+            if (last_block_start == std::string::npos)
             {
                 last_block_start = log.size() - end_block_max_length;
             }
@@ -1528,6 +1525,10 @@ namespace vcpkg
             fmt::format_to(std::back_inserter(out), skipped_msg.c_str(), skipped_lines);
             out.append(last, log.end());
         }
+        else
+        {
+            out += log;
+        }
 
         while (!out.empty() && out.back() == '\n')
         {
@@ -1536,17 +1537,20 @@ namespace vcpkg
         Strings::append(out, details_end);
     }
 
-    static void append_logs(const Filesystem& fs, const std::vector<std::string>& logs, int max_size, std::string& out)
+    void append_logs(View<std::pair<Path, std::string>> logs, int max_size, std::string& out)
     {
         int extra_size = 0;
         max_size -= static_cast<int>(logs.size()) * 2;
         auto size_per_log = max_size / static_cast<int>(logs.size());
-        for (auto& log : logs)
+        for (auto& entry : logs)
         {
             const auto old_size = out.size();
-            append_log(fs, log, size_per_log + extra_size, out);
+            append_log(entry.first, entry.second, size_per_log + extra_size, out);
             extra_size += size_per_log - static_cast<int>(out.size() - old_size);
-            out += "\n\n";
+            if (out.size() != old_size)
+            {
+                out += "\n\n";
+            }
         }
     }
 
@@ -1600,7 +1604,10 @@ namespace vcpkg
         }
 
         int max_body_size = MAX_ISSUE_SIZE - static_cast<int>(issue_body.size() + postfix.size());
-        append_logs(fs, build_result.error_logs, max_body_size, issue_body);
+        auto logs = Util::fmap(build_result.error_logs, [&](auto&& path) -> std::pair<Path, std::string> {
+            return {path, fs.read_contents(path, VCPKG_LINE_INFO)};
+        });
+        append_logs(logs, max_body_size, issue_body);
 
         issue_body.append(postfix);
 

--- a/src/vcpkg/commands.install.cpp
+++ b/src/vcpkg/commands.install.cpp
@@ -552,7 +552,8 @@ namespace vcpkg
                                         const VcpkgPaths& paths,
                                         StatusParagraphs& status_db,
                                         BinaryCache& binary_cache,
-                                        const IBuildLogsRecorder& build_logs_recorder)
+                                        const IBuildLogsRecorder& build_logs_recorder,
+                                        bool include_manifest_in_github_issue)
     {
         const ElapsedTimer timer;
         std::vector<SpecSummary> results;
@@ -584,7 +585,9 @@ namespace vcpkg
                 print_user_troubleshooting_message(action, paths, result.stdoutlog.then([&](auto&) -> Optional<Path> {
                     auto issue_body_path = paths.installed().root() / "vcpkg" / "issue_body.md";
                     paths.get_filesystem().write_contents(
-                        issue_body_path, create_github_issue(args, result, paths, action), VCPKG_LINE_INFO);
+                        issue_body_path,
+                        create_github_issue(args, result, paths, action, include_manifest_in_github_issue),
+                        VCPKG_LINE_INFO);
                     return issue_body_path;
                 }));
                 Checks::exit_fail(VCPKG_LINE_INFO);
@@ -1235,7 +1238,8 @@ namespace vcpkg
                                               host_triplet,
                                               keep_going,
                                               only_downloads,
-                                              print_cmake_usage);
+                                              print_cmake_usage,
+                                              true);
         }
 
         auto registry_set = paths.make_registry_set();

--- a/src/vcpkg/commands.set-installed.cpp
+++ b/src/vcpkg/commands.set-installed.cpp
@@ -179,7 +179,8 @@ namespace vcpkg
                                            Triplet host_triplet,
                                            const KeepGoing keep_going,
                                            const bool only_downloads,
-                                           const PrintUsage print_cmake_usage)
+                                           const PrintUsage print_cmake_usage,
+                                           bool include_manifest_in_github_issue)
     {
         auto& fs = paths.get_filesystem();
 
@@ -243,8 +244,14 @@ namespace vcpkg
         auto binary_cache = only_downloads ? BinaryCache(paths.get_filesystem())
                                            : BinaryCache::make(args, paths, stdout_sink).value_or_exit(VCPKG_LINE_INFO);
         binary_cache.fetch(action_plan.install_actions);
-        const auto summary = install_execute_plan(
-            args, action_plan, keep_going, paths, status_db, binary_cache, null_build_logs_recorder());
+        const auto summary = install_execute_plan(args,
+                                                  action_plan,
+                                                  keep_going,
+                                                  paths,
+                                                  status_db,
+                                                  binary_cache,
+                                                  null_build_logs_recorder(),
+                                                  include_manifest_in_github_issue);
 
         if (keep_going == KeepGoing::YES && summary.failed())
         {
@@ -340,6 +347,7 @@ namespace vcpkg
                                           host_triplet,
                                           keep_going,
                                           only_downloads,
-                                          print_cmake_usage);
+                                          print_cmake_usage,
+                                          false);
     }
 } // namespace vcpkg


### PR DESCRIPTION
In the past I sometimes got errors like 
```
➜  vcpkg git:(test-features) ✗   gh issue create -R microsoft/vcpkg --title "[llvm] Build failure" --body-file /Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed/vcpkg/issue_body.md

Creating issue in microsoft/vcpkg

GraphQL: Body is too long (maximum is 65536 characters) (createIssue)
```
With this PR the body size is enforced and dynamically distributed between the logs that are copied into the issue body. 
