### PR TITLE
AWS S3 cache miss should not issue warning

### DIFF
--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -1166,7 +1166,7 @@ namespace
                 // aws-cli is covered.
                 if (exit->exit_code == 0 || exit->exit_code == 1)
                 {
-                    if (Strings::trim(exit->output) == "")
+                    if (Strings::trim(exit->output).empty())
                     {
                         return CacheAvailability::unavailable;
                     }


### PR DESCRIPTION
This fixes https://github.com/microsoft/vcpkg/issues/31932

Previously, when using the AWS S3 binary cache, every cache miss triggered the following message:
```
warning: error: aws failed with exit code: (1).
```
This was both noisy and misleading (because it was not an actual error).

Now AWS cache misses are treated silently, the same way as cache misses from the local cache are.

> [!NOTE]
> I don't have access to either Google Cloud Storage or Tencent Cloud Object Storage sources, so I don't know whether the same kind of issue happens there too; in any case, fixing those should be easy using the newly introduced interface. (Their `stat()` and `download_file()` methods need to be adapted to return `CacheResult::miss` in the relevant cases.)