### PR TITLE
Use less shouty enums.

### DIFF
--- a/include/vcpkg/base/util.h
+++ b/include/vcpkg/base/util.h
@@ -487,13 +487,13 @@ namespace vcpkg::Util
         template<class E>
         E to_enum(bool b)
         {
-            return b ? E::YES : E::NO;
+            return b ? E::Yes : E::No;
         }
 
         template<class E>
         bool to_bool(E e)
         {
-            return e == E::YES;
+            return e == E::Yes;
         }
     }
 }

--- a/include/vcpkg/commands.build.h
+++ b/include/vcpkg/commands.build.h
@@ -78,33 +78,33 @@ namespace vcpkg
     };
 
     static constexpr BuildPackageOptions default_build_package_options{
-        BuildMissing::YES,
-        UseHeadVersion::NO,
-        AllowDownloads::YES,
-        OnlyDownloads::NO,
-        CleanBuildtrees::YES,
-        CleanPackages::YES,
-        CleanDownloads::NO,
-        DownloadTool::BUILT_IN,
-        PurgeDecompressFailure::YES,
-        Editable::NO,
-        BackcompatFeatures::ALLOW,
-        PrintUsage::YES,
+        BuildMissing::Yes,
+        UseHeadVersion::No,
+        AllowDownloads::Yes,
+        OnlyDownloads::No,
+        CleanBuildtrees::Yes,
+        CleanPackages::Yes,
+        CleanDownloads::No,
+        DownloadTool::Builtin,
+        PurgeDecompressFailure::Yes,
+        Editable::No,
+        BackcompatFeatures::Allow,
+        PrintUsage::Yes,
     };
 
     static constexpr BuildPackageOptions backcompat_prohibiting_package_options{
-        BuildMissing::YES,
-        UseHeadVersion::NO,
-        AllowDownloads::YES,
-        OnlyDownloads::NO,
-        CleanBuildtrees::YES,
-        CleanPackages::YES,
-        CleanDownloads::NO,
-        DownloadTool::BUILT_IN,
-        PurgeDecompressFailure::YES,
-        Editable::NO,
-        BackcompatFeatures::PROHIBIT,
-        PrintUsage::YES,
+        BuildMissing::Yes,
+        UseHeadVersion::No,
+        AllowDownloads::Yes,
+        OnlyDownloads::No,
+        CleanBuildtrees::Yes,
+        CleanPackages::Yes,
+        CleanDownloads::No,
+        DownloadTool::Builtin,
+        PurgeDecompressFailure::Yes,
+        Editable::No,
+        BackcompatFeatures::Prohibit,
+        PrintUsage::Yes,
     };
 
     struct BuildResultCounts
@@ -224,16 +224,16 @@ namespace vcpkg
 
     enum class LinkageType : char
     {
-        DYNAMIC,
-        STATIC,
+        Dynamic,
+        Static,
     };
 
     Optional<LinkageType> to_linkage_type(StringView str);
 
     struct BuildInfo
     {
-        LinkageType crt_linkage = LinkageType::DYNAMIC;
-        LinkageType library_linkage = LinkageType::DYNAMIC;
+        LinkageType crt_linkage = LinkageType::Dynamic;
+        LinkageType library_linkage = LinkageType::Dynamic;
 
         Optional<Version> detected_head_version;
 

--- a/include/vcpkg/commands.set-installed.h
+++ b/include/vcpkg/commands.set-installed.h
@@ -19,7 +19,7 @@ namespace vcpkg
     enum class DryRun : bool
     {
         No,
-        Yes,
+        Yes
     };
 
     extern const CommandMetadata CommandSetInstalledMetadata;

--- a/include/vcpkg/fwd/build.h
+++ b/include/vcpkg/fwd/build.h
@@ -4,94 +4,96 @@ namespace vcpkg
 {
     enum class BuildResult
     {
-        SUCCEEDED,
-        BUILD_FAILED,
-        POST_BUILD_CHECKS_FAILED,
-        FILE_CONFLICTS,
-        CASCADED_DUE_TO_MISSING_DEPENDENCIES,
-        EXCLUDED,
-        CACHE_MISSING,
-        DOWNLOADED,
-        REMOVED
+        Succeeded,
+        BuildFailed,
+        PostBuildChecksFailed,
+        FileConflicts,
+        CascadedDueToMissingDependencies,
+        Excluded,
+        CacheMissing,
+        Downloaded,
+        Removed
     };
 
     enum class UseHeadVersion
     {
-        NO = 0,
-        YES
+        No = 0,
+        Yes
     };
 
     enum class AllowDownloads
     {
-        NO = 0,
-        YES
+        No = 0,
+        Yes
     };
 
     enum class OnlyDownloads
     {
-        NO = 0,
-        YES
+        No = 0,
+        Yes
     };
 
     enum class CleanBuildtrees
     {
-        NO = 0,
-        YES
+        No = 0,
+        Yes
     };
 
     enum class CleanPackages
     {
-        NO = 0,
-        YES
+        No = 0,
+        Yes
     };
 
     enum class CleanDownloads
     {
-        NO = 0,
-        YES
+        No = 0,
+        Yes
     };
 
     enum class ConfigurationType
     {
-        DEBUG,
-        RELEASE,
+        Debug,
+        Release,
     };
 
     enum class DownloadTool
     {
-        BUILT_IN,
-        ARIA2,
+        Builtin,
+        Aria2,
     };
+
     enum class PurgeDecompressFailure
     {
-        NO = 0,
-        YES
+        No = 0,
+        Yes
     };
 
     enum class Editable
     {
-        NO = 0,
-        YES
+        No = 0,
+        Yes
     };
 
     enum class BackcompatFeatures
     {
-        ALLOW = 0,
-        PROHIBIT
+        Allow = 0,
+        Prohibit
     };
 
     enum class BuildMissing
     {
-        NO = 0,
-        YES
+        No = 0,
+        Yes
     };
 
     enum class PrintUsage
     {
-        YES = 0,
-        NO
+        No = 0,
+        Yes
     };
 
+    // These names are intended to match VCPKG_POLICY_Xxx constants settable in portfile.cmake
     enum class BuildPolicy
     {
         EMPTY_PACKAGE,

--- a/src/vcpkg-test/ci-baseline.cpp
+++ b/src/vcpkg-test/ci-baseline.cpp
@@ -333,7 +333,7 @@ TEST_CASE ("format_ci_result 1", "[ci-baseline]")
     SECTION ("SUCCEEDED")
     {
         const auto test = [&](PackageSpec s, bool allow_unexpected_passing) {
-            return format_ci_result(s, BuildResult::SUCCEEDED, cidata, "cifile", allow_unexpected_passing, false);
+            return format_ci_result(s, BuildResult::Succeeded, cidata, "cifile", allow_unexpected_passing, false);
         };
         CHECK(test({"pass", Test::X64_UWP}, true) == "");
         CHECK(test({"pass", Test::X64_UWP}, false) == "");
@@ -347,7 +347,7 @@ TEST_CASE ("format_ci_result 1", "[ci-baseline]")
     SECTION ("BUILD_FAILED")
     {
         const auto test = [&](PackageSpec s) {
-            return format_ci_result(s, BuildResult::BUILD_FAILED, cidata, "cifile", false, false);
+            return format_ci_result(s, BuildResult::BuildFailed, cidata, "cifile", false, false);
         };
         CHECK(test({"pass", Test::X64_UWP}) == fmt::format(failmsg, "pass:x64-uwp"));
         CHECK(test({"fail", Test::X64_UWP}) == "");
@@ -357,8 +357,7 @@ TEST_CASE ("format_ci_result 1", "[ci-baseline]")
     SECTION ("CASCADED_DUE_TO_MISSING_DEPENDENCIES")
     {
         const auto test = [&](PackageSpec s) {
-            return format_ci_result(
-                s, BuildResult::CASCADED_DUE_TO_MISSING_DEPENDENCIES, cidata, "cifile", false, false);
+            return format_ci_result(s, BuildResult::CascadedDueToMissingDependencies, cidata, "cifile", false, false);
         };
         CHECK(test({"pass", Test::X64_UWP}) == fmt::format(cascademsg, "pass:x64-uwp"));
         CHECK(test({"fail", Test::X64_UWP}) == "");

--- a/src/vcpkg-test/xunitwriter.cpp
+++ b/src/vcpkg-test/xunitwriter.cpp
@@ -10,7 +10,7 @@ TEST_CASE ("Simple XunitWriter", "[xunitwriter]")
     time_t time = {0};
     Triplet t = Triplet::from_canonical_name("triplet");
     PackageSpec spec("name", t);
-    x.add_test_results(spec, BuildResult::BUILD_FAILED, {}, std::chrono::system_clock::from_time_t(time), "", {});
+    x.add_test_results(spec, BuildResult::BuildFailed, {}, std::chrono::system_clock::from_time_t(time), "", {});
     CHECK(x.build_xml(t) == R"(<?xml version="1.0" encoding="utf-8"?><assemblies>
   <assembly name="name" run-date="1970-01-01" run-time="00:00:00" time="0">
     <collection name="triplet" time="0">
@@ -36,11 +36,11 @@ TEST_CASE ("XunitWriter Two", "[xunitwriter]")
     PackageSpec spec("name", t);
     PackageSpec spec2("name", t2);
     PackageSpec spec3("other", t2);
-    x.add_test_results(spec, BuildResult::SUCCEEDED, {}, std::chrono::system_clock::from_time_t(time), "abihash", {});
+    x.add_test_results(spec, BuildResult::Succeeded, {}, std::chrono::system_clock::from_time_t(time), "abihash", {});
     x.add_test_results(
-        spec2, BuildResult::POST_BUILD_CHECKS_FAILED, {}, std::chrono::system_clock::from_time_t(time), "", {});
+        spec2, BuildResult::PostBuildChecksFailed, {}, std::chrono::system_clock::from_time_t(time), "", {});
     x.add_test_results(
-        spec3, BuildResult::SUCCEEDED, {}, std::chrono::system_clock::from_time_t(time), "", {"core", "feature"});
+        spec3, BuildResult::Succeeded, {}, std::chrono::system_clock::from_time_t(time), "", {"core", "feature"});
     CHECK(x.build_xml(t3) == R"(<?xml version="1.0" encoding="utf-8"?><assemblies>
   <assembly name="name" run-date="1970-01-01" run-time="00:00:00" time="0">
     <collection name="triplet3" time="0">

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -345,7 +345,7 @@ namespace
                 auto archive_path = m_dir / files_archive_subpath(abi_tag);
                 if (m_fs.exists(archive_path, IgnoreErrors{}))
                 {
-                    auto to_remove = actions[i]->build_options.purge_decompress_failure == PurgeDecompressFailure::YES
+                    auto to_remove = actions[i]->build_options.purge_decompress_failure == PurgeDecompressFailure::Yes
                                          ? RemoveWhen::on_fail
                                          : RemoveWhen::nothing;
                     out_zip_paths[i].emplace(std::move(archive_path), to_remove);
@@ -2191,7 +2191,7 @@ namespace vcpkg
                     msgStoredBinariesToDestinations, msg::count = num_destinations, msg::elapsed = timer.elapsed());
             }
         }
-        if (action.build_options.clean_packages == CleanPackages::YES)
+        if (action.build_options.clean_packages == CleanPackages::Yes)
         {
             m_fs.remove_all(action.package_dir.value_or_exit(VCPKG_LINE_INFO), VCPKG_LINE_INFO);
         }

--- a/src/vcpkg/ci-baseline.cpp
+++ b/src/vcpkg/ci-baseline.cpp
@@ -208,9 +208,9 @@ namespace vcpkg
     {
         switch (result)
         {
-            case BuildResult::BUILD_FAILED:
-            case BuildResult::POST_BUILD_CHECKS_FAILED:
-            case BuildResult::FILE_CONFLICTS:
+            case BuildResult::BuildFailed:
+            case BuildResult::PostBuildChecksFailed:
+            case BuildResult::FileConflicts:
                 if (!cidata.expected_failures.contains(spec))
                 {
                     if (is_independent)
@@ -228,13 +228,13 @@ namespace vcpkg
                     }
                 }
                 break;
-            case BuildResult::SUCCEEDED:
+            case BuildResult::Succeeded:
                 if (!allow_unexpected_passing && cidata.expected_failures.contains(spec))
                 {
                     return msg::format(msgCiBaselineUnexpectedPass, msg::spec = spec, msg::path = cifile);
                 }
                 break;
-            case BuildResult::CASCADED_DUE_TO_MISSING_DEPENDENCIES:
+            case BuildResult::CascadedDueToMissingDependencies:
                 if (cidata.required_success.contains(spec))
                 {
                     return msg::format(msgCiBaselineDisallowedCascade, msg::spec = spec, msg::path = cifile);

--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -154,15 +154,15 @@ namespace vcpkg
         }
 
         action->build_options = default_build_package_options;
-        action->build_options.editable = Editable::YES;
-        action->build_options.clean_buildtrees = CleanBuildtrees::NO;
-        action->build_options.clean_packages = CleanPackages::NO;
+        action->build_options.editable = Editable::Yes;
+        action->build_options.clean_buildtrees = CleanBuildtrees::No;
+        action->build_options.clean_packages = CleanPackages::No;
 
         auto binary_cache = BinaryCache::make(args, paths, out_sink).value_or_exit(VCPKG_LINE_INFO);
         const ElapsedTimer build_timer;
         const auto result = build_package(args, paths, *action, build_logs_recorder, status_db);
         msg::print(msgElapsedForPackage, msg::spec = spec, msg::elapsed = build_timer);
-        if (result.code == BuildResult::CASCADED_DUE_TO_MISSING_DEPENDENCIES)
+        if (result.code == BuildResult::CascadedDueToMissingDependencies)
         {
             LocalizedString errorMsg = msg::format_error(msgBuildDependenciesMissing);
             for (const auto& p : result.unmet_dependencies)
@@ -173,9 +173,9 @@ namespace vcpkg
             Checks::msg_exit_with_message(VCPKG_LINE_INFO, errorMsg);
         }
 
-        Checks::check_exit(VCPKG_LINE_INFO, result.code != BuildResult::EXCLUDED);
+        Checks::check_exit(VCPKG_LINE_INFO, result.code != BuildResult::Excluded);
 
-        if (result.code != BuildResult::SUCCEEDED)
+        if (result.code != BuildResult::Succeeded)
         {
             LocalizedString warnings;
             for (auto&& msg : action->build_failure_messages)
@@ -272,8 +272,8 @@ namespace vcpkg
     {
         switch (tool)
         {
-            case DownloadTool::BUILT_IN: return NAME_BUILTIN_DOWNLOAD;
-            case DownloadTool::ARIA2: return NAME_ARIA2_DOWNLOAD;
+            case DownloadTool::Builtin: return NAME_BUILTIN_DOWNLOAD;
+            case DownloadTool::Aria2: return NAME_ARIA2_DOWNLOAD;
             default: Checks::unreachable(VCPKG_LINE_INFO);
         }
     }
@@ -282,8 +282,8 @@ namespace vcpkg
 
     Optional<LinkageType> to_linkage_type(StringView str)
     {
-        if (str == "dynamic") return LinkageType::DYNAMIC;
-        if (str == "static") return LinkageType::STATIC;
+        if (str == "dynamic") return LinkageType::Dynamic;
+        if (str == "static") return LinkageType::Static;
         return nullopt;
     }
 
@@ -763,7 +763,7 @@ namespace vcpkg
             {"Z_VCPKG_CHAINLOAD_TOOLCHAIN_FILE", action.pre_build_info(VCPKG_LINE_INFO).toolchain_file()},
         };
 
-        if (action.build_options.download_tool == DownloadTool::ARIA2)
+        if (action.build_options.download_tool == DownloadTool::Aria2)
         {
             variables.emplace_back("ARIA2", paths.get_tool_exe(Tools::ARIA2, out_sink));
         }
@@ -791,7 +791,7 @@ namespace vcpkg
             variables.emplace_back(cmake_arg);
         }
 
-        if (action.build_options.backcompat_features == BackcompatFeatures::PROHIBIT)
+        if (action.build_options.backcompat_features == BackcompatFeatures::Prohibit)
         {
             variables.emplace_back("_VCPKG_PROHIBIT_BACKCOMPAT_FEATURES", "1");
         }
@@ -979,11 +979,11 @@ namespace vcpkg
         if (build_failed)
         {
             // With the exception of empty or helper ports, builds in "Download Mode" result in failure.
-            if (action.build_options.only_downloads == OnlyDownloads::YES)
+            if (action.build_options.only_downloads == OnlyDownloads::Yes)
             {
                 // TODO: Capture executed command output and evaluate whether the failure was intended.
                 // If an unintended error occurs then return a BuildResult::DOWNLOAD_FAILURE status.
-                return ExtendedBuildResult{BuildResult::DOWNLOADED};
+                return ExtendedBuildResult{BuildResult::Downloaded};
             }
         }
 
@@ -999,7 +999,7 @@ namespace vcpkg
         get_global_metrics_collector().track_submission(std::move(metrics));
         if (!all_dependencies_satisfied)
         {
-            return ExtendedBuildResult{BuildResult::DOWNLOADED};
+            return ExtendedBuildResult{BuildResult::Downloaded};
         }
 
         if (build_failed)
@@ -1011,7 +1011,7 @@ namespace vcpkg
                 error_logs = fs.read_lines(logs).value_or_exit(VCPKG_LINE_INFO);
                 Util::erase_remove_if(error_logs, [](const auto& line) { return line.empty(); });
             }
-            return ExtendedBuildResult{BuildResult::BUILD_FAILED, stdoutlog, std::move(error_logs)};
+            return ExtendedBuildResult{BuildResult::BuildFailed, stdoutlog, std::move(error_logs)};
         }
 
         const BuildInfo build_info = read_build_info(fs, paths.build_info_file_path(action.spec));
@@ -1022,16 +1022,16 @@ namespace vcpkg
             error_count = perform_post_build_lint_checks(
                 action.spec, paths, pre_build_info, build_info, scfl.port_directory(), combo_sink);
         };
-        if (error_count != 0 && action.build_options.backcompat_features == BackcompatFeatures::PROHIBIT)
+        if (error_count != 0 && action.build_options.backcompat_features == BackcompatFeatures::Prohibit)
         {
-            return ExtendedBuildResult{BuildResult::POST_BUILD_CHECKS_FAILED};
+            return ExtendedBuildResult{BuildResult::PostBuildChecksFailed};
         }
 
         std::unique_ptr<BinaryControlFile> bcf = create_binary_control_file(action, build_info);
 
         write_sbom(paths, action, abi_info.heuristic_resources);
         write_binary_control_file(paths.get_filesystem(), action.package_dir.value_or_exit(VCPKG_LINE_INFO), *bcf);
-        return {BuildResult::SUCCEEDED, std::move(bcf)};
+        return {BuildResult::Succeeded, std::move(bcf)};
     }
 
     static ExtendedBuildResult do_build_package_and_clean_buildtrees(const VcpkgCmdArguments& args,
@@ -1041,7 +1041,7 @@ namespace vcpkg
     {
         auto result = do_build_package(args, paths, action, all_dependencies_satisfied);
 
-        if (action.build_options.clean_buildtrees == CleanBuildtrees::YES)
+        if (action.build_options.clean_buildtrees == CleanBuildtrees::Yes)
         {
             auto& fs = paths.get_filesystem();
             // Will keep the logs, which are regular files
@@ -1124,12 +1124,12 @@ namespace vcpkg
         abi_info.pre_build_info = std::move(proto_pre_build_info);
         abi_info.toolset.emplace(toolset);
 
-        if (action.build_options.use_head_version == UseHeadVersion::YES)
+        if (action.build_options.use_head_version == UseHeadVersion::Yes)
         {
             Debug::print("Binary caching for package ", action.spec, " is disabled due to --head\n");
             return;
         }
-        if (action.build_options.editable == Editable::YES)
+        if (action.build_options.editable == Editable::Yes)
         {
             Debug::print("Binary caching for package ", action.spec, " is disabled due to --editable\n");
             return;
@@ -1349,10 +1349,10 @@ namespace vcpkg
         const bool all_dependencies_satisfied = missing_fspecs.empty();
         if (!all_dependencies_satisfied && !Util::Enum::to_bool(action.build_options.only_downloads))
         {
-            return {BuildResult::CASCADED_DUE_TO_MISSING_DEPENDENCIES, std::move(missing_fspecs)};
+            return {BuildResult::CascadedDueToMissingDependencies, std::move(missing_fspecs)};
         }
 
-        if (action.build_options.only_downloads == OnlyDownloads::NO)
+        if (action.build_options.only_downloads == OnlyDownloads::No)
         {
             for (auto&& pspec : action.package_dependencies)
             {
@@ -1385,15 +1385,15 @@ namespace vcpkg
     {
         switch (build_result)
         {
-            case BuildResult::SUCCEEDED: ++succeeded; return;
-            case BuildResult::BUILD_FAILED: ++build_failed; return;
-            case BuildResult::POST_BUILD_CHECKS_FAILED: ++post_build_checks_failed; return;
-            case BuildResult::FILE_CONFLICTS: ++file_conflicts; return;
-            case BuildResult::CASCADED_DUE_TO_MISSING_DEPENDENCIES: ++cascaded_due_to_missing_dependencies; return;
-            case BuildResult::EXCLUDED: ++excluded; return;
-            case BuildResult::CACHE_MISSING: ++cache_missing; return;
-            case BuildResult::DOWNLOADED: ++downloaded; return;
-            case BuildResult::REMOVED: ++removed; return;
+            case BuildResult::Succeeded: ++succeeded; return;
+            case BuildResult::BuildFailed: ++build_failed; return;
+            case BuildResult::PostBuildChecksFailed: ++post_build_checks_failed; return;
+            case BuildResult::FileConflicts: ++file_conflicts; return;
+            case BuildResult::CascadedDueToMissingDependencies: ++cascaded_due_to_missing_dependencies; return;
+            case BuildResult::Excluded: ++excluded; return;
+            case BuildResult::CacheMissing: ++cache_missing; return;
+            case BuildResult::Downloaded: ++downloaded; return;
+            case BuildResult::Removed: ++removed; return;
             default: Checks::unreachable(VCPKG_LINE_INFO);
         }
     }
@@ -1427,15 +1427,15 @@ namespace vcpkg
     {
         switch (build_result)
         {
-            case BuildResult::SUCCEEDED: return "SUCCEEDED";
-            case BuildResult::BUILD_FAILED: return "BUILD_FAILED";
-            case BuildResult::POST_BUILD_CHECKS_FAILED: return "POST_BUILD_CHECKS_FAILED";
-            case BuildResult::FILE_CONFLICTS: return "FILE_CONFLICTS";
-            case BuildResult::CASCADED_DUE_TO_MISSING_DEPENDENCIES: return "CASCADED_DUE_TO_MISSING_DEPENDENCIES";
-            case BuildResult::EXCLUDED: return "EXCLUDED";
-            case BuildResult::CACHE_MISSING: return "CACHE_MISSING";
-            case BuildResult::DOWNLOADED: return "DOWNLOADED";
-            case BuildResult::REMOVED: return "REMOVED";
+            case BuildResult::Succeeded: return "SUCCEEDED";
+            case BuildResult::BuildFailed: return "BUILD_FAILED";
+            case BuildResult::PostBuildChecksFailed: return "POST_BUILD_CHECKS_FAILED";
+            case BuildResult::FileConflicts: return "FILE_CONFLICTS";
+            case BuildResult::CascadedDueToMissingDependencies: return "CASCADED_DUE_TO_MISSING_DEPENDENCIES";
+            case BuildResult::Excluded: return "EXCLUDED";
+            case BuildResult::CacheMissing: return "CACHE_MISSING";
+            case BuildResult::Downloaded: return "DOWNLOADED";
+            case BuildResult::Removed: return "REMOVED";
             default: Checks::unreachable(VCPKG_LINE_INFO);
         }
     }
@@ -1444,16 +1444,16 @@ namespace vcpkg
     {
         switch (build_result)
         {
-            case BuildResult::SUCCEEDED: return msg::format(msgBuildResultSucceeded);
-            case BuildResult::BUILD_FAILED: return msg::format(msgBuildResultBuildFailed);
-            case BuildResult::POST_BUILD_CHECKS_FAILED: return msg::format(msgBuildResultPostBuildChecksFailed);
-            case BuildResult::FILE_CONFLICTS: return msg::format(msgBuildResultFileConflicts);
-            case BuildResult::CASCADED_DUE_TO_MISSING_DEPENDENCIES:
+            case BuildResult::Succeeded: return msg::format(msgBuildResultSucceeded);
+            case BuildResult::BuildFailed: return msg::format(msgBuildResultBuildFailed);
+            case BuildResult::PostBuildChecksFailed: return msg::format(msgBuildResultPostBuildChecksFailed);
+            case BuildResult::FileConflicts: return msg::format(msgBuildResultFileConflicts);
+            case BuildResult::CascadedDueToMissingDependencies:
                 return msg::format(msgBuildResultCascadeDueToMissingDependencies);
-            case BuildResult::EXCLUDED: return msg::format(msgBuildResultExcluded);
-            case BuildResult::CACHE_MISSING: return msg::format(msgBuildResultCacheMissing);
-            case BuildResult::DOWNLOADED: return msg::format(msgBuildResultDownloaded);
-            case BuildResult::REMOVED: return msg::format(msgBuildResultRemoved);
+            case BuildResult::Excluded: return msg::format(msgBuildResultExcluded);
+            case BuildResult::CacheMissing: return msg::format(msgBuildResultCacheMissing);
+            case BuildResult::Downloaded: return msg::format(msgBuildResultDownloaded);
+            case BuildResult::Removed: return msg::format(msgBuildResultRemoved);
             default: Checks::unreachable(VCPKG_LINE_INFO);
         }
     }
@@ -1464,7 +1464,7 @@ namespace vcpkg
                                msg::spec = spec,
                                msg::build_result = to_string_locale_invariant(build_result.code));
 
-        if (build_result.code == BuildResult::CASCADED_DUE_TO_MISSING_DEPENDENCIES)
+        if (build_result.code == BuildResult::CascadedDueToMissingDependencies)
         {
             res.append_raw('\n').append_indent().append(msgBuildingPackageFailedDueToMissingDeps);
 
@@ -1829,9 +1829,9 @@ namespace vcpkg
                     if (variable_value.empty())
                         build_type = nullopt;
                     else if (Strings::case_insensitive_ascii_equals(variable_value, "debug"))
-                        build_type = ConfigurationType::DEBUG;
+                        build_type = ConfigurationType::Debug;
                     else if (Strings::case_insensitive_ascii_equals(variable_value, "release"))
-                        build_type = ConfigurationType::RELEASE;
+                        build_type = ConfigurationType::Release;
                     else
                         Checks::msg_exit_with_message(
                             VCPKG_LINE_INFO, msgUnknownSettingForBuildType, msg::option = variable_value);

--- a/src/vcpkg/commands.ci.cpp
+++ b/src/vcpkg/commands.ci.cpp
@@ -38,7 +38,7 @@ namespace
                                          const PackageSpec& spec,
                                          BuildResult result) const override
         {
-            if (result == BuildResult::SUCCEEDED)
+            if (result == BuildResult::Succeeded)
             {
                 return;
             }
@@ -187,20 +187,20 @@ namespace
             if (is_excluded(p->spec))
             {
                 ret->action_state_string.emplace_back("skip");
-                ret->known.emplace(p->spec, BuildResult::EXCLUDED);
+                ret->known.emplace(p->spec, BuildResult::Excluded);
                 will_fail.emplace(p->spec);
             }
             else if (Util::any_of(p->package_dependencies,
                                   [&](const PackageSpec& spec) { return Util::Sets::contains(will_fail, spec); }))
             {
                 ret->action_state_string.emplace_back("cascade");
-                ret->known.emplace(p->spec, BuildResult::CASCADED_DUE_TO_MISSING_DEPENDENCIES);
+                ret->known.emplace(p->spec, BuildResult::CascadedDueToMissingDependencies);
                 will_fail.emplace(p->spec);
             }
             else if (precheck_results[action_idx] == CacheAvailability::available)
             {
                 ret->action_state_string.emplace_back("pass");
-                ret->known.emplace(p->spec, BuildResult::SUCCEEDED);
+                ret->known.emplace(p->spec, BuildResult::Succeeded);
             }
             else
             {
@@ -232,7 +232,7 @@ namespace
 
             if (Util::Sets::contains(to_keep, it->spec))
             {
-                if (it_known != known.end() && it_known->second == BuildResult::EXCLUDED)
+                if (it_known != known.end() && it_known->second == BuildResult::Excluded)
                 {
                     it->plan_type = InstallPlanType::EXCLUDED;
                 }
@@ -425,8 +425,8 @@ namespace vcpkg
                 {
                     bool supp = supported_for_triplet(var_provider, provider, spec.package_spec);
                     split_specs->known.emplace(spec.package_spec,
-                                               supp ? BuildResult::CASCADED_DUE_TO_MISSING_DEPENDENCIES
-                                                    : BuildResult::EXCLUDED);
+                                               supp ? BuildResult::CascadedDueToMissingDependencies
+                                                    : BuildResult::Excluded);
 
                     if (cidata.expected_failures.contains(spec.package_spec))
                     {

--- a/src/vcpkg/commands.install.cpp
+++ b/src/vcpkg/commands.install.cpp
@@ -335,7 +335,7 @@ namespace vcpkg
                 msg::println(Color::warning, msgAlreadyInstalledNotHead, msg::spec = action.spec);
             else
                 msg::println(Color::success, msgAlreadyInstalled, msg::spec = action.spec);
-            return ExtendedBuildResult{BuildResult::SUCCEEDED};
+            return ExtendedBuildResult{BuildResult::Succeeded};
         }
 
         if (plan_type == InstallPlanType::BUILD_AND_INSTALL)
@@ -347,9 +347,9 @@ namespace vcpkg
                     fs, action.package_dir.value_or_exit(VCPKG_LINE_INFO), action.spec);
                 bcf = std::make_unique<BinaryControlFile>(std::move(maybe_bcf).value_or_exit(VCPKG_LINE_INFO));
             }
-            else if (action.build_options.build_missing == BuildMissing::NO)
+            else if (action.build_options.build_missing == BuildMissing::No)
             {
-                return ExtendedBuildResult{BuildResult::CACHE_MISSING};
+                return ExtendedBuildResult{BuildResult::CacheMissing};
             }
             else
             {
@@ -358,13 +358,13 @@ namespace vcpkg
 
                 auto result = build_package(args, paths, action, build_logs_recorder, status_db);
 
-                if (BuildResult::DOWNLOADED == result.code)
+                if (BuildResult::Downloaded == result.code)
                 {
                     msg::println(Color::success, msgDownloadedSources, msg::spec = action.display_name());
                     return result;
                 }
 
-                if (result.code != BuildResult::SUCCEEDED)
+                if (result.code != BuildResult::Succeeded)
                 {
                     LocalizedString warnings;
                     for (auto&& msg : action.build_failure_messages)
@@ -390,13 +390,13 @@ namespace vcpkg
             BuildResult code;
             switch (install_result)
             {
-                case InstallResult::SUCCESS: code = BuildResult::SUCCEEDED; break;
-                case InstallResult::FILE_CONFLICTS: code = BuildResult::FILE_CONFLICTS; break;
+                case InstallResult::SUCCESS: code = BuildResult::Succeeded; break;
+                case InstallResult::FILE_CONFLICTS: code = BuildResult::FileConflicts; break;
                 default: Checks::unreachable(VCPKG_LINE_INFO);
             }
             binary_cache.push_success(action);
 
-            if (action.build_options.clean_downloads == CleanDownloads::YES)
+            if (action.build_options.clean_downloads == CleanDownloads::Yes)
             {
                 for (auto& p : fs.get_regular_files_non_recursive(paths.downloads, IgnoreErrors{}))
                 {
@@ -410,7 +410,7 @@ namespace vcpkg
         if (plan_type == InstallPlanType::EXCLUDED)
         {
             msg::println(Color::warning, msgExcludedPackage, msg::spec = action.spec);
-            return ExtendedBuildResult{BuildResult::EXCLUDED};
+            return ExtendedBuildResult{BuildResult::Excluded};
         }
 
         Checks::unreachable(VCPKG_LINE_INFO);
@@ -457,7 +457,7 @@ namespace vcpkg
 
         for (const SpecSummary& result : this->results)
         {
-            if (result.build_result.value_or_exit(VCPKG_LINE_INFO).code != BuildResult::SUCCEEDED)
+            if (result.build_result.value_or_exit(VCPKG_LINE_INFO).code != BuildResult::Succeeded)
             {
                 msg::println(format_result_row(result));
             }
@@ -471,15 +471,15 @@ namespace vcpkg
         {
             switch (result.build_result.value_or_exit(VCPKG_LINE_INFO).code)
             {
-                case BuildResult::SUCCEEDED:
-                case BuildResult::REMOVED:
-                case BuildResult::DOWNLOADED:
-                case BuildResult::EXCLUDED: continue;
-                case BuildResult::BUILD_FAILED:
-                case BuildResult::POST_BUILD_CHECKS_FAILED:
-                case BuildResult::FILE_CONFLICTS:
-                case BuildResult::CASCADED_DUE_TO_MISSING_DEPENDENCIES:
-                case BuildResult::CACHE_MISSING: return true;
+                case BuildResult::Succeeded:
+                case BuildResult::Removed:
+                case BuildResult::Downloaded:
+                case BuildResult::Excluded: continue;
+                case BuildResult::BuildFailed:
+                case BuildResult::PostBuildChecksFailed:
+                case BuildResult::FileConflicts:
+                case BuildResult::CascadedDueToMissingDependencies:
+                case BuildResult::CacheMissing: return true;
                 default: Checks::unreachable(VCPKG_LINE_INFO);
             }
         }
@@ -575,7 +575,7 @@ namespace vcpkg
         {
             TrackedPackageInstallGuard this_install(action_index++, action_count, results, action);
             remove_package(fs, paths.installed(), action.spec, status_db);
-            results.back().build_result.emplace(BuildResult::REMOVED);
+            results.back().build_result.emplace(BuildResult::Removed);
         }
 
         for (auto&& action : action_plan.already_installed)
@@ -589,7 +589,7 @@ namespace vcpkg
             TrackedPackageInstallGuard this_install(action_index++, action_count, results, action);
             auto result =
                 perform_install_plan_action(args, paths, action, status_db, binary_cache, build_logs_recorder);
-            if (result.code != BuildResult::SUCCEEDED && keep_going == KeepGoing::NO)
+            if (result.code != BuildResult::Succeeded && keep_going == KeepGoing::NO)
             {
                 this_install.print_elapsed_time();
                 print_user_troubleshooting_message(action, paths, result.stdoutlog.then([&](auto&) -> Optional<Path> {
@@ -1059,7 +1059,7 @@ namespace vcpkg
                                                  ? UnsupportedPortAction::Warn
                                                  : UnsupportedPortAction::Error;
         const PrintUsage print_cmake_usage =
-            Util::Sets::contains(options.switches, OPTION_NO_PRINT_USAGE) ? PrintUsage::NO : PrintUsage::YES;
+            Util::Sets::contains(options.switches, OPTION_NO_PRINT_USAGE) ? PrintUsage::No : PrintUsage::Yes;
 
         get_global_metrics_collector().track_bool(BoolMetric::InstallManifestMode, paths.manifest_mode_enabled());
 
@@ -1118,8 +1118,8 @@ namespace vcpkg
 
         auto& fs = paths.get_filesystem();
 
-        DownloadTool download_tool = DownloadTool::BUILT_IN;
-        if (use_aria2) download_tool = DownloadTool::ARIA2;
+        DownloadTool download_tool = DownloadTool::Builtin;
+        if (use_aria2) download_tool = DownloadTool::Aria2;
 
         const BuildPackageOptions install_plan_options = {
             Util::Enum::to_enum<BuildMissing>(!no_build_missing),
@@ -1130,9 +1130,9 @@ namespace vcpkg
             Util::Enum::to_enum<CleanPackages>(clean_after_build || clean_packages_after_build),
             Util::Enum::to_enum<CleanDownloads>(clean_after_build || clean_downloads_after_build),
             download_tool,
-            PurgeDecompressFailure::NO,
+            PurgeDecompressFailure::No,
             Util::Enum::to_enum<Editable>(is_editable),
-            prohibit_backcompat_features ? BackcompatFeatures::PROHIBIT : BackcompatFeatures::ALLOW,
+            prohibit_backcompat_features ? BackcompatFeatures::Prohibit : BackcompatFeatures::Allow,
             print_cmake_usage};
 
         auto var_provider_storage = CMakeVars::make_triplet_cmake_var_provider(paths);
@@ -1261,8 +1261,8 @@ namespace vcpkg
             for (InstallPlanAction& action : install_plan.install_actions)
             {
                 action.build_options = install_plan_options;
-                action.build_options.use_head_version = UseHeadVersion::NO;
-                action.build_options.editable = Editable::NO;
+                action.build_options.use_head_version = UseHeadVersion::No;
+                action.build_options.editable = Editable::No;
             }
 
             // If the manifest refers to itself, it will be added to the install plan.
@@ -1313,8 +1313,8 @@ namespace vcpkg
             action.build_options = install_plan_options;
             if (action.request_type != RequestType::USER_REQUESTED)
             {
-                action.build_options.use_head_version = UseHeadVersion::NO;
-                action.build_options.editable = Editable::NO;
+                action.build_options.use_head_version = UseHeadVersion::No;
+                action.build_options.editable = Editable::No;
             }
         }
 
@@ -1409,7 +1409,7 @@ namespace vcpkg
             fs.write_contents(it_xunit->second, xwriter.build_xml(default_triplet), VCPKG_LINE_INFO);
         }
 
-        if (install_plan_options.print_usage == PrintUsage::YES)
+        if (install_plan_options.print_usage == PrintUsage::Yes)
         {
             std::set<std::string> printed_usages;
             for (auto&& result : summary.results)

--- a/src/vcpkg/commands.set-installed.cpp
+++ b/src/vcpkg/commands.set-installed.cpp
@@ -258,7 +258,7 @@ namespace vcpkg
             }
         }
 
-        if (print_cmake_usage == PrintUsage::YES)
+        if (print_cmake_usage == PrintUsage::Yes)
         {
             std::set<std::string> printed_usages;
             for (auto&& ur_spec : user_requested_specs)
@@ -301,7 +301,7 @@ namespace vcpkg
                                          ? KeepGoing::YES
                                          : KeepGoing::NO;
         const PrintUsage print_cmake_usage =
-            Util::Sets::contains(options.switches, OPTION_NO_PRINT_USAGE) ? PrintUsage::NO : PrintUsage::YES;
+            Util::Sets::contains(options.switches, OPTION_NO_PRINT_USAGE) ? PrintUsage::No : PrintUsage::Yes;
         const auto unsupported_port_action = Util::Sets::contains(options.switches, OPTION_ALLOW_UNSUPPORTED_PORT)
                                                  ? UnsupportedPortAction::Warn
                                                  : UnsupportedPortAction::Error;
@@ -331,7 +331,7 @@ namespace vcpkg
         {
             action.build_options = default_build_package_options;
             action.build_options.backcompat_features =
-                (prohibit_backcompat_features ? BackcompatFeatures::PROHIBIT : BackcompatFeatures::ALLOW);
+                (prohibit_backcompat_features ? BackcompatFeatures::Prohibit : BackcompatFeatures::Allow);
         }
 
         command_set_installed_and_exit_ex(args,

--- a/src/vcpkg/dependencies.cpp
+++ b/src/vcpkg/dependencies.cpp
@@ -431,7 +431,7 @@ namespace vcpkg
     static void format_plan_row(LocalizedString& out, const InstallPlanAction& action, const Path& builtin_ports_dir)
     {
         out.append_raw(request_type_indent(action.request_type)).append_raw(action.display_name());
-        if (action.build_options.use_head_version == UseHeadVersion::YES)
+        if (action.build_options.use_head_version == UseHeadVersion::Yes)
         {
             out.append_raw(" (+HEAD)");
         }

--- a/src/vcpkg/postbuildlint.cpp
+++ b/src/vcpkg/postbuildlint.cpp
@@ -974,7 +974,7 @@ namespace vcpkg
     {
         switch (linkage)
         {
-            case LinkageType::DYNAMIC:
+            case LinkageType::Dynamic:
                 if (release)
                 {
                     return msg::format(msgLinkageDynamicRelease);
@@ -984,7 +984,7 @@ namespace vcpkg
                     return msg::format(msgLinkageDynamicDebug);
                 }
                 break;
-            case LinkageType::STATIC:
+            case LinkageType::Static:
                 if (release)
                 {
                     return msg::format(msgLinkageStaticRelease);
@@ -1059,11 +1059,11 @@ namespace vcpkg
 
             switch (build_info.crt_linkage)
             {
-                case LinkageType::DYNAMIC:
+                case LinkageType::Dynamic:
                     fail |= this_lib.has_static_debug;
                     fail |= this_lib.has_static_release;
                     break;
-                case LinkageType::STATIC:
+                case LinkageType::Static:
                     fail |= this_lib.has_dynamic_debug;
                     fail |= this_lib.has_dynamic_release;
                     break;
@@ -1427,7 +1427,7 @@ namespace vcpkg
 
             switch (build_info.library_linkage)
             {
-                case LinkageType::DYNAMIC:
+                case LinkageType::Dynamic:
                 {
                     if (!pre_build_info.build_type &&
                         !build_info.policies.is_enabled(BuildPolicy::MISMATCHED_NUMBER_OF_BINARIES))
@@ -1447,7 +1447,7 @@ namespace vcpkg
                     }
                 }
                 break;
-                case LinkageType::STATIC:
+                case LinkageType::Static:
                 {
                     auto& dlls = debug_dlls;
                     dlls.insert(dlls.end(),

--- a/src/vcpkg/xunitwriter.cpp
+++ b/src/vcpkg/xunitwriter.cpp
@@ -25,12 +25,12 @@ namespace
         StringLiteral result_string = "";
         switch (test.result)
         {
-            case BuildResult::POST_BUILD_CHECKS_FAILED:
-            case BuildResult::FILE_CONFLICTS:
-            case BuildResult::BUILD_FAILED: result_string = "Fail"; break;
-            case BuildResult::EXCLUDED:
-            case BuildResult::CASCADED_DUE_TO_MISSING_DEPENDENCIES: result_string = "Skip"; break;
-            case BuildResult::SUCCEEDED: result_string = "Pass"; break;
+            case BuildResult::PostBuildChecksFailed:
+            case BuildResult::FileConflicts:
+            case BuildResult::BuildFailed: result_string = "Fail"; break;
+            case BuildResult::Excluded:
+            case BuildResult::CascadedDueToMissingDependencies: result_string = "Skip"; break;
+            case BuildResult::Succeeded: result_string = "Pass"; break;
             default: Checks::unreachable(VCPKG_LINE_INFO);
         }
 


### PR DESCRIPTION
I observed that some of our enum classes like DryRun use PascalCase like most of our type names, and others used ALL_CAPS_SNAKE_CASE. I resolved in favor of PascalCase since enum classes are already prefixed and thus unworried about conflicts.

(Visual Studio Control+R Control+R made most of these edits :))