### PR TITLE
Make print_plan actually print.

### DIFF
--- a/include/vcpkg/dependencies.h
+++ b/include/vcpkg/dependencies.h
@@ -214,5 +214,5 @@ namespace vcpkg
 
     FormattedPlan format_plan(const ActionPlan& action_plan, const Path& builtin_ports_dir);
 
-    void print_plan(const ActionPlan& action_plan, const bool is_recursive, const Path& builtin_ports_dir);
+    FormattedPlan print_plan(const ActionPlan& action_plan, const Path& builtin_ports_dir);
 }

--- a/src/vcpkg/commands.ci.cpp
+++ b/src/vcpkg/commands.ci.cpp
@@ -490,7 +490,7 @@ namespace vcpkg
 
         if (is_dry_run)
         {
-            print_plan(action_plan, true, paths.builtin_ports_directory());
+            print_plan(action_plan, paths.builtin_ports_directory());
             if (!regressions.empty())
             {
                 msg::println(Color::error, msgCiBaselineRegressionHeader);

--- a/src/vcpkg/commands.install.cpp
+++ b/src/vcpkg/commands.install.cpp
@@ -1324,7 +1324,12 @@ namespace vcpkg
         }
 #endif // defined(_WIN32)
 
-        print_plan(action_plan, is_recursive, paths.builtin_ports_directory());
+        const auto formatted = print_plan(action_plan, paths.builtin_ports_directory());
+        if (!is_recursive && formatted.has_removals)
+        {
+            msg::println_warning(msgPackagesToRebuildSuggestRecurse);
+            Checks::exit_fail(VCPKG_LINE_INFO);
+        }
 
         auto it_pkgsconfig = options.settings.find(SwitchXWriteNuGetPackagesConfig);
         if (it_pkgsconfig != options.settings.end())

--- a/src/vcpkg/commands.set-installed.cpp
+++ b/src/vcpkg/commands.set-installed.cpp
@@ -210,7 +210,7 @@ namespace vcpkg
         auto status_db = database_load_check(fs, paths.installed());
         adjust_action_plan_to_status_db(action_plan, status_db);
 
-        print_plan(action_plan, true, paths.builtin_ports_directory());
+        print_plan(action_plan, paths.builtin_ports_directory());
 
         if (auto p_pkgsconfig = maybe_pkgconfig.get())
         {

--- a/src/vcpkg/commands.upgrade.cpp
+++ b/src/vcpkg/commands.upgrade.cpp
@@ -190,7 +190,7 @@ namespace vcpkg
 
         Checks::check_exit(VCPKG_LINE_INFO, !action_plan.empty());
         action_plan.print_unsupported_warnings();
-        print_plan(action_plan, true, paths.builtin_ports_directory());
+        print_plan(action_plan, paths.builtin_ports_directory());
 
         if (!no_dry_run)
         {

--- a/src/vcpkg/dependencies.cpp
+++ b/src/vcpkg/dependencies.cpp
@@ -1316,15 +1316,11 @@ namespace vcpkg
         return ret;
     }
 
-    void print_plan(const ActionPlan& action_plan, const bool is_recursive, const Path& builtin_ports_dir)
+    FormattedPlan print_plan(const ActionPlan& action_plan, const Path& builtin_ports_dir)
     {
         auto formatted = format_plan(action_plan, builtin_ports_dir);
         msg::print(formatted.text);
-        if (!is_recursive && formatted.has_removals)
-        {
-            msg::println_warning(msgPackagesToRebuildSuggestRecurse);
-            Checks::exit_fail(VCPKG_LINE_INFO);
-        }
+        return formatted;
     }
 
     namespace


### PR DESCRIPTION
print_plan does 2 things. First, it formats the action plan and prints it to the console. Second, if there were removals in the plan and the intent is not recursive, it terminates vcpkg. A function named 'print' should not be terminating vcpkg.

Moreover, only one caller actually desires this terminating behavior: the install command. All other users hard coded a value of true.

This suggests that the decision to terminate should be localized to that one caller rather than spread over everything.