### PR TITLE
StringLiteral for command switches and settings

### DIFF
--- a/include/vcpkg/commands.build.h
+++ b/include/vcpkg/commands.build.h
@@ -3,9 +3,11 @@
 #include <vcpkg/base/fwd/system.process.h>
 
 #include <vcpkg/fwd/binarycaching.h>
+#include <vcpkg/fwd/build.h>
 #include <vcpkg/fwd/cmakevars.h>
 #include <vcpkg/fwd/dependencies.h>
 #include <vcpkg/fwd/portfileprovider.h>
+#include <vcpkg/fwd/vcpkgcmdarguments.h>
 
 #include <vcpkg/base/cache.h>
 #include <vcpkg/base/files.h>
@@ -19,7 +21,6 @@
 #include <vcpkg/packagespec.h>
 #include <vcpkg/statusparagraphs.h>
 #include <vcpkg/triplet.h>
-#include <vcpkg/vcpkgcmdarguments.h>
 #include <vcpkg/vcpkgpaths.h>
 
 #include <array>

--- a/include/vcpkg/commands.z-extract.h
+++ b/include/vcpkg/commands.z-extract.h
@@ -39,7 +39,7 @@ namespace vcpkg
         }
     };
 
-    ExpectedL<StripSetting> get_strip_setting(std::map<StringLiteral, std::string, std::less<>> settings);
+    ExpectedL<StripSetting> get_strip_setting(const std::map<StringLiteral, std::string, std::less<>>& settings);
 
     struct ExtractedArchive
     {

--- a/include/vcpkg/commands.z-extract.h
+++ b/include/vcpkg/commands.z-extract.h
@@ -39,7 +39,7 @@ namespace vcpkg
         }
     };
 
-    ExpectedL<StripSetting> get_strip_setting(std::map<std::string, std::string, std::less<>> settings);
+    ExpectedL<StripSetting> get_strip_setting(std::map<StringLiteral, std::string, std::less<>> settings);
 
     struct ExtractedArchive
     {

--- a/include/vcpkg/commands.z-generate-message-map.h
+++ b/include/vcpkg/commands.z-generate-message-map.h
@@ -1,11 +1,11 @@
 #pragma once
 
+#include <vcpkg/base/fwd/files.h>
 #include <vcpkg/base/fwd/messages.h>
 
-#include <vcpkg/base/files.h>
-#include <vcpkg/base/stringview.h>
+#include <vcpkg/fwd/vcpkgcmdarguments.h>
 
-#include <vcpkg/vcpkgcmdarguments.h>
+#include <vcpkg/base/stringview.h>
 
 #include <vector>
 

--- a/include/vcpkg/vcpkgcmdarguments.h
+++ b/include/vcpkg/vcpkgcmdarguments.h
@@ -22,9 +22,9 @@ namespace vcpkg
 {
     struct ParsedArguments
     {
-        std::set<std::string, std::less<>> switches;
-        std::map<std::string, std::string, std::less<>> settings;
-        std::map<std::string, std::vector<std::string>, std::less<>> multisettings;
+        std::set<StringLiteral, std::less<>> switches;
+        std::map<StringLiteral, std::string, std::less<>> settings;
+        std::map<StringLiteral, std::vector<std::string>, std::less<>> multisettings;
 
         const std::string* read_setting(StringLiteral setting) const noexcept;
 

--- a/include/vcpkg/vcpkgcmdarguments.h
+++ b/include/vcpkg/vcpkgcmdarguments.h
@@ -378,7 +378,7 @@ namespace vcpkg
         ParsedArguments parse_arguments(const CommandMetadata& command_metadata) const;
 
         void imbue_from_environment();
-        void imbue_from_fake_environment(const std::map<std::string, std::string, std::less<>>& env);
+        void imbue_from_fake_environment(const std::map<StringLiteral, std::string, std::less<>>& env);
 
         // Applies recursive settings from the environment or sets a global environment variable
         // to be consumed by subprocesses; may only be called once per process.

--- a/src/vcpkg-test/arguments.cpp
+++ b/src/vcpkg-test/arguments.cpp
@@ -161,7 +161,7 @@ TEST_CASE ("Combine asset cache params", "[arguments]")
     REQUIRE(v.asset_sources_template() == "x-azurl,value");
 
     std::map<StringLiteral, std::string, std::less<>> envmap = {
-        {VcpkgCmdArguments::ASSET_SOURCES_ENV.to_string(), "x-azurl,value1"},
+        {VcpkgCmdArguments::ASSET_SOURCES_ENV, "x-azurl,value1"},
     };
     v = VcpkgCmdArguments::create_from_arg_sequence(nullptr, nullptr);
     v.imbue_from_fake_environment(envmap);

--- a/src/vcpkg-test/arguments.cpp
+++ b/src/vcpkg-test/arguments.cpp
@@ -160,7 +160,7 @@ TEST_CASE ("Combine asset cache params", "[arguments]")
     v = VcpkgCmdArguments::create_from_arg_sequence(t.data(), t.data() + t.size());
     REQUIRE(v.asset_sources_template() == "x-azurl,value");
 
-    std::map<std::string, std::string, std::less<>> envmap = {
+    std::map<StringLiteral, std::string, std::less<>> envmap = {
         {VcpkgCmdArguments::ASSET_SOURCES_ENV.to_string(), "x-azurl,value1"},
     };
     v = VcpkgCmdArguments::create_from_arg_sequence(nullptr, nullptr);

--- a/src/vcpkg-test/commands.extract.cpp
+++ b/src/vcpkg-test/commands.extract.cpp
@@ -129,7 +129,7 @@ TEST_CASE ("Testing strip auto's get_common_prefix_count", "z-extract")
 
 TEST_CASE ("Testing get_strip_setting", "z-extract")
 {
-    std::map<std::string, std::string, std::less<>> settings;
+    std::map<StringLiteral, std::string, std::less<>> settings;
 
     SECTION ("Test no strip")
     {

--- a/src/vcpkg-test/dependencies.cpp
+++ b/src/vcpkg-test/dependencies.cpp
@@ -2466,14 +2466,14 @@ TEST_CASE ("dependency graph API snapshot: host and target")
     ActionPlan plan;
     plan.install_actions.push_back(std::move(install_a));
     plan.install_actions.push_back(std::move(install_a_host));
-    std::map<std::string, std::string, std::less<>> envmap = {
-        {VcpkgCmdArguments::GITHUB_JOB_ENV.to_string(), "123"},
-        {VcpkgCmdArguments::GITHUB_RUN_ID_ENV.to_string(), "123"},
-        {VcpkgCmdArguments::GITHUB_REF_ENV.to_string(), "refs/heads/main"},
-        {VcpkgCmdArguments::GITHUB_REPOSITORY_ENV.to_string(), "owner/repo"},
-        {VcpkgCmdArguments::GITHUB_SHA_ENV.to_string(), "abc123"},
-        {VcpkgCmdArguments::GITHUB_TOKEN_ENV.to_string(), "abc"},
-        {VcpkgCmdArguments::GITHUB_WORKFLOW_ENV.to_string(), "test"},
+    std::map<StringLiteral, std::string, std::less<>> envmap = {
+        {VcpkgCmdArguments::GITHUB_JOB_ENV, "123"},
+        {VcpkgCmdArguments::GITHUB_RUN_ID_ENV, "123"},
+        {VcpkgCmdArguments::GITHUB_REF_ENV, "refs/heads/main"},
+        {VcpkgCmdArguments::GITHUB_REPOSITORY_ENV, "owner/repo"},
+        {VcpkgCmdArguments::GITHUB_SHA_ENV, "abc123"},
+        {VcpkgCmdArguments::GITHUB_TOKEN_ENV, "abc"},
+        {VcpkgCmdArguments::GITHUB_WORKFLOW_ENV, "test"},
     };
     auto v = VcpkgCmdArguments::create_from_arg_sequence(nullptr, nullptr);
     v.imbue_from_fake_environment(envmap);

--- a/src/vcpkg-test/dependencies.cpp
+++ b/src/vcpkg-test/dependencies.cpp
@@ -4,6 +4,7 @@
 #include <vcpkg/dependencies.h>
 #include <vcpkg/portfileprovider.h>
 #include <vcpkg/sourceparagraph.h>
+#include <vcpkg/vcpkgcmdarguments.h>
 
 #include <memory>
 #include <vector>

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -21,6 +21,7 @@
 #include <vcpkg/documentation.h>
 #include <vcpkg/metrics.h>
 #include <vcpkg/tools.h>
+#include <vcpkg/vcpkgcmdarguments.h>
 #include <vcpkg/vcpkgpaths.h>
 
 #include <memory>

--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -31,6 +31,7 @@
 #include <vcpkg/spdx.h>
 #include <vcpkg/statusparagraphs.h>
 #include <vcpkg/tools.h>
+#include <vcpkg/vcpkgcmdarguments.h>
 #include <vcpkg/vcpkglib.h>
 #include <vcpkg/vcpkgpaths.h>
 

--- a/src/vcpkg/commands.ci.cpp
+++ b/src/vcpkg/commands.ci.cpp
@@ -249,7 +249,7 @@ namespace
         });
     }
 
-    void parse_exclusions(const std::map<std::string, std::string, std::less<>>& settings,
+    void parse_exclusions(const std::map<StringLiteral, std::string, std::less<>>& settings,
                           StringLiteral opt,
                           Triplet triplet,
                           ExclusionsMap& exclusions_map)

--- a/src/vcpkg/commands.cpp
+++ b/src/vcpkg/commands.cpp
@@ -53,6 +53,7 @@
 #include <vcpkg/commands.z-preregister-telemetry.h>
 #include <vcpkg/commands.z-print-config.h>
 #include <vcpkg/commands.z-upload-metrics.h>
+#include <vcpkg/vcpkgcmdarguments.h>
 
 namespace vcpkg
 {

--- a/src/vcpkg/commands.export.cpp
+++ b/src/vcpkg/commands.export.cpp
@@ -16,6 +16,7 @@
 #include <vcpkg/portfileprovider.h>
 #include <vcpkg/registries.h>
 #include <vcpkg/tools.h>
+#include <vcpkg/vcpkgcmdarguments.h>
 #include <vcpkg/vcpkglib.h>
 #include <vcpkg/vcpkgpaths.h>
 

--- a/src/vcpkg/commands.help.cpp
+++ b/src/vcpkg/commands.help.cpp
@@ -116,7 +116,7 @@ namespace vcpkg
     void help_topic_valid_triplet(const TripletDatabase& database)
     {
         std::map<StringView, std::vector<const TripletFile*>> triplets_per_location;
-        vcpkg::Util::group_by(database.available_triplets,
+        Util::group_by(database.available_triplets,
                               &triplets_per_location,
                               [](const TripletFile& triplet_file) -> StringView { return triplet_file.location; });
 

--- a/src/vcpkg/commands.help.cpp
+++ b/src/vcpkg/commands.help.cpp
@@ -117,8 +117,8 @@ namespace vcpkg
     {
         std::map<StringView, std::vector<const TripletFile*>> triplets_per_location;
         Util::group_by(database.available_triplets,
-                              &triplets_per_location,
-                              [](const TripletFile& triplet_file) -> StringView { return triplet_file.location; });
+                       &triplets_per_location,
+                       [](const TripletFile& triplet_file) -> StringView { return triplet_file.location; });
 
         LocalizedString result;
         result.append(msgBuiltInTriplets).append_raw('\n');

--- a/src/vcpkg/commands.install.cpp
+++ b/src/vcpkg/commands.install.cpp
@@ -22,6 +22,7 @@
 #include <vcpkg/paragraphs.h>
 #include <vcpkg/portfileprovider.h>
 #include <vcpkg/tools.h>
+#include <vcpkg/vcpkgcmdarguments.h>
 #include <vcpkg/vcpkglib.h>
 #include <vcpkg/vcpkgpaths.h>
 #include <vcpkg/xunitwriter.h>

--- a/src/vcpkg/commands.remove.cpp
+++ b/src/vcpkg/commands.remove.cpp
@@ -7,6 +7,7 @@
 #include <vcpkg/installedpaths.h>
 #include <vcpkg/portfileprovider.h>
 #include <vcpkg/registries.h>
+#include <vcpkg/vcpkgcmdarguments.h>
 #include <vcpkg/vcpkglib.h>
 #include <vcpkg/vcpkgpaths.h>
 

--- a/src/vcpkg/commands.z-applocal.cpp
+++ b/src/vcpkg/commands.z-applocal.cpp
@@ -18,7 +18,7 @@ using namespace vcpkg;
 
 namespace
 {
-    WriteFilePointer maybe_create_log(const std::map<std::string, std::string, std::less<>>& settings,
+    WriteFilePointer maybe_create_log(const std::map<StringLiteral, std::string, std::less<>>& settings,
                                       StringLiteral setting,
                                       const Filesystem& fs)
     {

--- a/src/vcpkg/commands.z-extract.cpp
+++ b/src/vcpkg/commands.z-extract.cpp
@@ -33,7 +33,7 @@ namespace vcpkg
         nullptr,
     };
 
-    ExpectedL<StripSetting> get_strip_setting(std::map<StringLiteral, std::string, std::less<>> settings)
+    ExpectedL<StripSetting> get_strip_setting(const std::map<StringLiteral, std::string, std::less<>>& settings)
     {
         auto iter = settings.find(OPTION_STRIP);
         if (iter == settings.end())

--- a/src/vcpkg/commands.z-extract.cpp
+++ b/src/vcpkg/commands.z-extract.cpp
@@ -33,7 +33,7 @@ namespace vcpkg
         nullptr,
     };
 
-    ExpectedL<StripSetting> get_strip_setting(std::map<std::string, std::string, std::less<>> settings)
+    ExpectedL<StripSetting> get_strip_setting(std::map<StringLiteral, std::string, std::less<>> settings)
     {
         auto iter = settings.find(OPTION_STRIP);
         if (iter == settings.end())

--- a/src/vcpkg/commands.z-generate-message-map.cpp
+++ b/src/vcpkg/commands.z-generate-message-map.cpp
@@ -1,3 +1,4 @@
+#include <vcpkg/base/files.h>
 #include <vcpkg/base/json.h>
 #include <vcpkg/base/messages.h>
 #include <vcpkg/base/setup-messages.h>
@@ -5,6 +6,7 @@
 #include <vcpkg/base/util.h>
 
 #include <vcpkg/commands.z-generate-message-map.h>
+#include <vcpkg/vcpkgcmdarguments.h>
 
 using namespace vcpkg;
 

--- a/src/vcpkg/configure-environment.cpp
+++ b/src/vcpkg/configure-environment.cpp
@@ -79,7 +79,7 @@ namespace
     constexpr const StringLiteral* ArtifactTargetPlatformSwitchNamesStorage[] = {
         &SWITCH_TARGET_X86, &SWITCH_TARGET_X64, &SWITCH_TARGET_ARM, &SWITCH_TARGET_ARM64};
 
-    bool more_than_one_mapped(View<const StringLiteral*> candidates, const std::set<std::string, std::less<>>& switches)
+    bool more_than_one_mapped(View<const StringLiteral*> candidates, const std::set<StringLiteral, std::less<>>& switches)
     {
         bool seen = false;
         for (auto&& candidate : candidates)

--- a/src/vcpkg/configure-environment.cpp
+++ b/src/vcpkg/configure-environment.cpp
@@ -79,7 +79,8 @@ namespace
     constexpr const StringLiteral* ArtifactTargetPlatformSwitchNamesStorage[] = {
         &SWITCH_TARGET_X86, &SWITCH_TARGET_X64, &SWITCH_TARGET_ARM, &SWITCH_TARGET_ARM64};
 
-    bool more_than_one_mapped(View<const StringLiteral*> candidates, const std::set<StringLiteral, std::less<>>& switches)
+    bool more_than_one_mapped(View<const StringLiteral*> candidates,
+                              const std::set<StringLiteral, std::less<>>& switches)
     {
         bool seen = false;
         for (auto&& candidate : candidates)

--- a/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/src/vcpkg/vcpkgcmdarguments.cpp
@@ -84,16 +84,16 @@ namespace
         for (const auto& switch_ : command_metadata.options.switches)
         {
             bool parse_result;
-            auto name = switch_.name.to_string();
+            ZStringView name = switch_.name;
             StabilityTag tag = StabilityTag::Standard;
             if (Strings::starts_with(name, "x-"))
             {
-                name.erase(0, 2);
+                name = name.substr(2);
                 tag = StabilityTag::Experimental;
             }
             else if (Strings::starts_with(name, "z-"))
             {
-                name.erase(0, 2);
+                name = name.substr(2);
                 tag = StabilityTag::ImplementationDetail;
             }
 
@@ -101,14 +101,14 @@ namespace
             {
                 if (cmd_parser.parse_switch(name, tag, parse_result, switch_.helpmsg.to_string()) && parse_result)
                 {
-                    output.switches.emplace(switch_.name.to_string());
+                    output.switches.emplace(switch_.name);
                 }
             }
             else
             {
                 if (cmd_parser.parse_switch(name, tag, parse_result) && parse_result)
                 {
-                    output.switches.emplace(switch_.name.to_string());
+                    output.switches.emplace(switch_.name);
                 }
             }
         }
@@ -117,16 +117,16 @@ namespace
             std::string maybe_parse_result;
             for (const auto& option : command_metadata.options.settings)
             {
-                auto name = option.name.to_string();
+                ZStringView name = option.name;
                 StabilityTag tag = StabilityTag::Standard;
                 if (Strings::starts_with(name, "x-"))
                 {
-                    name.erase(0, 2);
+                    name = name.substr(2);
                     tag = StabilityTag::Experimental;
                 }
                 else if (Strings::starts_with(name, "z-"))
                 {
-                    name.erase(0, 2);
+                    name = name.substr(2);
                     tag = StabilityTag::ImplementationDetail;
                 }
 
@@ -134,14 +134,14 @@ namespace
                 {
                     if (cmd_parser.parse_option(name, tag, maybe_parse_result, option.helpmsg.to_string()))
                     {
-                        output.settings.emplace(option.name.to_string(), std::move(maybe_parse_result));
+                        output.settings.emplace(option.name, std::move(maybe_parse_result));
                     }
                 }
                 else
                 {
                     if (cmd_parser.parse_option(name, tag, maybe_parse_result))
                     {
-                        output.settings.emplace(option.name.to_string(), std::move(maybe_parse_result));
+                        output.settings.emplace(option.name, std::move(maybe_parse_result));
                     }
                 }
             }
@@ -149,16 +149,16 @@ namespace
 
         for (const auto& option : command_metadata.options.multisettings)
         {
-            auto name = option.name.to_string();
+            ZStringView name = option.name;
             StabilityTag tag = StabilityTag::Standard;
             if (Strings::starts_with(name, "x-"))
             {
-                name.erase(0, 2);
+                name = name.substr(2);
                 tag = StabilityTag::Experimental;
             }
             else if (Strings::starts_with(name, "z-"))
             {
-                name.erase(0, 2);
+                name = name.substr(2);
                 tag = StabilityTag::ImplementationDetail;
             }
 
@@ -167,14 +167,14 @@ namespace
             {
                 if (cmd_parser.parse_multi_option(name, tag, maybe_parse_result, option.helpmsg.to_string()))
                 {
-                    output.multisettings.emplace(option.name.to_string(), std::move(maybe_parse_result));
+                    output.multisettings.emplace(option.name, std::move(maybe_parse_result));
                 }
             }
             else
             {
                 if (cmd_parser.parse_multi_option(name, tag, maybe_parse_result))
                 {
-                    output.multisettings.emplace(option.name.to_string(), std::move(maybe_parse_result));
+                    output.multisettings.emplace(option.name, std::move(maybe_parse_result));
                 }
             }
         }

--- a/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/src/vcpkg/vcpkgcmdarguments.cpp
@@ -530,7 +530,7 @@ namespace vcpkg
     }
 
     void VcpkgCmdArguments::imbue_from_environment() { imbue_from_environment_impl(&vcpkg::get_environment_variable); }
-    void VcpkgCmdArguments::imbue_from_fake_environment(const std::map<std::string, std::string, std::less<>>& env)
+    void VcpkgCmdArguments::imbue_from_fake_environment(const std::map<StringLiteral, std::string, std::less<>>& env)
     {
         imbue_from_environment_impl([&env](ZStringView var) -> Optional<std::string> {
             auto it = env.find(var);


### PR DESCRIPTION
Use `StringLiteral` for the switches and settings arrays.