### PR TITLE
Add VCPKG_SCRIPTS_DIR and VCPKG_TOOLS_DIR to the CMake command call

### DIFF
--- a/src/vcpkg/buildenvironment.cpp
+++ b/src/vcpkg/buildenvironment.cpp
@@ -17,6 +17,8 @@ namespace vcpkg
         local_variables.emplace_back("BUILDTREES_DIR", paths.buildtrees());
         local_variables.emplace_back("_VCPKG_INSTALLED_DIR", paths.installed().root());
         local_variables.emplace_back("DOWNLOADS", paths.downloads);
+        local_variables.emplace_back("VCPKG_SCRIPTS_DIR", paths.scripts);
+        local_variables.emplace_back("VCPKG_TOOLS_DIR", paths.tools);
         local_variables.emplace_back("VCPKG_MANIFEST_INSTALL", "OFF");
         return make_basic_cmake_cmd(paths.get_tool_exe(Tools::CMAKE, out_sink), cmake_script, local_variables);
     }


### PR DESCRIPTION
To make stuff mentioned in https://github.com/microsoft/vcpkg-tool/pull/1315#issuecomment-2138855647 not magically (and maybe even wrongly) calculate those paths. 