### PR TITLE
Fix unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -480,6 +480,8 @@ if (BUILD_TESTING)
         target_link_libraries(vcpkg-test PRIVATE log)
     endif()
 
+    add_dependencies(vcpkg-test reads-stdin closes-stdin closes-stdout test-editor)
+
     if(CMAKE_VERSION GREATER_EQUAL "3.16")
         target_precompile_headers(vcpkg-test REUSE_FROM vcpkglib)
     elseif(NOT MSVC)


### PR DESCRIPTION
Probably fixes https://github.com/microsoft/vcpkg-tool/pull/1256#issuecomment-1785445189
Target `vcpkg-test` doesn't declare build dependencies on test executables. As a result, unit tests fail if those executables were missing.