### PR TITLE
Remove hardcoding ".DS_Store"

### DIFF
--- a/src/vcpkg/archives.cpp
+++ b/src/vcpkg/archives.cpp
@@ -360,7 +360,7 @@ namespace vcpkg
                                                           .string_arg(destination)
                                                           .string_arg("*")
                                                           .string_arg("--exclude")
-                                                          .string_arg(".DS_Store"),
+                                                          .string_arg(FileDotDsStore),
                                                       settings),
                        "zip");
 #endif

--- a/src/vcpkg/archives.cpp
+++ b/src/vcpkg/archives.cpp
@@ -1,3 +1,4 @@
+#include <vcpkg/base/contractual-constants.h>
 #include <vcpkg/base/files.h>
 #include <vcpkg/base/parse.h>
 #include <vcpkg/base/strings.h>

--- a/src/vcpkg/commands.install.cpp
+++ b/src/vcpkg/commands.install.cpp
@@ -54,7 +54,7 @@ namespace vcpkg
                            fs.exists(source_dir, IgnoreErrors{}),
                            Strings::concat("Source directory ", source_dir, "does not exist"));
         auto files = fs.get_files_recursive(source_dir, VCPKG_LINE_INFO);
-        Util::erase_remove_if(files, [](Path& path) { return path.filename() == ".DS_Store"; });
+        Util::erase_remove_if(files, [](Path& path) { return path.filename() == FileDotDsStore; });
         install_files_and_write_listfile(fs, source_dir, files, destination_dir);
     }
     void install_files_and_write_listfile(const Filesystem& fs,
@@ -198,7 +198,7 @@ namespace vcpkg
     static SortedVector<std::string> build_list_of_package_files(const ReadOnlyFilesystem& fs, const Path& package_dir)
     {
         std::vector<Path> package_file_paths = fs.get_files_recursive(package_dir, IgnoreErrors{});
-        Util::erase_remove_if(package_file_paths, [](Path& path) { return path.filename() == ".DS_Store"; });
+        Util::erase_remove_if(package_file_paths, [](Path& path) { return path.filename() == FileDotDsStore; });
         const size_t package_remove_char_count = package_dir.native().size() + 1; // +1 for the slash
         auto package_files = Util::fmap(package_file_paths, [package_remove_char_count](const Path& target) {
             return std::string(target.generic_u8string(), package_remove_char_count);

--- a/src/vcpkg/paragraphs.cpp
+++ b/src/vcpkg/paragraphs.cpp
@@ -572,7 +572,7 @@ namespace vcpkg::Paragraphs
         Util::sort(port_dirs);
 
         Util::erase_remove_if(port_dirs,
-                              [&](auto&& port_dir_entry) { return port_dir_entry.filename() == ".DS_Store"; });
+                              [&](auto&& port_dir_entry) { return port_dir_entry.filename() == FileDotDsStore; });
 
         for (auto&& path : port_dirs)
         {

--- a/src/vcpkg/postbuildlint.cpp
+++ b/src/vcpkg/postbuildlint.cpp
@@ -1468,7 +1468,7 @@ namespace vcpkg
             for (auto&& absolute_path : fs.get_regular_files_non_recursive(start_in, IgnoreErrors{}))
             {
                 auto filename = absolute_path.filename();
-                if (filename == "CONTROL" || filename == "BUILD_INFO" || filename == ".DS_Store")
+                if (filename == "CONTROL" || filename == "BUILD_INFO" || filename == FileDotDsStore)
                 {
                     continue;
                 }

--- a/src/vcpkg/registries.cpp
+++ b/src/vcpkg/registries.cpp
@@ -752,7 +752,7 @@ namespace
             for (auto&& port_directory : *port_directories)
             {
                 auto filename = port_directory.filename();
-                if (filename == ".DS_Store") continue;
+                if (filename == FileDotDsStore) continue;
                 out.emplace_back(filename.data(), filename.size());
             }
 

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -1,5 +1,6 @@
 #include <vcpkg/base/fwd/message_sinks.h>
 
+#include <vcpkg/base/contractual-constants.h>
 #include <vcpkg/base/downloads.h>
 #include <vcpkg/base/expected.h>
 #include <vcpkg/base/files.h>
@@ -738,7 +739,7 @@ namespace vcpkg
             auto files = fs.get_regular_files_non_recursive(this->scripts / "cmake", VCPKG_LINE_INFO);
             for (auto&& file : files)
             {
-                if (file.filename() == ".DS_Store")
+                if (file.filename() == FileDotDsStore)
                 {
                     continue;
                 }


### PR DESCRIPTION
I found some hardcoding when I read the source of vcpkg search, seems ```contractual-constants``` is a new file and lots of hardcoding is not removed, like ```CONTROL``` and ```BUILD_INFO``` , and I only removed ```.DS_Store``` now.