### PR TITLE
Add unique repository ID detection in ADO and GitLab

### DIFF
--- a/include/vcpkg/vcpkgcmdarguments.h
+++ b/include/vcpkg/vcpkgcmdarguments.h
@@ -283,10 +283,9 @@ namespace vcpkg
         Optional<std::string> github_ref;
         constexpr static StringLiteral GITHUB_SHA_ENV = "GITHUB_SHA";
         Optional<std::string> github_sha;
-        constexpr static StringLiteral GITHUB_REPOSITORY_ID = "GITHUB_REPOSITORY_ID";
-        Optional<std::string> github_repository_id;
         constexpr static StringLiteral GITHUB_REPOSITORY_OWNER_ID = "GITHUB_REPOSITORY_OWNER_ID";
-        Optional<std::string> github_repository_owner_id;
+        Optional<std::string> ci_repository_id;
+        Optional<std::string> ci_repository_owner_id;
 
         constexpr static StringLiteral CMAKE_DEBUGGING_ARG = "cmake-debug";
         Optional<PortApplicableSetting> cmake_debug;

--- a/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/src/vcpkg/vcpkgcmdarguments.cpp
@@ -64,10 +64,13 @@ namespace
         {"BUILD_NUMBER", "Generic"},
     };
 
-    constexpr std::array<StringLiteral, 2> KNOWN_CI_REPOSITORY_IDENTIFIERS{
+    constexpr std::array<StringLiteral, 3> KNOWN_CI_REPOSITORY_IDENTIFIERS{
         // Azure Pipelines
         // https://learn.microsoft.com/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#build-variables-devops-services
         "BUILD_REPOSITORY_ID",
+        // GitLab CI
+        // https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
+        "CI_PROJECT_ID",
         // GitHub Actions
         // https://docs.github.com/actions/learn-github-actions/variables#default-environment-variables
         "GITHUB_REPOSITORY_ID",

--- a/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/src/vcpkg/vcpkgcmdarguments.cpp
@@ -64,6 +64,15 @@ namespace
         {"BUILD_NUMBER", "Generic"},
     };
 
+    constexpr std::array<StringLiteral, 2> KNOWN_CI_REPOSITORY_IDENTIFIERS{
+        // Azure Pipelines
+        // https://learn.microsoft.com/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#build-variables-devops-services
+        "BUILD_REPOSITORY_ID",
+        // GitHub Actions
+        // https://docs.github.com/actions/learn-github-actions/variables#default-environment-variables
+        "GITHUB_REPOSITORY_ID",
+    };
+
     void maybe_parse_cmd_arguments(CmdParser& cmd_parser,
                                    ParsedArguments& output,
                                    const CommandMetadata& command_metadata)
@@ -561,8 +570,7 @@ namespace vcpkg
         from_env(get_env, GITHUB_REF_ENV, github_ref);
         from_env(get_env, GITHUB_SHA_ENV, github_sha);
         from_env(get_env, GITHUB_JOB_ENV, github_job);
-        from_env(get_env, GITHUB_REPOSITORY_ID, github_repository_id);
-        from_env(get_env, GITHUB_REPOSITORY_OWNER_ID, github_repository_owner_id);
+        from_env(get_env, GITHUB_REPOSITORY_OWNER_ID, ci_repository_owner_id);
         from_env(get_env, GITHUB_RUN_ID_ENV, github_run_id);
         from_env(get_env, GITHUB_TOKEN_ENV, github_token);
         from_env(get_env, GITHUB_WORKFLOW_ENV, github_workflow);
@@ -573,6 +581,17 @@ namespace vcpkg
             if (get_env(ci_env_var.first).has_value())
             {
                 m_detected_ci_environment = ci_env_var.second;
+                break;
+            }
+        }
+
+        // detect unique repository identifier in CI environments
+        for (auto&& ci_id_var : KNOWN_CI_REPOSITORY_IDENTIFIERS)
+        {
+            auto maybe_ci_id = get_env(ci_id_var);
+            if (auto ci_id = maybe_ci_id.get())
+            {
+                ci_repository_id = std::move(*ci_id);
                 break;
             }
         }
@@ -766,12 +785,12 @@ namespace vcpkg
             submission.track_string(StringMetric::DetectedCiEnvironment, *ci_env);
         }
 
-        if (auto repo_id = github_repository_id.get())
+        if (auto repo_id = ci_repository_id.get())
         {
             submission.track_string(StringMetric::CiProjectId, *repo_id);
         }
 
-        if (auto owner_id = github_repository_owner_id.get())
+        if (auto owner_id = ci_repository_owner_id.get())
         {
             submission.track_string(StringMetric::CiOwnerId, *owner_id);
         }
@@ -842,7 +861,6 @@ namespace vcpkg
     constexpr StringLiteral VcpkgCmdArguments::GITHUB_REPOSITORY_ENV;
     constexpr StringLiteral VcpkgCmdArguments::GITHUB_REF_ENV;
     constexpr StringLiteral VcpkgCmdArguments::GITHUB_SHA_ENV;
-    constexpr StringLiteral VcpkgCmdArguments::GITHUB_REPOSITORY_ID;
     constexpr StringLiteral VcpkgCmdArguments::GITHUB_REPOSITORY_OWNER_ID;
     constexpr StringLiteral VcpkgCmdArguments::GITHUB_TOKEN_ENV;
     constexpr StringLiteral VcpkgCmdArguments::GITHUB_WORKFLOW_ENV;

--- a/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/src/vcpkg/vcpkgcmdarguments.cpp
@@ -48,6 +48,7 @@ namespace
 
         // Jenkins
         // https://wiki.jenkins.io/display/JENKINS/Building+a+software+project#Buildingasoftwareproject-belowJenkinsSetEnvironmentVariables
+        {"JENKINS_HOME", "Jenkins_CI"},
         {"JENKINS_URL", "Jenkins_CI"},
 
         // TeamCity


### PR DESCRIPTION
Use the repository ID to differentiate projects using vpckg in an ADO or GitLab CI environments.