### PR TITLE
Disallow invalid triplet names passed via `--triplet`

### DIFF
--- a/src/vcpkg-test/input.cpp
+++ b/src/vcpkg-test/input.cpp
@@ -105,6 +105,17 @@ See )" + docs::triplets_url + R"( for more information.
     REQUIRE(maybe_check.error() == expected_error);
 }
 
+TEST_CASE ("check_triplet rejects malformed triplet", "[input][check_triplet]")
+{
+    TripletDatabase db;
+    db.available_triplets.push_back(TripletFile{"invalid.triplet_name", "invalid.triplet_name.cmake"});
+    auto maybe_check = check_triplet("invalid.triplet_name", db);
+    REQUIRE(!maybe_check.has_value());
+    static constexpr StringLiteral expected_error{
+        "error: expected the end of input parsing a package spec; this usually means the indicated character is not allowed to be in a package spec. Port, triplet, and feature names are all lowercase alphanumeric+hypens."};
+    REQUIRE(maybe_check.error() == expected_error);
+}
+
 TEST_CASE ("check_and_get_package_spec validates the triplet", "[input][check_and_get_package_spec]")
 {
     TripletDatabase db;

--- a/src/vcpkg-test/input.cpp
+++ b/src/vcpkg-test/input.cpp
@@ -112,7 +112,8 @@ TEST_CASE ("check_triplet rejects malformed triplet", "[input][check_triplet]")
     auto maybe_check = check_triplet("invalid.triplet_name", db);
     REQUIRE(!maybe_check.has_value());
     static constexpr StringLiteral expected_error{
-        "error: expected the end of input parsing a package spec; this usually means the indicated character is not allowed to be in a package spec. Port, triplet, and feature names are all lowercase alphanumeric+hypens."};
+        "error: expected the end of input parsing a package spec; this usually means the indicated character is not "
+        "allowed to be in a package spec. Port, triplet, and feature names are all lowercase alphanumeric+hypens."};
     REQUIRE(maybe_check.error() == expected_error);
 }
 

--- a/src/vcpkg/input.cpp
+++ b/src/vcpkg/input.cpp
@@ -1,6 +1,6 @@
-
 #include <vcpkg/base/checks.h>
 #include <vcpkg/base/messages.h>
+#include <vcpkg/base/parse.h>
 #include <vcpkg/base/strings.h>
 
 #include <vcpkg/commands.help.h>
@@ -26,6 +26,12 @@ namespace vcpkg
     {
         // Intentionally show the lowercased string
         auto as_lower = Strings::ascii_to_lowercase(name);
+        
+        if (std::find_if_not(name.begin(), name.end(), ParserBase::is_package_name_char) != name.end())
+        {
+            return msg::format_error(msgParseQualifiedSpecifierNotEof);
+        }
+
         if (!database.is_valid_triplet_canonical_name(as_lower))
         {
             LocalizedString result = msg::format_error(msgInvalidTriplet, msg::triplet = as_lower);

--- a/src/vcpkg/input.cpp
+++ b/src/vcpkg/input.cpp
@@ -26,7 +26,7 @@ namespace vcpkg
     {
         // Intentionally show the lowercased string
         auto as_lower = Strings::ascii_to_lowercase(name);
-        
+
         if (std::find_if_not(name.begin(), name.end(), ParserBase::is_package_name_char) != name.end())
         {
             return msg::format_error(msgParseQualifiedSpecifierNotEof);


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/10120

Triplets specified together with ports, e.g. `zlib:x64-windows` are restricted to lowercase alphanumeric characters and hyphens. However, triplets passed using `--triplet` or `--host-triplet` weren't checked for this requirement.

This PR resolves this inconsistency by adding validation of triplet names to `check_triplet`.