### PR TITLE
Suggest running `git pull` when a version is not found in the database.

### DIFF
--- a/include/vcpkg/base/message-data.inc.h
+++ b/include/vcpkg/base/message-data.inc.h
@@ -413,7 +413,10 @@ DECLARE_MESSAGE(
     "build system. To suppress this message, add set(VCPKG_POLICY_SKIP_ARCHITECTURE_CHECK enabled)")
 DECLARE_MESSAGE(ChecksFailedCheck, (), "", "vcpkg has crashed; no additional details are available.")
 DECLARE_MESSAGE(ChecksUnreachableCode, (), "", "unreachable code was reached")
-DECLARE_MESSAGE(ChecksUpdateVcpkg, (), "", "updating vcpkg by rerunning bootstrap-vcpkg or running `git pull` may resolve this failure.")
+DECLARE_MESSAGE(ChecksUpdateVcpkg,
+                (),
+                "",
+                "updating vcpkg by rerunning `git pull` and bootstrap-vcpkg may resolve this failure.")
 DECLARE_MESSAGE(CiBaselineAllowUnexpectedPassingRequiresBaseline,
                 (),
                 "",

--- a/include/vcpkg/base/message-data.inc.h
+++ b/include/vcpkg/base/message-data.inc.h
@@ -413,7 +413,7 @@ DECLARE_MESSAGE(
     "build system. To suppress this message, add set(VCPKG_POLICY_SKIP_ARCHITECTURE_CHECK enabled)")
 DECLARE_MESSAGE(ChecksFailedCheck, (), "", "vcpkg has crashed; no additional details are available.")
 DECLARE_MESSAGE(ChecksUnreachableCode, (), "", "unreachable code was reached")
-DECLARE_MESSAGE(ChecksUpdateVcpkg, (), "", "updating vcpkg by rerunning bootstrap-vcpkg may resolve this failure.")
+DECLARE_MESSAGE(ChecksUpdateVcpkg, (), "", "updating vcpkg by rerunning bootstrap-vcpkg or running `git pull` may resolve this failure.")
 DECLARE_MESSAGE(CiBaselineAllowUnexpectedPassingRequiresBaseline,
                 (),
                 "",

--- a/locales/messages.json
+++ b/locales/messages.json
@@ -271,7 +271,7 @@
   "_CMakeUsingExportedLibs.comment": "{value} is a CMake command line switch of the form -DFOO=BAR",
   "ChecksFailedCheck": "vcpkg has crashed; no additional details are available.",
   "ChecksUnreachableCode": "unreachable code was reached",
-  "ChecksUpdateVcpkg": "updating vcpkg by rerunning bootstrap-vcpkg may resolve this failure.",
+  "ChecksUpdateVcpkg": "updating vcpkg by rerunning bootstrap-vcpkg or running `git pull` may resolve this failure.",
   "CiBaselineAllowUnexpectedPassingRequiresBaseline": "--allow-unexpected-passing can only be used if a baseline is provided via --ci-baseline.",
   "CiBaselineDisallowedCascade": "REGRESSION: {spec} cascaded, but it is required to pass. ({path}).",
   "_CiBaselineDisallowedCascade.comment": "An example of {spec} is zlib:x64-windows. An example of {path} is /foo/bar.",

--- a/locales/messages.json
+++ b/locales/messages.json
@@ -271,7 +271,7 @@
   "_CMakeUsingExportedLibs.comment": "{value} is a CMake command line switch of the form -DFOO=BAR",
   "ChecksFailedCheck": "vcpkg has crashed; no additional details are available.",
   "ChecksUnreachableCode": "unreachable code was reached",
-  "ChecksUpdateVcpkg": "updating vcpkg by rerunning bootstrap-vcpkg or running `git pull` may resolve this failure.",
+  "ChecksUpdateVcpkg": "updating vcpkg by rerunning `git pull` and bootstrap-vcpkg may resolve this failure.",
   "CiBaselineAllowUnexpectedPassingRequiresBaseline": "--allow-unexpected-passing can only be used if a baseline is provided via --ci-baseline.",
   "CiBaselineDisallowedCascade": "REGRESSION: {spec} cascaded, but it is required to pass. ({path}).",
   "_CiBaselineDisallowedCascade.comment": "An example of {spec} is zlib:x64-windows. An example of {path} is /foo/bar.",


### PR DESCRIPTION
Might help diagnosing failures caused by an updated `builtin-baseline` and an outdated Git registry.