### PR TITLE
Use correct branch name in json schema ids

### DIFF
--- a/docs/artifact.schema.json
+++ b/docs/artifact.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/master/docs/artifact.schema.json",
+  "$id": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/artifact.schema.json",
   "type": "object",
   "properties": {
     "id": {

--- a/docs/vcpkg-configuration.schema.json
+++ b/docs/vcpkg-configuration.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/master/docs/vcpkg-configuration.schema.json",
+  "$id": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg-configuration.schema.json",
   "type": "object",
   "properties": {
     "default-registry": {

--- a/docs/vcpkg-schema-definitions.schema.json
+++ b/docs/vcpkg-schema-definitions.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/master/docs/vcpkg-schema-definitions.schema.json",
+  "$id": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg-schema-definitions.schema.json",
   "definitions": {
     "artifact-references": {
       "description": "A key/value pair of artifact name to selected artifact version.",

--- a/docs/vcpkg.schema.json
+++ b/docs/vcpkg.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/master/docs/vcpkg.schema.json",
+  "$id": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "type": "object",
   "allOf": [
     {


### PR DESCRIPTION
The `$id` fields in all JSON schemas were wrongly referring to a non-existent `master` branch. This isn't too bad because GitHub has some magic to fall back to the default branch when non-existent `master` branches are requested, but it is still incorrect. Fix it.
