### PR TITLE
Fix several console output nitpicks.

### DIFF
--- a/azure-pipelines/end-to-end-tests-dir/post-build-checks.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/post-build-checks.ps1
@@ -948,7 +948,7 @@ note: $($buildtreesRoot)
 "@
 # downloads directory here
 $expectedFooter = @"
-$($packagesRoot)$($NativeSlash)vcpkg-policy-absolute-paths_$($Triplet)$($NativeSlash)include$($NativeSlash)vcpkg-policy-absolute-paths.h: note: Absolute paths found here
+$($packagesRoot)$($NativeSlash)vcpkg-policy-absolute-paths_$($Triplet)$($NativeSlash)include$($NativeSlash)vcpkg-policy-absolute-paths.h: note: absolute paths found here
 "@
 
 foreach ($bad_dir in @('build-dir', 'downloads', 'installed-root', 'package-dir')) {
@@ -964,9 +964,9 @@ foreach ($bad_dir in @('build-dir', 'downloads', 'installed-root', 'package-dir'
 
 $expectedFooter = @"
 $($PortfilePath): note: Adding a call to ``vcpkg_fixup_pkgconfig()`` may fix absolute paths in .pc files
-$($packagesRoot)$($NativeSlash)vcpkg-policy-absolute-paths_$($Triplet)$($NativeSlash)include$($NativeSlash)vcpkg-policy-absolute-paths.h: note: Absolute paths found here
-$($packagesRoot)$($NativeSlash)vcpkg-policy-absolute-paths_$($Triplet)$($NativeSlash)share$($NativeSlash)pkgconfig$($NativeSlash)vcpkg-policy-absolute-paths.pc: note: Absolute paths found here
-$($packagesRoot)$($NativeSlash)vcpkg-policy-absolute-paths_$($Triplet)$($NativeSlash)tools$($NativeSlash)vcpkg-policy-absolute-paths$($NativeSlash)bin$($NativeSlash)port-config.sh: note: Absolute paths found here
+$($packagesRoot)$($NativeSlash)vcpkg-policy-absolute-paths_$($Triplet)$($NativeSlash)include$($NativeSlash)vcpkg-policy-absolute-paths.h: note: absolute paths found here
+$($packagesRoot)$($NativeSlash)vcpkg-policy-absolute-paths_$($Triplet)$($NativeSlash)share$($NativeSlash)pkgconfig$($NativeSlash)vcpkg-policy-absolute-paths.pc: note: absolute paths found here
+$($packagesRoot)$($NativeSlash)vcpkg-policy-absolute-paths_$($Triplet)$($NativeSlash)tools$($NativeSlash)vcpkg-policy-absolute-paths$($NativeSlash)bin$($NativeSlash)port-config.sh: note: absolute paths found here
 "@
 
 foreach ($bad_dir in @('build-dir', 'downloads', 'installed-root', 'package-dir')) {

--- a/include/vcpkg/base/message-data.inc.h
+++ b/include/vcpkg/base/message-data.inc.h
@@ -1287,7 +1287,7 @@ DECLARE_MESSAGE(FilesContainAbsolutePath1,
                 "followed by a list of found files.",
                 "There should be no absolute paths, such as the following, in an installed package. To suppress this "
                 "message, add set(VCPKG_POLICY_SKIP_ABSOLUTE_PATHS_CHECK enabled)")
-DECLARE_MESSAGE(FilesContainAbsolutePath2, (), "", "Absolute paths found here")
+DECLARE_MESSAGE(FilesContainAbsolutePath2, (), "", "absolute paths found here")
 DECLARE_MESSAGE(FilesContainAbsolutePathPkgconfigNote,
                 (),
                 "",

--- a/locales/messages.json
+++ b/locales/messages.json
@@ -778,7 +778,7 @@
   "_FileSeekFailed.comment": "An example of {path} is /foo/bar. An example of {byte_offset} is 42.",
   "FilesContainAbsolutePath1": "There should be no absolute paths, such as the following, in an installed package. To suppress this message, add set(VCPKG_POLICY_SKIP_ABSOLUTE_PATHS_CHECK enabled)",
   "_FilesContainAbsolutePath1.comment": "This message is printed before a list of found absolute paths, followed by FilesContainAbsolutePath2, followed by a list of found files.",
-  "FilesContainAbsolutePath2": "Absolute paths found here",
+  "FilesContainAbsolutePath2": "absolute paths found here",
   "FilesContainAbsolutePathPkgconfigNote": "Adding a call to `vcpkg_fixup_pkgconfig()` may fix absolute paths in .pc files",
   "FilesExported": "Files exported at: {path}",
   "_FilesExported.comment": "An example of {path} is /foo/bar.",

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -752,6 +752,7 @@ namespace
                 {
                     msg_sink.println(Color::error,
                                      msg::format(msgPushingVendorFailed, msg::vendor = "NuGet", msg::path = write_src)
+                                         .append_raw('\n')
                                          .append(msgSeeURL, msg::url = docs::troubleshoot_binary_cache_url));
                 }
                 else
@@ -770,6 +771,7 @@ namespace
                     msg_sink.println(
                         Color::error,
                         msg::format(msgPushingVendorFailed, msg::vendor = "NuGet config", msg::path = write_cfg)
+                            .append_raw('\n')
                             .append(msgSeeURL, msg::url = docs::troubleshoot_binary_cache_url));
                 }
                 else

--- a/src/vcpkg/commands.add-version.cpp
+++ b/src/vcpkg/commands.add-version.cpp
@@ -233,11 +233,11 @@ namespace
                                      .append_raw(git_tree)
                                      .append_raw("\n-- ")
                                      .append(msgAddVersionCommitChangesReminder)
-                                     .append_raw("\n***")
+                                     .append_raw("\n*** ")
                                      .append(msgAddVersionNoFilesUpdated)
-                                     .append_raw("\n***")
+                                     .append_raw("\n*** ")
                                      .append(msgSeeURL, msg::url = docs::add_version_command_url)
-                                     .append_raw("***"));
+                                     .append_raw("\n***"));
             if (keep_going) return UpdateResult::NotUpdated;
             Checks::exit_fail(VCPKG_LINE_INFO);
         }
@@ -349,7 +349,7 @@ namespace vcpkg
                 VCPKG_LINE_INFO,
                 add_all,
                 msg::format(msgAddVersionUseOptionAll, msg::command_name = "x-add-version", msg::option = SwitchAll)
-                    .append_raw("\n")
+                    .append_raw('\n')
                     .append(msgSeeURL, msg::url = docs::add_version_command_url));
 
             for (auto&& port_dir : fs.get_directories_non_recursive(paths.builtin_ports_directory(), VCPKG_LINE_INFO))

--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -1535,7 +1535,7 @@ namespace vcpkg
             }
         }
 
-        return res.append(msgSeeURL, msg::url = docs::troubleshoot_build_failures_url);
+        return res.append_raw('\n').append(msgSeeURL, msg::url = docs::troubleshoot_build_failures_url);
     }
 
     void append_log(const Path& path, const std::string& log, size_t max_log_length, std::string& out)

--- a/src/vcpkg/registries.cpp
+++ b/src/vcpkg/registries.cpp
@@ -1052,7 +1052,7 @@ namespace
             error_msg.append_indent().append_raw(version.to_string()).append_raw('\n');
         }
 
-        error_msg.append(msgVersionIncomparable4, msg::url = docs::versioning_url);
+        error_msg.append(msgVersionIncomparable4, msg::url = docs::versioning_url).append_raw('\n');
         error_msg.append(msgSeeURL, msg::url = docs::troubleshoot_versioning_url);
         return error_msg;
     }

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -799,6 +799,7 @@ namespace vcpkg
 
         Checks::msg_exit_with_error(VCPKG_LINE_INFO,
                                     msg::format(msgVcpkgDisallowedClassicMode)
+                                        .append_raw('\n')
                                         .append(msgSeeURL, msg::url = docs::troubleshoot_build_failures_url));
     }
 
@@ -811,6 +812,7 @@ namespace vcpkg
 
         Checks::msg_exit_with_error(VCPKG_LINE_INFO,
                                     msg::format(msgVcpkgDisallowedClassicMode)
+                                        .append_raw('\n')
                                         .append(msgSeeURL, msg::url = docs::troubleshoot_build_failures_url));
     }
 
@@ -823,6 +825,7 @@ namespace vcpkg
 
         Checks::msg_exit_with_error(VCPKG_LINE_INFO,
                                     msg::format(msgVcpkgDisallowedClassicMode)
+                                        .append_raw('\n')
                                         .append(msgSeeURL, msg::url = docs::troubleshoot_build_failures_url));
     }
 


### PR DESCRIPTION
* In https://github.com/microsoft/vcpkg-tool/pull/1455 I missed making absolute lowercase.
* In https://github.com/microsoft/vcpkg-tool/pull/1408 a lot of whitespace was missed leading to output like

error: building vtk:x64-linux failed with: BUILD_FAILEDSee https://learn.microsoft.com/vcpkg/troubleshoot/build-failures?WT.mc_id=vcpkg_inproduct_cli for more information.