### PR TITLE
Fix macos-ci preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -14,8 +14,8 @@
             "name": "base",
             "hidden": true,
             "generator": "Ninja",
-            "binaryDir": "out\\build\\${presetName}",
-            "installDir": "out\\install\\${presetName}",
+            "binaryDir": "out/build/${presetName}",
+            "installDir": "out/install/${presetName}",
             "cacheVariables": {
                 "VCPKG_BUILD_BENCHMARKING": true,
                 "VCPKG_BUILD_FUZZING": true


### PR DESCRIPTION
Before:

Creates a directory called `out\\build\\macos-ci`

After:

Creates a directory in `out`/`build`/`macos-ci`

:)