### PR TITLE
Don't require VCPKG_FORCE_SYSTEM_BINARIES on arm64 Linux

### DIFF
--- a/include/vcpkg/tools.test.h
+++ b/include/vcpkg/tools.test.h
@@ -29,7 +29,7 @@ namespace vcpkg
         Path exe_path(const Path& tools_base_path) const { return tools_base_path / tool_dir_subpath / exe_subpath; }
     };
 
-    Optional<ToolData> parse_tool_data_from_xml(StringView XML, StringView XML_PATH, StringView tool, StringView os);
+    Optional<ToolData> parse_tool_data_from_xml(StringView XML, StringView XML_PATH, StringView tool, StringView os, StringView host_processor);
 
     Optional<std::array<int, 3>> parse_tool_version_string(StringView string_version);
 }

--- a/include/vcpkg/tools.test.h
+++ b/include/vcpkg/tools.test.h
@@ -29,7 +29,8 @@ namespace vcpkg
         Path exe_path(const Path& tools_base_path) const { return tools_base_path / tool_dir_subpath / exe_subpath; }
     };
 
-    Optional<ToolData> parse_tool_data_from_xml(StringView XML, StringView XML_PATH, StringView tool, StringView os, StringView host_processor);
+    Optional<ToolData> parse_tool_data_from_xml(
+        StringView XML, StringView XML_PATH, StringView tool, StringView os, StringView host_processor);
 
     Optional<std::array<int, 3>> parse_tool_version_string(StringView string_version);
 }

--- a/src/vcpkg-test/tools.cpp
+++ b/src/vcpkg-test/tools.cpp
@@ -4,6 +4,7 @@
 #include <vcpkg/tools.test.h>
 
 #include <array>
+
 #include "vcpkg/base/system.h"
 
 using namespace vcpkg;
@@ -72,15 +73,18 @@ TEST_CASE ("parse_tool_data_from_xml", "[tools]")
 )";
 
     {
-        auto data = parse_tool_data_from_xml(tool_doc, "vcpkgTools.xml", "tool1", "windows", to_zstring_view(get_host_processor()));
+        auto data = parse_tool_data_from_xml(
+            tool_doc, "vcpkgTools.xml", "tool1", "windows", to_zstring_view(get_host_processor()));
         REQUIRE(!data.has_value());
     }
     {
-        auto data = parse_tool_data_from_xml(tool_doc, "vcpkgTools.xml", "node", "unknown", to_zstring_view(get_host_processor()));
+        auto data = parse_tool_data_from_xml(
+            tool_doc, "vcpkgTools.xml", "node", "unknown", to_zstring_view(get_host_processor()));
         REQUIRE(!data.has_value());
     }
     {
-        auto data = parse_tool_data_from_xml(tool_doc, "vcpkgTools.xml", "node", "windows", to_zstring_view(get_host_processor()));
+        auto data = parse_tool_data_from_xml(
+            tool_doc, "vcpkgTools.xml", "node", "windows", to_zstring_view(get_host_processor()));
         REQUIRE(data.has_value());
         auto& p = *data.get();
         CHECK(p.is_archive);
@@ -93,7 +97,8 @@ TEST_CASE ("parse_tool_data_from_xml", "[tools]")
         CHECK(p.url == "https://nodejs.org/dist/v16.12.0/node-v16.12.0-win-x64.7z");
     }
     {
-        auto data = parse_tool_data_from_xml(tool_doc, "vcpkgTools.xml", "nuget", "osx", to_zstring_view(get_host_processor()));
+        auto data =
+            parse_tool_data_from_xml(tool_doc, "vcpkgTools.xml", "nuget", "osx", to_zstring_view(get_host_processor()));
         REQUIRE(data.has_value());
         auto& p = *data.get();
         CHECK_FALSE(p.is_archive);
@@ -106,7 +111,8 @@ TEST_CASE ("parse_tool_data_from_xml", "[tools]")
         CHECK(p.url == "https://dist.nuget.org/win-x86-commandline/v5.11.0/nuget.exe");
     }
     {
-        auto data = parse_tool_data_from_xml(tool_doc, "vcpkgTools.xml", "git", "linux", to_zstring_view(get_host_processor()));
+        auto data =
+            parse_tool_data_from_xml(tool_doc, "vcpkgTools.xml", "git", "linux", to_zstring_view(get_host_processor()));
         REQUIRE(data.has_value());
         auto& p = *data.get();
         CHECK_FALSE(p.is_archive);

--- a/src/vcpkg-test/tools.cpp
+++ b/src/vcpkg-test/tools.cpp
@@ -4,6 +4,7 @@
 #include <vcpkg/tools.test.h>
 
 #include <array>
+#include "vcpkg/base/system.h"
 
 using namespace vcpkg;
 
@@ -71,15 +72,15 @@ TEST_CASE ("parse_tool_data_from_xml", "[tools]")
 )";
 
     {
-        auto data = parse_tool_data_from_xml(tool_doc, "vcpkgTools.xml", "tool1", "windows");
+        auto data = parse_tool_data_from_xml(tool_doc, "vcpkgTools.xml", "tool1", "windows", to_zstring_view(get_host_processor()));
         REQUIRE(!data.has_value());
     }
     {
-        auto data = parse_tool_data_from_xml(tool_doc, "vcpkgTools.xml", "node", "unknown");
+        auto data = parse_tool_data_from_xml(tool_doc, "vcpkgTools.xml", "node", "unknown", to_zstring_view(get_host_processor()));
         REQUIRE(!data.has_value());
     }
     {
-        auto data = parse_tool_data_from_xml(tool_doc, "vcpkgTools.xml", "node", "windows");
+        auto data = parse_tool_data_from_xml(tool_doc, "vcpkgTools.xml", "node", "windows", to_zstring_view(get_host_processor()));
         REQUIRE(data.has_value());
         auto& p = *data.get();
         CHECK(p.is_archive);
@@ -92,7 +93,7 @@ TEST_CASE ("parse_tool_data_from_xml", "[tools]")
         CHECK(p.url == "https://nodejs.org/dist/v16.12.0/node-v16.12.0-win-x64.7z");
     }
     {
-        auto data = parse_tool_data_from_xml(tool_doc, "vcpkgTools.xml", "nuget", "osx");
+        auto data = parse_tool_data_from_xml(tool_doc, "vcpkgTools.xml", "nuget", "osx", to_zstring_view(get_host_processor()));
         REQUIRE(data.has_value());
         auto& p = *data.get();
         CHECK_FALSE(p.is_archive);
@@ -105,7 +106,7 @@ TEST_CASE ("parse_tool_data_from_xml", "[tools]")
         CHECK(p.url == "https://dist.nuget.org/win-x86-commandline/v5.11.0/nuget.exe");
     }
     {
-        auto data = parse_tool_data_from_xml(tool_doc, "vcpkgTools.xml", "git", "linux");
+        auto data = parse_tool_data_from_xml(tool_doc, "vcpkgTools.xml", "git", "linux", to_zstring_view(get_host_processor()));
         REQUIRE(data.has_value());
         auto& p = *data.get();
         CHECK_FALSE(p.is_archive);

--- a/src/vcpkg.cpp
+++ b/src/vcpkg.cpp
@@ -267,7 +267,7 @@ int main(const int argc, const char* const* const argv)
      ((defined(__ppc64__) || defined(__PPC64__) || defined(__ppc64le__) || defined(__PPC64LE__)) &&                    \
       defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)) ||                                       \
      defined(_M_ARM) || defined(_M_ARM64)) &&                                                                          \
-    !defined(_WIN32) && !defined(__APPLE__)
+    !defined(_WIN32) && !defined(__APPLE__) && !(defined(__aarch64__) && defined(__linux__))
     if (!get_environment_variable("VCPKG_FORCE_SYSTEM_BINARIES").has_value())
     {
         Checks::msg_exit_with_message(VCPKG_LINE_INFO, msgForceSystemBinariesOnWeirdPlatforms);

--- a/src/vcpkg/tools.cpp
+++ b/src/vcpkg/tools.cpp
@@ -96,10 +96,14 @@ namespace vcpkg
                                msg::expected_version = XML_VERSION,
                                msg::actual_version = match_xml_version[1].str());
 
-        const std::regex tool_regex{fmt::format(R"###(<tool[\s]+name="{}"[\s]+os="{}" arch="{}>)###", tool, os, host_processor)};
+        const std::regex tool_regex_with_arch{fmt::format(R"###(<tool[\s]+name="{}"[\s]+os="{}" arch="{}>)###", tool, os, host_processor)};
         std::cmatch match_tool_entry;
-        const bool has_tool_entry = std::regex_search(XML.begin(), XML.end(), match_tool_entry, tool_regex);
-        if (!has_tool_entry) return nullopt;
+        const bool has_tool_entry_with_arch = std::regex_search(XML.begin(), XML.end(), match_tool_entry, tool_regex_with_arch);
+        if (!has_tool_entry_with_arch) {
+            const std::regex tool_regex_without_arch{fmt::format(R"###(<tool[\s]+name="{}"[\s]+os="{}">)###", tool, os)};
+            const bool has_tool_entry_without_arch = std::regex_search(XML.begin(), XML.end(), match_tool_entry, tool_regex_with_arch);
+            if (!has_tool_entry_without_arch) return nullopt;
+        }
 
         const std::string tool_data =
             Strings::find_exactly_one_enclosed(XML, match_tool_entry[0].str(), "</tool>").to_string();

--- a/src/vcpkg/tools.cpp
+++ b/src/vcpkg/tools.cpp
@@ -17,6 +17,7 @@
 #include <vcpkg/versions.h>
 
 #include <regex>
+
 #include "vcpkg/base/fwd/system.h"
 
 namespace vcpkg
@@ -78,7 +79,8 @@ namespace vcpkg
 #endif
     }
 
-    Optional<ToolData> parse_tool_data_from_xml(StringView XML, StringView XML_PATH, StringView tool, StringView os, StringView host_processor)
+    Optional<ToolData> parse_tool_data_from_xml(
+        StringView XML, StringView XML_PATH, StringView tool, StringView os, StringView host_processor)
     {
         static const char* XML_VERSION = "2";
         static const std::regex XML_VERSION_REGEX{R"###(<tools[\s]+version="([^"]+)">)###"};
@@ -96,12 +98,17 @@ namespace vcpkg
                                msg::expected_version = XML_VERSION,
                                msg::actual_version = match_xml_version[1].str());
 
-        const std::regex tool_regex_with_arch{fmt::format(R"###(<tool[\s]+name="{}"[\s]+os="{}" arch="{}>)###", tool, os, host_processor)};
+        const std::regex tool_regex_with_arch{
+            fmt::format(R"###(<tool[\s]+name="{}"[\s]+os="{}" arch="{}>)###", tool, os, host_processor)};
         std::cmatch match_tool_entry;
-        const bool has_tool_entry_with_arch = std::regex_search(XML.begin(), XML.end(), match_tool_entry, tool_regex_with_arch);
-        if (!has_tool_entry_with_arch) {
-            const std::regex tool_regex_without_arch{fmt::format(R"###(<tool[\s]+name="{}"[\s]+os="{}">)###", tool, os)};
-            const bool has_tool_entry_without_arch = std::regex_search(XML.begin(), XML.end(), match_tool_entry, tool_regex_without_arch);
+        const bool has_tool_entry_with_arch =
+            std::regex_search(XML.begin(), XML.end(), match_tool_entry, tool_regex_with_arch);
+        if (!has_tool_entry_with_arch)
+        {
+            const std::regex tool_regex_without_arch{
+                fmt::format(R"###(<tool[\s]+name="{}"[\s]+os="{}">)###", tool, os)};
+            const bool has_tool_entry_without_arch =
+                std::regex_search(XML.begin(), XML.end(), match_tool_entry, tool_regex_without_arch);
             if (!has_tool_entry_without_arch) return nullopt;
         }
 

--- a/src/vcpkg/tools.cpp
+++ b/src/vcpkg/tools.cpp
@@ -101,7 +101,7 @@ namespace vcpkg
         const bool has_tool_entry_with_arch = std::regex_search(XML.begin(), XML.end(), match_tool_entry, tool_regex_with_arch);
         if (!has_tool_entry_with_arch) {
             const std::regex tool_regex_without_arch{fmt::format(R"###(<tool[\s]+name="{}"[\s]+os="{}">)###", tool, os)};
-            const bool has_tool_entry_without_arch = std::regex_search(XML.begin(), XML.end(), match_tool_entry, tool_regex_with_arch);
+            const bool has_tool_entry_without_arch = std::regex_search(XML.begin(), XML.end(), match_tool_entry, tool_regex_without_arch);
             if (!has_tool_entry_without_arch) return nullopt;
         }
 

--- a/src/vcpkg/tools.cpp
+++ b/src/vcpkg/tools.cpp
@@ -17,6 +17,7 @@
 #include <vcpkg/versions.h>
 
 #include <regex>
+#include "vcpkg/base/fwd/system.h"
 
 namespace vcpkg
 {
@@ -63,21 +64,21 @@ namespace vcpkg
     static Optional<ToolData> parse_tool_data_from_xml(StringView XML, StringView XML_PATH, StringView tool)
     {
 #if defined(_WIN32)
-        return parse_tool_data_from_xml(XML, XML_PATH, tool, "windows");
+        return parse_tool_data_from_xml(XML, XML_PATH, tool, "windows", to_zstring_view(get_host_processor()));
 #elif defined(__APPLE__)
-        return parse_tool_data_from_xml(XML, XML_PATH, tool, "osx");
+        return parse_tool_data_from_xml(XML, XML_PATH, tool, "osx", to_zstring_view(get_host_processor()));
 #elif defined(__linux__)
-        return parse_tool_data_from_xml(XML, XML_PATH, tool, "linux");
+        return parse_tool_data_from_xml(XML, XML_PATH, tool, "linux", to_zstring_view(get_host_processor()));
 #elif defined(__FreeBSD__)
-        return parse_tool_data_from_xml(XML, XML_PATH, tool, "freebsd");
+        return parse_tool_data_from_xml(XML, XML_PATH, tool, "freebsd", to_zstring_view(get_host_processor()));
 #elif defined(__OpenBSD__)
-        return parse_tool_data_from_xml(XML, XML_PATH, tool, "openbsd");
+        return parse_tool_data_from_xml(XML, XML_PATH, tool, "openbsd", to_zstring_view(get_host_processor()));
 #else
         return nullopt;
 #endif
     }
 
-    Optional<ToolData> parse_tool_data_from_xml(StringView XML, StringView XML_PATH, StringView tool, StringView os)
+    Optional<ToolData> parse_tool_data_from_xml(StringView XML, StringView XML_PATH, StringView tool, StringView os, StringView host_processor)
     {
         static const char* XML_VERSION = "2";
         static const std::regex XML_VERSION_REGEX{R"###(<tools[\s]+version="([^"]+)">)###"};
@@ -95,7 +96,7 @@ namespace vcpkg
                                msg::expected_version = XML_VERSION,
                                msg::actual_version = match_xml_version[1].str());
 
-        const std::regex tool_regex{fmt::format(R"###(<tool[\s]+name="{}"[\s]+os="{}">)###", tool, os)};
+        const std::regex tool_regex{fmt::format(R"###(<tool[\s]+name="{}"[\s]+os="{}" arch="{}>)###", tool, os, host_processor)};
         std::cmatch match_tool_entry;
         const bool has_tool_entry = std::regex_search(XML.begin(), XML.end(), match_tool_entry, tool_regex);
         if (!has_tool_entry) return nullopt;


### PR DESCRIPTION
This is the basic set of changes to the tool to allow having entries in vcpkgTools.xml per-architecture. 

Obviously this requires some changes to vcpkgTools.xml. This has been tested on arm64 Linux with

```patch
-    <tool name="cmake" os="linux">
+    <tool name="cmake" os="linux" arch="x64">
         <version>3.27.1</version>
         <exeRelativePath>cmake-3.27.1-linux-x86_64/bin/cmake</exeRelativePath>
         <url>https://github.com/Kitware/CMake/releases/download/v3.27.1/cmake-3.27.1-linux-x86_64.tar.gz</url>
         <sha512>192374a68e2971f04974a194645726196d9b8ee7abd650d1e6f65f7aa2ccc9b186c3edb473bb4958c764532edcdd42f4182ee1fcb86b17d78b0bcd6305ce3df1</sha512>
         <archiveName>cmake-3.27.1-linux-x86_64.tar.gz</archiveName>
     </tool>
+    <tool name="cmake" os="linux" arch="arm64">
+        <version>3.27.1</version>
+        <exeRelativePath>cmake-3.27.1-linux-x86_64/bin/cmake</exeRelativePath>
+        <url>https://github.com/Kitware/CMake/releases/download/v3.27.1/cmake-3.27.1-linux-aarch64.tar.gz</url>
+        <sha512>de458163eb066efe76ab3ece2e0781d1e3d3091b1eda00d9f49b323ada1f65ab9138c52e1af5e6fe74dbd4a4327d4185336c71a9c7430bb5817962ece5696fc1</sha512>
+        <archiveName>cmake-3.27.1-linux-aarch64.tar.gz</archiveName>
+    </tool>
```

applied to vcpkgTools.xml.

Is there potentially interest in this? My usecase is I'd really like to use this arm64 Linux machine for development (a Mac Studio), and have it be able to download binarycache'd artifacts from our server. The problem with `FORCE_SYSTEM_BINARIES` is that it sets verison 0 in for cmake in the ABI, so it has to recompile everything. This combined with `--host-triplet` lets me download the binary cache.

Opening as draft because it requires parallel changes to vcpkgTools.xml, so the PR cannot be merged without a plan on how to do that. 