### PR TITLE
Colorize multi-triplet dot graphs

### DIFF
--- a/src/vcpkg/commands.depend-info.cpp
+++ b/src/vcpkg/commands.depend-info.cpp
@@ -173,7 +173,17 @@ namespace vcpkg
 
         for (const auto& package : depend_info)
         {
-            fmt::format_to(std::back_inserter(s), "\"{}\";\n", package.package);
+            const char* node_style = "";
+            if (Strings::ends_with(package.package, ":host"))
+            {
+                node_style = " [color=gray fontcolor=gray]";
+            }
+            else if (Strings::contains(package.package, ':'))
+            {
+                node_style = " [color=blue fontcolor=blue]";
+            }
+
+            fmt::format_to(std::back_inserter(s), "\"{}\"{};\n", package.package, node_style);
             if (package.dependencies.empty())
             {
                 empty_node_count++;
@@ -182,7 +192,16 @@ namespace vcpkg
 
             for (const auto& d : package.dependencies)
             {
-                fmt::format_to(std::back_inserter(s), "\"{}\" -> \"{}\";\n", package.package, d);
+                const char* edge_style = " [color=blue fontcolor=blue]";
+                if (!Strings::contains(d, ':'))
+                {
+                    edge_style = "";
+                }
+                else if (Strings::ends_with(d, ":host"))
+                {
+                    edge_style = " [color=gray fontcolor=gray]";
+                }
+                fmt::format_to(std::back_inserter(s), "\"{}\" -> \"{}\"{};\n", package.package, d, edge_style);
             }
         }
 

--- a/src/vcpkg/commands.depend-info.cpp
+++ b/src/vcpkg/commands.depend-info.cpp
@@ -176,7 +176,7 @@ namespace vcpkg
             const char* node_style = "";
             if (Strings::ends_with(package.package, ":host"))
             {
-                node_style = " [color=gray fontcolor=gray]";
+                node_style = " [color=gray51 fontcolor=gray51]";
             }
             else if (Strings::contains(package.package, ':'))
             {
@@ -199,7 +199,7 @@ namespace vcpkg
                 }
                 else if (Strings::ends_with(d, ":host"))
                 {
-                    edge_style = " [color=gray fontcolor=gray]";
+                    edge_style = " [color=gray51 fontcolor=gray51]";
                 }
                 fmt::format_to(std::back_inserter(s), "\"{}\" -> \"{}\"{};\n", package.package, d, edge_style);
             }

--- a/src/vcpkg/commands.depend-info.cpp
+++ b/src/vcpkg/commands.depend-info.cpp
@@ -165,6 +165,18 @@ namespace
 
 namespace vcpkg
 {
+    namespace
+    {
+        const char* get_dot_element_style(const std::string& label)
+        {
+            if (!Strings::contains(label, ':')) return "";
+
+            if (Strings::ends_with(label, ":host")) return " [color=gray51 fontcolor=gray51]";
+
+            return " [color=blue fontcolor=blue]";
+        }
+    }
+
     std::string create_dot_as_string(const std::vector<PackageDependInfo>& depend_info)
     {
         int empty_node_count = 0;
@@ -173,17 +185,8 @@ namespace vcpkg
 
         for (const auto& package : depend_info)
         {
-            const char* node_style = "";
-            if (Strings::ends_with(package.package, ":host"))
-            {
-                node_style = " [color=gray51 fontcolor=gray51]";
-            }
-            else if (Strings::contains(package.package, ':'))
-            {
-                node_style = " [color=blue fontcolor=blue]";
-            }
-
-            fmt::format_to(std::back_inserter(s), "\"{}\"{};\n", package.package, node_style);
+            fmt::format_to(
+                std::back_inserter(s), "\"{}\"{};\n", package.package, get_dot_element_style(package.package));
             if (package.dependencies.empty())
             {
                 empty_node_count++;
@@ -192,16 +195,8 @@ namespace vcpkg
 
             for (const auto& d : package.dependencies)
             {
-                const char* edge_style = " [color=blue fontcolor=blue]";
-                if (!Strings::contains(d, ':'))
-                {
-                    edge_style = "";
-                }
-                else if (Strings::ends_with(d, ":host"))
-                {
-                    edge_style = " [color=gray51 fontcolor=gray51]";
-                }
-                fmt::format_to(std::back_inserter(s), "\"{}\" -> \"{}\"{};\n", package.package, d, edge_style);
+                fmt::format_to(
+                    std::back_inserter(s), "\"{}\" -> \"{}\"{};\n", package.package, d, get_dot_element_style(d));
             }
         }
 


### PR DESCRIPTION
Just https://github.com/microsoft/vcpkg-tool/pull/1371/commits/8361878a4bc4dab9c5dcae6344974e12d76fd160
Depends on (for now, includes) #1369 and #1370.

Example:
~~~
vcpkg depend-info proj:arm64-linux proj tiff[core] --triplet x64-linux-dynamic --dot | dot -Tpng -oimg.png && xdg-open img.png
~~~
Output:
![img](https://github.com/microsoft/vcpkg-tool/assets/13567791/eb634a69-de7c-4994-a8ec-6f32a3da85a0)

