### PR TITLE
Fix stealth merge conflict

### DIFF
--- a/src/vcpkg/registries.cpp
+++ b/src/vcpkg/registries.cpp
@@ -1074,7 +1074,14 @@ namespace
 
         const auto& git_tree = port_versions_soa.git_trees()[it - port_versions.begin()];
         return m_paths.versions_dot_git_dir()
-            .then([&, this](Path&& dot_git) { return m_paths.git_checkout_port(port_name, git_tree, dot_git); })
+            .then([&, this](Path&& dot_git) {
+                return m_paths.git_checkout_port(port_name, git_tree, dot_git).map_error([](LocalizedString&& err) {
+                    return std::move(err)
+                        .append_raw('\n')
+                        .append_raw(NotePrefix)
+                        .append(msgSeeURL, msg::url = docs::troubleshoot_versioning_url);
+                });
+            })
             .map([&git_tree](Path&& p) -> PortLocation {
                 return {
                     std::move(p),

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -1210,7 +1210,6 @@ namespace vcpkg
             }
 
             error.append_raw('\n').append(std::move(maybe_git_read_tree_output).error());
-            error.append(msgSeeURL, msg::url = docs::troubleshoot_versioning_url);
             return error;
         }
 


### PR DESCRIPTION
Between:
* https://github.com/microsoft/vcpkg-tool/pull/1210
* https://github.com/microsoft/vcpkg-tool/pull/1408

This adds the URL to normal registries use of this but doesn't repeat the URL over and over again in ci-verify-versions.