### PR TITLE
Consider tools provided by Visual Studio.

### DIFF
--- a/include/vcpkg/fwd/vcpkgpaths.h
+++ b/include/vcpkg/fwd/vcpkgpaths.h
@@ -4,6 +4,7 @@ namespace vcpkg
 {
     struct ToolsetArchOption;
     struct Toolset;
+    struct ToolsetsInformation;
     struct ManifestAndPath;
     struct VcpkgPaths;
 

--- a/include/vcpkg/fwd/visualstudio.h
+++ b/include/vcpkg/fwd/visualstudio.h
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace vcpkg::VisualStudio
+{
+    enum class ReleaseType
+    {
+        // These must be sorted by the order that we want them given a choice
+        STABLE,
+        PRERELEASE,
+        LEGACY,
+        UNKNOWN,
+    };
+
+    struct VisualStudioInstance;
+} // namespace vcpkg::VisualStudio

--- a/include/vcpkg/tools.h
+++ b/include/vcpkg/tools.h
@@ -5,9 +5,11 @@
 #include <vcpkg/base/fwd/files.h>
 
 #include <vcpkg/fwd/tools.h>
+#include <vcpkg/fwd/visualstudio.h>
 
 #include <vcpkg/base/stringview.h>
 
+#include <functional>
 #include <string>
 
 namespace vcpkg
@@ -54,10 +56,13 @@ namespace vcpkg
     ExpectedL<Path> find_system_tar(const ReadOnlyFilesystem& fs);
     ExpectedL<Path> find_system_cmake(const ReadOnlyFilesystem& fs);
 
-    std::unique_ptr<ToolCache> get_tool_cache(const Filesystem& fs,
-                                              std::shared_ptr<const DownloadManager> downloader,
-                                              Path downloads,
-                                              Path xml_config,
-                                              Path tools,
-                                              RequireExactVersions abiToolVersionHandling);
+    std::unique_ptr<ToolCache> get_tool_cache(
+        const Filesystem& fs,
+        const std::shared_ptr<const DownloadManager>& downloader,
+        StringView downloads,
+        StringView xml_config,
+        StringView tools,
+        RequireExactVersions abiToolVersionHandling,
+        const std::function<const std::vector<VisualStudio::VisualStudioInstance>&()>&
+            get_sorted_visual_studio_instances);
 }

--- a/include/vcpkg/vcpkgpaths.h
+++ b/include/vcpkg/vcpkgpaths.h
@@ -17,6 +17,7 @@
 #include <vcpkg/fwd/triplet.h>
 #include <vcpkg/fwd/vcpkgcmdarguments.h>
 #include <vcpkg/fwd/vcpkgpaths.h>
+#include <vcpkg/fwd/visualstudio.h>
 
 #include <vcpkg/base/optional.h>
 #include <vcpkg/base/path.h>
@@ -43,6 +44,17 @@ namespace vcpkg
         ZStringView version;
         std::string full_version;
         std::vector<ToolsetArchOption> supported_architectures;
+    };
+
+    struct ToolsetsInformation
+    {
+        std::vector<Toolset> toolsets;
+
+#if defined(_WIN32)
+        std::vector<Path> paths_examined;
+        std::vector<Toolset> excluded_toolsets;
+        LocalizedString get_localized_debug_info() const;
+#endif
     };
 
     struct VcpkgPaths
@@ -145,6 +157,8 @@ namespace vcpkg
         const Environment& get_action_env(const PreBuildInfo& pre_build_info, const Toolset& toolset) const;
         const std::string& get_triplet_info(const PreBuildInfo& pre_build_info, const Toolset& toolset) const;
         const CompilerInfo& get_compiler_info(const PreBuildInfo& pre_build_info, const Toolset& toolset) const;
+
+        const std::vector<VisualStudio::VisualStudioInstance>& get_sorted_visual_studio_instances() const;
 
         const FeatureFlagSettings& get_feature_flags() const;
 

--- a/include/vcpkg/visualstudio.h
+++ b/include/vcpkg/visualstudio.h
@@ -1,35 +1,34 @@
 #pragma once
 
+#include <vcpkg/base/fwd/files.h>
 #include <vcpkg/base/fwd/messages.h>
 
 #include <vcpkg/fwd/vcpkgpaths.h>
-
-#include <vcpkg/base/files.h>
+#include <vcpkg/fwd/visualstudio.h>
 
 #include <string>
 #include <vector>
 
-namespace vcpkg
-{
-    struct ToolsetsInformation
-    {
-        std::vector<Toolset> toolsets;
-
-#if defined(_WIN32)
-        std::vector<Path> paths_examined;
-        std::vector<Toolset> excluded_toolsets;
-        LocalizedString get_localized_debug_info() const;
-#endif
-    };
-}
-
-#if defined(_WIN32)
-
 namespace vcpkg::VisualStudio
 {
-    std::vector<std::string> get_visual_studio_instances(const ReadOnlyFilesystem& fs);
+    StringLiteral to_string_literal(ReleaseType release_type) noexcept;
 
-    ToolsetsInformation find_toolset_instances_preferred_first(const ReadOnlyFilesystem& fs);
+    struct VisualStudioInstance
+    {
+        Path root_path;
+        std::string version;
+        ReleaseType release_type;
+
+        VisualStudioInstance(Path&& root_path, std::string&& version, ReleaseType release_type);
+        std::string to_string() const;
+        std::string major_version() const;
+    };
+
+    std::vector<VisualStudioInstance> get_sorted_visual_studio_instances(const ReadOnlyFilesystem& fs);
+
+    ToolsetsInformation find_toolset_instances_preferred_first(
+        const ReadOnlyFilesystem& fs, const std::vector<VisualStudioInstance>& sorted_visual_studio_instances);
 }
 
-#endif
+VCPKG_FORMAT_WITH_TO_STRING(vcpkg::VisualStudio::VisualStudioInstance);
+VCPKG_FORMAT_WITH_TO_STRING_LITERAL_NONMEMBER(vcpkg::VisualStudio::ReleaseType);

--- a/src/vcpkg/commands.vsinstances.cpp
+++ b/src/vcpkg/commands.vsinstances.cpp
@@ -23,11 +23,9 @@ namespace vcpkg
     {
 #if defined(_WIN32)
         const ParsedArguments parsed_args = args.parse_arguments(CommandVsInstancesMetadata);
-
-        const auto instances = vcpkg::VisualStudio::get_visual_studio_instances(paths.get_filesystem());
-        for (const std::string& instance : instances)
+        for (const VisualStudio::VisualStudioInstance& instance : paths.get_sorted_visual_studio_instances())
         {
-            msg::write_unlocalized_text(Color::none, instance + "\n");
+            msg::write_unlocalized_text(Color::none, instance.to_string() + "\n");
         }
 
         Checks::exit_success(VCPKG_LINE_INFO);

--- a/src/vcpkg/tools.cpp
+++ b/src/vcpkg/tools.cpp
@@ -265,7 +265,7 @@ namespace vcpkg
             for (auto&& vs_instance : get_sorted_visual_studio_instances())
             {
                 out_candidate_paths.push_back(vs_instance.root_path / "Common7" / "IDE" / "CommonExtensions" /
-                                              "Microsoft" / "TeamFoundation" / "CMake" / "CMake" / "bin" / "cmake.exe");
+                                              "Microsoft" / "CMake" / "CMake" / "bin" / "cmake.exe");
             }
         }
 #endif

--- a/src/vcpkg/tools.cpp
+++ b/src/vcpkg/tools.cpp
@@ -15,6 +15,7 @@
 #include <vcpkg/tools.h>
 #include <vcpkg/tools.test.h>
 #include <vcpkg/versions.h>
+#include <vcpkg/visualstudio.h>
 
 #include <regex>
 
@@ -192,10 +193,14 @@ namespace vcpkg
         // considered.
         virtual bool ignore_version() const { return false; }
 
-        virtual void add_system_paths(const ReadOnlyFilesystem& fs, std::vector<Path>& out_candidate_paths) const
+        virtual void add_system_paths(const ReadOnlyFilesystem& fs,
+                                      std::vector<Path>& out_candidate_paths,
+                                      const std::function<const std::vector<VisualStudio::VisualStudioInstance>&()>&
+                                          get_sorted_visual_studio_instances) const
         {
             (void)fs;
             (void)out_candidate_paths;
+            (void)get_sorted_visual_studio_instances;
         }
 
         virtual ExpectedL<std::string> get_version(const ToolCache& cache,
@@ -240,7 +245,10 @@ namespace vcpkg
         virtual std::array<int, 3> default_min_version() const override { return {3, 17, 1}; }
 
 #if defined(_WIN32)
-        virtual void add_system_paths(const ReadOnlyFilesystem&, std::vector<Path>& out_candidate_paths) const override
+        virtual void add_system_paths(const ReadOnlyFilesystem&,
+                                      std::vector<Path>& out_candidate_paths,
+                                      const std::function<const std::vector<VisualStudio::VisualStudioInstance>&()>&
+                                          get_sorted_visual_studio_instances) const override
         {
             const auto& program_files = get_program_files_platform_bitness();
             if (const auto pf = program_files.get())
@@ -252,6 +260,12 @@ namespace vcpkg
             if (const auto pf = program_files_32_bit.get())
             {
                 out_candidate_paths.push_back(*pf / "CMake" / "bin" / "cmake.exe");
+            }
+
+            for (auto&& vs_instance : get_sorted_visual_studio_instances())
+            {
+                out_candidate_paths.push_back(vs_instance.root_path / "Common7" / "IDE" / "CommonExtensions" /
+                                              "Microsoft" / "TeamFoundation" / "CMake" / "CMake" / "bin" / "cmake.exe");
             }
         }
 #endif
@@ -346,12 +360,28 @@ namespace vcpkg
         virtual std::array<int, 3> default_min_version() const override { return {16, 12, 0}; }
 
 #if defined(_WIN32)
-        virtual void add_system_paths(const ReadOnlyFilesystem&, std::vector<Path>& out_candidate_paths) const override
+        virtual void add_system_paths(const ReadOnlyFilesystem&,
+                                      std::vector<Path>& out_candidate_paths,
+                                      const std::function<const std::vector<VisualStudio::VisualStudioInstance>&()>&
+                                          get_sorted_visual_studio_instances) const override
         {
             const auto& program_files = get_program_files_platform_bitness();
-            if (const auto pf = program_files.get()) out_candidate_paths.push_back(*pf / "nodejs" / "node.exe");
+            if (const auto pf = program_files.get())
+            {
+                out_candidate_paths.push_back(*pf / "nodejs" / "node.exe");
+            }
+
             const auto& program_files_32_bit = get_program_files_32_bit();
-            if (const auto pf = program_files_32_bit.get()) out_candidate_paths.push_back(*pf / "nodejs" / "node.exe");
+            if (const auto pf = program_files_32_bit.get())
+            {
+                out_candidate_paths.push_back(*pf / "nodejs" / "node.exe");
+            }
+
+            for (auto&& vs_instance : get_sorted_visual_studio_instances())
+            {
+                out_candidate_paths.push_back(vs_instance.root_path / "MSBuild" / "Microsoft" / "VisualStudio" /
+                                              "NodeJs" / "node.exe");
+            }
         }
 #endif
 
@@ -373,14 +403,28 @@ namespace vcpkg
         virtual std::array<int, 3> default_min_version() const override { return {2, 7, 4}; }
 
 #if defined(_WIN32)
-        virtual void add_system_paths(const ReadOnlyFilesystem&, std::vector<Path>& out_candidate_paths) const override
+        virtual void add_system_paths(const ReadOnlyFilesystem&,
+                                      std::vector<Path>& out_candidate_paths,
+                                      const std::function<const std::vector<VisualStudio::VisualStudioInstance>&()>&
+                                          get_sorted_visual_studio_instances) const override
         {
             const auto& program_files = get_program_files_platform_bitness();
-            if (const auto pf = program_files.get()) out_candidate_paths.push_back(*pf / "git" / "cmd" / "git.exe");
+            if (const auto pf = program_files.get())
+            {
+                out_candidate_paths.push_back(*pf / "git" / "cmd" / "git.exe");
+            }
+
             const auto& program_files_32_bit = get_program_files_32_bit();
             if (const auto pf = program_files_32_bit.get())
             {
                 out_candidate_paths.push_back(*pf / "git" / "cmd" / "git.exe");
+            }
+
+            for (auto&& vs_instance : get_sorted_visual_studio_instances())
+            {
+                out_candidate_paths.push_back(vs_instance.root_path / "Common7" / "IDE" / "CommonExtensions" /
+                                              "Microsoft" / "TeamFoundation" / "Team Explorer" / "Git" / "cmd" /
+                                              "git.exe");
             }
         }
 #endif
@@ -542,8 +586,10 @@ namespace vcpkg
             }
         }
 
-        virtual void add_system_paths(const ReadOnlyFilesystem& fs,
-                                      std::vector<Path>& out_candidate_paths) const override
+        virtual void add_system_paths(
+            const ReadOnlyFilesystem& fs,
+            std::vector<Path>& out_candidate_paths,
+            const std::function<const std::vector<VisualStudio::VisualStudioInstance>&()>&) const override
         {
             const auto& program_files = get_program_files_platform_bitness();
             if (const auto pf = program_files.get())
@@ -609,22 +655,26 @@ namespace vcpkg
         const Path xml_config;
         const Path tools;
         const RequireExactVersions abiToolVersionHandling;
+        std::function<const std::vector<VisualStudio::VisualStudioInstance>&()> get_sorted_visual_studio_instances;
 
         vcpkg::Lazy<std::string> xml_config_contents;
         vcpkg::Cache<std::string, PathAndVersion> path_version_cache;
 
         ToolCacheImpl(const Filesystem& fs,
                       const std::shared_ptr<const DownloadManager>& downloader,
-                      Path downloads,
-                      Path xml_config,
-                      Path tools,
-                      RequireExactVersions abiToolVersionHandling)
+                      StringView downloads,
+                      StringView xml_config,
+                      StringView tools,
+                      RequireExactVersions abiToolVersionHandling,
+                      const std::function<const std::vector<VisualStudio::VisualStudioInstance>&()>&
+                          get_sorted_visual_studio_instances)
             : fs(fs)
             , downloader(downloader)
-            , downloads(std::move(downloads))
-            , xml_config(std::move(xml_config))
-            , tools(std::move(tools))
+            , downloads(downloads)
+            , xml_config(xml_config)
+            , tools(tools)
             , abiToolVersionHandling(abiToolVersionHandling)
+            , get_sorted_visual_studio_instances(get_sorted_visual_studio_instances)
         {
         }
 
@@ -777,7 +827,7 @@ namespace vcpkg
                 // (e.g Program Files).
                 auto paths_from_path = fs.find_from_PATH(system_exe_stems);
                 candidate_paths.insert(candidate_paths.end(), paths_from_path.cbegin(), paths_from_path.cend());
-                tool.add_system_paths(fs, candidate_paths);
+                tool.add_system_paths(fs, candidate_paths, get_sorted_visual_studio_instances);
             }
 
             std::string considered_versions;
@@ -969,14 +1019,17 @@ namespace vcpkg
             ;
     }
 
-    std::unique_ptr<ToolCache> get_tool_cache(const Filesystem& fs,
-                                              std::shared_ptr<const DownloadManager> downloader,
-                                              Path downloads,
-                                              Path xml_config,
-                                              Path tools,
-                                              RequireExactVersions abiToolVersionHandling)
+    std::unique_ptr<ToolCache> get_tool_cache(
+        const Filesystem& fs,
+        const std::shared_ptr<const DownloadManager>& downloader,
+        StringView downloads,
+        StringView xml_config,
+        StringView tools,
+        RequireExactVersions abiToolVersionHandling,
+        const std::function<const std::vector<VisualStudio::VisualStudioInstance>&()>&
+            get_sorted_visual_studio_instances)
     {
         return std::make_unique<ToolCacheImpl>(
-            fs, std::move(downloader), downloads, xml_config, tools, abiToolVersionHandling);
+            fs, downloader, downloads, xml_config, tools, abiToolVersionHandling, get_sorted_visual_studio_instances);
     }
 }

--- a/src/vcpkg/visualstudio.cpp
+++ b/src/vcpkg/visualstudio.cpp
@@ -11,6 +11,7 @@
 #include <vcpkg/vcpkgpaths.h>
 #include <vcpkg/visualstudio.h>
 
+#if defined(_WIN32)
 namespace
 {
     using namespace vcpkg;
@@ -21,6 +22,7 @@ namespace
     constexpr StringLiteral V_142 = "v142";
     constexpr StringLiteral V_143 = "v143";
 } // unnamed namespace
+#endif // ^^^ _WIN32
 
 namespace vcpkg::VisualStudio
 {


### PR DESCRIPTION
It is frustrating that Visual Studio comes with perfectly good versions of some of our dependencies, but we stubbornly don't use them because they aren't available on a PATH or anything like that.

This change fixes that by looking at the VS instances from vswhere and considering tools therein if they are present.

This change needs approval from the teams that own Git, CMake, and Node in VS before it can land.