### PR TITLE
Fix wrong Header-only usage message

### DIFF
--- a/azure-pipelines/e2e-ports/overlays/vcpkg-header-only/portfile.cmake
+++ b/azure-pipelines/e2e-ports/overlays/vcpkg-header-only/portfile.cmake
@@ -1,0 +1,4 @@
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" "license text")
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/include")
+file(WRITE "${CURRENT_PACKAGES_DIR}/include/vcpkg-header-only.h" "// header only port")

--- a/azure-pipelines/e2e-ports/overlays/vcpkg-header-only/vcpkg.json
+++ b/azure-pipelines/e2e-ports/overlays/vcpkg-header-only/vcpkg.json
@@ -1,0 +1,4 @@
+{
+  "name": "vcpkg-header-only",
+  "version": "1"
+}

--- a/azure-pipelines/end-to-end-tests-dir/usage.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/usage.ps1
@@ -34,17 +34,25 @@ wrong-pkgconfig provides pkg-config modules:
 
   # Test lib
   wrong-pkgconfig
+"@,
+@"
+vcpkg-header-only is header-only and can be used from CMake via:
+
+  find_path(VCPKG_HEADER_ONLY_INCLUDE_DIRS "vcpkg-header-only.h")
+  target_include_directories(main PRIVATE `${VCPKG_HEADER_ONLY_INCLUDE_DIRS})
 "@
 )
 
 [string[]]$prohibitedUsages = @(
-    'vcpkg-empty-port provides CMake targets'
+    'vcpkg-empty-port provides CMake targets',
+    'vcpkg-header-only provides CMake targets'
 )
 
 [string]$usage = Run-VcpkgAndCaptureOutput ($commonArgs + @('install',
     'vcpkg-cmake-config-many-targets',
     'vcpkg-empty-port',
     'vcpkg-explicit-usage',
+    'vcpkg-header-only',
     'vcpkg-hello-world-1',
     'vcpkg-hello-world-2',
     'wrong-pkgconfig[header-only-good]'

--- a/src/vcpkg/commands.install.cpp
+++ b/src/vcpkg/commands.install.cpp
@@ -981,7 +981,7 @@ namespace vcpkg
                 msg.append_indent()
                     .append_raw("find_path(")
                     .append_raw(name)
-                    .append_raw("_INCLUDE_DIRS \")")
+                    .append_raw("_INCLUDE_DIRS \"")
                     .append_raw(header_path)
                     .append_raw("\")\n");
                 msg.append_indent()


### PR DESCRIPTION
This regression is from PR #1368.
The wrong message as below:
```
bext-sml is header-only and can be used from CMake via:

  find_path(BEXT_SML_INCLUDE_DIRS ")boost/sml.hpp")
  target_include_directories(main PRIVATE ${BEXT_SML_INCLUDE_DIRS})
```