### PR TITLE
Improve `depend-info --dot` output

### DIFF
--- a/src/vcpkg-test/dependinfo-graphs.cpp
+++ b/src/vcpkg-test/dependinfo-graphs.cpp
@@ -7,7 +7,7 @@ using namespace vcpkg;
 namespace
 {
     const auto DOT_TEMPLATE =
-        "digraph G{{ rankdir=LR; edge [minlen=3]; overlap=false;{}empty [label=\"{} singletons...\"]; }}";
+        "digraph G{{ rankdir=LR; node [fontname=Sans]; edge [minlen=3]; overlap=false;\n{}\"{} singletons...\";\n}}";
 
     const auto DGML_TEMPLATE =
         "<?xml version=\"1.0\" encoding=\"utf-8\"?><DirectedGraph "
@@ -32,13 +32,17 @@ TEST_CASE ("depend-info DOT graph output", "[depend-info]")
 
     SECTION ("single node")
     {
-        CHECK(create_dot_as_string(single_node_dependencies()) == fmt::format(DOT_TEMPLATE, "a;a -> a;", 0));
+        CHECK(create_dot_as_string(single_node_dependencies()) ==
+              fmt::format(DOT_TEMPLATE, "\"a\";\n\"a\" -> \"a\";\n", 0));
     }
 
     SECTION ("4 nodes")
     {
         CHECK(create_dot_as_string(four_nodes_dependencies()) ==
-              fmt::format(DOT_TEMPLATE, "a;a -> b;a -> c;a -> d;b;b -> c;c;c -> d;", 1));
+              fmt::format(DOT_TEMPLATE,
+                          "\"a\";\n\"a\" -> \"b\";\n\"a\" -> \"c\";\n\"a\" -> \"d\";\n\"b\";\n\"b\" -> "
+                          "\"c\";\n\"c\";\n\"c\" -> \"d\";\n\"d\";\n",
+                          1));
     }
 }
 

--- a/src/vcpkg/commands.depend-info.cpp
+++ b/src/vcpkg/commands.depend-info.cpp
@@ -165,7 +165,7 @@ namespace vcpkg
     {
         int empty_node_count = 0;
 
-        std::string s = "digraph G{ rankdir=LR; edge [minlen=3]; overlap=false;\n";
+        std::string s = "digraph G{ rankdir=LR; node [fontname=Sans]; edge [minlen=3]; overlap=false;\n";
 
         for (const auto& package : depend_info)
         {

--- a/src/vcpkg/commands.depend-info.cpp
+++ b/src/vcpkg/commands.depend-info.cpp
@@ -175,12 +175,10 @@ namespace vcpkg
                 continue;
             }
 
-            const std::string name = Strings::replace_all(std::string{package.package}, "-", "_");
-            fmt::format_to(std::back_inserter(s), "{};\n", name);
+            fmt::format_to(std::back_inserter(s), "\"{}\";\n", package.package);
             for (const auto& d : package.dependencies)
             {
-                const std::string dependency_name = Strings::replace_all(std::string{d}, "-", "_");
-                fmt::format_to(std::back_inserter(s), "{} -> {};\n", name, dependency_name);
+                fmt::format_to(std::back_inserter(s), "\"{}\" -> \"{}\";\n", package.package, d);
             }
         }
 

--- a/src/vcpkg/commands.depend-info.cpp
+++ b/src/vcpkg/commands.depend-info.cpp
@@ -182,7 +182,7 @@ namespace vcpkg
             }
         }
 
-        fmt::format_to(std::back_inserter(s), "empty [label=\"{} singletons...\"];\n}}", empty_node_count);
+        fmt::format_to(std::back_inserter(s), "\"{} singletons...\";\n}}", empty_node_count);
         return s;
     }
 

--- a/src/vcpkg/commands.depend-info.cpp
+++ b/src/vcpkg/commands.depend-info.cpp
@@ -165,7 +165,7 @@ namespace vcpkg
     {
         int empty_node_count = 0;
 
-        std::string s = "digraph G{ rankdir=LR; edge [minlen=3]; overlap=false;";
+        std::string s = "digraph G{ rankdir=LR; edge [minlen=3]; overlap=false;\n";
 
         for (const auto& package : depend_info)
         {
@@ -176,15 +176,15 @@ namespace vcpkg
             }
 
             const std::string name = Strings::replace_all(std::string{package.package}, "-", "_");
-            fmt::format_to(std::back_inserter(s), "{};", name);
+            fmt::format_to(std::back_inserter(s), "{};\n", name);
             for (const auto& d : package.dependencies)
             {
                 const std::string dependency_name = Strings::replace_all(std::string{d}, "-", "_");
-                fmt::format_to(std::back_inserter(s), "{} -> {};", name, dependency_name);
+                fmt::format_to(std::back_inserter(s), "{} -> {};\n", name, dependency_name);
             }
         }
 
-        fmt::format_to(std::back_inserter(s), "empty [label=\"{} singletons...\"]; }}", empty_node_count);
+        fmt::format_to(std::back_inserter(s), "empty [label=\"{} singletons...\"];\n}}", empty_node_count);
         return s;
     }
 

--- a/src/vcpkg/commands.depend-info.cpp
+++ b/src/vcpkg/commands.depend-info.cpp
@@ -169,13 +169,13 @@ namespace vcpkg
 
         for (const auto& package : depend_info)
         {
+            fmt::format_to(std::back_inserter(s), "\"{}\";\n", package.package);
             if (package.dependencies.empty())
             {
                 empty_node_count++;
                 continue;
             }
 
-            fmt::format_to(std::back_inserter(s), "\"{}\";\n", package.package);
             for (const auto& d : package.dependencies)
             {
                 fmt::format_to(std::back_inserter(s), "\"{}\" -> \"{}\";\n", package.package, d);


### PR DESCRIPTION
Make test format more readable for humans with line breaks. (Note: https://learn.microsoft.com/en-us/vcpkg/commands/depend-info#dot doesn't show literal output.)
Use pristine package names via quotes.
Use "Sans" font.

Output for `ableton-link`:
~~~dot
digraph G{ rankdir=LR; node [fontname=Sans]; edge [minlen=3]; overlap=false;
"ableton";
"ableton" -> "ableton-link";
"ableton-link";
"ableton-link" -> "asio";
"ableton-link" -> "vcpkg-cmake";
"ableton-link" -> "vcpkg-cmake-config";
"asio";
"asio" -> "vcpkg-cmake";
"asio" -> "vcpkg-cmake-config";
"vcpkg-cmake";
"vcpkg-cmake-config";
"2 singletons...";
}
~~~

![img](https://github.com/microsoft/vcpkg-tool/assets/13567791/599054e0-bc1c-4705-8c23-b2ea3d561ef0)


Wish list:
- Drop the "singletons" comment node.
- Top-bottom rankdir, which is the default format for dot, also for mermaid.
  (Users can override it with `dot -Grankdir=TB`.) Output:
  ![img](https://github.com/microsoft/vcpkg-tool/assets/13567791/b40e829d-e809-42c8-98f7-f0fd31d3cf27)

