### PR TITLE
Add support for selecting specific MSVC toolset from ENV instead of custom triplet.

### DIFF
--- a/include/vcpkg/base/message-data.inc.h
+++ b/include/vcpkg/base/message-data.inc.h
@@ -1086,6 +1086,10 @@ DECLARE_MESSAGE(
     "",
     "Could not detect vcpkg-root. If you are trying to use a copy of vcpkg that you've built, you must "
     "define the VCPKG_ROOT environment variable to point to a cloned copy of https://github.com/Microsoft/vcpkg.")
+DECLARE_MESSAGE(ErrorNoMSVCToolset,
+                (msg::triplet, msg::version),
+                "",
+                "in triplet {triplet}: Unable to find the specific MSVC toolset version {version}")
 DECLARE_MESSAGE(ErrorNoVSInstance,
                 (msg::triplet),
                 "",

--- a/locales/messages.json
+++ b/locales/messages.json
@@ -641,6 +641,8 @@
   "ErrorInvalidManifestModeOption": "The option --{option} is not supported in manifest mode.",
   "_ErrorInvalidManifestModeOption.comment": "An example of {option} is editable.",
   "ErrorMissingVcpkgRoot": "Could not detect vcpkg-root. If you are trying to use a copy of vcpkg that you've built, you must define the VCPKG_ROOT environment variable to point to a cloned copy of https://github.com/Microsoft/vcpkg.",
+  "ErrorNoMSVCToolset": "in triplet {triplet}: Unable to find the specific MSVC toolset version {version}",
+  "_ErrorNoMSVCToolset.comment": "An example of {triplet} is x64-windows. An example of {version} is 1.3.8.",
   "ErrorNoVSInstance": "in triplet {triplet}: Unable to find a valid Visual Studio instance",
   "_ErrorNoVSInstance.comment": "An example of {triplet} is x64-windows.",
   "ErrorNoVSInstanceAt": "at \"{path}\"",

--- a/locales/messages.zh-Hans.json
+++ b/locales/messages.zh-Hans.json
@@ -453,6 +453,7 @@
   "ErrorInvalidExtractOption": "--{option} 必须设置为非负整数或 \"AUTO\"。",
   "ErrorInvalidManifestModeOption": "清单模式下不支持选项 --{option}。",
   "ErrorMissingVcpkgRoot": "无法检测 vcpkg-root。如果尝试使用已生成的 vcpkg 的副本，则必须定义 VCPKG_ROOT 环境变量，以指向 https://github.com/Microsoft/vcpkg 的克隆副本。",
+  "ErrorNoMSVCToolset": "在三元组 {triplet} 中: 无法找到指定的 MSVC 版本 {version}",
   "ErrorNoVSInstance": "在三元组 {triplet} 中: 无法找到有效的 Visual Studio 实例",
   "ErrorNoVSInstanceAt": "位于“{path}”",
   "ErrorNoVSInstanceFullVersion": "具有工具集版本前缀 {version}",


### PR DESCRIPTION
First of all, triplet `x64-windows` is just selecting a MSVC toolset by sorting order, it doesn't tie to any specific MSVC toolset version. So, I don't agree we need to create a separate custom triplet for selecting another MSVC toolset than vcpkg automatically selects for us. Creating a custom one is adding unnessesary complexity and nothing is better than a envvar.

It is quite common for a developer that have multiple MSVC toolset installed. It is also common that not all old version ports can be compiled with latest MSVC toolset, for example, Qt 6.4.3 cannot be compiled with latest 14.40 toolset.

So, very reasonable to provide a environment variable to force vcpkg choosing a specific version of MSVC. 

In both classic and manifest mode, if the toolset version changes, it will cause the buildtree to rebuild because the compiler hash changed. So, not a problem.

Related topic: https://github.com/microsoft/vcpkg/discussions/25905