### PR TITLE
Add quotes around the VCPKG_ROOT and Z_POWERSHELL_EXE variable path assignments.

### DIFF
--- a/vcpkg-init/vcpkg-init.ps1
+++ b/vcpkg-init/vcpkg-init.ps1
@@ -109,22 +109,22 @@ IF EXIST $null DEL $null
 
 :: Figure out where VCPKG_ROOT is
 IF EXIST "%~dp0.vcpkg-root" (
-  SET VCPKG_ROOT=%~dp0
+  SET "VCPKG_ROOT=%~dp0"
 )
 
 IF "%VCPKG_ROOT:~-1%"=="\" (
-  SET VCPKG_ROOT=%VCPKG_ROOT:~0,-1%
+  SET "VCPKG_ROOT=%VCPKG_ROOT:~0,-1%"
 )
 
 IF "%VCPKG_ROOT%"=="" (
-  SET VCPKG_ROOT=%USERPROFILE%\.vcpkg
+  SET "VCPKG_ROOT=%USERPROFILE%\.vcpkg"
 )
 
 :: Call powershell which may or may not invoke bootstrap if there's a version mismatch
 SET Z_POWERSHELL_EXE=
 FOR %%i IN (pwsh.exe powershell.exe) DO (
   IF EXIST "%%~$PATH:i" (
-    SET Z_POWERSHELL_EXE=%%~$PATH:i
+    SET "Z_POWERSHELL_EXE=%%~$PATH:i"
     GOTO :gotpwsh
   )
 )


### PR DESCRIPTION
Add quotes around the VCPKG_ROOT and Z_POWERSHELL_EXE variable path assignments.

Without adding quotes around the set variable path assignments, paths that contain a close parenthesis character `)` would cause the command/batch file to exit prematurely and vs batch call chains (e.g., vcvarsall.bat) to fail.