### PR TITLE
Unify usage hint formatting

### DIFF
--- a/azure-pipelines/end-to-end-tests-dir/usage.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/usage.ps1
@@ -32,8 +32,8 @@ vcpkg-hello-world-2 provides CMake targets:
 @"
 wrong-pkgconfig provides pkg-config modules:
 
-    # Test lib
-    wrong-pkgconfig
+  # Test lib
+  wrong-pkgconfig
 "@
 )
 

--- a/src/vcpkg/commands.install.cpp
+++ b/src/vcpkg/commands.install.cpp
@@ -977,18 +977,24 @@ namespace vcpkg
                 };
 
                 const auto name = cmakeify(bpgh.spec.name());
-                auto msg = msg::format(msgHeaderOnlyUsage, msg::package_name = bpgh.spec.name()).extract_data();
-                Strings::append(msg, "\n\n");
-                Strings::append(msg, "    find_path(", name, "_INCLUDE_DIRS \"", header_path, "\")\n");
-                Strings::append(msg, "    target_include_directories(main PRIVATE ${", name, "_INCLUDE_DIRS})\n\n");
+                auto msg = msg::format(msgHeaderOnlyUsage, msg::package_name = bpgh.spec.name()).append_raw("\n\n");
+                msg.append_indent()
+                    .append_raw("find_path(")
+                    .append_raw(name)
+                    .append_raw("_INCLUDE_DIRS \")")
+                    .append_raw(header_path)
+                    .append_raw("\")\n");
+                msg.append_indent()
+                    .append_raw("target_include_directories(main PRIVATE ${")
+                    .append_raw(name)
+                    .append_raw("_INCLUDE_DIRS})\n\n");
 
-                ret.message = std::move(msg);
+                ret.message = msg.extract_data();
             }
             if (!pkgconfig_files.empty())
             {
-                auto msg = msg::format(msgCMakePkgConfigTargetsUsage, msg::package_name = bpgh.spec.name())
-                               .append_raw("\n\n")
-                               .extract_data();
+                auto msg =
+                    msg::format(msgCMakePkgConfigTargetsUsage, msg::package_name = bpgh.spec.name()).append_raw("\n\n");
                 for (auto&& path : pkgconfig_files)
                 {
                     const auto lines = fs.read_lines(path).value_or_exit(VCPKG_LINE_INFO);
@@ -996,14 +1002,16 @@ namespace vcpkg
                     {
                         if (Strings::starts_with(line, "Description: "))
                         {
-                            Strings::append(msg, "    # ", line.substr(StringLiteral("Description: ").size()), '\n');
+                            msg.append_indent()
+                                .append_raw("# ")
+                                .append_raw(line.substr(StringLiteral("Description: ").size()))
+                                .append_raw('\n');
                             break;
                         }
                     }
-                    const auto name = path.stem();
-                    Strings::append(msg, "    ", name, "\n\n");
+                    msg.append_indent().append_raw(path.stem()).append_raw("\n\n");
                 }
-                ret.message += msg;
+                ret.message += msg.extract_data();
             }
         }
         return ret;


### PR DESCRIPTION
Follow pattern from CMake packages. In particular, indent with `append_indent()`.

Fixes mixed indentation when a port has both CMake and pkg-config (and copied like that into `usage` files, e.g.):
~~~
libosdp provides CMake targets:

  find_package(LibOSDP CONFIG REQUIRED)
  target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:libosdp::osdp>,libosdp::osdp,libosdp::osdpstatic>)

libosdp provides pkg-config modules:

    # Open Supervised Device Protocol (OSDP) Library
    libosdp
~~~
~~~
 ^^^