### PR TITLE
Fix missing includes

### DIFF
--- a/src/vcpkg-test/system.process.cpp
+++ b/src/vcpkg-test/system.process.cpp
@@ -2,6 +2,10 @@
 
 #include <vcpkg/base/system.process.h>
 
+#ifndef _WIN32
+#include <sys/wait.h>
+#endif
+
 using namespace vcpkg;
 
 TEST_CASE ("captures-output", "[system.process]")


### PR DESCRIPTION
WIFEXITED requires <sys/wait.h> header. On some platforms, the transitive includes have this symbol, but not all.

Specifically, this fixes building on FreeBSD.