### PR TITLE
Http proxy basic authentication on windows

### DIFF
--- a/include/vcpkg/base/downloads.h
+++ b/include/vcpkg/base/downloads.h
@@ -130,7 +130,7 @@ namespace vcpkg
         std::wstring password;
     };
 
-    bool operator==(const ProxyCredentials &lhs, const ProxyCredentials &rhs);
+    bool operator==(const ProxyCredentials& lhs, const ProxyCredentials& rhs);
 
     struct ProxyUrlParts
     {
@@ -138,7 +138,7 @@ namespace vcpkg
         Optional<ProxyCredentials> credentials;
     };
 
-    bool operator==(const ProxyUrlParts &lhs, const ProxyUrlParts &rhs);
+    bool operator==(const ProxyUrlParts& lhs, const ProxyUrlParts& rhs);
 
     // Parses strings such as http://login:password@host.com:8080
     // Into plain URL and credentials

--- a/include/vcpkg/base/downloads.h
+++ b/include/vcpkg/base/downloads.h
@@ -123,4 +123,24 @@ namespace vcpkg
     // Notably, callers of this function can't use Strings::percent_encode because the URL
     // is likely to contain query parameters or similar.
     std::string url_encode_spaces(StringView url);
+
+    struct ProxyCredentials
+    {
+        std::wstring username;
+        std::wstring password;
+    };
+
+    bool operator==(const ProxyCredentials &lhs, const ProxyCredentials &rhs);
+
+    struct ProxyUrlParts
+    {
+        std::wstring host;
+        Optional<ProxyCredentials> credentials;
+    };
+
+    bool operator==(const ProxyUrlParts &lhs, const ProxyUrlParts &rhs);
+
+    // Parses strings such as http://login:password@host.com:8080
+    // Into plain URL and credentials
+    ProxyUrlParts parse_proxy_url(const std::wstring& url);
 }

--- a/src/vcpkg-test/downloads.cpp
+++ b/src/vcpkg-test/downloads.cpp
@@ -178,3 +178,13 @@ TEST_CASE ("url_encode_spaces", "[downloads]")
     REQUIRE(url_encode_spaces("https://example.com/a  space/b?query=value&query2=value2") ==
             "https://example.com/a%20%20space/b?query=value&query2=value2");
 }
+
+TEST_CASE ("parse_proxy_url", "[downloads]")
+{
+    REQUIRE(parse_proxy_url(L"my-hostname.com:8080") == ProxyUrlParts{L"my-hostname.com:8080", {}});
+    REQUIRE(parse_proxy_url(L"Joe:secret@my-hostname.com:8080") ==
+            ProxyUrlParts{L"my-hostname.com:8080", ProxyCredentials{L"Joe", L"secret"}});
+    REQUIRE(parse_proxy_url(L"https://my-hostname.com:8080") == ProxyUrlParts{L"https://my-hostname.com:8080", {}});
+    REQUIRE(parse_proxy_url(L"https://Joe:secret@my-hostname.com:8080") ==
+            ProxyUrlParts{L"https://my-hostname.com:8080", ProxyCredentials{L"Joe", L"secret"}});
+}

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -134,8 +134,8 @@ namespace vcpkg
     void set_proxy_credentials_on_redirect(HINTERNET hInternet,
                                            DWORD_PTR dwContext,
                                            DWORD dwInternetStatus,
-                                           LPVOID lpvStatusInformation,
-                                           DWORD dwStatusInformationLength)
+                                           LPVOID /*lpvStatusInformation*/,
+                                           DWORD /*dwStatusInformationLength*/)
     {
         if (dwInternetStatus == WINHTTP_CALLBACK_STATUS_REDIRECT)
         {

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -42,14 +42,14 @@ namespace vcpkg
         return lhs.username == rhs.username && lhs.password == rhs.password;
     }
 
-    bool operator==(const ProxyUrlParts &lhs, const ProxyUrlParts &rhs)
+    bool operator==(const ProxyUrlParts& lhs, const ProxyUrlParts& rhs)
     {
         return lhs.host == rhs.host && lhs.credentials == rhs.credentials;
     }
 
     ProxyUrlParts parse_proxy_url(const std::wstring& url)
     {
-        std::wregex scheme_pattern(L"^(.+://)(.*)");   // Matches scheme part
+        std::wregex scheme_pattern(L"^(.+://)(.*)");           // Matches scheme part
         std::wregex credentials_pattern(L"([^:]+):(.*)@(.*)"); // Matches login:pwd@host:port
 
         std::wstring protocol;


### PR DESCRIPTION
This is a proposition to solve the issue reported in this [discussion](https://github.com/microsoft/vcpkg/discussions/38827).

Instead of just providing the content of HTTPS_PROXY environment variable, we now parse it to extract proxy credentials, then provide it to WinHTTP API (which is not as simple as one could expect).

I've been able to validate the behaviour in a test environment with a squid proxy.

**Notes**
- use of regex may be overkill ... 
- In order to have the whole chain working, this would need to be ported to C executable tls12-download. Otherwise, windows users behind a proxy still need to download vcpkg.exe without the bootstrap script
