### PR TITLE
Style: Use double newlines in generated issue body

### DIFF
--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -1580,11 +1580,11 @@ namespace vcpkg
 
         fmt::format_to(std::back_inserter(issue_body), "-{}\n", paths.get_toolver_diagnostics());
         fmt::format_to(std::back_inserter(issue_body),
-                       "**To Reproduce**\n\n`vcpkg {} {}`\n",
+                       "**To Reproduce**\n\n`vcpkg {} {}`\n\n",
                        args.get_command(),
                        Strings::join(" ", args.get_forwardable_arguments()));
         fmt::format_to(std::back_inserter(issue_body),
-                       "**Failure logs**\n\n```\n{}\n```\n",
+                       "**Failure logs**\n\n```\n{}\n```\n\n",
                        paths.get_filesystem().read_contents(build_result.stdoutlog.value_or_exit(VCPKG_LINE_INFO),
                                                             VCPKG_LINE_INFO));
 


### PR DESCRIPTION
The generated issue bodies lack a second newline after the command, resulting in this slightly odd formatting:

![image](https://github.com/microsoft/vcpkg-tool/assets/30873659/cedb2a52-bd9c-461e-855c-4ccd435ff38e)

This should fix the issue by adding another newline.