### PR TITLE
Print "@version" when talking about port versions more frequently.

### DIFF
--- a/azure-pipelines/end-to-end-tests-dir/e2e-registry.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/e2e-registry.ps1
@@ -86,7 +86,7 @@ try
     $out = Run-VcpkgAndCaptureOutput @commonArgs install
     Throw-IfFailed
     if ($out -match 'error: the baseline does not contain an entry for port removed' -Or
-        $out -notmatch 'The following packages will be built and installed:\s+removed:[^ ]+ -> 1.0.0 -- [^ ]+git-trees[\\/]9b82c31964570870d27a5bb634f5b84e13f8b90a'
+        $out -notmatch 'The following packages will be built and installed:\s+removed:[^ ]+@1.0.0 -- [^ ]+git-trees[\\/]9b82c31964570870d27a5bb634f5b84e13f8b90a'
         )
     {
         throw 'Baseline removed port could not be selected with overrides'

--- a/azure-pipelines/end-to-end-tests-dir/upgrade.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/upgrade.ps1
@@ -7,7 +7,7 @@ try
     git -C "$TestingRoot/temp-repo" switch -d e1934f4a2a0c58bb75099d89ed980832379907fa # vcpkg-cmake @ 2022-12-22
     $output = Run-VcpkgAndCaptureOutput install vcpkg-cmake
     Throw-IfFailed
-    if (-Not ($output -match 'vcpkg-cmake:[^ ]+ -> 2022-12-22'))
+    if (-Not ($output -match 'vcpkg-cmake:[^ ]+@2022-12-22'))
     {
         throw 'Unexpected vcpkg-cmake install'
     }
@@ -20,14 +20,14 @@ try
         throw "Upgrade didn't handle dry-run correctly"
     }
 
-    if (-Not ($output -match '\* vcpkg-cmake:[^ ]+ -> 2023-05-04'))
+    if (-Not ($output -match '\* vcpkg-cmake:[^ ]+@2023-05-04'))
     {
         throw "Upgrade didn't choose expected version"
     }
 
     $output = Run-VcpkgAndCaptureOutput upgrade --no-dry-run
     Throw-IfFailed
-    if (-Not ($output -match '\* vcpkg-cmake:[^ ]+ -> 2023-05-04'))
+    if (-Not ($output -match '\* vcpkg-cmake:[^ ]+@2023-05-04'))
     {
         throw "Upgrade didn't choose expected version"
     }

--- a/include/vcpkg/binaryparagraph.h
+++ b/include/vcpkg/binaryparagraph.h
@@ -24,7 +24,7 @@ namespace vcpkg
 
         void canonicalize();
 
-        std::string displayname() const;
+        std::string display_name() const;
 
         std::string fullstem() const;
 

--- a/include/vcpkg/dependencies.h
+++ b/include/vcpkg/dependencies.h
@@ -28,8 +28,6 @@ namespace vcpkg
 
     struct PackageAction : BasicAction
     {
-        std::string displayname() const;
-
         std::vector<PackageSpec> package_dependencies;
         InternalFeatureSet feature_list;
     };
@@ -57,6 +55,7 @@ namespace vcpkg
         Optional<const std::string&> package_abi() const;
         const PreBuildInfo& pre_build_info(LineInfo li) const;
         Version version() const;
+        std::string display_name() const;
 
         Optional<const SourceControlFileAndLocation&> source_control_file_and_location;
         Optional<InstalledPackageView> installed_package;

--- a/src/vcpkg-test/dependencies.cpp
+++ b/src/vcpkg-test/dependencies.cpp
@@ -2361,6 +2361,7 @@ TEST_CASE ("formatting plan 1", "[dependencies]")
     const Path pr = "packages_root";
     InstallPlanAction install_a(
         {"a", Test::X64_OSX}, scfl_a, pr, RequestType::AUTO_SELECTED, Test::X64_ANDROID, {}, {}, {});
+    REQUIRE(install_a.display_name() == "a:x64-osx@1");
     InstallPlanAction install_b(
         {"b", Test::X64_OSX}, scfl_b, pr, RequestType::AUTO_SELECTED, Test::X64_ANDROID, {{"1", {}}}, {}, {});
     InstallPlanAction install_c(
@@ -2372,6 +2373,7 @@ TEST_CASE ("formatting plan 1", "[dependencies]")
     InstallPlanAction already_installed_d(
         status_db.get_installed_package_view({"d", Test::X86_WINDOWS}).value_or_exit(VCPKG_LINE_INFO),
         RequestType::AUTO_SELECTED);
+    REQUIRE(already_installed_d.display_name() == "d:x86-windows@1");
     InstallPlanAction already_installed_e(
         status_db.get_installed_package_view({"e", Test::X86_WINDOWS}).value_or_exit(VCPKG_LINE_INFO),
         RequestType::USER_REQUESTED);
@@ -2403,7 +2405,7 @@ TEST_CASE ("formatting plan 1", "[dependencies]")
                   "    a:x64-osx\n"
                   "    b:x64-osx\n"
                   "The following packages will be built and installed:\n"
-                  "    c:x64-osx -> 1 -- c\n");
+                  "    c:x64-osx@1 -- c\n");
 
     plan.remove_actions.push_back(remove_c);
     REQUIRE_LINES(format_plan(plan, "c").text,
@@ -2411,15 +2413,15 @@ TEST_CASE ("formatting plan 1", "[dependencies]")
                   "    a:x64-osx\n"
                   "    b:x64-osx\n"
                   "The following packages will be rebuilt:\n"
-                  "    c:x64-osx -> 1\n");
+                  "    c:x64-osx@1\n");
 
     plan.install_actions.push_back(std::move(install_b));
     REQUIRE_LINES(format_plan(plan, "c").text,
                   "The following packages will be removed:\n"
                   "    a:x64-osx\n"
                   "The following packages will be rebuilt:\n"
-                  "  * b[1]:x64-osx -> 1 -- b\n"
-                  "    c:x64-osx -> 1\n"
+                  "  * b[1]:x64-osx@1 -- b\n"
+                  "    c:x64-osx@1\n"
                   "Additional packages (*) will be modified to complete this operation.\n");
 
     plan.install_actions.push_back(std::move(install_a));
@@ -2430,26 +2432,26 @@ TEST_CASE ("formatting plan 1", "[dependencies]")
         CHECK(formatted.has_removals);
         REQUIRE_LINES(formatted.text,
                       "The following packages are already installed:\n"
-                      "  * d:x86-windows -> 1\n"
-                      "    e:x86-windows -> 1\n"
+                      "  * d:x86-windows@1\n"
+                      "    e:x86-windows@1\n"
                       "The following packages will be rebuilt:\n"
-                      "  * a:x64-osx -> 1 -- a\n"
-                      "  * b[1]:x64-osx -> 1\n"
-                      "    c:x64-osx -> 1 -- c\n"
+                      "  * a:x64-osx@1 -- a\n"
+                      "  * b[1]:x64-osx@1\n"
+                      "    c:x64-osx@1 -- c\n"
                       "Additional packages (*) will be modified to complete this operation.\n");
     }
 
     plan.install_actions.push_back(std::move(install_f));
     REQUIRE_LINES(format_plan(plan, "b").text,
                   "The following packages are excluded:\n"
-                  "    f:x64-osx -> 1 -- f\n"
+                  "    f:x64-osx@1 -- f\n"
                   "The following packages are already installed:\n"
-                  "  * d:x86-windows -> 1\n"
-                  "    e:x86-windows -> 1\n"
+                  "  * d:x86-windows@1\n"
+                  "    e:x86-windows@1\n"
                   "The following packages will be rebuilt:\n"
-                  "  * a:x64-osx -> 1 -- a\n"
-                  "  * b[1]:x64-osx -> 1\n"
-                  "    c:x64-osx -> 1 -- c\n"
+                  "  * a:x64-osx@1 -- a\n"
+                  "  * b[1]:x64-osx@1\n"
+                  "    c:x64-osx@1 -- c\n"
                   "Additional packages (*) will be modified to complete this operation.\n");
 }
 

--- a/src/vcpkg/binaryparagraph.cpp
+++ b/src/vcpkg/binaryparagraph.cpp
@@ -153,7 +153,7 @@ namespace vcpkg
         }
     }
 
-    std::string BinaryParagraph::displayname() const
+    std::string BinaryParagraph::display_name() const
     {
         if (!this->is_feature() || this->feature == "core")
         {

--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -1560,9 +1560,8 @@ namespace vcpkg
         // The logs excerpts are as large as possible. So the issue body will often reach MAX_ISSUE_SIZE.
         issue_body.reserve(MAX_ISSUE_SIZE);
         fmt::format_to(std::back_inserter(issue_body),
-                       "Package: {} -> {}\n\n**Host Environment**\n\n- Host: {}-{}\n",
-                       action.displayname(),
-                       action.source_control_file_and_location.value_or_exit(VCPKG_LINE_INFO).to_version(),
+                       "Package: {}\n\n**Host Environment**\n\n- Host: {}-{}\n",
+                       action.display_name(),
                        to_zstring_view(get_host_processor()),
                        get_host_os_name());
 

--- a/src/vcpkg/commands.install.cpp
+++ b/src/vcpkg/commands.install.cpp
@@ -179,7 +179,7 @@ namespace vcpkg
                 continue;
             }
 
-            const std::string name = t.pgh.package.displayname();
+            const std::string name = t.pgh.package.display_name();
 
             for (const std::string& file : t.files)
             {
@@ -352,16 +352,14 @@ namespace vcpkg
             }
             else
             {
-                if (use_head_version)
-                    msg::println(msgBuildingFromHead, msg::spec = action.displayname());
-                else
-                    msg::println(msgBuildingPackage, msg::spec = action.displayname());
+                msg::println(use_head_version ? msgBuildingFromHead : msgBuildingPackage,
+                             msg::spec = action.display_name());
 
                 auto result = build_package(args, paths, action, build_logs_recorder, status_db);
 
                 if (BuildResult::DOWNLOADED == result.code)
                 {
-                    msg::println(Color::success, msgDownloadedSources, msg::spec = action.displayname());
+                    msg::println(Color::success, msgDownloadedSources, msg::spec = action.display_name());
                     return result;
                 }
 
@@ -502,7 +500,7 @@ namespace vcpkg
             msg::println(msgInstallingPackage,
                          msg::action_index = action_index,
                          msg::count = action_count,
-                         msg::spec = action.spec);
+                         msg::spec = action.display_name());
         }
 
         TrackedPackageInstallGuard(const size_t action_index,

--- a/src/vcpkg/commands.list.cpp
+++ b/src/vcpkg/commands.list.cpp
@@ -60,7 +60,7 @@ namespace
         {
             msg::write_unlocalized_text_to_stdout(Color::none,
                                                   fmt::format("{:<50}{:<20}{:<}\n",
-                                                              pgh.package.displayname(),
+                                                              pgh.package.display_name(),
                                                               full_version,
                                                               fmt::join(pgh.package.description, "\n\n")));
         }
@@ -73,7 +73,7 @@ namespace
             }
             msg::write_unlocalized_text_to_stdout(Color::none,
                                                   fmt::format("{:<50}{:<20}{:<}\n",
-                                                              vcpkg::shorten_text(pgh.package.displayname(), 50),
+                                                              vcpkg::shorten_text(pgh.package.display_name(), 50),
                                                               vcpkg::shorten_text(full_version, 16),
                                                               vcpkg::shorten_text(description, 51)));
         }
@@ -124,7 +124,7 @@ namespace vcpkg
         std::sort(installed_packages.begin(),
                   installed_packages.end(),
                   [](const StatusParagraph* lhs, const StatusParagraph* rhs) -> bool {
-                      return lhs->package.displayname() < rhs->package.displayname();
+                      return lhs->package.display_name() < rhs->package.display_name();
                   });
 
         const auto enable_fulldesc = Util::Sets::contains(options.switches, OPTION_FULLDESC.to_string());
@@ -133,7 +133,7 @@ namespace vcpkg
         {
             auto& query = options.command_arguments[0];
             auto pghs = Util::filter(installed_packages, [query](const StatusParagraph* status_paragraph) {
-                return Strings::case_insensitive_ascii_contains(status_paragraph->package.displayname(), query);
+                return Strings::case_insensitive_ascii_contains(status_paragraph->package.display_name(), query);
             });
             installed_packages = pghs;
         }

--- a/src/vcpkg/commands.owns.cpp
+++ b/src/vcpkg/commands.owns.cpp
@@ -23,7 +23,7 @@ namespace
                 if (file.find(file_substr) != std::string::npos)
                 {
                     msg::write_unlocalized_text_to_stdout(Color::none,
-                                                          fmt::format("{}: {}\n", pgh.package.displayname(), file));
+                                                          fmt::format("{}: {}\n", pgh.package.display_name(), file));
                 }
             }
         }

--- a/src/vcpkg/dependencies.cpp
+++ b/src/vcpkg/dependencies.cpp
@@ -430,10 +430,7 @@ namespace vcpkg
 
     static void format_plan_row(LocalizedString& out, const InstallPlanAction& action, const Path& builtin_ports_dir)
     {
-        out.append_raw(request_type_indent(action.request_type))
-            .append_raw(action.displayname())
-            .append_raw(" -> ")
-            .append_raw(action.version());
+        out.append_raw(request_type_indent(action.request_type)).append_raw(action.display_name());
         if (action.build_options.use_head_version == UseHeadVersion::YES)
         {
             out.append_raw(" (+HEAD)");
@@ -462,17 +459,6 @@ namespace vcpkg
     bool BasicAction::compare_by_name(const BasicAction* left, const BasicAction* right)
     {
         return left->spec.name() < right->spec.name();
-    }
-
-    std::string PackageAction::displayname() const
-    {
-        if (this->feature_list.empty_or_only_core())
-        {
-            return this->spec.to_string();
-        }
-
-        const std::string features = Strings::join(",", feature_list);
-        return fmt::format("{}[{}]:{}", this->spec.name(), features, this->spec.triplet());
     }
 
     static std::vector<PackageSpec> fdeps_to_pdeps(const PackageSpec& self,
@@ -577,6 +563,18 @@ namespace vcpkg
         {
             Checks::unreachable(VCPKG_LINE_INFO);
         }
+    }
+
+    std::string InstallPlanAction::display_name() const
+    {
+        auto version = this->version();
+        if (this->feature_list.empty_or_only_core())
+        {
+            return fmt::format("{}@{}", this->spec.to_string(), version);
+        }
+
+        const std::string features = Strings::join(",", feature_list);
+        return fmt::format("{}[{}]:{}@{}", this->spec.name(), features, this->spec.triplet(), version);
     }
 
     NotInstalledAction::NotInstalledAction(const PackageSpec& spec) : BasicAction{spec} { }


### PR DESCRIPTION
In https://github.com/microsoft/vcpkg/pull/35164 there was some confusion where a customer thought `vcpkg ci` was building an old version of openvino because we only printed the version to build for the `--dry-run` prepass and didn't print the version to build for the actual build. The customer thought we were building the old version rather than the new version as a result.

This change ensures we print the version we are discussing after "Installing" or "Building" and consistently uses the "packagespec@version" form in all the places. For consistency the "packagespec -> version" form we used in a few places is replaced with the @ form.