### PR TITLE
Fixed crash on non-existent port with version override

### DIFF
--- a/src/vcpkg/portfileprovider.cpp
+++ b/src/vcpkg/portfileprovider.cpp
@@ -173,6 +173,11 @@ namespace vcpkg
                 const auto& maybe_ent = entry(version_spec.port_name);
                 if (auto ent = maybe_ent.get())
                 {
+                    if (!ent->get())
+                    {
+                        return msg::format_error(msgPortDoesNotExist, msg::package_name = version_spec.port_name);
+                    }
+
                     auto maybe_path = ent->get()->get_version(version_spec.version);
                     if (auto path = maybe_path.get())
                     {


### PR DESCRIPTION
Fixes this issue reported in the vcpkg project:
https://github.com/microsoft/vcpkg/issues/36994

The "entry" function does not return an error but an empty RegistryEntry in some situations, needs to be checked for.

An alternative solution would be to refactor all registry implementations to never return an empty RegistryEntry, but an error instead. 
That should be done in a separate issue after this fix is merged.