### PR TITLE
Delete BuildInfo::version.

### DIFF
--- a/include/vcpkg/commands.build.h
+++ b/include/vcpkg/commands.build.h
@@ -230,8 +230,6 @@ namespace vcpkg
         LinkageType crt_linkage = LinkageType::DYNAMIC;
         LinkageType library_linkage = LinkageType::DYNAMIC;
 
-        Optional<std::string> version;
-
         BuildPolicies policies;
     };
 

--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -603,8 +603,7 @@ namespace vcpkg
         return ret;
     }
 
-    static std::unique_ptr<BinaryControlFile> create_binary_control_file(const InstallPlanAction& action,
-                                                                         const BuildInfo& build_info)
+    static std::unique_ptr<BinaryControlFile> create_binary_control_file(const InstallPlanAction& action)
     {
         const auto& scfl = action.source_control_file_and_location.value_or_exit(VCPKG_LINE_INFO);
 
@@ -617,10 +616,7 @@ namespace vcpkg
                              action.spec.triplet(),
                              action.public_abi(),
                              fspecs_to_pspecs(find_itr->second));
-        if (const auto p_ver = build_info.version.get())
-        {
-            bpgh.version = *p_ver;
-        }
+
         bcf->core_paragraph = std::move(bpgh);
 
         bcf->features.reserve(action.feature_list.size());
@@ -1037,7 +1033,7 @@ namespace vcpkg
             return ExtendedBuildResult{BuildResult::POST_BUILD_CHECKS_FAILED};
         }
 
-        std::unique_ptr<BinaryControlFile> bcf = create_binary_control_file(action, build_info);
+        std::unique_ptr<BinaryControlFile> bcf = create_binary_control_file(action);
 
         write_sbom(paths, action, abi_info.heuristic_resources);
         write_binary_control_file(paths.get_filesystem(), action.package_dir.value_or_exit(VCPKG_LINE_INFO), *bcf);
@@ -1664,8 +1660,7 @@ namespace vcpkg
             }
         }
 
-        std::string version = parser.optional_field("Version");
-        if (!version.empty()) build_info.version = std::move(version);
+        (void)parser.optional_field("Version");
 
         std::unordered_map<BuildPolicy, bool> policies;
         for (const auto& policy : ALL_POLICIES)


### PR DESCRIPTION
In the only place this was used, create_binary_control_file, the version is passed in via the constructor of BinaryParagraph:

```c++
    BinaryParagraph::BinaryParagraph(const SourceParagraph& spgh,
                                     const std::vector<std::string>& default_features,
                                     Triplet triplet,
                                     const std::string& abi_tag,
                                     std::vector<PackageSpec> deps)
        : spec(spgh.name, triplet)
        , version(spgh.raw_version)    // <-- !!!
        , port_version(spgh.port_version)
        , description(spgh.description)
        , maintainers(spgh.maintainers)
        , feature()
        , default_features(default_features)
        , dependencies(std::move(deps))
        , abi(abi_tag)
    {
        canonicalize();
    }
```