### PR TITLE
DLL policies should apply in static triplets, lib policies should apply in dynamic triplets.

### DIFF
--- a/src/vcpkg/postbuildlint.cpp
+++ b/src/vcpkg/postbuildlint.cpp
@@ -709,11 +709,9 @@ namespace vcpkg
         return LintStatus::SUCCESS;
     }
 
-    static LintStatus check_no_dlls_present(const BuildPolicies& policies,
-                                            const std::vector<Path>& dlls,
-                                            MessageSink& msg_sink)
+    static LintStatus check_no_dlls_present(const std::vector<Path>& dlls, MessageSink& msg_sink)
     {
-        if (dlls.empty() || policies.is_enabled(BuildPolicy::DLLS_IN_STATIC_LIBRARY))
+        if (dlls.empty())
         {
             return LintStatus::SUCCESS;
         }
@@ -774,13 +772,10 @@ namespace vcpkg
         return LintStatus::SUCCESS;
     }
 
-    static LintStatus check_bin_folders_are_not_present_in_static_build(const BuildPolicies& policies,
-                                                                        const ReadOnlyFilesystem& fs,
+    static LintStatus check_bin_folders_are_not_present_in_static_build(const ReadOnlyFilesystem& fs,
                                                                         const Path& package_dir,
                                                                         MessageSink& msg_sink)
     {
-        if (policies.is_enabled(BuildPolicy::DLLS_IN_STATIC_LIBRARY)) return LintStatus::SUCCESS;
-
         const auto bin = package_dir / "bin";
         const auto debug_bin = package_dir / "debug" / "bin";
 
@@ -1419,47 +1414,40 @@ namespace vcpkg
             error_count += perform_post_build_checks_dll_loads(fs, dlls_data, release_dlls, msg_sink);
             error_count += check_bad_kernel32_from_xbox(dlls_data, pre_build_info, msg_sink);
 
-            switch (build_info.library_linkage)
+            if (!pre_build_info.build_type &&
+                !build_info.policies.is_enabled(BuildPolicy::MISMATCHED_NUMBER_OF_BINARIES))
+                error_count += check_matching_debug_and_release_binaries(debug_dlls, release_dlls, msg_sink);
+
+            error_count += check_lib_files_are_available_if_dlls_are_available(
+                build_info.policies, debug_libs.size(), debug_dlls.size(), debug_lib_dir, msg_sink);
+            error_count += check_lib_files_are_available_if_dlls_are_available(
+                build_info.policies, release_libs.size(), release_dlls.size(), release_lib_dir, msg_sink);
+
+            error_count += check_exports_of_dlls(build_info.policies, dlls_data, msg_sink);
+            error_count += check_uwp_bit_of_dlls(pre_build_info.cmake_system_name, dlls_data, msg_sink);
+            error_count += check_outdated_crt_linkage_of_dlls(dlls_data, build_info, pre_build_info, msg_sink);
+            if (!build_info.policies.is_enabled(BuildPolicy::SKIP_ARCHITECTURE_CHECK))
             {
-                case LinkageType::Dynamic:
-                {
-                    if (!pre_build_info.build_type &&
-                        !build_info.policies.is_enabled(BuildPolicy::MISMATCHED_NUMBER_OF_BINARIES))
-                        error_count += check_matching_debug_and_release_binaries(debug_dlls, release_dlls, msg_sink);
-
-                    error_count += check_lib_files_are_available_if_dlls_are_available(
-                        build_info.policies, debug_libs.size(), debug_dlls.size(), debug_lib_dir, msg_sink);
-                    error_count += check_lib_files_are_available_if_dlls_are_available(
-                        build_info.policies, release_libs.size(), release_dlls.size(), release_lib_dir, msg_sink);
-
-                    error_count += check_exports_of_dlls(build_info.policies, dlls_data, msg_sink);
-                    error_count += check_uwp_bit_of_dlls(pre_build_info.cmake_system_name, dlls_data, msg_sink);
-                    error_count += check_outdated_crt_linkage_of_dlls(dlls_data, build_info, pre_build_info, msg_sink);
-                    if (!build_info.policies.is_enabled(BuildPolicy::SKIP_ARCHITECTURE_CHECK))
-                    {
-                        error_count += check_dll_architecture(pre_build_info.target_architecture, dlls_data, msg_sink);
-                    }
-                }
-                break;
-                case LinkageType::Static:
-                {
-                    auto& dlls = debug_dlls;
-                    dlls.insert(dlls.end(),
-                                std::make_move_iterator(release_dlls.begin()),
-                                std::make_move_iterator(release_dlls.end()));
-                    error_count += check_no_dlls_present(build_info.policies, dlls, msg_sink);
-                    error_count += check_bin_folders_are_not_present_in_static_build(
-                        build_info.policies, fs, package_dir, msg_sink);
-                    if (!build_info.policies.is_enabled(BuildPolicy::ONLY_RELEASE_CRT))
-                    {
-                        error_count += check_crt_linkage_of_libs(fs, build_info, false, debug_libs, msg_sink);
-                    }
-
-                    error_count += check_crt_linkage_of_libs(fs, build_info, true, release_libs, msg_sink);
-                    break;
-                }
-                default: Checks::unreachable(VCPKG_LINE_INFO);
+                error_count += check_dll_architecture(pre_build_info.target_architecture, dlls_data, msg_sink);
             }
+
+            if (build_info.library_linkage == LinkageType::Static &&
+                !build_info.policies.is_enabled(BuildPolicy::DLLS_IN_STATIC_LIBRARY))
+            {
+                auto& dlls = debug_dlls;
+                dlls.insert(dlls.end(),
+                            std::make_move_iterator(release_dlls.begin()),
+                            std::make_move_iterator(release_dlls.end()));
+                error_count += check_no_dlls_present(dlls, msg_sink);
+                error_count += check_bin_folders_are_not_present_in_static_build(fs, package_dir, msg_sink);
+            }
+
+            if (!build_info.policies.is_enabled(BuildPolicy::ONLY_RELEASE_CRT))
+            {
+                error_count += check_crt_linkage_of_libs(fs, build_info, false, debug_libs, msg_sink);
+            }
+
+            error_count += check_crt_linkage_of_libs(fs, build_info, true, release_libs, msg_sink);
         }
 
         error_count += check_no_empty_folders(fs, package_dir, msg_sink);


### PR DESCRIPTION
DLLs can be in static triplets if BuildPolicy::DLLS_IN_STATIC_LIBRARY is turned on. Those DLLs should still have CRT and architecture checked, that sort of thing.

Static libs can be in dynamic triplets, and their CRT linkage still needs to match.