### PR TITLE
Update default arm registry to new URL

### DIFF
--- a/vcpkg-artifacts/constants.ts
+++ b/vcpkg-artifacts/constants.ts
@@ -20,7 +20,7 @@ export const defaultConfig =
     {
       "kind": "artifact",
       "name": "arm",
-      "location": "https://artifacts.keil.arm.com/vcpkg-ce-registry/registry.zip"
+      "location": "https://artifacts.tools.arm.com/vcpkg-registry"
     }
   ]
 }


### PR DESCRIPTION
Arm has a new more general URL for hosting our artifact registry. This PR updates the default configuration to use the new URL.

The old URL remains functional for backwards compatibility.