### PR TITLE
Added `extract_regex_match` function and updated `NuGetProvider`

### DIFF
--- a/include/vcpkg/tools.h
+++ b/include/vcpkg/tools.h
@@ -50,6 +50,10 @@ namespace vcpkg
                                                           StringLiteral tool_name,
                                                           std::string&& output,
                                                           const Path& exe_path);
+    ExpectedL<std::string> extract_regex_match(StringLiteral regex,
+                                               StringLiteral tool_name,
+                                               std::string &&output,
+                                               const Path &exe_path);
 
     ExpectedL<Path> find_system_tar(const ReadOnlyFilesystem& fs);
     ExpectedL<Path> find_system_cmake(const ReadOnlyFilesystem& fs);

--- a/include/vcpkg/tools.h
+++ b/include/vcpkg/tools.h
@@ -52,8 +52,8 @@ namespace vcpkg
                                                           const Path& exe_path);
     ExpectedL<std::string> extract_regex_match(StringLiteral regex,
                                                StringLiteral tool_name,
-                                               std::string &&output,
-                                               const Path &exe_path);
+                                               std::string&& output,
+                                               const Path& exe_path);
 
     ExpectedL<Path> find_system_tar(const ReadOnlyFilesystem& fs);
     ExpectedL<Path> find_system_cmake(const ReadOnlyFilesystem& fs);

--- a/src/vcpkg/tools.cpp
+++ b/src/vcpkg/tools.cpp
@@ -180,6 +180,22 @@ namespace vcpkg
                              .append_raw(std::move(output)));
     }
 
+    ExpectedL<std::string> extract_regex_match(StringLiteral regex,
+                                               StringLiteral tool_name,
+                                               std::string &&output,
+                                               const Path &exe_path)
+    {
+        std::smatch match;
+        if (std::regex_search(output, match, std::regex(regex.data(), regex.size())))
+        {
+            return { match[1], expected_left_tag };
+        }
+
+        return std::move(msg::format_error(msgUnexpectedToolOutput, msg::tool_name = tool_name, msg::path = exe_path)
+                         .append_raw('\n')
+                         .append_raw(std::move(output)));
+    }
+
     struct ToolProvider
     {
         virtual StringView tool_data_name() const = 0;
@@ -316,7 +332,7 @@ namespace vcpkg
                     // NuGet Version: 4.6.2.5055
                     // usage: NuGet <command> [args] [options]
                     // Type 'NuGet help <command>' for help on a specific command.
-                    return extract_prefixed_nonwhitespace("NuGet Version: ", Tools::NUGET, std::move(output), exe_path);
+                    return extract_regex_match(R"###(^NuGet [^:]+: (\S+))###", Tools::NUGET, std::move(output), exe_path);
                 });
         }
     };

--- a/src/vcpkg/tools.cpp
+++ b/src/vcpkg/tools.cpp
@@ -182,18 +182,18 @@ namespace vcpkg
 
     ExpectedL<std::string> extract_regex_match(StringLiteral regex,
                                                StringLiteral tool_name,
-                                               std::string &&output,
-                                               const Path &exe_path)
+                                               std::string&& output,
+                                               const Path& exe_path)
     {
         std::smatch match;
         if (std::regex_search(output, match, std::regex(regex.data(), regex.size())))
         {
-            return { match[1], expected_left_tag };
+            return {match[1], expected_left_tag};
         }
 
         return std::move(msg::format_error(msgUnexpectedToolOutput, msg::tool_name = tool_name, msg::path = exe_path)
-                         .append_raw('\n')
-                         .append_raw(std::move(output)));
+                             .append_raw('\n')
+                             .append_raw(std::move(output)));
     }
 
     struct ToolProvider
@@ -332,7 +332,8 @@ namespace vcpkg
                     // NuGet Version: 4.6.2.5055
                     // usage: NuGet <command> [args] [options]
                     // Type 'NuGet help <command>' for help on a specific command.
-                    return extract_regex_match(R"###(^NuGet [^:]+: (\S+))###", Tools::NUGET, std::move(output), exe_path);
+                    return extract_regex_match(
+                        R"###(^NuGet [^:]+: (\S+))###", Tools::NUGET, std::move(output), exe_path);
                 });
         }
     };


### PR DESCRIPTION
A new function `extract_regex_match` has been added to the `vcpkg` namespace in `tools.cpp`. This function performs a regex search on an output string and returns the first match or a formatted error message.

The `NuGetProvider` struct has been updated to replace the `extract_prefixed_nonwhitespace` function call with the new `extract_regex_match` function. This change enhances the flexibility and robustness of version extraction by using a regex match instead of a fixed prefix.

Fixes microsoft/vcpkg#38940