### PR TITLE
Reset PROCESSOR_ARCHITECTURE on start

### DIFF
--- a/include/vcpkg/base/message-data.inc.h
+++ b/include/vcpkg/base/message-data.inc.h
@@ -2705,6 +2705,10 @@ DECLARE_MESSAGE(UnexpectedToolOutput,
                 (msg::tool_name, msg::path),
                 "The actual command line output will be appended after this message.",
                 "{tool_name} ({path}) produced unexpected output when attempting to determine the version:")
+DECLARE_MESSAGE(UnexpectedWindowsArchitecture,
+                (msg::actual),
+                "{actual} is the CPU kind we observed like ARM or MIPS",
+                "unexpected Windows host architecture: {actual}")
 DECLARE_MESSAGE(UnknownBaselineFileContent,
                 (),
                 "",

--- a/include/vcpkg/base/system.h
+++ b/include/vcpkg/base/system.h
@@ -36,6 +36,8 @@ namespace vcpkg
     ExpectedL<std::string> get_registry_string(void* base_hkey, StringView subkey, StringView valuename);
 
     ExpectedL<std::uint32_t> get_registry_dword(void* base_hkey, StringView subkey, StringView valuename);
+
+    void reset_processor_architecture_environment_variable();
 #endif
 
     long get_process_id();

--- a/locales/messages.json
+++ b/locales/messages.json
@@ -1530,6 +1530,8 @@
   "_UnexpectedSwitch.comment": "Switch is a command line switch like --switch An example of {option} is editable.",
   "UnexpectedToolOutput": "{tool_name} ({path}) produced unexpected output when attempting to determine the version:",
   "_UnexpectedToolOutput.comment": "The actual command line output will be appended after this message. An example of {tool_name} is aria2. An example of {path} is /foo/bar.",
+  "UnexpectedWindowsArchitecture": "unexpected Windows host architecture: {actual}",
+  "_UnexpectedWindowsArchitecture.comment": "{actual} is the CPU kind we observed like ARM or MIPS",
   "UnknownBaselineFileContent": "unrecognizable baseline entry; expected 'port:triplet=(fail|skip|pass)'",
   "UnknownBinaryProviderType": "unknown binary provider type: valid providers are 'clear', 'default', 'nuget', 'nugetconfig','nugettimeout', 'interactive', 'x-azblob', 'x-gcs', 'x-aws', 'x-aws-config', 'http', and 'files'",
   "UnknownBooleanSetting": "unknown boolean setting for {option}: \"{value}\". Valid values are '', '1', '0', 'ON', 'OFF', 'TRUE', and 'FALSE'.",

--- a/src/vcpkg.cpp
+++ b/src/vcpkg.cpp
@@ -233,6 +233,8 @@ int main(const int argc, const char* const* const argv)
     SetConsoleOutputCP(CP_UTF8);
 
     initialize_global_job_object();
+
+    reset_processor_architecture_environment_variable();
 #else
     static const char* const utf8_locales[] = {
         "C.UTF-8",


### PR DESCRIPTION
A customer reported a problem where sometimes `vcpkg-cmake` can't detect that Ninja is safe to use. There, despite being on an amd64 system, this block didn't detect that things were OK:

https://github.com/microsoft/vcpkg/blob/08c4e71048eb54733d9b180a28b9b1d7ce637454/ports/vcpkg-cmake/vcpkg_cmake_configure.cmake#L55-L61

We are unable to replicate the problem, but suspect that they may be in an environment where `PROCESSOR_ARCHITECTURE` isn't set properly, similar to what we experienced in https://github.com/microsoft/vcpkg-tool/pull/769 .

Try to fix this problem by explicitly setting it to what it should be.

Before:

```console
PS D:\vcpkg> rm env:PROCESSOR_ARCHITECTURE
Remove-Item: Cannot find path 'Env:\PROCESSOR_ARCHITECTURE' because it does not exist.
PS D:\vcpkg> rm env:PROCESSOR_ARCHITEW6432
Remove-Item: Cannot find path 'Env:\PROCESSOR_ARCHITEW6432' because it does not exist.
PS D:\vcpkg> echo "PROCESSOR_ARCHITEW6432: $env:PROCESSOR_ARCHITEW6432 PROCESSOR_ARCHITECTURE: $env:PROCESSOR_ARCHITECTURE"
PROCESSOR_ARCHITEW6432:  PROCESSOR_ARCHITECTURE:
PS D:\vcpkg> .\vcpkg.exe env
Microsoft Windows [Version 10.0.22631.2715]
(c) Microsoft Corporation. All rights reserved.

D:\vcpkg>echo PROCESSOR_ARCHITEW6432: %PROCESSOR_ARCHITEW6432% PROCESSOR_ARCHITECTURE: %PROCESSOR_ARCHITECTURE%
PROCESSOR_ARCHITEW6432: %PROCESSOR_ARCHITEW6432% PROCESSOR_ARCHITECTURE: %PROCESSOR_ARCHITECTURE%

D:\vcpkg>exit
PS D:\vcpkg> echo "PROCESSOR_ARCHITEW6432: $env:PROCESSOR_ARCHITEW6432 PROCESSOR_ARCHITECTURE: $env:PROCESSOR_ARCHITECTURE"
PROCESSOR_ARCHITEW6432:  PROCESSOR_ARCHITECTURE:
PS D:\vcpkg> .\vcpkg.exe env C:\Windows\SysWOW64\cmd.exe
Microsoft Windows [Version 10.0.22631.2715]
(c) Microsoft Corporation. All rights reserved.

D:\vcpkg>echo PROCESSOR_ARCHITEW6432: %PROCESSOR_ARCHITEW6432% PROCESSOR_ARCHITECTURE: %PROCESSOR_ARCHITECTURE%
PROCESSOR_ARCHITEW6432: %PROCESSOR_ARCHITEW6432% PROCESSOR_ARCHITECTURE: %PROCESSOR_ARCHITECTURE%
```

After:

```console
PS D:\vcpkg> rm env:PROCESSOR_ARCHITECTURE
PS D:\vcpkg> rm env:PROCESSOR_ARCHITEW6432
Remove-Item: Cannot find path 'Env:\PROCESSOR_ARCHITEW6432' because it does not exist.
PS D:\vcpkg> echo "PROCESSOR_ARCHITEW6432: $env:PROCESSOR_ARCHITEW6432 PROCESSOR_ARCHITECTURE: $env:PROCESSOR_ARCHITECTURE"
PROCESSOR_ARCHITEW6432:  PROCESSOR_ARCHITECTURE:
PS D:\vcpkg> .\vcpkg.exe env
Microsoft Windows [Version 10.0.22631.2715]
(c) Microsoft Corporation. All rights reserved.

D:\vcpkg>echo PROCESSOR_ARCHITEW6432: %PROCESSOR_ARCHITEW6432% PROCESSOR_ARCHITECTURE: %PROCESSOR_ARCHITECTURE%
PROCESSOR_ARCHITEW6432: %PROCESSOR_ARCHITEW6432% PROCESSOR_ARCHITECTURE: AMD64

D:\vcpkg>exit
PS D:\vcpkg> echo "PROCESSOR_ARCHITEW6432: $env:PROCESSOR_ARCHITEW6432 PROCESSOR_ARCHITECTURE: $env:PROCESSOR_ARCHITECTURE"
PROCESSOR_ARCHITEW6432:  PROCESSOR_ARCHITECTURE:
PS D:\vcpkg> .\vcpkg.exe env C:\Windows\SysWOW64\cmd.exe
Microsoft Windows [Version 10.0.22631.2715]
(c) Microsoft Corporation. All rights reserved.

D:\vcpkg>echo PROCESSOR_ARCHITEW6432: %PROCESSOR_ARCHITEW6432% PROCESSOR_ARCHITECTURE: %PROCESSOR_ARCHITECTURE%
PROCESSOR_ARCHITEW6432: AMD64 PROCESSOR_ARCHITECTURE: x86
```