### PR TITLE
[vcpkg] Avoid name conflicts with sdk functions

### DIFF
--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -326,8 +326,8 @@ namespace
         }
         explicit operator bool() const noexcept { return snapshot != INVALID_HANDLE_VALUE; }
 
-        BOOL Process32First(PPROCESSENTRY32W entry) const noexcept { return Process32FirstW(snapshot, entry); }
-        BOOL Process32Next(PPROCESSENTRY32W entry) const noexcept { return Process32NextW(snapshot, entry); }
+        BOOL Process32First(PPROCESSENTRY32W entry) const noexcept { return ::Process32FirstW(snapshot, entry); }
+        BOOL Process32Next(PPROCESSENTRY32W entry) const noexcept { return ::Process32NextW(snapshot, entry); }
 
     private:
         HANDLE snapshot;


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/issues/34442

Use namespaces `::` to limit repeated calls to SDK `TlHelp32.h` function names:
`TlHelp32.h`: 
```
#ifdef UNICODE
#define Process32First Process32FirstW
#define Process32Next Process32NextW
#define PROCESSENTRY32 PROCESSENTRY32W
#define PPROCESSENTRY32 PPROCESSENTRY32W
#define LPPROCESSENTRY32 LPPROCESSENTRY32W
#endif  // !UNICODE
 ```