### PR TITLE
Restore printing full paths to files containing absolute paths.

### DIFF
--- a/azure-pipelines/end-to-end-tests-dir/post-build-checks.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/post-build-checks.ps1
@@ -948,9 +948,7 @@ note: $($buildtreesRoot)
 "@
 # downloads directory here
 $expectedFooter = @"
-note: Absolute paths were found in the following files
-$($packagesRoot)$($NativeSlash)vcpkg-policy-absolute-paths_$($Triplet): note: the files are relative to `${CURRENT_PACKAGES_DIR} here
-note: include/vcpkg-policy-absolute-paths.h
+$($packagesRoot)$($NativeSlash)vcpkg-policy-absolute-paths_$($Triplet)$($NativeSlash)include$($NativeSlash)vcpkg-policy-absolute-paths.h: note: Absolute paths found here
 "@
 
 foreach ($bad_dir in @('build-dir', 'downloads', 'installed-root', 'package-dir')) {
@@ -966,11 +964,9 @@ foreach ($bad_dir in @('build-dir', 'downloads', 'installed-root', 'package-dir'
 
 $expectedFooter = @"
 $($PortfilePath): note: Adding a call to ``vcpkg_fixup_pkgconfig()`` may fix absolute paths in .pc files
-note: Absolute paths were found in the following files
-$($packagesRoot)$($NativeSlash)vcpkg-policy-absolute-paths_$($Triplet): note: the files are relative to `${CURRENT_PACKAGES_DIR} here
-note: include/vcpkg-policy-absolute-paths.h
-note: share/pkgconfig/vcpkg-policy-absolute-paths.pc
-note: tools/vcpkg-policy-absolute-paths/bin/port-config.sh
+$($packagesRoot)$($NativeSlash)vcpkg-policy-absolute-paths_$($Triplet)$($NativeSlash)include$($NativeSlash)vcpkg-policy-absolute-paths.h: note: Absolute paths found here
+$($packagesRoot)$($NativeSlash)vcpkg-policy-absolute-paths_$($Triplet)$($NativeSlash)share$($NativeSlash)pkgconfig$($NativeSlash)vcpkg-policy-absolute-paths.pc: note: Absolute paths found here
+$($packagesRoot)$($NativeSlash)vcpkg-policy-absolute-paths_$($Triplet)$($NativeSlash)tools$($NativeSlash)vcpkg-policy-absolute-paths$($NativeSlash)bin$($NativeSlash)port-config.sh: note: Absolute paths found here
 "@
 
 foreach ($bad_dir in @('build-dir', 'downloads', 'installed-root', 'package-dir')) {

--- a/include/vcpkg/base/message-data.inc.h
+++ b/include/vcpkg/base/message-data.inc.h
@@ -1283,7 +1283,7 @@ DECLARE_MESSAGE(FilesContainAbsolutePath1,
                 "followed by a list of found files.",
                 "There should be no absolute paths, such as the following, in an installed package. To suppress this "
                 "message, add set(VCPKG_POLICY_SKIP_ABSOLUTE_PATHS_CHECK enabled)")
-DECLARE_MESSAGE(FilesContainAbsolutePath2, (), "", "Absolute paths were found in the following files")
+DECLARE_MESSAGE(FilesContainAbsolutePath2, (), "", "Absolute paths found here")
 DECLARE_MESSAGE(FilesContainAbsolutePathPkgconfigNote,
                 (),
                 "",

--- a/locales/messages.json
+++ b/locales/messages.json
@@ -778,7 +778,7 @@
   "_FileSeekFailed.comment": "An example of {path} is /foo/bar. An example of {byte_offset} is 42.",
   "FilesContainAbsolutePath1": "There should be no absolute paths, such as the following, in an installed package. To suppress this message, add set(VCPKG_POLICY_SKIP_ABSOLUTE_PATHS_CHECK enabled)",
   "_FilesContainAbsolutePath1.comment": "This message is printed before a list of found absolute paths, followed by FilesContainAbsolutePath2, followed by a list of found files.",
-  "FilesContainAbsolutePath2": "Absolute paths were found in the following files",
+  "FilesContainAbsolutePath2": "Absolute paths found here",
   "FilesContainAbsolutePathPkgconfigNote": "Adding a call to `vcpkg_fixup_pkgconfig()` may fix absolute paths in .pc files",
   "FilesExported": "Files exported at: {path}",
   "_FilesExported.comment": "An example of {path} is /foo/bar.",

--- a/src/vcpkg/postbuildlint.cpp
+++ b/src/vcpkg/postbuildlint.cpp
@@ -1589,23 +1589,32 @@ namespace vcpkg
                        LocalizedString::from_raw(portfile_cmake)
                            .append_raw(": ")
                            .append_raw(WarningPrefix)
-                           .append(msgFilesContainAbsolutePath1));
+                           .append(msgFilesContainAbsolutePath1)
+                           .append_raw('\n'));
         for (auto&& absolute_path : prohibited_absolute_paths)
         {
-            msg_sink.print(LocalizedString::from_raw("\n").append_raw(NotePrefix).append_raw(absolute_path));
+            msg_sink.print(LocalizedString::from_raw(NotePrefix).append_raw(absolute_path).append_raw('\n'));
         }
 
         if (any_pc_file_fails)
         {
-            msg_sink.print(LocalizedString::from_raw("\n")
-                               .append_raw(portfile_cmake)
+            msg_sink.print(LocalizedString::from_raw(portfile_cmake)
                                .append_raw(": ")
                                .append_raw(NotePrefix)
-                               .append(msgFilesContainAbsolutePathPkgconfigNote));
+                               .append(msgFilesContainAbsolutePathPkgconfigNote)
+                               .append_raw('\n'));
         }
 
-        msg_sink.print(LocalizedString::from_raw("\n").append_raw(NotePrefix).append(msgFilesContainAbsolutePath2));
-        print_relative_paths(msg_sink, msgFilesRelativeToThePackageDirectoryHere, package_dir, failing_files);
+        for (auto&& failing_file : failing_files)
+        {
+            failing_file.make_preferred();
+            msg_sink.print(LocalizedString::from_raw(package_dir / failing_file)
+                               .append_raw(": ")
+                               .append_raw(NotePrefix)
+                               .append(msgFilesContainAbsolutePath2)
+                               .append_raw('\n'));
+        }
+
         return LintStatus::PROBLEM_DETECTED;
     }
 


### PR DESCRIPTION
@autoantwort points out that it makes sense for those to be clickable.

He also wants us to drop the note: prefix from newlines if we aren't attached to a tty; I'm not sure if that is correct.