### PR TITLE
Fix export command usage

### DIFF
--- a/include/vcpkg/base/message-data.inc.h
+++ b/include/vcpkg/base/message-data.inc.h
@@ -613,7 +613,7 @@ DECLARE_MESSAGE(CmdExportEmptyPlan,
 DECLARE_MESSAGE(CmdExportExample1,
                 (),
                 "This is a command line, only <port names> and the out_dir part should be localized",
-                "vcpkg export <port names> [--nuget] [--directory=out_dir]")
+                "vcpkg export <port names> [--nuget] [--output-dir=out_dir]")
 DECLARE_MESSAGE(CmdExportOpt7Zip, (), "", "Exports to a 7zip (.7z) file")
 DECLARE_MESSAGE(CmdExportOptChocolatey, (), "", "Exports a Chocolatey package (experimental)")
 DECLARE_MESSAGE(CmdExportOptDebug, (), "", "Enables prefab debug")

--- a/locales/messages.json
+++ b/locales/messages.json
@@ -358,7 +358,7 @@
   "CmdEnvOptions": "Adds installed {path} to {env_var}",
   "_CmdEnvOptions.comment": "An example of {path} is /foo/bar. An example of {env_var} is VCPKG_DEFAULT_TRIPLET.",
   "CmdExportEmptyPlan": "Refusing to create an export of zero packages. Install packages before exporting.",
-  "CmdExportExample1": "vcpkg export <port names> [--nuget] [--directory=out_dir]",
+  "CmdExportExample1": "vcpkg export <port names> [--nuget] [--output-dir=out_dir]",
   "_CmdExportExample1.comment": "This is a command line, only <port names> and the out_dir part should be localized",
   "CmdExportOpt7Zip": "Exports to a 7zip (.7z) file",
   "CmdExportOptChocolatey": "Exports a Chocolatey package (experimental)",


### PR DESCRIPTION
It seems export command gives wrong help message for specifying output directory.

```
C:\Users\myd7349>vcpkg export edflib --directory D:\edflib
error: unexpected switch: --directory
vcpkg export <port names> [--nuget] [--directory=out_dir]
vcpkg export zlib zlib:x64-windows boost --nuget
Options:
    ...
```