### PR TITLE
Add missing new line

### DIFF
--- a/src/vcpkg/base/checks.cpp
+++ b/src/vcpkg/base/checks.cpp
@@ -146,6 +146,7 @@ namespace vcpkg
     [[noreturn]] void Checks::msg_exit_maybe_upgrade(const LineInfo& line_info, const LocalizedString& error_message)
     {
         msg::write_unlocalized_text_to_stderr(Color::error, error_message);
+        msg::write_unlocalized_text_to_stderr(Color::none, "\n");
         display_upgrade_message();
         exit_fail(line_info);
     }


### PR DESCRIPTION
Fixes #38883 
Before:
```
➜  vcpkg git:(test-features) ✗ ./vcpkg x-package-info libtorch
This command requires --x-jsonnote: updating vcpkg by rerunning bootstrap-vcpkg may resolve this failure.
```
After:
```
➜  vcpkg git:(test-features) ✗ vcpkg x-package-info libtorch                                   
This command requires --x-json
note: updating vcpkg by rerunning bootstrap-vcpkg may resolve this failure.
```