### PR TITLE
Fix binary caching push failures (set `BinaryProviders::nuget_repo`) & remove unused field

### DIFF
--- a/include/vcpkg/binarycaching.h
+++ b/include/vcpkg/binarycaching.h
@@ -157,7 +157,6 @@ namespace vcpkg
         // These are filled in after construction by reading from args and environment
         std::string nuget_prefix;
         bool use_nuget_cache = false;
-        NuGetRepoInfo nuget_repo_info;
 
         void clear();
     };

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -1880,8 +1880,11 @@ namespace vcpkg
 
             s.nuget_prefix = args.nuget_id_prefix.value_or("");
             if (!s.nuget_prefix.empty()) s.nuget_prefix.push_back('_');
+            ret.nuget_prefix = s.nuget_prefix;
+
             s.use_nuget_cache = args.use_nuget_cache.value_or(false);
-            s.nuget_repo_info = get_nuget_repo_info_from_env(args);
+
+            ret.nuget_repo = get_nuget_repo_info_from_env(args);
 
             auto& fs = paths.get_filesystem();
             auto& tools = paths.get_tool_cache();


### PR DESCRIPTION
`BinaryProviders::nuget_repo` wasn't getting set anywhere, even though `BinaryCache::push_success()` uses it.
Also removed `BinaryConfigParserState::nuget_repo_info` which was unused.

Without this change, pushing any package into my GHE nuget cache resulted in these kinds of errors (started happening 3+ months ago on my Ubuntu 20.04 GitHub Actions runner):
```
Pushing vcpkg-cmake-config_x64-linux.2022.2.6-vcpkga66b0ae909b0dfb01b299ab9de46b1e919ddf11d8565c40906a893993d6b3ce8.nupkg to 'https://nuget.git.[redacted]'...
  PUT https://nuget.git.[redacted]
WARNING: No destination repository detected. Ensure the source project has a 'RepositoryUrl' property defined. If you're using a nuspec file, ensure that it has a repository element with the required 'type' and 'url' attributes.
  BadRequest https://nuget.git.[redacted] 283ms
Response status code does not indicate success: 400 (Bad Request).
```

Potential reviewer: @BillyONeal 