### PR TITLE
Workaround for statically linking with GCC 9 and libpthread

### DIFF
--- a/azure-pipelines/vcpkg-linux/toolchain.cmake
+++ b/azure-pipelines/vcpkg-linux/toolchain.cmake
@@ -16,6 +16,8 @@ endfunction()
 
 add_toolchain_linker_flag("-Wl,--rpath-link=/crossrootfs/x64/lib/x86_64-linux-gnu")
 add_toolchain_linker_flag("-Wl,--rpath-link=/crossrootfs/x64/usr/lib/x86_64-linux-gnu")
+# Workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=52590
+set(CMAKE_EXE_LINKER_FLAGS "-Wl,--whole-archive -lpthread -Wl,--no-whole-archive")
 
 set(CMAKE_C_COMPILER /usr/bin/gcc)
 set(CMAKE_CXX_COMPILER /usr/bin/g++)


### PR DESCRIPTION
See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=52590 for context, and https://github.com/microsoft/vcpkg/issues/37842 for more details on my analysis towards this problem.

Was first introduced with 2023-03-29 release, as compiler changed from RHEL 7.5 (GCC 4.something) to Ubuntu 16.04 (GCC 9).

Possibly there are nicer ways to fix this, but this felt appropriate. Tested it on my machines, works as expected.