### PR TITLE
Fix crash if `"platform": "mips64"` is used

### DIFF
--- a/src/vcpkg/platform-expression.cpp
+++ b/src/vcpkg/platform-expression.cpp
@@ -571,6 +571,7 @@ namespace vcpkg::PlatformExpression
                         case Identifier::qnx: return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "QNX");
                         case Identifier::vxworks: return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "VxWorks");
                         case Identifier::wasm32: return true_if_exists_and_equal("VCPKG_TARGET_ARCHITECTURE", "wasm32");
+                        case Identifier::mips64: return true_if_exists_and_equal("VCPKG_TARGET_ARCHITECTURE", "mips64");
                         case Identifier::static_link:
                             return true_if_exists_and_equal("VCPKG_LIBRARY_LINKAGE", "static");
                         case Identifier::static_crt: return true_if_exists_and_equal("VCPKG_CRT_LINKAGE", "static");
@@ -584,8 +585,8 @@ namespace vcpkg::PlatformExpression
 
                             return is_native->second == "1";
                         }
-                        default: Checks::unreachable(VCPKG_LINE_INFO);
                     }
+                    Checks::unreachable(VCPKG_LINE_INFO);
                 }
                 else if (expr.kind == ExprKind::op_not)
                 {


### PR DESCRIPTION
Since https://github.com/microsoft/vcpkg-tool/pull/1226 there is a mips64 identifier, but it is not handled which causes vcpkg to crash. 