### PR TITLE
Fix OpenBSD Compilation

### DIFF
--- a/src/vcpkg/base/system.mac.cpp
+++ b/src/vcpkg/base/system.mac.cpp
@@ -9,7 +9,7 @@
 
 #if !defined(_WIN32)
 #include <net/if.h>
-#if defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <ifaddrs.h>
 
 #include <net/if_dl.h>
@@ -150,7 +150,7 @@ namespace vcpkg
                 }
             }
         }
-#elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
+#elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
         // The getifaddrs(ifaddrs** ifap) function creates a linked list of structures
         // describing the network interfaces of the local system, and stores
         // the address of the first item of the list in *ifap.
@@ -191,7 +191,7 @@ namespace vcpkg
             auto address = reinterpret_cast<sockaddr_ll*>(interface->ifa_addr);
             if (address->sll_halen != MAC_BYTES_LENGTH) continue;
             auto mac_bytes = Span<char>(reinterpret_cast<char*>(address->sll_addr), MAC_BYTES_LENGTH);
-#elif defined(__APPLE__) || defined(__FreeBSD__)
+#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
             auto address = reinterpret_cast<sockaddr_dl*>(interface->ifa_addr);
             if (address->sdl_alen != MAC_BYTES_LENGTH) continue;
             // The macro LLADDR() returns the start of the link-layer network address.

--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -241,7 +241,7 @@ namespace vcpkg
         std::unique_ptr<char> canonicalPath(realpath(buf, NULL));
         Checks::check_exit(VCPKG_LINE_INFO, result != -1, "Could not determine current executable path.");
         return canonicalPath.get();
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__OpenBSD__)
         int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1};
         char exePath[2048];
         size_t len = sizeof(exePath);

--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -254,6 +254,9 @@ namespace vcpkg
         Checks::check_exit(VCPKG_LINE_INFO, progname != nullptr, "progname() returned NULL");
         char resolved_path[PATH_MAX];
         auto ret = realpath(progname, resolved_path);
+        if (ret == nullptr) {
+          printf("realpath failed: %s\n", strerror(errno));
+        }
         Checks::check_exit(VCPKG_LINE_INFO, ret != nullptr, "Could not determine current executable path.");
         return resolved_path;
 #else /* LINUX */

--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -255,6 +255,7 @@ namespace vcpkg
         char resolved_path[PATH_MAX];
         auto ret = realpath(progname, resolved_path);
         if (ret == nullptr) {
+          printf("progname=%s\n", progname);
           printf("realpath failed: %s\n", strerror(errno));
         }
         Checks::check_exit(VCPKG_LINE_INFO, ret != nullptr, "Could not determine current executable path.");

--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -259,10 +259,10 @@ namespace vcpkg
         argv.resize(argc);
         auto argv_query = sysctl(mib, 4, &argv[0], &argc, nullptr, 0);
         Checks::check_exit(VCPKG_LINE_INFO, argv_query == 0, "Could not determine current executable path.");
-        for(size_t i=0; i<argc; ++i) {
-            printf("argv[%d]=%s\n", (int)i, argv[i]);
-        }
-        return Path(argv[0], strlen(argv[0]));
+        char buf[PATH_MAX];
+        char *exePath(realpath(argv[0], buf));
+        printf("exePath=%s\n", exePath);
+        return Path(exePath, strlen(argv[0]));
 #else /* LINUX */
         char buf[1024 * 4] = {};
         auto written = readlink("/proc/self/exe", buf, sizeof(buf));

--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -255,8 +255,9 @@ namespace vcpkg
         auto argc_query = sysctl(mib, 4, nullptr, &argc, nullptr, 0);
         Checks::check_exit(VCPKG_LINE_INFO, argc_query == 0, "Could not determine current executable path.");
         Checks::check_exit(VCPKG_LINE_INFO, argc > 0, "Could not determine current executable path.");
-        char *argv[argc];
-        auto argv_query = sysctl(mib, 4, argv, &argc, nullptr, 0);
+        std::vector<char*> argv;
+        argv.resize(argc);
+        auto argv_query = sysctl(mib, 4, &argv[0], &argc, nullptr, 0);
         Checks::check_exit(VCPKG_LINE_INFO, argv_query == 0, "Could not determine current executable path.");
         for(size_t i=0; i<argc; ++i) {
             printf("argv[%d]=%s\n", (int)i, argv[i]);

--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -261,8 +261,8 @@ namespace vcpkg
         Checks::check_exit(VCPKG_LINE_INFO, argv_query == 0, "Could not determine current executable path.");
         char buf[PATH_MAX];
         char *exePath(realpath(argv[0], buf));
-        printf("exePath=%s\n", exePath);
-        return Path(exePath, strlen(argv[0]));
+        Checks::check_exit(VCPKG_LINE_INFO, exePath != nullptr, "Could not determine current executable path.");
+        return Path(exePath);
 #else /* LINUX */
         char buf[1024 * 4] = {};
         auto written = readlink("/proc/self/exe", buf, sizeof(buf));

--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -251,6 +251,7 @@ namespace vcpkg
         return Path(exePath, len - 1);
 #elif defined(__OpenBSD__)
         const char* progname = getprogname();
+        Checks::check_exit(VCPKG_LINE_INFO, progname != nullptr, "progname() returned NULL");
         char resolved_path[PATH_MAX];
         auto ret = realpath(progname, resolved_path);
         Checks::check_exit(VCPKG_LINE_INFO, ret != nullptr, "Could not determine current executable path.");

--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -19,7 +19,7 @@ extern char** environ;
 #include <mach-o/dyld.h>
 #endif
 
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
 extern char** environ;
 #include <sys/sysctl.h>
 #include <sys/wait.h>

--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -258,8 +258,8 @@ namespace vcpkg
         char *argv[argc];
         auto argv_query = sysctl(mib, 4, argv, &argc, nullptr, 0);
         Checks::check_exit(VCPKG_LINE_INFO, argv_query == 0, "Could not determine current executable path.");
-        for(int i=0; i<argc; ++i) {
-            printf("argv[%d]=%s\n", argv[i]);
+        for(size_t i=0; i<argc; ++i) {
+            printf("argv[%d]=%s\n", (int)i, argv[i]);
         }
         return Path(argv[0], strlen(argv[0]));
 #else /* LINUX */


### PR DESCRIPTION
Fixes #36812
Fixes #36813

Use `__FreeBSD__` branches wherever they are compatible in order to fix compilation issues.

Also, use OpenBSD's `KERN_PROC_ARGV` interface to query the application's name when evaluating it's path.