### PR TITLE
Fix regression in x-script from fixing doskey macros.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,6 +161,24 @@ endif()
 
 include(GNUInstallDirs)
 
+file(GLOB VCPKGLIB_BASE_SOURCES CONFIGURE_DEPENDS "src/vcpkg/base/*.cpp")
+file(GLOB VCPKGLIB_SOURCES CONFIGURE_DEPENDS "src/vcpkg/*.cpp")
+file(GLOB VCPKGLIB_BASE_INCLUDES CONFIGURE_DEPENDS "include/vcpkg/base/*.h" "include/vcpkg/base/fwd/*.h")
+file(GLOB VCPKGLIB_INCLUDES CONFIGURE_DEPENDS "include/vcpkg/*.h" "include/vcpkg/fwd/*.h")
+
+set(VCPKG_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/vcpkg.cpp")
+
+file(GLOB VCPKG_TEST_SOURCES CONFIGURE_DEPENDS "src/vcpkg-test/*.cpp")
+file(GLOB VCPKG_TEST_INCLUDES CONFIGURE_DEPENDS "include/vcpkg-test/*.h")
+
+set(VCPKG_FUZZ_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/vcpkg-fuzz/main.cpp")
+set(TLS12_DOWNLOAD_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/tls12-download.c")
+set(CLOSES_STDIN_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/closes-stdin.c")
+set(CLOSES_STDOUT_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/closes-stdout.c")
+set(READS_STDIN_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/reads-stdin.c")
+set(TEST_EDITOR_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/test-editor.c")
+set(TEST_SCRIPT_ASSET_CACHE_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/test-script-asset-cache.c")
+
 # ====================
 # === Dependencies ===
 # ====================
@@ -186,11 +204,6 @@ if(NOT MSVC)
 endif()
 
 # === Target: vcpkglib ===
-
-file(GLOB VCPKGLIB_SOURCES CONFIGURE_DEPENDS "src/vcpkg/*.cpp")
-file(GLOB VCPKGLIB_BASE_SOURCES CONFIGURE_DEPENDS "src/vcpkg/base/*.cpp")
-file(GLOB VCPKGLIB_INCLUDES CONFIGURE_DEPENDS "include/vcpkg/*.h" "include/vcpkg/fwd/*.h")
-file(GLOB VCPKGLIB_BASE_INCLUDES CONFIGURE_DEPENDS "include/vcpkg/base/*.h" "include/vcpkg/base/fwd/*.h")
 
 add_library(vcpkglib OBJECT
     ${VCPKGLIB_BASE_SOURCES}
@@ -437,7 +450,7 @@ add_custom_command(
 add_custom_target(vcpkg-ps1 ALL DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/vcpkg.ps1")
 
 # === Target: vcpkg ===
-set(VCPKG_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/vcpkg.cpp")
+
 add_executable(vcpkg ${VCPKG_SOURCES} "${CMAKE_CURRENT_SOURCE_DIR}/src/vcpkg.manifest")
 target_link_libraries(vcpkg PRIVATE vcpkglib)
 
@@ -472,9 +485,6 @@ add_custom_target(generate-message-map
 if (BUILD_TESTING)
     enable_testing()
 
-    file(GLOB VCPKG_TEST_SOURCES CONFIGURE_DEPENDS "src/vcpkg-test/*.cpp")
-    file(GLOB VCPKG_TEST_INCLUDES CONFIGURE_DEPENDS "include/vcpkg-test/*.h")
-
     add_executable(vcpkg-test
         ${VCPKG_TEST_SOURCES}
         ${VCPKG_TEST_INCLUDES}
@@ -502,7 +512,6 @@ if (BUILD_TESTING)
 endif()
 
 # === Target: vcpkg-fuzz ===
-set(VCPKG_FUZZ_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/vcpkg-fuzz/main.cpp")
 if(VCPKG_BUILD_FUZZING)
     add_executable(vcpkg-fuzz ${VCPKG_FUZZ_SOURCES} "${CMAKE_CURRENT_SOURCE_DIR}/src/vcpkg.manifest")
     target_link_libraries(vcpkg-fuzz PRIVATE vcpkglib)
@@ -511,7 +520,7 @@ endif()
 
 
 # === Target: tls12-download ===
-set(TLS12_DOWNLOAD_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/tls12-download.c")
+
 if(VCPKG_BUILD_TLS12_DOWNLOADER)
     add_executable(tls12-download ${TLS12_DOWNLOAD_SOURCES} "${CMAKE_CURRENT_SOURCE_DIR}/src/vcpkg.manifest")
     set_property(TARGET tls12-download PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded")
@@ -523,27 +532,28 @@ endif()
 if (BUILD_TESTING)
 # === Target: closes-stdin ===
 
-set(CLOSES_STDIN_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/closes-stdin.c")
 add_executable(closes-stdin ${CLOSES_STDIN_SOURCES} "${CMAKE_CURRENT_SOURCE_DIR}/src/vcpkg.manifest")
 set_property(TARGET closes-stdin PROPERTY PDB_NAME "closes-stdin${VCPKG_PDB_SUFFIX}")
 
 # === Target: closes-stdout ===
 
-set(CLOSES_STDOUT_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/closes-stdout.c")
 add_executable(closes-stdout ${CLOSES_STDOUT_SOURCES} "${CMAKE_CURRENT_SOURCE_DIR}/src/vcpkg.manifest")
 set_property(TARGET closes-stdout PROPERTY PDB_NAME "closes-stdout${VCPKG_PDB_SUFFIX}")
 
 # === Target: reads-stdin ===
 
-set(READS_STDIN_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/reads-stdin.c")
 add_executable(reads-stdin ${READS_STDIN_SOURCES} "${CMAKE_CURRENT_SOURCE_DIR}/src/vcpkg.manifest")
 set_property(TARGET reads-stdin PROPERTY PDB_NAME "reads-stdin${VCPKG_PDB_SUFFIX}")
 
 # === Target: test-editor ===
 
-set(TEST_EDITOR_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/test-editor.c")
 add_executable(test-editor ${TEST_EDITOR_SOURCES} "${CMAKE_CURRENT_SOURCE_DIR}/src/vcpkg.manifest")
 set_property(TARGET test-editor PROPERTY PDB_NAME "test-editor${VCPKG_PDB_SUFFIX}")
+
+# === Target: test-editor ===
+
+add_executable(test-script-asset-cache ${TEST_SCRIPT_ASSET_CACHE_SOURCES} "${CMAKE_CURRENT_SOURCE_DIR}/src/vcpkg.manifest")
+set_property(TARGET test-script-asset-cache PROPERTY PDB_NAME "test-script-asset-cache${VCPKG_PDB_SUFFIX}")
 endif()
 
 # === Target: format ===
@@ -563,12 +573,9 @@ if(CLANG_FORMAT)
         COMMAND "${CLANG_FORMAT}" -i -verbose ${VCPKG_TEST_SOURCES}
         COMMAND "${CLANG_FORMAT}" -i -verbose ${VCPKG_TEST_INCLUDES}
 
-        COMMAND "${CLANG_FORMAT}" -i -verbose ${VCPKG_FUZZ_SOURCES}
-        COMMAND "${CLANG_FORMAT}" -i -verbose ${TLS12_DOWNLOAD_SOURCES}
-        COMMAND "${CLANG_FORMAT}" -i -verbose ${CLOSES_STDIN_SOURCES}
-        COMMAND "${CLANG_FORMAT}" -i -verbose ${CLOSES_STDOUT_SOURCES}
-        COMMAND "${CLANG_FORMAT}" -i -verbose ${READS_STDIN_SOURCES}
-        COMMAND "${CLANG_FORMAT}" -i -verbose ${TEST_EDITOR_SOURCES}
+        COMMAND "${CLANG_FORMAT}" -i -verbose ${VCPKG_FUZZ_SOURCES} ${TLS12_DOWNLOAD_SOURCES}
+            ${CLOSES_STDIN_SOURCES} ${CLOSES_STDOUT_SOURCES} ${READS_STDIN_SOURCES}
+            ${TEST_EDITOR_SOURCES} ${TEST_SCRIPT_ASSET_CACHE_SOURCES}
     )
 endif()
 

--- a/azure-pipelines/e2e-ports/vcpkg-test-x-script/portfile.cmake
+++ b/azure-pipelines/e2e-ports/vcpkg-test-x-script/portfile.cmake
@@ -1,0 +1,14 @@
+# This port is for testing that x-script works; see test-script-asset-cache.c
+vcpkg_download_distfile(
+    SOURCE_PATH
+    URLS https://example.com/hello-world.txt
+    SHA512 09E1E2A84C92B56C8280F4A1203C7CFFD61B162CFE987278D4D6BE9AFBF38C0E8934CDADF83751F4E99D111352BFFEFC958E5A4852C8A7A29C95742CE59288A8
+    FILENAME hello-world.txt
+)
+
+file(READ "${SOURCE_PATH}" CONTENTS)
+if (NOT CONTENTS STREQUAL "Hello, world!\n")
+    message(FATAL_ERROR "Downloaded file has incorrect contents: ${CONTENTS}")
+endif()
+
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/azure-pipelines/e2e-ports/vcpkg-test-x-script/vcpkg.json
+++ b/azure-pipelines/e2e-ports/vcpkg-test-x-script/vcpkg.json
@@ -1,0 +1,4 @@
+{
+	"name": "vcpkg-test-x-script",
+	"version-string": "1.0.0"
+}

--- a/azure-pipelines/end-to-end-tests-dir/asset-caching.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/asset-caching.ps1
@@ -1,0 +1,5 @@
+. $PSScriptRoot/../end-to-end-tests-prelude.ps1
+
+Refresh-TestRoot
+Run-Vcpkg -TestArgs ($commonArgs + @("install", "vcpkg-test-x-script", "--x-binarysource=clear", "--overlay-ports=$PSScriptRoot/../e2e-ports", "--x-asset-sources=x-script,$TestScriptAssetCacheExe {url} {sha512} {dst};x-block-origin"))
+Throw-IfFailed

--- a/azure-pipelines/end-to-end-tests-dir/binary-caching.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/binary-caching.ps1
@@ -6,7 +6,7 @@ $commonArgs += @(
 )
 
 # Test simple installation
-Run-Vcpkg -TestArgs ($commonArgs + @("install", "vcpkg-hello-world-1", "vcpkg-cmake", "vcpkg-cmake-config", "--binarycaching", "--x-binarysource=clear;files,$ArchiveRoot,write"))
+Run-Vcpkg -TestArgs ($commonArgs + @("install", "vcpkg-hello-world-1", "vcpkg-cmake", "vcpkg-cmake-config", "--x-binarysource=clear;files,$ArchiveRoot,write"))
 Throw-IfFailed
 
 # Test simple removal
@@ -16,14 +16,14 @@ Require-FileNotExists "$installRoot/$Triplet/include"
 
 if(-Not $IsLinux -and -Not $IsMacOS) {
     # Test simple nuget installation
-    Run-Vcpkg -TestArgs ($commonArgs + @("install", "vcpkg-hello-world-1", "vcpkg-cmake", "vcpkg-cmake-config", "--binarycaching", "--x-binarysource=clear;nuget,$NuGetRoot,readwrite"))
+    Run-Vcpkg -TestArgs ($commonArgs + @("install", "vcpkg-hello-world-1", "vcpkg-cmake", "vcpkg-cmake-config", "--x-binarysource=clear;nuget,$NuGetRoot,readwrite"))
     Throw-IfFailed
 }
 
 # Test restoring from files archive
 Remove-Item -Recurse -Force $installRoot
 Remove-Item -Recurse -Force $buildtreesRoot
-Run-Vcpkg -TestArgs ($commonArgs + @("install","vcpkg-hello-world-1", "vcpkg-cmake", "vcpkg-cmake-config","--binarycaching","--x-binarysource=clear;files,$ArchiveRoot,read"))
+Run-Vcpkg -TestArgs ($commonArgs + @("install","vcpkg-hello-world-1", "vcpkg-cmake", "vcpkg-cmake-config", "--x-binarysource=clear;files,$ArchiveRoot,read"))
 Throw-IfFailed
 Require-FileExists "$installRoot/$Triplet/include/hello-1.h"
 Require-FileNotExists "$buildtreesRoot/vcpkg-hello-world-1/src"
@@ -32,7 +32,7 @@ Require-FileExists "$buildtreesRoot/detect_compiler"
 # Test --no-binarycaching
 Remove-Item -Recurse -Force $installRoot
 Remove-Item -Recurse -Force $buildtreesRoot
-Run-Vcpkg -TestArgs ($commonArgs + @("install","vcpkg-hello-world-1", "vcpkg-cmake", "vcpkg-cmake-config","--no-binarycaching","--x-binarysource=clear;files,$ArchiveRoot,read"))
+Run-Vcpkg -TestArgs ($commonArgs + @("install","vcpkg-hello-world-1", "vcpkg-cmake", "vcpkg-cmake-config", "--no-binarycaching", "--x-binarysource=clear;files,$ArchiveRoot,read"))
 Throw-IfFailed
 Require-FileExists "$installRoot/$Triplet/include/hello-1.h"
 Require-FileExists "$buildtreesRoot/vcpkg-hello-world-1/src"
@@ -41,7 +41,7 @@ Require-FileExists "$buildtreesRoot/detect_compiler"
 # Test --editable
 Remove-Item -Recurse -Force $installRoot
 Remove-Item -Recurse -Force $buildtreesRoot
-Run-Vcpkg -TestArgs ($commonArgs + @("install","vcpkg-hello-world-1", "vcpkg-cmake", "vcpkg-cmake-config","--editable","--x-binarysource=clear;files,$ArchiveRoot,read"))
+Run-Vcpkg -TestArgs ($commonArgs + @("install","vcpkg-hello-world-1", "vcpkg-cmake", "vcpkg-cmake-config", "--editable", "--x-binarysource=clear;files,$ArchiveRoot,read"))
 Throw-IfFailed
 Require-FileExists "$installRoot/$Triplet/include/hello-1.h"
 Require-FileExists "$buildtreesRoot/vcpkg-hello-world-1/src"
@@ -51,7 +51,7 @@ if(-Not $IsLinux -and -Not $IsMacOS) {
     # Test restoring from nuget
     Remove-Item -Recurse -Force $installRoot
     Remove-Item -Recurse -Force $buildtreesRoot
-    Run-Vcpkg -TestArgs ($commonArgs + @("install", "vcpkg-hello-world-1", "vcpkg-cmake", "vcpkg-cmake-config", "--binarycaching", "--x-binarysource=clear;nuget,$NuGetRoot"))
+    Run-Vcpkg -TestArgs ($commonArgs + @("install", "vcpkg-hello-world-1", "vcpkg-cmake", "vcpkg-cmake-config", "--x-binarysource=clear;nuget,$NuGetRoot"))
     Throw-IfFailed
     Require-FileExists "$installRoot/$Triplet/include/hello-1.h"
     Require-FileNotExists "$buildtreesRoot/vcpkg-hello-world-1/src"
@@ -72,7 +72,7 @@ if(-Not $IsLinux -and -Not $IsMacOS) {
     Throw-IfFailed
     Remove-Item -Recurse -Force $NuGetRoot -ErrorAction SilentlyContinue
     mkdir $NuGetRoot
-    Run-Vcpkg -TestArgs ($commonArgs + @("install", "vcpkg-hello-world-1", "vcpkg-hello-world-2", "vcpkg-cmake", "vcpkg-cmake-config", "--binarycaching", "--x-binarysource=clear;nuget,$NuGetRoot2;nuget,$NuGetRoot,write"))
+    Run-Vcpkg -TestArgs ($commonArgs + @("install", "vcpkg-hello-world-1", "vcpkg-hello-world-2", "vcpkg-cmake", "vcpkg-cmake-config", "--x-binarysource=clear;nuget,$NuGetRoot2;nuget,$NuGetRoot,write"))
     Throw-IfFailed
     Require-FileExists "$installRoot/$Triplet/include/hello-1.h"
     Require-FileExists "$installRoot/$Triplet/include/hello-2.h"

--- a/src/test-script-asset-cache.c
+++ b/src/test-script-asset-cache.c
@@ -1,0 +1,47 @@
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+
+static const char expected_uri[] = "https://example.com/hello-world.txt";
+static const char expected_sha[] = "09e1e2a84c92b56c8280f4a1203c7cffd61b162cfe987278d4d6be9afbf38c0e8934cdadf83751f4e99"
+                                   "d111352bffefc958e5a4852c8a7a29c95742ce59288a8";
+
+static const char result_data[] = "Hello, world!\n";
+
+int main(int argc, char** argv)
+{
+    if (argc != 4)
+    {
+        puts("Bad argument count; usage: test-script-asset-cache {url} {sha512} {dst}");
+        return 1;
+    }
+
+    if (strcmp(argv[1], expected_uri) != 0)
+    {
+        printf("Bad argument 1; expected url: %s, got %s\n", expected_uri, argv[1]);
+        return 1;
+    }
+
+    if (strcmp(argv[2], expected_sha) != 0)
+    {
+        printf("Bad argument 2; expected sha512: %s, got %s\n", expected_sha, argv[2]);
+        return 1;
+    }
+
+    FILE* fp = fopen(argv[3], "wb");
+    if (!fp)
+    {
+        puts("fopen failed");
+        return 1;
+    }
+
+    if (fwrite(result_data, 1, sizeof(result_data) - 1, fp) != sizeof(result_data) - 1)
+    {
+        puts("fputs failed");
+        fclose(fp);
+        return 1;
+    }
+
+    fclose(fp);
+    return 0;
+}

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -959,7 +959,8 @@ namespace vcpkg
                     const auto escaped_url = Command(urls[0]).extract();
                     const auto escaped_sha512 = Command(*hash).extract();
                     const auto escaped_dpath = Command(download_path_part_path).extract();
-                    auto cmd = Command{api_stable_format(*script, [&](std::string& out, StringView key) {
+                    Command cmd;
+                    cmd.raw_arg(api_stable_format(*script, [&](std::string& out, StringView key) {
                                            if (key == "url")
                                            {
                                                Strings::append(out, escaped_url);
@@ -972,7 +973,7 @@ namespace vcpkg
                                            {
                                                Strings::append(out, escaped_dpath);
                                            }
-                                       }).value_or_exit(VCPKG_LINE_INFO)};
+                                       }).value_or_exit(VCPKG_LINE_INFO));
 
                     RedirectedProcessLaunchSettings settings;
                     settings.environment = get_clean_environment();


### PR DESCRIPTION
In https://github.com/microsoft/vcpkg-tool/pull/1295 I missed that the entire command should be passed as a raw_arg. This was causing the intended arguments of the command to be formatted as if they were the command's executable.

Also adds an end-to-end test for asset caching's x-script.

Also ensures the various `_SOURCES` are available in the CMake script so that the clang-format target can see them even if `BUILD_TESTING` is off.