### PR TITLE
Fix regression on windows: Env var names are case insensitive

### DIFF
--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -661,8 +661,9 @@ namespace vcpkg
         {
             auto pos = env_var.find('=');
             auto key = env_var.substr(0, pos);
-            if (Util::Sets::contains(env_strings, key) ||
-                Util::any_of(env_prefix_string, [&](auto&& group) { return Strings::starts_with(key, group); }))
+            if (Util::Sets::contains(env_strings, key) || Util::any_of(env_prefix_string, [&](auto&& group) {
+                    return Strings::case_insensitive_ascii_starts_with(key, group);
+                }))
             {
                 auto value = pos == std::string::npos ? "" : env_var.substr(pos + 1);
                 env.add_entry(key, value);

--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -555,7 +555,7 @@ namespace vcpkg
                         system32_env,
                         "\\WindowsPowerShell\\v1.0\\");
 
-        std::unordered_set<std::string> env_strings = {
+        std::vector<std::string> env_strings = {
             "ALLUSERSPROFILE",
             "APPDATA",
             "CommonProgramFiles",
@@ -650,20 +650,25 @@ namespace vcpkg
                 }
                 else
                 {
-                    env_strings.emplace(std::move(var));
+                    env_strings.emplace_back(std::move(var));
                 }
             }
         }
 
         Environment env;
+        std::unordered_set<std::string> env_strings_uppercase;
+        for (auto&& env_var : env_strings)
+        {
+            env_strings_uppercase.emplace(Strings::ascii_to_uppercase(env_var));
+        }
 
         for (auto&& env_var : get_environment_variables())
         {
             auto pos = env_var.find('=');
             auto key = env_var.substr(0, pos);
-            if (Util::Sets::contains(env_strings, key) || Util::any_of(env_prefix_string, [&](auto&& group) {
-                    return Strings::case_insensitive_ascii_starts_with(key, group);
-                }))
+            if (Util::Sets::contains(env_strings_uppercase, Strings::ascii_to_uppercase(key)) ||
+                Util::any_of(env_prefix_string,
+                             [&](auto&& group) { return Strings::case_insensitive_ascii_starts_with(key, group); }))
             {
                 auto value = pos == std::string::npos ? "" : env_var.substr(pos + 1);
                 env.add_entry(key, value);


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/41199

Thank you @tmp64 for identifying why the problem exists :)

[The old code](https://github.com/microsoft/vcpkg-tool/commit/d3fc35774f86782f356ef0f9352ba857fa57302e#diff-33cf7c311a76d4a838f91b078c2f8cbc984557379f7b345a268ec6deb665a91eL672) was also case insensitive, because `get_environment_variable` is case insensitive