### PR TITLE
Allow vcpkg to be built arm64ec.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,12 @@ if(MSVC)
         string(APPEND CMAKE_EXE_LINKER_FLAGS_RELEASE " /CETCOMPAT")
     endif()
 
+    # Avoid CMake's default taking of the pretty names
+    string(REPLACE "/DAMD64" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+    string(REPLACE "/DAMD64" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+    string(REPLACE "/DARM64EC" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+    string(REPLACE "/DARM64EC" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+
     if(VCPKG_DEVELOPMENT_WARNINGS)
         string(APPEND CMAKE_C_FLAGS " /W4 /sdl")
         string(APPEND CMAKE_CXX_FLAGS " /W4 /sdl")


### PR DESCRIPTION
We have no reason to build vcpkg as arm64ec, but the C++ compiler team have asked us to make this work since they use us as a test case.

Unfortunately, CMake's defaults ( https://gitlab.kitware.com/cmake/cmake/-/blob/master/Modules/Platform/Windows-MSVC.cmake#L243 ) take the pretty names AMD64 and ARM64EC which we use in the COFF file reader. This removes those defines.

Thanks to Wei Lin Wang for the bug report and @markle11m for help.