### PR TITLE
Use curl for download on windows when proxy auth is required

### DIFF
--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -761,7 +761,13 @@ namespace vcpkg
         download_path_part_path += ".part";
 
 #if defined(_WIN32)
-        if (headers.size() == 0)
+        auto maybe_https_proxy_env = get_environment_variable(EnvironmentVariableHttpsProxy);
+        bool needs_proxy_auth = false;
+        if (maybe_https_proxy_env) {
+            const auto& proxy_url = maybe_https_proxy_env.value_or_exit(VCPKG_LINE_INFO);
+            needs_proxy_auth = proxy_url.find('@') != std::string::npos;
+        }
+        if (headers.size() == 0 && !needs_proxy_auth)
         {
             auto split_uri = split_uri_view(url).value_or_exit(VCPKG_LINE_INFO);
             auto authority = split_uri.authority.value_or_exit(VCPKG_LINE_INFO).substr(2);

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -763,7 +763,8 @@ namespace vcpkg
 #if defined(_WIN32)
         auto maybe_https_proxy_env = get_environment_variable(EnvironmentVariableHttpsProxy);
         bool needs_proxy_auth = false;
-        if (maybe_https_proxy_env) {
+        if (maybe_https_proxy_env)
+        {
             const auto& proxy_url = maybe_https_proxy_env.value_or_exit(VCPKG_LINE_INFO);
             needs_proxy_auth = proxy_url.find('@') != std::string::npos;
         }


### PR DESCRIPTION
This is a proposition to solve the issue reported in this https://github.com/microsoft/vcpkg/discussions/38827.

This replaces the first proposed implementation in https://github.com/microsoft/vcpkg-tool/pull/1410, following suggestions of @BillyONeal : curl is now used instead of winhttp for download as soon as we have credentials in the URL provided for HTTP proxy (through the HTTPS_PROXY environment variable).

**Status:**
 - Quick implementation to check that it is a better way to go than previous implementation.
   Just checking for "@" in the proxy URL, which might need some refinement ? not obvious though.
 - Successfully tested with squid proxy in test env
 - Question: should we use curl download as soon as a proxy url is defined ? that would eliminate some code from the winhttp download implementation.