### PR TITLE
Allow "baseline" in filesystem registries.

### DIFF
--- a/docs/vcpkg-schema-definitions.schema.json
+++ b/docs/vcpkg-schema-definitions.schema.json
@@ -363,6 +363,11 @@
             "type": "string",
             "description": "The location on the filesystem where the registry is rooted."
           },
+          "baseline": {
+            "description": "The key in the JSON document of baseline.json which will be used for version selection",
+            "type": "string",
+            "default": "default"
+          },
           "packages": true
         },
         "required": [


### PR DESCRIPTION
Related: https://github.com/microsoft/vcpkg/issues/30939

![image](https://github.com/user-attachments/assets/08ddb54f-9458-4b3e-955a-f2dcd0a30c2c)
