### PR TITLE
Add a better error message for unlimited argument commands.

### DIFF
--- a/include/vcpkg/base/message-data.inc.h
+++ b/include/vcpkg/base/message-data.inc.h
@@ -2138,6 +2138,10 @@ DECLARE_MESSAGE(NonRangeArgs,
                 "{actual} is an integer",
                 "the command '{command_name}' requires between {lower} and {upper} arguments, inclusive, but {actual} "
                 "were provided")
+DECLARE_MESSAGE(NonRangeArgsGreater,
+                (msg::command_name, msg::lower, msg::actual),
+                "{actual} is an integer",
+                "the command '{command_name}' requires at least {lower} arguments, but {actual} were provided")
 DECLARE_MESSAGE(NonZeroOrOneRemainingArgs,
                 (msg::command_name),
                 "",

--- a/locales/messages.json
+++ b/locales/messages.json
@@ -1187,6 +1187,8 @@
   "_NonOneRemainingArgs.comment": "An example of {command_name} is install.",
   "NonRangeArgs": "the command '{command_name}' requires between {lower} and {upper} arguments, inclusive, but {actual} were provided",
   "_NonRangeArgs.comment": "{actual} is an integer An example of {command_name} is install. An example of {lower} is 42. An example of {upper} is 42.",
+  "NonRangeArgsGreater": "the command '{command_name}' requires at least {lower} arguments, but {actual} were provided",
+  "_NonRangeArgsGreater.comment": "{actual} is an integer An example of {command_name} is install. An example of {lower} is 42.",
   "NonZeroOrOneRemainingArgs": "the command '{command_name}' requires zero or one arguments",
   "_NonZeroOrOneRemainingArgs.comment": "An example of {command_name} is install.",
   "NonZeroRemainingArgs": "the command '{command_name}' does not accept any additional arguments",

--- a/src/vcpkg-test/cmd-parser.cpp
+++ b/src/vcpkg-test/cmd-parser.cpp
@@ -891,6 +891,15 @@ TEST_CASE ("Consume remaining args", "[cmd_parser]")
         CHECK(uut.get_errors() == expected_errors);
         CHECK(uut.get_remaining_args().empty());
     }
+
+    {
+        CmdParser uut{std::vector<std::string>{"first-arg", "second-arg"}};
+        CHECK(uut.consume_remaining_args("command", 3, SIZE_MAX) == std::vector<std::string>{});
+        const auto expected_errors =
+            localized({"error: the command 'command' requires at least 3 arguments, but 2 were provided"});
+        CHECK(uut.get_errors() == expected_errors);
+        CHECK(uut.get_remaining_args().empty());
+    }
 }
 
 TEST_CASE ("delistify_conjoined_value", "[cmd_parser]")

--- a/src/vcpkg/base/cmd-parser.cpp
+++ b/src/vcpkg/base/cmd-parser.cpp
@@ -964,11 +964,22 @@ namespace vcpkg
         bool error = consume_remaining_args_impl(results);
         if (max_arity < results.size() || results.size() < min_arity)
         {
-            errors.emplace_back(msg::format_error(msgNonRangeArgs,
-                                                  msg::command_name = command_name,
-                                                  msg::lower = min_arity,
-                                                  msg::upper = max_arity,
-                                                  msg::actual = results.size()));
+            if (max_arity == SIZE_MAX)
+            {
+                errors.emplace_back(msg::format_error(msgNonRangeArgsGreater,
+                                                      msg::command_name = command_name,
+                                                      msg::lower = min_arity,
+                                                      msg::actual = results.size()));
+            }
+            else
+            {
+                errors.emplace_back(msg::format_error(msgNonRangeArgs,
+                                                      msg::command_name = command_name,
+                                                      msg::lower = min_arity,
+                                                      msg::upper = max_arity,
+                                                      msg::actual = results.size()));
+            }
+
             for (std::size_t idx = max_arity; idx < results.size(); ++idx)
             {
                 errors.emplace_back(msg::format_error(msgUnexpectedArgument, msg::option = results[idx]));


### PR DESCRIPTION
Before / after:

```console
PS D:\vcpkg\test> ..\vcpkg.exe new --application
PS D:\vcpkg\test> ..\vcpkg.exe add rapidjson
error: the command 'add' requires between 2 and 18446744073709551615 arguments, inclusive, but 1 were provided
[...]

PS D:\vcpkg\test> D:\vcpkg-tool\out\build\Win-x64-Debug-WithArtifacts\vcpkg.exe add rapidjson
error: the command 'add' requires at least 2 arguments, but 1 were provided
```