### PR TITLE
parallel operations for some binary caching providers

### DIFF
--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -1049,8 +1049,9 @@ namespace
         {
             if (!request.zip_path) return 0;
             const auto& zip_path = *request.zip_path.get();
-            std::atomic_size_t upload_count = 0;
-            parallel_for_each(m_prefixes, [&](std::string const& prefix) {
+            size_t upload_count = 0;
+            for (const auto& prefix : m_prefixes)
+            {
                 auto res = m_tool->upload_file(make_object_path(prefix, request.package_abi), zip_path);
                 if (res)
                 {
@@ -1060,7 +1061,7 @@ namespace
                 {
                     msg_sink.println_warning(res.error());
                 }
-            });
+            }
             return upload_count;
         }
 

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -991,9 +991,8 @@ namespace
         {
             parallel_transform(
                 actions, out_zip_paths.begin(), [&](const InstallPlanAction* plan) -> Optional<ZipResource> {
-                    auto&& action = *plan;
-                    const auto& abi = action.package_abi().value_or_exit(VCPKG_LINE_INFO);
-                    auto tmp = make_temp_archive_path(m_buildtrees, action.spec);
+                    const auto& abi = plan->package_abi().value_or_exit(VCPKG_LINE_INFO);
+                    auto tmp = make_temp_archive_path(m_buildtrees, plan->spec);
                     auto res = m_tool->download_file(make_object_path(m_prefix, abi), tmp);
                     if (res)
                     {
@@ -1010,8 +1009,7 @@ namespace
         void precheck(View<const InstallPlanAction*> actions, Span<CacheAvailability> cache_status) const override
         {
             parallel_transform(actions, cache_status.begin(), [&](const InstallPlanAction* plan) {
-                auto&& action = *plan;
-                const auto& abi = action.package_abi().value_or_exit(VCPKG_LINE_INFO);
+                const auto& abi = plan->package_abi().value_or_exit(VCPKG_LINE_INFO);
                 if (m_tool->stat(make_object_path(m_prefix, abi)))
                 {
                     return CacheAvailability::available;

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -962,7 +962,11 @@ namespace
 
         virtual LocalizedString restored_message(size_t count,
                                                  std::chrono::high_resolution_clock::duration elapsed) const = 0;
+        /// checks if package abi is present in this storage
+        /// NOTE: Operation must be thread safe. Multiple calls will occur in parallel
         virtual ExpectedL<Unit> stat(StringView url) const = 0;
+        /// download a package zip from this storage
+        /// NOTE: Operation must be thread safe. Multiple calls will occur in parallel
         virtual ExpectedL<Unit> download_file(StringView object, const Path& archive) const = 0;
         virtual ExpectedL<Unit> upload_file(StringView object, const Path& archive) const = 0;
     };


### PR DESCRIPTION
https://github.com/microsoft/vcpkg/issues/38404

This adds parallel operations using `parallel_for_each` /  `parallel_transform` to `ObjectStorageProvider`. There is currently no limitation placed on the parallelisation past that imposed by the threadpool.

This impacts the following caching providers
* `GcsStorageTool`
* `AwsStorageTool`
* `CosStorageTool`

Questions
- [ ] This adds parallelisation at the provider level. Is this the right place to add it?
- [ ] Testing?
  * I couldn't find any tests for the affected caching providers and this isn't something I would normally test for anyway (implementation detail).