### PR TITLE
Remove unnecessary use of std::array

### DIFF
--- a/include/vcpkg/base/util.h
+++ b/include/vcpkg/base/util.h
@@ -53,6 +53,11 @@ namespace vcpkg::Util
             const auto last = end(container);
             return std::find(first, last, item) != last;
         }
+        template<class Vec, class Key, size_t N>
+        bool contains(const Vec (&container)[N], const Key& item)
+        {
+            return std::find(container, container + N, item) != container + N;
+        }
         template<class T>
         std::vector<T> concat(View<T> r1, View<T> r2)
         {

--- a/include/vcpkg/metrics.h
+++ b/include/vcpkg/metrics.h
@@ -4,7 +4,6 @@
 
 #include <vcpkg/base/stringview.h>
 
-#include <array>
 #include <atomic>
 #include <map>
 #include <mutex>
@@ -49,7 +48,7 @@ namespace vcpkg
         StringLiteral name;
     };
 
-    extern const std::array<DefineMetricEntry, static_cast<size_t>(DefineMetric::COUNT)> all_define_metrics;
+    extern const DefineMetricEntry all_define_metrics[static_cast<size_t>(DefineMetric::COUNT)];
 
     enum class StringMetric
     {
@@ -82,7 +81,7 @@ namespace vcpkg
         StringLiteral preregister_value; // mock values
     };
 
-    extern const std::array<StringMetricEntry, static_cast<size_t>(StringMetric::COUNT)> all_string_metrics;
+    extern const StringMetricEntry all_string_metrics[static_cast<size_t>(StringMetric::COUNT)];
 
     enum class BoolMetric
     {
@@ -105,7 +104,7 @@ namespace vcpkg
         StringLiteral name;
     };
 
-    extern const std::array<BoolMetricEntry, static_cast<size_t>(BoolMetric::COUNT)> all_bool_metrics;
+    extern const BoolMetricEntry all_bool_metrics[static_cast<size_t>(BoolMetric::COUNT)];
 
     // Batches metrics changes so they can be submitted under a single lock acquisition or
     // in a single JSON payload.

--- a/src/vcpkg-test/metrics.cpp
+++ b/src/vcpkg-test/metrics.cpp
@@ -9,7 +9,7 @@
 using namespace vcpkg;
 
 template<typename MetricEntry, size_t Size>
-void validate_enum_values_and_names(const std::array<MetricEntry, Size>& entries)
+void validate_enum_values_and_names(const MetricEntry (&entries)[Size])
 {
     static_assert(static_cast<size_t>(decltype(entries[0].metric)::COUNT) == Size,
                   "COUNT must be the last enum entry.");

--- a/src/vcpkg-test/specifier.cpp
+++ b/src/vcpkg-test/specifier.cpp
@@ -22,13 +22,13 @@ TEST_CASE ("specifier conversion", "[specifier]")
         Util::sort(fspecs);
         REQUIRE(fspecs.size() == SPEC_SIZE);
 
-        std::array<const char*, SPEC_SIZE> features = {"0", "1", "2", "3"};
-        std::array<PackageSpec*, SPEC_SIZE> specs = {&a_spec, &a_spec, &b_spec, &b_spec};
+        constexpr const char* features[SPEC_SIZE] = {"0", "1", "2", "3"};
+        PackageSpec* specs[SPEC_SIZE] = {&a_spec, &a_spec, &b_spec, &b_spec};
 
         for (std::size_t i = 0; i < SPEC_SIZE; ++i)
         {
-            REQUIRE(features.at(i) == fspecs.at(i).feature());
-            REQUIRE(*specs.at(i) == fspecs.at(i).spec());
+            REQUIRE(features[i] == fspecs[i].feature());
+            REQUIRE(*specs[i] == fspecs[i].spec());
         }
     }
 }

--- a/src/vcpkg/base/hash.cpp
+++ b/src/vcpkg/base/hash.cpp
@@ -297,7 +297,7 @@ namespace vcpkg::Hash
 
             ShaAlgorithm m_impl{};
 
-            std::array<uchar, chunk_size> m_chunk{};
+            uchar m_chunk[chunk_size] = {};
             std::size_t m_current_chunk_size = 0;
             message_length_type m_message_length = 0;
         };
@@ -327,7 +327,7 @@ namespace vcpkg::Hash
 
             Sha256Algorithm() noexcept { clear(); }
 
-            void process_full_chunk(const std::array<uchar, chunk_size>& chunk) noexcept
+            void process_full_chunk(const uchar (&chunk)[chunk_size]) noexcept
             {
                 std::uint32_t words[64];
 
@@ -387,7 +387,7 @@ namespace vcpkg::Hash
                 m_digest[7] = 0x5be0cd19;
             }
 
-            constexpr static std::array<std::uint32_t, number_of_rounds> round_constants = {
+            constexpr static std::uint32_t round_constants[number_of_rounds] = {
                 0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
                 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
                 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
@@ -413,7 +413,7 @@ namespace vcpkg::Hash
 
             Sha512Algorithm() noexcept { clear(); }
 
-            void process_full_chunk(const std::array<uchar, chunk_size>& chunk) noexcept
+            void process_full_chunk(const uchar (&chunk)[chunk_size]) noexcept
             {
                 std::uint64_t words[80];
 
@@ -473,7 +473,7 @@ namespace vcpkg::Hash
                 m_digest[7] = 0x5be0cd19137e2179;
             }
 
-            constexpr static std::array<std::uint64_t, number_of_rounds> round_constants = {
+            constexpr static std::uint64_t round_constants[number_of_rounds] = {
                 0x428a2f98d728ae22, 0x7137449123ef65cd, 0xb5c0fbcfec4d3b2f, 0xe9b5dba58189dbbc, 0x3956c25bf348b538,
                 0x59f111f1b605d019, 0x923f82a4af194f9b, 0xab1c5ed5da6d8118, 0xd807aa98a3030242, 0x12835b0145706fbe,
                 0x243185be4ee4b28c, 0x550c7dc3d5ffb4e2, 0x72be5d74f27b896f, 0x80deb1fe3b1696b1, 0x9bdc06a725c71235,
@@ -496,10 +496,6 @@ namespace vcpkg::Hash
 
             std::uint64_t m_digest[8];
         };
-
-        // This is required on older compilers, since it was required in C++14
-        constexpr std::array<std::uint32_t, Sha256Algorithm::number_of_rounds> Sha256Algorithm::round_constants;
-        constexpr std::array<std::uint64_t, Sha512Algorithm::number_of_rounds> Sha512Algorithm::round_constants;
 #endif
     }
 

--- a/src/vcpkg/base/hash.cpp
+++ b/src/vcpkg/base/hash.cpp
@@ -267,18 +267,19 @@ namespace vcpkg::Hash
                     add_to_unprocessed(&temp, &temp + 1);
                 }
 
+                const auto chunk_end = m_chunk + chunk_size;
                 // append 0 to the message so that the resulting length is just enough
                 // to add the message length
                 if (chunk_size - m_current_chunk_size < sizeof(m_message_length))
                 {
                     // not enough space to add the message length
                     // just resize and process full chunk
-                    std::fill(chunk_begin(), m_chunk.end(), static_cast<uchar>(0));
+                    std::fill(chunk_begin(), chunk_end, static_cast<uchar>(0));
                     m_impl.process_full_chunk(m_chunk);
                     m_current_chunk_size = 0;
                 }
 
-                const auto before_length = m_chunk.end() - sizeof(m_message_length);
+                const auto before_length = chunk_end - sizeof(m_message_length);
                 std::fill(chunk_begin(), before_length, static_cast<uchar>(0));
                 std::generate(before_length, m_chunk.end(), [length = message_length]() mutable {
                     const auto result = top_bits(length);
@@ -289,7 +290,7 @@ namespace vcpkg::Hash
                 m_impl.process_full_chunk(m_chunk);
             }
 
-            auto chunk_begin() { return m_chunk.begin() + m_current_chunk_size; }
+            auto chunk_begin() { return m_chunk + m_current_chunk_size; }
 
             using underlying_type = typename ShaAlgorithm::underlying_type;
             using message_length_type = typename ShaAlgorithm::message_length_type;

--- a/src/vcpkg/base/hash.cpp
+++ b/src/vcpkg/base/hash.cpp
@@ -281,7 +281,7 @@ namespace vcpkg::Hash
 
                 const auto before_length = chunk_end - sizeof(m_message_length);
                 std::fill(chunk_begin(), before_length, static_cast<uchar>(0));
-                std::generate(before_length, m_chunk.end(), [length = message_length]() mutable {
+                std::generate(before_length, chunk_end, [length = message_length]() mutable {
                     const auto result = top_bits(length);
                     length <<= 8;
                     return result;

--- a/src/vcpkg/base/messages.cpp
+++ b/src/vcpkg/base/messages.cpp
@@ -158,18 +158,23 @@ namespace vcpkg
     {
         static constexpr const size_t max_number_of_args = 5;
 
+        struct ExamplesArray
+        {
+            const StringLiteral* examples[max_number_of_args];
+        };
+
         struct MessageData
         {
             StringLiteral name;
-            std::array<const StringLiteral*, max_number_of_args> arg_examples;
+            ExamplesArray arg_examples;
             const char* comment;
             StringLiteral builtin_message;
         };
 
         template<class... Args>
-        constexpr std::array<const StringLiteral*, max_number_of_args> make_arg_examples_array(Args...)
+        constexpr ExamplesArray make_arg_examples_array(Args...)
         {
-            return std::array<const StringLiteral*, max_number_of_args>{&ArgExample<Args>::example...};
+            return ExamplesArray{&ArgExample<Args>::example...};
         }
 
         constexpr MessageData message_data[] = {
@@ -205,7 +210,7 @@ namespace vcpkg
             {
                 if (index >= detail::number_of_messages) Checks::unreachable(VCPKG_LINE_INFO);
                 std::string msg = message_data[index].comment;
-                for (auto&& ex : message_data[index].arg_examples)
+                for (auto&& ex : message_data[index].arg_examples.examples)
                 {
                     if (ex == nullptr || ex->empty()) continue;
                     if (!msg.empty()) msg.push_back(' ');

--- a/src/vcpkg/base/system.mac.cpp
+++ b/src/vcpkg/base/system.mac.cpp
@@ -51,7 +51,7 @@ namespace vcpkg
     {
         // this exclusion list is the taken from VS Code's source code
         // https://github.com/microsoft/vscode/blob/main/src/vs/base/node/macAddress.ts
-        static constexpr std::array<StringLiteral, 3> invalid_macs{
+        static constexpr StringLiteral invalid_macs[] = {
             "00:00:00:00:00:00",
             "ff:ff:ff:ff:ff:ff",
             // iBridge MAC address used on some Apple devices

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -1834,7 +1834,7 @@ namespace vcpkg
     {
         std::vector<std::string> invalid_keys;
         auto result = api_stable_format(url_template, [&](std::string&, StringView key) {
-            static constexpr std::array<StringLiteral, 4> valid_keys = {"name", "version", "sha", "triplet"};
+            static constexpr StringLiteral valid_keys[] = {"name", "version", "sha", "triplet"};
             if (!Util::Vectors::contains(valid_keys, key))
             {
                 invalid_keys.push_back(key.to_string());

--- a/src/vcpkg/cmakevars.cpp
+++ b/src/vcpkg/cmakevars.cpp
@@ -318,8 +318,9 @@ endfunction()
     {
         std::vector<std::vector<std::pair<std::string, std::string>>> vars(1);
         // Hack: PackageSpecs should never have .name==""
-        const auto file_path = create_tag_extraction_file(std::array<std::pair<FullPackageSpec, std::string>, 1>{
-            std::pair<FullPackageSpec, std::string>{FullPackageSpec{{"", triplet}, {}}, ""}});
+        std::pair<FullPackageSpec, std::string> tag_extracts{FullPackageSpec{{"", triplet}, {}}, ""};
+        const auto file_path =
+            create_tag_extraction_file(View<std::pair<FullPackageSpec, std::string>>{&tag_extracts, 1});
         launch_and_split(file_path, vars);
         paths.get_filesystem().remove(file_path, VCPKG_LINE_INFO);
 

--- a/src/vcpkg/metrics.cpp
+++ b/src/vcpkg/metrics.cpp
@@ -30,10 +30,10 @@ namespace
     using namespace vcpkg;
 
     template<typename T, typename MetricEntry, size_t Size>
-    constexpr StringLiteral get_metric_name(const T metric, const std::array<MetricEntry, Size>& entries) noexcept
+    constexpr StringLiteral get_metric_name(const T metric, const MetricEntry (&entries)[Size]) noexcept
     {
         auto metric_index = static_cast<size_t>(metric);
-        if (metric_index < entries.size())
+        if (metric_index < Size)
         {
             return entries[metric_index].name;
         }
@@ -87,7 +87,7 @@ namespace
 
 namespace vcpkg
 {
-    const constexpr std::array<DefineMetricEntry, static_cast<size_t>(DefineMetric::COUNT)> all_define_metrics{{
+    const constexpr DefineMetricEntry all_define_metrics[static_cast<size_t>(DefineMetric::COUNT)] = {
         {DefineMetric::AssetSource, "asset-source"},
         {DefineMetric::BinaryCachingAws, "binarycaching_aws"},
         {DefineMetric::BinaryCachingAzBlob, "binarycaching_azblob"},
@@ -113,7 +113,7 @@ namespace vcpkg
         {DefineMetric::VersioningErrorVersion, "versioning-error-version"},
         {DefineMetric::X_VcpkgRegistriesCache, "X_VCPKG_REGISTRIES_CACHE"},
         {DefineMetric::X_WriteNugetPackagesConfig, "x-write-nuget-packages-config"},
-    }};
+    };
 
     // SHA256s separated by colons, separated by commas
     static constexpr char plan_example[] = "0000000011111111aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff:"
@@ -123,7 +123,7 @@ namespace vcpkg
                                            "0000000011111111aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff:"
                                            "0000000011111111aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff";
 
-    const constexpr std::array<StringMetricEntry, static_cast<size_t>(StringMetric::COUNT)> all_string_metrics{{
+    const constexpr StringMetricEntry all_string_metrics[static_cast<size_t>(StringMetric::COUNT)] = {
         // registryUri:id:version,...
         {StringMetric::AcquiredArtifacts, "acquired_artifacts", plan_example},
         {StringMetric::ActivatedArtifacts, "activated_artifacts", plan_example},
@@ -146,9 +146,9 @@ namespace vcpkg
         {StringMetric::UserMac, "user_mac", "0"},
         {StringMetric::VcpkgVersion, "vcpkg_version", "2999-12-31-unknownhash"},
         {StringMetric::Warning, "warning", "warning"},
-    }};
+    };
 
-    const constexpr std::array<BoolMetricEntry, static_cast<size_t>(BoolMetric::COUNT)> all_bool_metrics{{
+    const constexpr BoolMetricEntry all_bool_metrics[static_cast<size_t>(BoolMetric::COUNT)] = {
         {BoolMetric::DetectedContainer, "detected_container"},
         {BoolMetric::DependencyGraphSuccess, "dependency-graph-success"},
         {BoolMetric::FeatureFlagBinaryCaching, "feature-flag-binarycaching"},
@@ -159,7 +159,7 @@ namespace vcpkg
         {BoolMetric::FeatureFlagVersions, "feature-flag-versions"},
         {BoolMetric::InstallManifestMode, "install_manifest_mode"},
         {BoolMetric::OptionOverlayPorts, "option_overlay_ports"},
-    }};
+    };
 
     void MetricsSubmission::track_elapsed_us(double value)
     {

--- a/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/src/vcpkg/vcpkgcmdarguments.cpp
@@ -66,7 +66,7 @@ namespace
         {EnvironmentVariableBuildNumber, "Generic"},
     };
 
-    constexpr std::array<StringLiteral, 3> KNOWN_CI_REPOSITORY_IDENTIFIERS{
+    constexpr StringLiteral KNOWN_CI_REPOSITORY_IDENTIFIERS[] = {
         // Azure Pipelines
         // https://learn.microsoft.com/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#build-variables-devops-services
         EnvironmentVariableBuildRepositoryId,


### PR DESCRIPTION
std::array is actually not that cheap to compile and we did not really need it in these cases. ( https://raw.githubusercontent.com/ned14/stl-header-heft/master/graphs/msvs-2019.png )

The remaining place we still use it is in tools.cpp where it represents a version breakdown; that change was invasive so I've separated this off for now.