### PR TITLE
Fix empty ABI string

### DIFF
--- a/src/vcpkg/commands.install.cpp
+++ b/src/vcpkg/commands.install.cpp
@@ -526,7 +526,7 @@ namespace vcpkg
         void print_abi_hash() const
         {
             auto bpgh = current_summary.get_binary_paragraph();
-            if (bpgh)
+            if (bpgh && !bpgh->abi.empty())
             {
                 msg::println(msgPackageAbi, msg::spec = bpgh->display_name(), msg::package_abi = bpgh->abi);
             }


### PR DESCRIPTION
If vcpkg is in editable mode or has disabled compiler tracking, the package ABI message will be empty.