### PR TITLE
Optimize the output of portsdiff command

### DIFF
--- a/src/vcpkg/commands.portsdiff.cpp
+++ b/src/vcpkg/commands.portsdiff.cpp
@@ -17,12 +17,12 @@ namespace
 
     std::string format_name_and_version(StringView name, const Version& version)
     {
-        return fmt::format("\t- {:<15}{:<}\n", name, version);
+        return fmt::format("\t- {:<15} {:<}\n", name, version);
     }
 
     std::string format_name_and_version_diff(StringView name, const VersionDiff& version_diff)
     {
-        return fmt::format("\t- {:<15}{:<}\n", name, version_diff);
+        return fmt::format("\t- {:<15} {:<}\n", name, version_diff);
     }
 
     std::vector<VersionSpec> read_ports_from_commit(const VcpkgPaths& paths, StringView git_commit_id)


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/40030
The portsdiff command output lacks a space between the port name and version. This modification adds a space between the output name and version.
before fixing：
![image](https://github.com/user-attachments/assets/bb1fd3ef-c6d6-45c1-a890-85434e521853)
After：
![image](https://github.com/user-attachments/assets/0a98a00f-fe44-48fc-b8a2-faee5bec470a)
