### PR TITLE
Keep DWORD exit code on Windows cmd_execute

### DIFF
--- a/src/closes-exit-negative.c
+++ b/src/closes-exit-negative.c
@@ -1,0 +1,3 @@
+int main() {
+    return 1 << 31;
+}

--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -1422,9 +1422,8 @@ namespace vcpkg
             return std::move(process_create).error();
         }
 
-        auto long_exit_code = process_info.wait();
-        if (long_exit_code > INT_MAX) long_exit_code = INT_MAX;
-        return static_cast<int>(long_exit_code);
+        auto uint_exit_code = process_info.wait();
+        return static_cast<int>(uint_exit_code);
 #else
         Command real_command_line_builder;
         if (const auto wd = settings.working_directory.get())


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/issues/40850, exit code ​​greater than `INT_MAX` will be overwritten by `INT_MAX`.

No comment found in https://github.com/microsoft/vcpkg/pull/9897/files#diff-c7f689f08ecad87b9789f06f001ec0717d627ebe406f20abcec575cc013cf34f.

No modification required for the `DWORD` exit code from `GetExitCodeProcess`, values ​​exceeding `INT_MAX` will be represented as negative `int`.