### PR TITLE
Fix use-out-of-constexpr lifetime detected by prerelease MSVC

### DIFF
--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -1484,9 +1484,9 @@ namespace vcpkg
 
     void append_log(const Path& path, const std::string& log, size_t max_log_length, std::string& out)
     {
-        StringLiteral details_start = "<details><summary>{}</summary>\n\n```\n";
-        StringLiteral skipped_msg = "\n...\nSkipped {} lines\n...";
-        StringLiteral details_end = "\n```\n</details>\n\n";
+        static constexpr StringLiteral details_start = "<details><summary>{}</summary>\n\n```\n";
+        static constexpr StringLiteral skipped_msg = "\n...\nSkipped {} lines\n...";
+        static constexpr StringLiteral details_end = "\n```\n</details>\n\n";
         const size_t context_size = path.native().size() + details_start.size() + details_end.size() +
                                     skipped_msg.size() + 6 /* digits for skipped count */;
         const size_t minimum_log_size = std::min(size_t{100}, log.size());


### PR DESCRIPTION
```console
commands.build.cpp

E:\Repro\RWC\vcpkg_tool_repro\vcpkg-tool\src\vcpkg\commands.build.cpp(1498,68): error C7595: 'fmt::v10::basic_format_string<char,const std::string &>::basic_format_string': call to immediate function is not a constant expression

E:\Repro\RWC\vcpkg_tool_repro\vcpkg-tool\include\vcpkg\base\stringview.h(33,62): note: failure was caused by a read of a variable outside its lifetime

E:\Repro\RWC\vcpkg_tool_repro\vcpkg-tool\include\vcpkg\base\stringview.h(33,62): note: see usage of 'details_start'

E:\Repro\RWC\vcpkg_tool_repro\vcpkg-tool\src\vcpkg\commands.build.cpp(1498,68): note: the call stack of the evaluation (the oldest call first) is

E:\Repro\RWC\vcpkg_tool_repro\vcpkg-tool\src\vcpkg\commands.build.cpp(1498,68): note: while evaluating function 'const char *vcpkg::ZStringView::c_str(void) noexcept const'

E:\Repro\RWC\vcpkg_tool_repro\vcpkg-tool\include\vcpkg\base\stringview.h(85,67): note: while evaluating function 'const char *vcpkg::StringView::data(void) noexcept const'
```

This was originally reported by @Zhaojun-Liu of Beyondsoft . This fix was suggested by @joemmett of the compiler frontend team.