### PR TITLE
`<unsaved>` is an origin: Fix `format-manifest` command

### DIFF
--- a/src/vcpkg/commands.format-manifest.cpp
+++ b/src/vcpkg/commands.format-manifest.cpp
@@ -110,7 +110,7 @@ namespace
         auto res = serialize_manifest(data.scf);
 
         // reparse res to ensure no semantic changes were made
-        auto maybe_reparsed = SourceControlFile::parse_project_manifest_object(StringView{}, res, null_sink);
+        auto maybe_reparsed = SourceControlFile::parse_project_manifest_object("<unsaved>", res, null_sink);
         bool reparse_matches;
         if (auto reparsed = maybe_reparsed.get())
         {

--- a/src/vcpkg/commands.format-manifest.cpp
+++ b/src/vcpkg/commands.format-manifest.cpp
@@ -104,7 +104,7 @@ namespace
         }
         else
         {
-            Debug::println("Converting ", file_to_write_string, " -> ", original_path_string);
+            Debug::println("Converting ", original_path_string, " -> ", file_to_write_string);
         }
 
         auto res = serialize_manifest(data.scf);


### PR DESCRIPTION
Amends #1346.
Fix abort in debug builds where an empty `origin` was passed into `SpdxLicenseExpressionParser`, cf. https://github.com/microsoft/vcpkg-tool/pull/1346#discussion_r1548919401.
Fix wrong direction in debug output when converting `CONTROL` files.

