### PR TITLE
Paths in PrebuildInfo should be `Path` instead of `std::string`

### DIFF
--- a/include/vcpkg/commands.build.h
+++ b/include/vcpkg/commands.build.h
@@ -162,7 +162,7 @@ namespace vcpkg
         Optional<std::string> public_abi_override;
         std::vector<std::string> passthrough_env_vars;
         std::vector<std::string> passthrough_env_vars_tracked;
-        std::vector<std::string> hash_additional_files;
+        std::vector<Path> hash_additional_files;
         Optional<Path> gamedk_latest_path;
 
         Path toolchain_file() const;

--- a/include/vcpkg/commands.build.h
+++ b/include/vcpkg/commands.build.h
@@ -157,7 +157,7 @@ namespace vcpkg
         Optional<std::string> platform_toolset;
         Optional<std::string> platform_toolset_version;
         Optional<Path> visual_studio_path;
-        Optional<std::string> external_toolchain_file;
+        Optional<Path> external_toolchain_file;
         Optional<ConfigurationType> build_type;
         Optional<std::string> public_abi_override;
         std::vector<std::string> passthrough_env_vars;

--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -1805,11 +1805,7 @@ namespace vcpkg
         Util::assign_if_set_and_nonempty(public_abi_override, cmakevars, CMakeVariablePublicAbiOverride);
         if (auto value = Util::value_if_set_and_nonempty(cmakevars, CMakeVariableHashAdditionalFiles))
         {
-            auto files_str = Strings::split(*value, ';');
-            std::transform(files_str.begin(),
-                           files_str.end(),
-                           std::back_inserter(hash_additional_files),
-                           [](auto&& str) { return Path(std::move(str)); });
+            hash_additional_files = Util::fmap(Strings::split(*value, ';'), [](auto&& str) { return Path(std::move(str)); });
         }
         // Note that this value must come after CMakeVariableChainloadToolchainFile because its default depends upon it
         load_vcvars_env = !external_toolchain_file.has_value();

--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -1805,7 +1805,8 @@ namespace vcpkg
         Util::assign_if_set_and_nonempty(public_abi_override, cmakevars, CMakeVariablePublicAbiOverride);
         if (auto value = Util::value_if_set_and_nonempty(cmakevars, CMakeVariableHashAdditionalFiles))
         {
-            hash_additional_files = Util::fmap(Strings::split(*value, ';'), [](auto&& str) { return Path(std::move(str)); });
+            hash_additional_files =
+                Util::fmap(Strings::split(*value, ';'), [](auto&& str) { return Path(std::move(str)); });
         }
         // Note that this value must come after CMakeVariableChainloadToolchainFile because its default depends upon it
         load_vcvars_env = !external_toolchain_file.has_value();

--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -1169,8 +1169,9 @@ namespace vcpkg
             {
                 Checks::msg_exit_with_message(VCPKG_LINE_INFO, msgInvalidValueHashAdditionalFiles, msg::path = file);
             }
-            auto hash = Hash::get_file_hash(fs, file, Hash::Algorithm::Sha256).value_or_exit(VCPKG_LINE_INFO);
-            abi_tag_entries.emplace_back(fmt::format("additional_file_{}", i), std::move(hash));
+            abi_tag_entries.emplace_back(
+                fmt::format("additional_file_{}", i),
+                Hash::get_file_hash(fs, file, Hash::Algorithm::Sha256).value_or_exit(VCPKG_LINE_INFO));
         }
 
         auto&& scfl = action.source_control_file_and_location.value_or_exit(VCPKG_LINE_INFO);


### PR DESCRIPTION
- Store files as vector of Path right away.
  This is semantically more correct and saves extra string copies.
- Turn `external_toolchain_file` into a Path
- Drive by: Don't leak i outside the loop