### PR TITLE
Fix grammar in HashPortManyFiles warning message

### DIFF
--- a/include/vcpkg/base/message-data.inc.h
+++ b/include/vcpkg/base/message-data.inc.h
@@ -1387,7 +1387,7 @@ DECLARE_MESSAGE(HashFileFailureToRead,
 DECLARE_MESSAGE(HashPortManyFiles,
                 (msg::package_name, msg::count),
                 "",
-                "The port '{package_name}' contains {count} files. Hashing these contents may take a long time when "
+                "{package_name} contains {count} files. Hashing these contents may take a long time when "
                 "determining the ABI hash for binary caching. Consider reducing the number of files. Common causes of "
                 "this are accidentally checking out source or build files into a port's directory.")
 DECLARE_MESSAGE(HeaderOnlyUsage,

--- a/include/vcpkg/base/message-data.inc.h
+++ b/include/vcpkg/base/message-data.inc.h
@@ -1387,7 +1387,7 @@ DECLARE_MESSAGE(HashFileFailureToRead,
 DECLARE_MESSAGE(HashPortManyFiles,
                 (msg::package_name, msg::count),
                 "",
-                "The {package_name} contains {count} files. Hashing these contents may take a long time when "
+                "The port '{package_name}' contains {count} files. Hashing these contents may take a long time when "
                 "determining the ABI hash for binary caching. Consider reducing the number of files. Common causes of "
                 "this are accidentally checking out source or build files into a port's directory.")
 DECLARE_MESSAGE(HeaderOnlyUsage,

--- a/locales/messages.json
+++ b/locales/messages.json
@@ -833,7 +833,7 @@
   "_GraphCycleDetected.comment": "A list of package names comprising the cycle will be printed after this message. An example of {package_name} is zlib.",
   "HashFileFailureToRead": "failed to read file \"{path}\" for hashing: ",
   "_HashFileFailureToRead.comment": "Printed after ErrorMessage and before the specific failing filesystem operation (like file not found) An example of {path} is /foo/bar.",
-  "HashPortManyFiles": "The port '{package_name}' contains {count} files. Hashing these contents may take a long time when determining the ABI hash for binary caching. Consider reducing the number of files. Common causes of this are accidentally checking out source or build files into a port's directory.",
+  "HashPortManyFiles": "{package_name} contains {count} files. Hashing these contents may take a long time when determining the ABI hash for binary caching. Consider reducing the number of files. Common causes of this are accidentally checking out source or build files into a port's directory.",
   "_HashPortManyFiles.comment": "An example of {package_name} is zlib. An example of {count} is 42.",
   "HeaderOnlyUsage": "{package_name} is header-only and can be used from CMake via:",
   "_HeaderOnlyUsage.comment": "'header' refers to C/C++ .h files An example of {package_name} is zlib.",

--- a/locales/messages.json
+++ b/locales/messages.json
@@ -833,7 +833,7 @@
   "_GraphCycleDetected.comment": "A list of package names comprising the cycle will be printed after this message. An example of {package_name} is zlib.",
   "HashFileFailureToRead": "failed to read file \"{path}\" for hashing: ",
   "_HashFileFailureToRead.comment": "Printed after ErrorMessage and before the specific failing filesystem operation (like file not found) An example of {path} is /foo/bar.",
-  "HashPortManyFiles": "The {package_name} contains {count} files. Hashing these contents may take a long time when determining the ABI hash for binary caching. Consider reducing the number of files. Common causes of this are accidentally checking out source or build files into a port's directory.",
+  "HashPortManyFiles": "The port '{package_name}' contains {count} files. Hashing these contents may take a long time when determining the ABI hash for binary caching. Consider reducing the number of files. Common causes of this are accidentally checking out source or build files into a port's directory.",
   "_HashPortManyFiles.comment": "An example of {package_name} is zlib. An example of {count} is 42.",
   "HeaderOnlyUsage": "{package_name} is header-only and can be used from CMake via:",
   "_HeaderOnlyUsage.comment": "'header' refers to C/C++ .h files An example of {package_name} is zlib.",


### PR DESCRIPTION
Previous message said `The zlib contains 42 files`. Now says `The port 'zlib' contains 42 files`