### PR TITLE
Modify the judgment method of manifest mode

### DIFF
--- a/src/vcpkg/commands.install.cpp
+++ b/src/vcpkg/commands.install.cpp
@@ -1060,8 +1060,9 @@ namespace vcpkg
 
         get_global_metrics_collector().track_bool(BoolMetric::InstallManifestMode, paths.manifest_mode_enabled());
 
-        if (auto p = paths.get_manifest().get())
+        if (paths.manifest_mode_enabled())
         {
+            auto p = paths.get_manifest().get()
             bool failure = false;
             if (!options.command_arguments.empty())
             {

--- a/src/vcpkg/commands.install.cpp
+++ b/src/vcpkg/commands.install.cpp
@@ -1062,7 +1062,7 @@ namespace vcpkg
 
         if (paths.manifest_mode_enabled())
         {
-            auto p = paths.get_manifest().get()
+            auto p = paths.get_manifest().get();
             bool failure = false;
             if (!options.command_arguments.empty())
             {

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -1257,7 +1257,18 @@ namespace vcpkg
         return nullopt;
     }
 
-    bool VcpkgPaths::manifest_mode_enabled() const { return !m_pimpl->m_manifest_dir.empty(); }
+    bool VcpkgPaths::manifest_mode_enabled() const
+    { 
+        if (!m_pimpl->m_manifest_dir.empty() && 
+            m_pimpl->m_global_config.native().find(m_pimpl->m_manifest_dir.native()) ==std::string::npos)
+        {
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
 
     const ConfigurationAndSource& VcpkgPaths::get_configuration() const { return m_pimpl->m_config; }
 

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -1258,9 +1258,9 @@ namespace vcpkg
     }
 
     bool VcpkgPaths::manifest_mode_enabled() const
-    { 
-        if (!m_pimpl->m_manifest_dir.empty() && 
-            m_pimpl->m_global_config.native().find(m_pimpl->m_manifest_dir.native()) ==std::string::npos)
+    {
+        if (!m_pimpl->m_manifest_dir.empty() &&
+            m_pimpl->m_global_config.native().find(m_pimpl->m_manifest_dir.native()) == std::string::npos)
         {
             return true;
         }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/36888

As mentioned in the issue above, when my vcpkg has a parent directory and there is a vcpkg.json file in the parent directory, when I install the port in classic mode in vcpkg, it will be mistakenly judged as manifest mode.

I modified the determination method of the manifest mode. The manifest mode is used only when the path of the vcpkg.json file does not coincide with the vcpkg classic mode path, otherwise the classic mode is used.