### PR TITLE
Clarify BuildInfo::version's purpose.

### DIFF
--- a/azure-pipelines/e2e-ports/overlays/set-detected-head-version/portfile.cmake
+++ b/azure-pipelines/e2e-ports/overlays/set-detected-head-version/portfile.cmake
@@ -1,0 +1,4 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+if (VCPKG_USE_HEAD_VERSION)
+	set(VCPKG_HEAD_VERSION "detected-head")
+endif()

--- a/azure-pipelines/e2e-ports/overlays/set-detected-head-version/vcpkg.json
+++ b/azure-pipelines/e2e-ports/overlays/set-detected-head-version/vcpkg.json
@@ -1,0 +1,4 @@
+{
+  "name": "set-detected-head-version",
+  "version": "1.0.0"
+}

--- a/azure-pipelines/end-to-end-tests-dir/classic-versions.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/classic-versions.ps1
@@ -24,5 +24,5 @@ Throw-IfFailed
 $listResults = Run-VcpkgAndCaptureOutput @commonArgs list
 if (-Not ($listResults.Trim() -match "set-detected-head-version:[\S]+[\s]+detected-head"))
 {
-    throw "Expected list to list the declared version"
+    throw "Expected list to list the detected version"
 }

--- a/azure-pipelines/end-to-end-tests-dir/classic-versions.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/classic-versions.ps1
@@ -1,9 +1,28 @@
 . $PSScriptRoot/../end-to-end-tests-prelude.ps1
 
 # Not a number
+Refresh-TestRoot
 $out = Run-VcpkgAndCaptureOutput @commonArgs install classic-versions-b
 Throw-IfNotFailed
 if ($out -notmatch ".*warning:.*dependency classic-versions-a.*at least version 2.*is currently 1.*")
 {
     throw "Expected to fail and print warning about mismatched versions"
+}
+
+Refresh-TestRoot
+Run-Vcpkg @commonArgs install set-detected-head-version
+Throw-IfFailed
+$listResults = Run-VcpkgAndCaptureOutput @commonArgs list
+if (-Not ($listResults.Trim() -match "set-detected-head-version:[\S]+[\s]+1.0.0"))
+{
+    throw "Expected list to list the declared version"
+}
+
+Refresh-TestRoot
+Run-Vcpkg @commonArgs install set-detected-head-version --head
+Throw-IfFailed
+$listResults = Run-VcpkgAndCaptureOutput @commonArgs list
+if (-Not ($listResults.Trim() -match "set-detected-head-version:[\S]+[\s]+detected-head"))
+{
+    throw "Expected list to list the declared version"
 }

--- a/include/vcpkg/commands.build.h
+++ b/include/vcpkg/commands.build.h
@@ -230,7 +230,7 @@ namespace vcpkg
         LinkageType crt_linkage = LinkageType::DYNAMIC;
         LinkageType library_linkage = LinkageType::DYNAMIC;
 
-        Optional<std::string> version;
+        Optional<std::string> detected_head_version;
 
         BuildPolicies policies;
     };

--- a/include/vcpkg/versions.h
+++ b/include/vcpkg/versions.h
@@ -171,6 +171,9 @@ namespace vcpkg
     bool try_extract_external_date_version(ParsedExternalVersion& out, StringView version);
     // /(\d+)(\.\d+|$)(\.\d+)?.*/
     bool try_extract_external_dot_version(ParsedExternalVersion& out, StringView version);
+
+    // remove as few characters as possible from `target` to make it a valid `version-string` [^#]*(#\d+)?
+    void sanitize_version_string(std::string& target);
 }
 
 VCPKG_FORMAT_WITH_TO_STRING(vcpkg::Version);

--- a/include/vcpkg/versions.h
+++ b/include/vcpkg/versions.h
@@ -172,7 +172,7 @@ namespace vcpkg
     // /(\d+)(\.\d+|$)(\.\d+)?.*/
     bool try_extract_external_dot_version(ParsedExternalVersion& out, StringView version);
 
-    // remove as few characters as possible from `target` to make it a valid `version-string` [^#]*(#\d+)?
+    // remove as few characters as possible from `target` to make it a valid `version-string` [^#]+(#\d+)?, or empty
     void sanitize_version_string(std::string& target);
 }
 

--- a/src/vcpkg-test/versions.cpp
+++ b/src/vcpkg-test/versions.cpp
@@ -1,0 +1,50 @@
+#include <vcpkg-test/util.h>
+
+#include <vcpkg/versions.h>
+
+#include <string>
+
+using namespace vcpkg;
+
+TEST_CASE ("sanitize", "[versions]")
+{
+    std::string content;
+    sanitize_version_string(content);
+    CHECK(content.empty());
+
+    content = "some version text";
+    sanitize_version_string(content);
+    CHECK(content == "some version text");
+
+    content = "some version with missing number port version#";
+    sanitize_version_string(content);
+    CHECK(content == "some version with missing number port version");
+
+    content = "some version with port version#1";
+    sanitize_version_string(content);
+    CHECK(content == "some version with port version#1");
+
+    content = "some version with bad version # hashes";
+    sanitize_version_string(content);
+    CHECK(content == "some version with bad version  hashes");
+
+    content = "some version with bad version # hashes#1";
+    sanitize_version_string(content);
+    CHECK(content == "some version with bad version  hashes#1");
+
+    content = "1";
+    sanitize_version_string(content);
+    CHECK(content == "1");
+
+    content = "1234";
+    sanitize_version_string(content);
+    CHECK(content == "1234");
+
+    content = "#1234";
+    sanitize_version_string(content);
+    CHECK(content == "1234");
+
+    content = "#1234#1234";
+    sanitize_version_string(content);
+    CHECK(content == "1234#1234");
+}

--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -617,7 +617,7 @@ namespace vcpkg
                              action.spec.triplet(),
                              action.public_abi(),
                              fspecs_to_pspecs(find_itr->second));
-        if (const auto p_ver = build_info.version.get())
+        if (const auto p_ver = build_info.detected_head_version.get())
         {
             bpgh.version = *p_ver;
         }
@@ -1665,7 +1665,11 @@ namespace vcpkg
         }
 
         std::string version = parser.optional_field("Version");
-        if (!version.empty()) build_info.version = std::move(version);
+        if (!version.empty())
+        {
+            sanitize_version_string(version);
+            build_info.detected_head_version = std::move(version);
+        }
 
         std::unordered_map<BuildPolicy, bool> policies;
         for (const auto& policy : ALL_POLICIES)


### PR DESCRIPTION
Alternative resolution of https://github.com/microsoft/vcpkg-tool/pull/1259

This adds a test that we store the detected build tree version, and adds paranoia defenses that the resulting version can at least be interpreted as a `version-string`.