### PR TITLE
Fixed version export in spdx module

### DIFF
--- a/src/vcpkg-test/spdx.cpp
+++ b/src/vcpkg-test/spdx.cpp
@@ -43,7 +43,7 @@ TEST_CASE ("spdx maximum serialization", "[spdx]")
   "name": "zlib:arm-uwp@1.0#5 ABIHASH",
   "creationInfo": {
     "creators": [
-      "Tool: vcpkg-unknownhash"
+      "Tool: vcpkg-2999-12-31-unknownhash"
     ],
     "created": "now"
   },
@@ -197,7 +197,7 @@ TEST_CASE ("spdx minimum serialization", "[spdx]")
   "name": "zlib:arm-uwp@1.0 deadbeef",
   "creationInfo": {
     "creators": [
-      "Tool: vcpkg-unknownhash"
+      "Tool: vcpkg-2999-12-31-unknownhash"
     ],
     "created": "now+1"
   },
@@ -338,7 +338,7 @@ TEST_CASE ("spdx concat resources", "[spdx]")
   "name": "zlib:arm-uwp@1.0 deadbeef",
   "creationInfo": {
     "creators": [
-      "Tool: vcpkg-unknownhash"
+      "Tool: vcpkg-2999-12-31-unknownhash"
     ],
     "created": "now+1"
   },

--- a/src/vcpkg/spdx.cpp
+++ b/src/vcpkg/spdx.cpp
@@ -160,7 +160,7 @@ std::string vcpkg::create_spdx_sbom(const InstallPlanAction& action,
     {
         auto& cinfo = doc.insert(SpdxCreationInfo, Json::Object());
         auto& creators = cinfo.insert(JsonIdCreators, Json::Array());
-        creators.push_back(Strings::concat("Tool: vcpkg-", VCPKG_VERSION_AS_STRING));
+        creators.push_back(Strings::concat("Tool: vcpkg-", VCPKG_BASE_VERSION_AS_STRING, '-', VCPKG_VERSION_AS_STRING));
         cinfo.insert(JsonIdCreated, std::move(created_time));
     }
 


### PR DESCRIPTION
Fixed version export in spdx module.

Current behavior: `Tool: vcpkg-$hash`
New behavior: `Tool: vcpkg-$version-$hash` like in [Curl module](https://github.com/microsoft/vcpkg-tool/blob/968db4d0d2d2b210d5c825351648886cf67e306c/src/vcpkg/base/downloads.cpp#L607).

Perhaps there should only be $version, without $hash: `Tool: vcpkg-$version`.