### PR TITLE
Return after resolving promise

### DIFF
--- a/vcpkg-artifacts/vcpkg.ts
+++ b/vcpkg-artifacts/vcpkg.ts
@@ -19,7 +19,10 @@ function streamVcpkg(vcpkgCommand: string | undefined, args: Array<string>, list
     subproc.stderr.pipe(process.stdout);
     subproc.on('error', (err) => { reject(err); });
     subproc.on('close', (code: number, signal) => {
-      if (code === 0) { accept(); }
+      if (code === 0) {
+        accept();
+        return;
+      }
       reject(i`Running vcpkg internally returned a nonzero exit code: ${code}`);
     });
   });


### PR DESCRIPTION
A quick PR to guard from running the promise `reject()` function straight after the `resolve()` function.