### PR TITLE
Add "-ForceEnglishOutput" flag to the NuGet help command in tools.cpp

### DIFF
--- a/src/vcpkg/tools.cpp
+++ b/src/vcpkg/tools.cpp
@@ -303,9 +303,7 @@ namespace vcpkg
 #if !defined(_WIN32)
             cmd.string_arg(cache.get_tool_path(Tools::MONO, status_sink));
 #endif // ^^^ !_WIN32
-            cmd.string_arg(exe_path)
-                .string_arg("help")
-                .string_arg("-ForceEnglishOutput");
+            cmd.string_arg(exe_path).string_arg("help").string_arg("-ForceEnglishOutput");
             return run_to_extract_version(Tools::NUGET, exe_path, std::move(cmd))
 #if !defined(_WIN32)
                 .map_error([](LocalizedString&& error) {

--- a/src/vcpkg/tools.cpp
+++ b/src/vcpkg/tools.cpp
@@ -303,7 +303,9 @@ namespace vcpkg
 #if !defined(_WIN32)
             cmd.string_arg(cache.get_tool_path(Tools::MONO, status_sink));
 #endif // ^^^ !_WIN32
-            cmd.string_arg(exe_path);
+            cmd.string_arg(exe_path)
+                .string_arg("help")
+                .string_arg("-ForceEnglishOutput");
             return run_to_extract_version(Tools::NUGET, exe_path, std::move(cmd))
 #if !defined(_WIN32)
                 .map_error([](LocalizedString&& error) {


### PR DESCRIPTION
This pull request rewrites #1418 without adding any new function for regex matching. Instead, it uses the `nuget help -ForceEnglishOutput` command instead of just the plain `nuget` command used to detect its version.

Fixes microsoft/vcpkg#38940.