### PR TITLE
Take CPU set into account when determining concurrency on Linux.

### DIFF
--- a/src/vcpkg/base/system.cpp
+++ b/src/vcpkg/base/system.cpp
@@ -9,6 +9,10 @@
 #include <sys/sysctl.h>
 #endif
 
+#if defined(__linux__)
+#include <sched.h>
+#endif
+
 #if defined(_WIN32)
 #include <lmcons.h>
 #include <winbase.h>
@@ -686,6 +690,15 @@ namespace vcpkg
             }
             else
             {
+#if defined(__linux__)
+                // Get the number of threads we are allowed to run on,
+                // this might be less than the number of hardware threads.
+                cpu_set_t set;
+                if (sched_getaffinity(getpid(), sizeof(set), &set) == 0)
+                {
+                    return static_cast<unsigned int>(CPU_COUNT(&set)) + 1;
+                }
+#endif
                 return std::thread::hardware_concurrency() + 1;
             }
         }();


### PR DESCRIPTION
vcpkg overrides Ninja's logic to guess the ideal number of threads to use.
Unfortunately the C++ `std::thread::hardware_concurrency()` doesn't take into account the platform specific CPU affinity.

This means that starting a container (docker or systemd-nspawn) with specific CPUs assigned will attempt to start more threads than usable.
The common use-case would be for CI, where you have limited resources and worse than just suboptimal number of threads you can actually go out of memory with current behavior.

This can of course be manually fixed by setting the environment variable `VCPKG_MAX_CONCURRENCY` but it seems reasonable to ignore CPUs we can't use anyway, like Ninja [does](https://github.com/ninja-build/ninja/blob/fd7067652cae480190bf13b2ee5475efdf09ac7d/src/util.cc#L798).

Ninja also has platform specific code to do the same thing on Windows and FreeBSD but I don't have such machines to test so this PR just includes the Linux-specific version.

Note: to test this on Linux you can use `taskset 1 vcpkg ...` which will restrict vcpkg (and all its children) to only use one CPU.