### PR TITLE
Fix doubled warnings being printed for manifest warnings when loading ports.

### DIFF
--- a/azure-pipelines/e2e-ports/vcpkg-bad-spdx-license/portfile.cmake
+++ b/azure-pipelines/e2e-ports/vcpkg-bad-spdx-license/portfile.cmake
@@ -1,0 +1,1 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/azure-pipelines/e2e-ports/vcpkg-bad-spdx-license/vcpkg.json
+++ b/azure-pipelines/e2e-ports/vcpkg-bad-spdx-license/vcpkg.json
@@ -1,0 +1,5 @@
+{
+  "name": "vcpkg-bad-spdx-license",
+  "version": "1",
+  "license": "BSD-new"
+}

--- a/azure-pipelines/end-to-end-tests-dir/build-test-ports.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/build-test-ports.ps1
@@ -60,3 +60,19 @@ Throw-IfFailed
 if ($output -notmatch 'vcpkg-internal-e2e-test-port3:[^ ]+ is already installed -- not building from HEAD') {
     throw 'Wrong already installed message for --head'
 }
+
+Refresh-TestRoot
+$output = Run-VcpkgAndCaptureOutput @commonArgs --x-builtin-ports-root="$PSScriptRoot/../e2e-ports" install vcpkg-bad-spdx-license
+Throw-IfFailed
+$output = $output.Replace("`r`n", "`n")
+$expected = @"
+vcpkg.json: warning: $.license (an SPDX license expression): warning: Unknown license identifier 'BSD-new'. Known values are listed at https://spdx.org/licenses/
+  on expression: BSD-new
+                 ^
+"@
+$firstMatch = $output.IndexOf($expected)
+if ($firstMatch -lt 0) {
+    throw 'Did not detect expected bad license'
+} elseif ($output.IndexOf($expected, $firstMatch + 1) -ge 0) {
+    throw 'Duplicated bad license'
+}

--- a/include/vcpkg/base/message-data.inc.h
+++ b/include/vcpkg/base/message-data.inc.h
@@ -3033,10 +3033,6 @@ DECLARE_MESSAGE(VersionMissingRequiredFeature,
                 (msg::version_spec, msg::feature, msg::constraint_origin),
                 "",
                 "{version_spec} does not have required feature {feature} needed by {constraint_origin}")
-DECLARE_MESSAGE(VersionNotFound,
-                (msg::expected, msg::actual),
-                "{expected} and {actual} are versions",
-                "{expected} not available, only {actual} is available")
 DECLARE_MESSAGE(VersionNotFoundInVersionsFile2,
                 (msg::version_spec),
                 "",

--- a/include/vcpkg/fwd/sourceparagraph.h
+++ b/include/vcpkg/fwd/sourceparagraph.h
@@ -12,4 +12,5 @@ namespace vcpkg
     struct PortLocation;
     struct SourceControlFile;
     struct SourceControlFileAndLocation;
+    struct PortLoadResult;
 }

--- a/include/vcpkg/fwd/sourceparagraph.h
+++ b/include/vcpkg/fwd/sourceparagraph.h
@@ -12,5 +12,4 @@ namespace vcpkg
     struct PortLocation;
     struct SourceControlFile;
     struct SourceControlFileAndLocation;
-    struct PortLoadResult;
 }

--- a/include/vcpkg/metrics.h
+++ b/include/vcpkg/metrics.h
@@ -37,7 +37,7 @@ namespace vcpkg
         VcpkgDefaultBinaryCache,
         VcpkgNugetRepository,
         VersioningErrorBaseline,
-        VersioningErrorVersion,
+        VersioningErrorVersion, // no longer used
         X_VcpkgRegistriesCache,
         X_WriteNugetPackagesConfig,
         COUNT // always keep COUNT last

--- a/include/vcpkg/paragraphs.h
+++ b/include/vcpkg/paragraphs.h
@@ -26,12 +26,6 @@ namespace vcpkg::Paragraphs
 
     bool is_port_directory(const ReadOnlyFilesystem& fs, const Path& maybe_directory);
 
-    struct PortLoadResult
-    {
-        ExpectedL<SourceControlFileAndLocation> maybe_scfl;
-        std::string on_disk_contents;
-    };
-
     // If an error occurs, the Expected will be in the error state.
     // Otherwise, if the port is known, the maybe_scfl.get()->source_control_file contains the loaded port information.
     // Otherwise, maybe_scfl.get()->source_control_file is nullptr.

--- a/include/vcpkg/paragraphs.h
+++ b/include/vcpkg/paragraphs.h
@@ -26,6 +26,12 @@ namespace vcpkg::Paragraphs
 
     bool is_port_directory(const ReadOnlyFilesystem& fs, const Path& maybe_directory);
 
+    struct PortLoadResult
+    {
+        ExpectedL<SourceControlFileAndLocation> maybe_scfl;
+        std::string on_disk_contents;
+    };
+
     // If an error occurs, the Expected will be in the error state.
     // Otherwise, if the port is known, the maybe_scfl.get()->source_control_file contains the loaded port information.
     // Otherwise, maybe_scfl.get()->source_control_file is nullptr.

--- a/include/vcpkg/paragraphs.h
+++ b/include/vcpkg/paragraphs.h
@@ -52,10 +52,8 @@ namespace vcpkg::Paragraphs
         std::vector<std::pair<std::string, LocalizedString>> errors;
     };
 
-    LoadResults try_load_all_registry_ports(const ReadOnlyFilesystem& fs, const RegistrySet& registries);
-
-    std::vector<SourceControlFileAndLocation> load_all_registry_ports(const ReadOnlyFilesystem& fs,
-                                                                      const RegistrySet& registries);
+    LoadResults try_load_all_registry_ports(const RegistrySet& registries);
+    std::vector<SourceControlFileAndLocation> load_all_registry_ports(const RegistrySet& registries);
 
     LoadResults try_load_overlay_ports(const ReadOnlyFilesystem& fs, const Path& dir);
     std::vector<SourceControlFileAndLocation> load_overlay_ports(const ReadOnlyFilesystem& fs, const Path& dir);

--- a/include/vcpkg/portfileprovider.h
+++ b/include/vcpkg/portfileprovider.h
@@ -63,8 +63,7 @@ namespace vcpkg
 
     struct PathsPortFileProvider : PortFileProvider
     {
-        explicit PathsPortFileProvider(const ReadOnlyFilesystem& fs,
-                                       const RegistrySet& registry_set,
+        explicit PathsPortFileProvider(const RegistrySet& registry_set,
                                        std::unique_ptr<IFullOverlayProvider>&& overlay);
         ExpectedL<const SourceControlFileAndLocation&> get_control_file(const std::string& src_name) const override;
         std::vector<const SourceControlFileAndLocation*> load_all_control_files() const override;
@@ -76,8 +75,7 @@ namespace vcpkg
     };
 
     std::unique_ptr<IBaselineProvider> make_baseline_provider(const RegistrySet& registry_set);
-    std::unique_ptr<IFullVersionedPortfileProvider> make_versioned_portfile_provider(const ReadOnlyFilesystem& fs,
-                                                                                     const RegistrySet& registry_set);
+    std::unique_ptr<IFullVersionedPortfileProvider> make_versioned_portfile_provider(const RegistrySet& registry_set);
     std::unique_ptr<IFullOverlayProvider> make_overlay_provider(const ReadOnlyFilesystem& fs,
                                                                 const Path& original_cwd,
                                                                 View<std::string> overlay_ports);

--- a/include/vcpkg/registries.h
+++ b/include/vcpkg/registries.h
@@ -58,7 +58,7 @@ namespace vcpkg
     {
         virtual ExpectedL<View<Version>> get_port_versions() const = 0;
 
-        virtual ExpectedL<PortLocation> get_version(const Version& version) const = 0;
+        virtual ExpectedL<SourceControlFileAndLocation> try_load_port(const Version& version) const = 0;
 
         virtual ~RegistryEntry() = default;
     };

--- a/include/vcpkg/sourceparagraph.h
+++ b/include/vcpkg/sourceparagraph.h
@@ -218,6 +218,12 @@ namespace vcpkg
         std::string spdx_location;
     };
 
+    struct PortLoadResult
+    {
+        ExpectedL<SourceControlFileAndLocation> maybe_scfl;
+        std::string on_disk_contents;
+    };
+
     void print_error_message(const LocalizedString& message);
 
     std::string parse_spdx_license_expression(StringView sv, ParseMessages& messages);

--- a/include/vcpkg/sourceparagraph.h
+++ b/include/vcpkg/sourceparagraph.h
@@ -210,6 +210,17 @@ namespace vcpkg
         VersionSpec to_version_spec() const { return source_control_file->to_version_spec(); }
         Path port_directory() const { return control_path.parent_path(); }
 
+        SourceControlFileAndLocation clone() const
+        {
+            std::unique_ptr<SourceControlFile> scf;
+            if (source_control_file)
+            {
+                scf = std::make_unique<SourceControlFile>(source_control_file->clone());
+            }
+
+            return SourceControlFileAndLocation{std::move(scf), control_path, spdx_location};
+        }
+
         std::unique_ptr<SourceControlFile> source_control_file;
         Path control_path;
 

--- a/include/vcpkg/sourceparagraph.h
+++ b/include/vcpkg/sourceparagraph.h
@@ -229,12 +229,6 @@ namespace vcpkg
         std::string spdx_location;
     };
 
-    struct PortLoadResult
-    {
-        ExpectedL<SourceControlFileAndLocation> maybe_scfl;
-        std::string on_disk_contents;
-    };
-
     void print_error_message(const LocalizedString& message);
 
     std::string parse_spdx_license_expression(StringView sv, ParseMessages& messages);

--- a/locales/messages.json
+++ b/locales/messages.json
@@ -1613,8 +1613,6 @@
   "_VersionMissing.comment": "The names version, version-date, version-semver, and version-string are code and must not be localized",
   "VersionMissingRequiredFeature": "{version_spec} does not have required feature {feature} needed by {constraint_origin}",
   "_VersionMissingRequiredFeature.comment": "An example of {version_spec} is zlib:x64-windows@1.0.0. An example of {feature} is avisynthplus. An example of {constraint_origin} is zlib:x64-windows@1.0.0.",
-  "VersionNotFound": "{expected} not available, only {actual} is available",
-  "_VersionNotFound.comment": "{expected} and {actual} are versions",
   "VersionNotFoundInVersionsFile2": "{version_spec} was not found in versions database",
   "_VersionNotFoundInVersionsFile2.comment": "An example of {version_spec} is zlib:x64-windows@1.0.0.",
   "VersionNotFoundInVersionsFile3": "the version should be in this file",

--- a/src/vcpkg/commands.build-external.cpp
+++ b/src/vcpkg/commands.build-external.cpp
@@ -48,7 +48,7 @@ namespace vcpkg
 
         auto& fs = paths.get_filesystem();
         auto registry_set = paths.make_registry_set();
-        PathsPortFileProvider provider(fs, *registry_set, make_overlay_provider(fs, paths.original_cwd, overlays));
+        PathsPortFileProvider provider(*registry_set, make_overlay_provider(fs, paths.original_cwd, overlays));
         command_build_and_exit_ex(args, paths, host_triplet, build_options, spec, provider, null_build_logs_recorder());
     }
 }

--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -107,8 +107,8 @@ namespace vcpkg
 
         auto& fs = paths.get_filesystem();
         auto registry_set = paths.make_registry_set();
-        PathsPortFileProvider provider(
-            fs, *registry_set, make_overlay_provider(fs, paths.original_cwd, paths.overlay_ports));
+        PathsPortFileProvider provider(*registry_set,
+                                       make_overlay_provider(fs, paths.original_cwd, paths.overlay_ports));
         Checks::exit_with_code(VCPKG_LINE_INFO,
                                command_build_ex(args,
                                                 paths,

--- a/src/vcpkg/commands.check-support.cpp
+++ b/src/vcpkg/commands.check-support.cpp
@@ -128,8 +128,8 @@ namespace vcpkg
 
         auto& fs = paths.get_filesystem();
         auto registry_set = paths.make_registry_set();
-        PathsPortFileProvider provider(
-            fs, *registry_set, make_overlay_provider(fs, paths.original_cwd, paths.overlay_ports));
+        PathsPortFileProvider provider(*registry_set,
+                                       make_overlay_provider(fs, paths.original_cwd, paths.overlay_ports));
         auto cmake_vars = CMakeVars::make_triplet_cmake_var_provider(paths);
 
         // for each spec in the user-requested specs, check all dependencies

--- a/src/vcpkg/commands.ci.cpp
+++ b/src/vcpkg/commands.ci.cpp
@@ -375,8 +375,8 @@ namespace vcpkg
             build_logs_recorder_storage ? *(build_logs_recorder_storage.get()) : null_build_logs_recorder();
 
         auto registry_set = paths.make_registry_set();
-        PathsPortFileProvider provider(
-            filesystem, *registry_set, make_overlay_provider(filesystem, paths.original_cwd, paths.overlay_ports));
+        PathsPortFileProvider provider(*registry_set,
+                                       make_overlay_provider(filesystem, paths.original_cwd, paths.overlay_ports));
         auto var_provider_storage = CMakeVars::make_triplet_cmake_var_provider(paths);
         auto& var_provider = *var_provider_storage;
 

--- a/src/vcpkg/commands.depend-info.cpp
+++ b/src/vcpkg/commands.depend-info.cpp
@@ -409,8 +409,8 @@ namespace vcpkg
 
         auto& fs = paths.get_filesystem();
         auto registry_set = paths.make_registry_set();
-        PathsPortFileProvider provider(
-            fs, *registry_set, make_overlay_provider(fs, paths.original_cwd, paths.overlay_ports));
+        PathsPortFileProvider provider(*registry_set,
+                                       make_overlay_provider(fs, paths.original_cwd, paths.overlay_ports));
         auto var_provider_storage = CMakeVars::make_triplet_cmake_var_provider(paths);
         auto& var_provider = *var_provider_storage;
 

--- a/src/vcpkg/commands.env.cpp
+++ b/src/vcpkg/commands.env.cpp
@@ -80,8 +80,8 @@ namespace vcpkg
         const ParsedArguments options = args.parse_arguments(CommandEnvMetadata);
 
         auto registry_set = paths.make_registry_set();
-        PathsPortFileProvider provider(
-            fs, *registry_set, make_overlay_provider(fs, paths.original_cwd, paths.overlay_ports));
+        PathsPortFileProvider provider(*registry_set,
+                                       make_overlay_provider(fs, paths.original_cwd, paths.overlay_ports));
         auto var_provider_storage = CMakeVars::make_triplet_cmake_var_provider(paths);
         auto& var_provider = *var_provider_storage;
 

--- a/src/vcpkg/commands.export.cpp
+++ b/src/vcpkg/commands.export.cpp
@@ -602,8 +602,8 @@ namespace vcpkg
         // Load ports from ports dirs
         auto& fs = paths.get_filesystem();
         auto registry_set = paths.make_registry_set();
-        PathsPortFileProvider provider(
-            fs, *registry_set, make_overlay_provider(fs, paths.original_cwd, paths.overlay_ports));
+        PathsPortFileProvider provider(*registry_set,
+                                       make_overlay_provider(fs, paths.original_cwd, paths.overlay_ports));
 
         // create the plan
         std::vector<ExportPlanAction> export_plan = create_export_plan(opts.specs, status_db);

--- a/src/vcpkg/commands.find.cpp
+++ b/src/vcpkg/commands.find.cpp
@@ -138,7 +138,7 @@ namespace vcpkg
         Checks::check_exit(VCPKG_LINE_INFO, msg::default_output_stream == OutputStream::StdErr);
         auto& fs = paths.get_filesystem();
         auto registry_set = paths.make_registry_set();
-        PathsPortFileProvider provider(fs, *registry_set, make_overlay_provider(fs, paths.original_cwd, overlay_ports));
+        PathsPortFileProvider provider(*registry_set, make_overlay_provider(fs, paths.original_cwd, overlay_ports));
         auto source_paragraphs =
             Util::fmap(provider.load_all_control_files(),
                        [](auto&& port) -> const SourceControlFile* { return port->source_control_file.get(); });

--- a/src/vcpkg/commands.format-manifest.cpp
+++ b/src/vcpkg/commands.format-manifest.cpp
@@ -41,7 +41,8 @@ namespace
         auto res = serialize_manifest(*data.scf);
 
         // reparse res to ensure no semantic changes were made
-        auto maybe_reparsed = SourceControlFile::parse_project_manifest_object(StringLiteral{"reparse"}, res, null_sink);
+        auto maybe_reparsed =
+            SourceControlFile::parse_project_manifest_object(StringLiteral{"<unsaved>"}, res, null_sink);
         bool reparse_matches;
         if (auto reparsed = maybe_reparsed.get())
         {

--- a/src/vcpkg/commands.format-manifest.cpp
+++ b/src/vcpkg/commands.format-manifest.cpp
@@ -41,7 +41,7 @@ namespace
         auto res = serialize_manifest(*data.scf);
 
         // reparse res to ensure no semantic changes were made
-        auto maybe_reparsed = SourceControlFile::parse_project_manifest_object(StringView{}, res, null_sink);
+        auto maybe_reparsed = SourceControlFile::parse_project_manifest_object(StringLiteral{"reparse"}, res, null_sink);
         bool reparse_matches;
         if (auto reparsed = maybe_reparsed.get())
         {

--- a/src/vcpkg/commands.install.cpp
+++ b/src/vcpkg/commands.install.cpp
@@ -1237,7 +1237,7 @@ namespace vcpkg
 
             const bool add_builtin_ports_directory_as_overlay =
                 registry_set->is_default_builtin_registry() && !paths.use_git_default_registry();
-            auto verprovider = make_versioned_portfile_provider(fs, *registry_set);
+            auto verprovider = make_versioned_portfile_provider(*registry_set);
             auto baseprovider = make_baseline_provider(*registry_set);
 
             std::vector<std::string> extended_overlay_ports;
@@ -1278,8 +1278,8 @@ namespace vcpkg
         }
 
         auto registry_set = paths.make_registry_set();
-        PathsPortFileProvider provider(
-            fs, *registry_set, make_overlay_provider(fs, paths.original_cwd, paths.overlay_ports));
+        PathsPortFileProvider provider(*registry_set,
+                                       make_overlay_provider(fs, paths.original_cwd, paths.overlay_ports));
 
         const std::vector<FullPackageSpec> specs = Util::fmap(options.command_arguments, [&](const std::string& arg) {
             return check_and_get_full_package_spec(arg, default_triplet, paths.get_triplet_db())

--- a/src/vcpkg/commands.package-info.cpp
+++ b/src/vcpkg/commands.package-info.cpp
@@ -102,8 +102,8 @@ namespace vcpkg
             Json::Object response;
             Json::Object results;
             auto registry_set = paths.make_registry_set();
-            PathsPortFileProvider provider(
-                fs, *registry_set, make_overlay_provider(fs, paths.original_cwd, paths.overlay_ports));
+            PathsPortFileProvider provider(*registry_set,
+                                           make_overlay_provider(fs, paths.original_cwd, paths.overlay_ports));
 
             for (auto&& arg : options.command_arguments)
             {

--- a/src/vcpkg/commands.remove.cpp
+++ b/src/vcpkg/commands.remove.cpp
@@ -196,8 +196,8 @@ namespace vcpkg
             // Load ports from ports dirs
             auto& fs = paths.get_filesystem();
             auto registry_set = paths.make_registry_set();
-            PathsPortFileProvider provider(
-                fs, *registry_set, make_overlay_provider(fs, paths.original_cwd, paths.overlay_ports));
+            PathsPortFileProvider provider(*registry_set,
+                                           make_overlay_provider(fs, paths.original_cwd, paths.overlay_ports));
 
             specs =
                 Util::fmap(find_outdated_packages(provider, status_db), [](auto&& outdated) { return outdated.spec; });

--- a/src/vcpkg/commands.set-installed.cpp
+++ b/src/vcpkg/commands.set-installed.cpp
@@ -314,8 +314,8 @@ namespace vcpkg
 
         auto& fs = paths.get_filesystem();
         auto registry_set = paths.make_registry_set();
-        PathsPortFileProvider provider(
-            fs, *registry_set, make_overlay_provider(fs, paths.original_cwd, paths.overlay_ports));
+        PathsPortFileProvider provider(*registry_set,
+                                       make_overlay_provider(fs, paths.original_cwd, paths.overlay_ports));
         auto cmake_vars = CMakeVars::make_triplet_cmake_var_provider(paths);
 
         Optional<Path> pkgsconfig;

--- a/src/vcpkg/commands.update.cpp
+++ b/src/vcpkg/commands.update.cpp
@@ -68,8 +68,8 @@ namespace vcpkg
         const StatusParagraphs status_db = database_load_check(fs, paths.installed());
 
         auto registry_set = paths.make_registry_set();
-        PathsPortFileProvider provider(
-            fs, *registry_set, make_overlay_provider(fs, paths.original_cwd, paths.overlay_ports));
+        PathsPortFileProvider provider(*registry_set,
+                                       make_overlay_provider(fs, paths.original_cwd, paths.overlay_ports));
 
         const auto outdated_packages = SortedVector<OutdatedPackage, decltype(&OutdatedPackage::compare_by_name)>(
             find_outdated_packages(provider, status_db), &OutdatedPackage::compare_by_name);

--- a/src/vcpkg/commands.upgrade.cpp
+++ b/src/vcpkg/commands.upgrade.cpp
@@ -81,8 +81,8 @@ namespace vcpkg
         // Load ports from ports dirs
         auto& fs = paths.get_filesystem();
         auto registry_set = paths.make_registry_set();
-        PathsPortFileProvider provider(
-            fs, *registry_set, make_overlay_provider(fs, paths.original_cwd, paths.overlay_ports));
+        PathsPortFileProvider provider(*registry_set,
+                                       make_overlay_provider(fs, paths.original_cwd, paths.overlay_ports));
         auto var_provider_storage = CMakeVars::make_triplet_cmake_var_provider(paths);
         auto& var_provider = *var_provider_storage;
 

--- a/src/vcpkg/portfileprovider.cpp
+++ b/src/vcpkg/portfileprovider.cpp
@@ -12,27 +12,6 @@
 
 using namespace vcpkg;
 
-namespace
-{
-    struct OverlayRegistryEntry final : RegistryEntry
-    {
-        OverlayRegistryEntry(Path&& p, Version&& v) : root(p), version(v) { }
-
-        ExpectedL<View<Version>> get_port_versions() const override { return View<Version>{&version, 1}; }
-        ExpectedL<PortLocation> get_version(const Version& v) const override
-        {
-            if (v == version)
-            {
-                return PortLocation{root};
-            }
-            return msg::format(msgVersionNotFound, msg::expected = v, msg::actual = version);
-        }
-
-        Path root;
-        Version version;
-    };
-}
-
 namespace vcpkg
 {
     MapPortFileProvider::MapPortFileProvider(const std::unordered_map<std::string, SourceControlFileAndLocation>& map)

--- a/src/vcpkg/portfileprovider.cpp
+++ b/src/vcpkg/portfileprovider.cpp
@@ -159,7 +159,6 @@ namespace vcpkg
                         }
                         else
                         {
-                            get_global_metrics_collector().track_define(DefineMetric::VersioningErrorVersion);
                             return msg::format_error(msgVersionSpecMismatch,
                                                      msg::path = scfl->control_path,
                                                      msg::expected_version = version_spec,

--- a/src/vcpkg/registries.cpp
+++ b/src/vcpkg/registries.cpp
@@ -444,8 +444,6 @@ namespace
         PortVersionsGitTreesStructOfArrays port_versions_soa;
     };
 
-    struct FilesystemRegistry;
-
     struct FilesystemRegistryEntry final : RegistryEntry
     {
         explicit FilesystemRegistryEntry(const ReadOnlyFilesystem& fs,
@@ -588,8 +586,6 @@ namespace
         ExpectedL<Optional<Version>> get_baseline_version(StringView) const override;
 
     private:
-        friend FilesystemRegistryEntry;
-
         const ReadOnlyFilesystem& m_fs;
 
         Path m_path;

--- a/src/vcpkg/registries.cpp
+++ b/src/vcpkg/registries.cpp
@@ -246,7 +246,7 @@ namespace
                          std::vector<GitVersionDbEntry>&& version_entries);
 
         ExpectedL<View<Version>> get_port_versions() const override;
-        ExpectedL<PortLocation> get_version(const Version& version) const override;
+        ExpectedL<SourceControlFileAndLocation> try_load_port(const Version& version) const override;
 
     private:
         ExpectedL<Unit> ensure_not_stale() const;
@@ -282,7 +282,7 @@ namespace
         ExpectedL<Optional<Version>> get_baseline_version(StringView) const override;
 
     private:
-        friend struct GitRegistryEntry;
+        friend GitRegistryEntry;
 
         const ExpectedL<LockFile::Entry>& get_lock_entry() const
         {
@@ -401,27 +401,29 @@ namespace
 
     struct BuiltinPortTreeRegistryEntry final : RegistryEntry
     {
-        BuiltinPortTreeRegistryEntry(StringView name_, Path root_, Version version_)
-            : name(name_.to_string()), root(root_), version(version_)
+        BuiltinPortTreeRegistryEntry(const SourceControlFileAndLocation& load_result_,
+                                     StringView port_name_,
+                                     Version version_)
+            : load_result(load_result_), port_name(port_name_.data(), port_name_.size()), version(version_)
         {
         }
 
         ExpectedL<View<Version>> get_port_versions() const override { return View<Version>{&version, 1}; }
-        ExpectedL<PortLocation> get_version(const Version& v) const override
+        ExpectedL<SourceControlFileAndLocation> try_load_port(const Version& v) const override
         {
             if (v == version)
             {
-                return PortLocation{root, "git+https://github.com/Microsoft/vcpkg#ports/" + name};
+                return load_result.clone();
             }
 
             return msg::format_error(msgVersionBuiltinPortTreeEntryMissing,
-                                     msg::package_name = name,
+                                     msg::package_name = port_name,
                                      msg::expected = v.to_string(),
                                      msg::actual = version.to_string());
         }
 
-        std::string name;
-        Path root;
+        const SourceControlFileAndLocation& load_result;
+        std::string port_name;
         Version version;
     };
 
@@ -433,7 +435,7 @@ namespace
         {
             return View<Version>{port_versions_soa.port_versions()};
         }
-        ExpectedL<PortLocation> get_version(const Version& version) const override;
+        ExpectedL<SourceControlFileAndLocation> try_load_port(const Version& version) const override;
 
         const VcpkgPaths& m_paths;
 
@@ -442,14 +444,27 @@ namespace
         PortVersionsGitTreesStructOfArrays port_versions_soa;
     };
 
+    struct FilesystemRegistry;
+
     struct FilesystemRegistryEntry final : RegistryEntry
     {
-        explicit FilesystemRegistryEntry(std::string&& port_name) : port_name(port_name) { }
+        explicit FilesystemRegistryEntry(const ReadOnlyFilesystem& fs,
+                                         StringView port_name,
+                                         std::vector<FilesystemVersionDbEntry>&& version_entries)
+            : fs(fs), port_name(port_name.data(), port_name.size())
+        {
+            for (auto&& version_entry : version_entries)
+            {
+                port_versions.push_back(std::move(version_entry.version.version));
+                version_paths.push_back(std::move(version_entry.p));
+            }
+        }
 
         ExpectedL<View<Version>> get_port_versions() const override { return View<Version>{port_versions}; }
 
-        ExpectedL<PortLocation> get_version(const Version& version) const override;
+        ExpectedL<SourceControlFileAndLocation> try_load_port(const Version& version) const override;
 
+        const ReadOnlyFilesystem& fs;
         std::string port_name;
         // these two map port versions to paths
         // these shall have the same size, and paths[i] shall be the path for port_versions[i]
@@ -481,8 +496,9 @@ namespace
         DelayedInit<Baseline> m_baseline;
 
     private:
-        const ExpectedL<SourceControlFileAndLocation>& get_scfl(StringView port_name, const Path& path) const
+        const ExpectedL<SourceControlFileAndLocation>& get_scfl(StringView port_name) const
         {
+            auto path = m_builtin_ports_directory / port_name;
             return m_scfls.get_lazy(path, [&, this]() {
                 return Paragraphs::try_load_port(m_fs, port_name, PortLocation{path}).maybe_scfl;
             });
@@ -572,6 +588,8 @@ namespace
         ExpectedL<Optional<Version>> get_baseline_version(StringView) const override;
 
     private:
+        friend FilesystemRegistryEntry;
+
         const ReadOnlyFilesystem& m_fs;
 
         Path m_path;
@@ -694,9 +712,8 @@ namespace
     // { BuiltinFilesRegistry::RegistryImplementation
     ExpectedL<std::unique_ptr<RegistryEntry>> BuiltinFilesRegistry::get_port_entry(StringView port_name) const
     {
-        auto port_directory = m_builtin_ports_directory / port_name;
-        return get_scfl(port_name, port_directory)
-            .then([&](const SourceControlFileAndLocation& scfl) -> ExpectedL<std::unique_ptr<RegistryEntry>> {
+        return get_scfl(port_name).then(
+            [&](const SourceControlFileAndLocation& scfl) -> ExpectedL<std::unique_ptr<RegistryEntry>> {
                 auto scf = scfl.source_control_file.get();
                 if (!scf)
                 {
@@ -705,30 +722,28 @@ namespace
 
                 if (scf->core_paragraph->name == port_name)
                 {
-                    return std::make_unique<BuiltinPortTreeRegistryEntry>(
-                        scf->core_paragraph->name, port_directory, scf->to_version());
+                    return std::make_unique<BuiltinPortTreeRegistryEntry>(scfl, port_name, scf->to_version());
                 }
 
                 return msg::format_error(msgUnexpectedPortName,
                                          msg::expected = scf->core_paragraph->name,
                                          msg::actual = port_name,
-                                         msg::path = port_directory);
+                                         msg::path = scfl.port_directory());
             });
     }
 
     ExpectedL<Optional<Version>> BuiltinFilesRegistry::get_baseline_version(StringView port_name) const
     {
         // if a baseline is not specified, use the ports directory version
-        return get_scfl(port_name, m_builtin_ports_directory / port_name)
-            .then([&](const SourceControlFileAndLocation& scfl) -> ExpectedL<Optional<Version>> {
-                auto scf = scfl.source_control_file.get();
-                if (!scf)
-                {
-                    return Optional<Version>();
-                }
+        return get_scfl(port_name).then([&](const SourceControlFileAndLocation& scfl) -> ExpectedL<Optional<Version>> {
+            auto scf = scfl.source_control_file.get();
+            if (!scf)
+            {
+                return Optional<Version>();
+            }
 
-                return scf->to_version();
-            });
+            return scf->to_version();
+        });
     }
 
     ExpectedL<Unit> BuiltinFilesRegistry::append_all_port_names(std::vector<std::string>& out) const
@@ -851,14 +866,7 @@ namespace
                     return std::unique_ptr<RegistryEntry>{};
                 }
 
-                auto res = std::make_unique<FilesystemRegistryEntry>(port_name.to_string());
-                for (auto&& version_entry : *version_entries)
-                {
-                    res->port_versions.push_back(std::move(version_entry.version.version));
-                    res->version_paths.push_back(std::move(version_entry.p));
-                }
-
-                return res;
+                return std::make_unique<FilesystemRegistryEntry>(m_fs, port_name, std::move(*version_entries));
             });
     }
 
@@ -1060,7 +1068,7 @@ namespace
     // { RegistryEntry
 
     // { BuiltinRegistryEntry::RegistryEntry
-    ExpectedL<PortLocation> BuiltinGitRegistryEntry::get_version(const Version& version) const
+    ExpectedL<SourceControlFileAndLocation> BuiltinGitRegistryEntry::try_load_port(const Version& version) const
     {
         auto& port_versions = port_versions_soa.port_versions();
         auto it = std::find(port_versions.begin(), port_versions.end(), version);
@@ -1082,17 +1090,20 @@ namespace
                         .append(msgSeeURL, msg::url = docs::troubleshoot_versioning_url);
                 });
             })
-            .map([&git_tree](Path&& p) -> PortLocation {
-                return {
-                    std::move(p),
-                    "git+https://github.com/Microsoft/vcpkg@" + git_tree,
-                };
+            .then([this, &git_tree](Path&& p) -> ExpectedL<SourceControlFileAndLocation> {
+                return Paragraphs::try_load_port_required(m_paths.get_filesystem(),
+                                                          port_name,
+                                                          PortLocation{
+                                                              std::move(p),
+                                                              "git+https://github.com/Microsoft/vcpkg@" + git_tree,
+                                                          })
+                    .maybe_scfl;
             });
     }
     // } BuiltinRegistryEntry::RegistryEntry
 
     // { FilesystemRegistryEntry::RegistryEntry
-    ExpectedL<PortLocation> FilesystemRegistryEntry::get_version(const Version& version) const
+    ExpectedL<SourceControlFileAndLocation> FilesystemRegistryEntry::try_load_port(const Version& version) const
     {
         auto it = std::find(port_versions.begin(), port_versions.end(), version);
         if (it == port_versions.end())
@@ -1101,7 +1112,8 @@ namespace
                 msgVersionDatabaseEntryMissing, msg::package_name = port_name, msg::version = version);
         }
 
-        return PortLocation{version_paths[it - port_versions.begin()]};
+        const auto& load_path = version_paths[it - port_versions.begin()];
+        return Paragraphs::try_load_port_required(fs, port_name, PortLocation{load_path}).maybe_scfl;
     }
     // } FilesystemRegistryEntry::RegistryEntry
 
@@ -1153,7 +1165,7 @@ namespace
         return std::move(maybe_not_stale).error();
     }
 
-    ExpectedL<PortLocation> GitRegistryEntry::get_version(const Version& version) const
+    ExpectedL<SourceControlFileAndLocation> GitRegistryEntry::try_load_port(const Version& version) const
     {
         auto it = std::find(last_loaded.port_versions().begin(), last_loaded.port_versions().end(), version);
         if (it == last_loaded.port_versions().end() && stale)
@@ -1174,12 +1186,15 @@ namespace
         }
 
         const auto& git_tree = last_loaded.git_trees()[it - last_loaded.port_versions().begin()];
-        return parent.m_paths.git_extract_tree_from_remote_registry(git_tree).map(
-            [this, &git_tree](Path&& p) -> PortLocation {
-                return {
-                    std::move(p),
-                    Strings::concat("git+", parent.m_repo, "@", git_tree),
-                };
+        return parent.m_paths.git_extract_tree_from_remote_registry(git_tree).then(
+            [this, &git_tree](Path&& p) -> ExpectedL<SourceControlFileAndLocation> {
+                return Paragraphs::try_load_port_required(parent.m_paths.get_filesystem(),
+                                                          port_name,
+                                                          PortLocation{
+                                                              p,
+                                                              Strings::concat("git+", parent.m_repo, "@", git_tree),
+                                                          })
+                    .maybe_scfl;
             });
     }
 

--- a/src/vcpkg/sourceparagraph.cpp
+++ b/src/vcpkg/sourceparagraph.cpp
@@ -1339,6 +1339,8 @@ namespace vcpkg
         {
             ret.feature_paragraphs.push_back(std::make_unique<FeatureParagraph>(*feat_ptr));
         }
+
+        ret.extra_features_info = extra_features_info;
         return ret;
     }
 


### PR DESCRIPTION
Resolves https://github.com/microsoft/vcpkg/issues/24084
Resolves https://github.com/microsoft/vcpkg/issues/34095

The root cause of this bug is the separation between the BaselineProvider and the PortfileProvider. For the built in registry, to determine what the baseline version for the builtin registry is, we must load and parse the requested port to read what version is declared in its JSON/CONTROL file. However, the interface by which the registry tells the calling code what to do passed only the directory with the port inside:

```c++
    struct RegistryEntry
    {
        // This forces BuiltinRegistry to parse the JSON/CONTROL
        virtual ExpectedL<View<Version>> get_port_versions() const = 0;
 
        // This forces the caller to parse the JSON/CONTROL
        virtual ExpectedL<PortLocation> get_version(const Version& version) const = 0;
 
        virtual ~RegistryEntry() = default;
    };
```

Thus, callers were forced to parse the files *again*, causing reemission of any warnings like bad SPDX expressions.

The fix is to push the parsing of the port files into `RegistryEntry` so that the builtin registry can return a clone of the file it already parsed, rather than getting it to be parsed again.