### PR TITLE
[vcpkg-tool] Add a cmake preset for boostrap-vcpkg.sh

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -172,6 +172,25 @@
                 "CMAKE_OSX_DEPLOYMENT_TARGET": "10.13",
                 "VCPKG_WARNINGS_AS_ERRORS": true
             }
+        },
+        {
+            "name": "bootstrap.sh",
+            "description": "Preset used by vcpkg's bootstrap-vcpkg.sh",
+            "generator": "Ninja",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "VCPKG_DEVELOPMENT_WARNINGS": "OFF"
+            }
+        },
+        {
+            "name": "bootstrap.sh parallel build",
+            "description": "Preset used by vcpkg's bootstrap-vcpkg.sh when the VCPKG_MAX_CONCURRENCY variable is non-empty",
+            "inherits": ["bootstrap.sh"],
+            "cacheVariables": {
+                "CMAKE_JOB_POOL_COMPILE": "compile",
+                "CMAKE_JOB_POOL_LINK": "link",
+                "CMAKE_JOB_POOLS": "compile=$env{VCPKG_MAX_CONCURRENCY};link=$env{VCPKG_MAX_CONCURRENCY}"
+            }
         }
     ],
     "buildPresets": [


### PR DESCRIPTION
[scripts/bootrap.sh](https://github.com/microsoft/vcpkg/blob/master/scripts/bootstrap.sh) does some rather interesting composition of a cmake call around [lines 214](https://github.com/microsoft/vcpkg/blob/master/scripts/bootstrap.sh#L214) which results in having to use `eval` to get rid of the double-escaping of some strings.

Further, the ninja-specific multi-task build job rules are quite nasty and probably don't provide us with anything that passing `--parallel` to `cmake --build` could also do.

Add a CMakePreset.json representing the cmake invokation of `bootstrap.sh`, and replace the ninja specific code by `--build` - or - if the ninja specialization has to stay, derive a ninja multi-tasking preset from the regular, which allows simplifying the bootstrap script, as well as invoking cmake in a vcpkg-tool checkout.

Fixes: microsoft/vcpkg#37958