### PR TITLE
Http binary cache: One must use the {sha} variable if other variables are used.

### DIFF
--- a/include/vcpkg/base/message-data.inc.h
+++ b/include/vcpkg/base/message-data.inc.h
@@ -1211,6 +1211,10 @@ DECLARE_MESSAGE(MissingAssetBlockOrigin,
                 (msg::path),
                 "x-block-origin is a vcpkg term. Do not translate",
                 "Missing {path} and downloads are blocked by x-block-origin.")
+DECLARE_MESSAGE(MissingShaVariable,
+                (),
+                "{{sha}} should not be translated",
+                "The {{sha}} variable must be used in the template if other variables are used.")
 DECLARE_MESSAGE(AssetCacheMissBlockOrigin,
                 (msg::path),
                 "x-block-origin is a vcpkg term. Do not translate",

--- a/locales/messages.json
+++ b/locales/messages.json
@@ -1148,6 +1148,8 @@
   "_MissingRequiredField.comment": "Example completely formatted message:\nerror: missing required field 'dependencies' (an array of dependencies) An example of {json_field} is identifer. An example of {json_type} is an array of identifiers.",
   "MissingRequiredField2": "missing required field '{json_field}'",
   "_MissingRequiredField2.comment": "An example of {json_field} is identifer.",
+  "MissingShaVariable": "The {{sha}} variable must be used in the template if other variables are used.",
+  "_MissingShaVariable.comment": "{{sha}} should not be translated",
   "MixingBooleanOperationsNotAllowed": "mixing & and | is not allowed; use () to specify order of operations",
   "MonoInstructions": "This may be caused by an incomplete mono installation. Full mono is available on some systems via `sudo apt install mono-complete`. Ubuntu 18.04 users may need a newer version of mono, available at https://www.mono-project.com/download/stable/",
   "MultiArch": "Multi-Arch must be 'same' but was {option}",

--- a/src/vcpkg-test/configparser.cpp
+++ b/src/vcpkg-test/configparser.cpp
@@ -531,6 +531,35 @@ TEST_CASE ("BinaryConfigParser GCS provider", "[binaryconfigparser]")
     }
 }
 
+TEST_CASE ("BinaryConfigParser HTTP provider", "[binaryconfigparser]")
+{
+    {
+        auto parsed = parse_binary_provider_configs("http,http://example.org/", {});
+        auto state = parsed.value_or_exit(VCPKG_LINE_INFO);
+
+        REQUIRE(state.url_templates_to_get.size() == 1);
+        REQUIRE(state.url_templates_to_get[0].url_template == "http://example.org/{sha}.zip");
+    }
+    {
+        auto parsed = parse_binary_provider_configs("http,http://example.org", {});
+        auto state = parsed.value_or_exit(VCPKG_LINE_INFO);
+
+        REQUIRE(state.url_templates_to_get.size() == 1);
+        REQUIRE(state.url_templates_to_get[0].url_template == "http://example.org/{sha}.zip");
+    }
+    {
+        auto parsed = parse_binary_provider_configs("http,http://example.org/{triplet}/{sha}", {});
+        auto state = parsed.value_or_exit(VCPKG_LINE_INFO);
+
+        REQUIRE(state.url_templates_to_get.size() == 1);
+        REQUIRE(state.url_templates_to_get[0].url_template == "http://example.org/{triplet}/{sha}");
+    }
+    {
+        auto parsed = parse_binary_provider_configs("http,http://example.org/{triplet}", {});
+        REQUIRE(!parsed.has_value());
+    }
+}
+
 TEST_CASE ("AssetConfigParser azurl provider", "[assetconfigparser]")
 {
     CHECK(parse_download_configuration({}));

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -1666,6 +1666,30 @@ namespace
                 {
                     return add_error(std::move(err), segments[1].first);
                 }
+                bool has_sha = false;
+                bool has_other = false;
+                api_stable_format(url_template.url_template, [&](std::string&, StringView key) {
+                    if (key == "sha")
+                    {
+                        has_sha = true;
+                    }
+                    else
+                    {
+                        has_other = true;
+                    }
+                });
+                if (!has_sha)
+                {
+                    if (has_other)
+                    {
+                        return add_error(msg::format(msgMissingShaVariable), segments[1].first);
+                    }
+                    if (url_template.url_template.back() != '/')
+                    {
+                        url_template.url_template.push_back('/');
+                    }
+                    url_template.url_template.append("{sha}.zip");
+                }
                 if (segments.size() == 4)
                 {
                     url_template.headers.push_back(segments[3].second);


### PR DESCRIPTION


Fixes https://github.com/microsoft/vcpkg/issues/39871