### PR TITLE
Add "maybe" operations to JSON.

### DIFF
--- a/include/vcpkg/base/json.h
+++ b/include/vcpkg/base/json.h
@@ -108,14 +108,22 @@ namespace vcpkg::Json
         int64_t integer(LineInfo li) const noexcept;
         double number(LineInfo li) const noexcept;
         StringView string(LineInfo li) const noexcept;
+        std::string* maybe_string() noexcept;
+        const std::string* maybe_string() const noexcept;
 
         const Array& array(LineInfo li) const& noexcept;
         Array& array(LineInfo li) & noexcept;
         Array&& array(LineInfo li) && noexcept;
 
+        Array* maybe_array() noexcept;
+        const Array* maybe_array() const noexcept;
+
         const Object& object(LineInfo li) const& noexcept;
         Object& object(LineInfo li) & noexcept;
         Object&& object(LineInfo li) && noexcept;
+
+        Object* maybe_object() noexcept;
+        const Object* maybe_object() const noexcept;
 
         static Value null(std::nullptr_t) noexcept;
         static Value boolean(bool) noexcept;

--- a/src/vcpkg/base/json.cpp
+++ b/src/vcpkg/base/json.cpp
@@ -157,6 +157,26 @@ namespace vcpkg::Json
         return underlying_->string;
     }
 
+    std::string* Value::maybe_string() noexcept
+    {
+        if (underlying_ && underlying_->tag == VK::String)
+        {
+            return &underlying_->string;
+        }
+
+        return nullptr;
+    }
+
+    const std::string* Value::maybe_string() const noexcept
+    {
+        if (underlying_ && underlying_->tag == VK::String)
+        {
+            return &underlying_->string;
+        }
+
+        return nullptr;
+    }
+
     const Array& Value::array(LineInfo li) const& noexcept
     {
         vcpkg::Checks::msg_check_exit(li, is_array(), msgJsonValueNotArray);
@@ -169,6 +189,26 @@ namespace vcpkg::Json
     }
     Array&& Value::array(LineInfo li) && noexcept { return std::move(this->array(li)); }
 
+    Array* Value::maybe_array() noexcept
+    {
+        if (underlying_ && underlying_->tag == VK::Array)
+        {
+            return &underlying_->array;
+        }
+
+        return nullptr;
+    }
+
+    const Array* Value::maybe_array() const noexcept
+    {
+        if (underlying_ && underlying_->tag == VK::Array)
+        {
+            return &underlying_->array;
+        }
+
+        return nullptr;
+    }
+
     const Object& Value::object(LineInfo li) const& noexcept
     {
         vcpkg::Checks::msg_check_exit(li, is_object(), msgJsonValueNotObject);
@@ -180,6 +220,26 @@ namespace vcpkg::Json
         return underlying_->object;
     }
     Object&& Value::object(LineInfo li) && noexcept { return std::move(this->object(li)); }
+
+    Object* Value::maybe_object() noexcept
+    {
+        if (underlying_ && underlying_->tag == VK::Object)
+        {
+            return &underlying_->object;
+        }
+
+        return nullptr;
+    }
+
+    const Object* Value::maybe_object() const noexcept
+    {
+        if (underlying_ && underlying_->tag == VK::Object)
+        {
+            return &underlying_->object;
+        }
+
+        return nullptr;
+    }
 
     Value::Value() noexcept = default;
     Value::Value(Value&&) noexcept = default;
@@ -1120,9 +1180,9 @@ namespace vcpkg::Json
     {
         return parse(text, origin).then([&](ParsedJson&& mabeValueIsh) -> ExpectedL<Json::Object> {
             auto& asValue = mabeValueIsh.value;
-            if (asValue.is_object())
+            if (auto as_object = asValue.maybe_object())
             {
-                return std::move(asValue).object(VCPKG_LINE_INFO);
+                return std::move(*as_object);
             }
 
             return msg::format(msgJsonErrorMustBeAnObject, msg::path = origin);

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -812,10 +812,12 @@ namespace
                 auto maybe_json = Json::parse_object(*p, m_url);
                 if (auto json = maybe_json.get())
                 {
-                    auto archive_location = json->get(JsonIdArchiveCapitalLocation);
-                    if (archive_location && archive_location->is_string())
+                    if (auto archive_location = json->get(JsonIdArchiveCapitalLocation))
                     {
-                        return archive_location->string(VCPKG_LINE_INFO).to_string();
+                        if (auto archive_location_string = archive_location->maybe_string())
+                        {
+                            return *archive_location_string;
+                        }
                     }
                 }
             }

--- a/src/vcpkg/bundlesettings.cpp
+++ b/src/vcpkg/bundlesettings.cpp
@@ -32,18 +32,17 @@ namespace
 
     bool parse_optional_json_string(const Json::Object& doc, StringLiteral field_name, Optional<std::string>& output)
     {
-        auto value = doc.get(field_name);
-        if (!value)
+        if (auto value = doc.get(field_name))
         {
-            return true;
-        }
+            if (auto value_string = value->maybe_string())
+            {
+                output = *value_string;
+                return true;
+            }
 
-        if (!value->is_string())
-        {
             return false;
         }
 
-        output = value->string(VCPKG_LINE_INFO).to_string();
         return true;
     }
 }

--- a/src/vcpkg/configuration.cpp
+++ b/src/vcpkg/configuration.cpp
@@ -441,20 +441,20 @@ namespace
                 continue;
             }
 
-            if (!el.second.is_object())
+            auto maybe_demand_obj = el.second.maybe_object();
+            if (!maybe_demand_obj)
             {
                 r.add_generic_error(type_name(), msg::format(msgJsonFieldNotObject, msg::json_field = key));
                 continue;
             }
 
-            const auto& demand_obj = el.second.object(VCPKG_LINE_INFO);
-            if (demand_obj.contains(JsonIdDemands))
+            if (maybe_demand_obj->contains(JsonIdDemands))
             {
                 r.add_generic_error(type_name(),
                                     msg::format(msgConfigurationNestedDemands, msg::json_field = el.first));
             }
 
-            auto maybe_demand = r.visit(demand_obj, CeMetadataDeserializer::instance);
+            auto maybe_demand = r.visit(*maybe_demand_obj, CeMetadataDeserializer::instance);
             if (maybe_demand.has_value())
             {
                 ret.insert_or_replace(key, maybe_demand.value_or_exit(VCPKG_LINE_INFO));
@@ -602,13 +602,14 @@ namespace
         auto serialize_demands = [](const Json::Object& obj, Json::Object& put_into) {
             if (auto demands = obj.get(JsonIdDemands))
             {
-                if (!demands->is_object())
+                auto demands_obj = demands->maybe_object();
+                if (!demands_obj)
                 {
                     return;
                 }
 
                 Json::Object serialized_demands;
-                for (const auto& el : demands->object(VCPKG_LINE_INFO))
+                for (const auto& el : *demands_obj)
                 {
                     auto key = el.first;
                     if (Strings::starts_with(key, "$"))
@@ -617,10 +618,10 @@ namespace
                         continue;
                     }
 
-                    if (el.second.is_object())
+                    if (auto demand_obj = el.second.maybe_object())
                     {
                         auto& inserted = serialized_demands.insert_or_replace(key, Json::Object{});
-                        serialize_ce_metadata(el.second.object(VCPKG_LINE_INFO), inserted);
+                        serialize_ce_metadata(*demand_obj, inserted);
                     }
                 }
                 put_into.insert_or_replace(JsonIdDemands, serialized_demands);
@@ -667,12 +668,13 @@ namespace
 
             if (el.first == JsonIdDemands)
             {
-                if (!el.second.is_object())
+                auto maybe_demands_object = el.second.maybe_object();
+                if (!maybe_demands_object)
                 {
                     continue;
                 }
 
-                for (const auto& demand : el.second.object(VCPKG_LINE_INFO))
+                for (const auto& demand : *maybe_demands_object)
                 {
                     if (Strings::starts_with(demand.first, "$"))
                     {
@@ -840,13 +842,13 @@ namespace vcpkg
         }
 
         auto conf_value = std::move(conf).value(VCPKG_LINE_INFO).value;
-        if (!conf_value.is_object())
+        if (auto conf_value_object = conf_value.maybe_object())
         {
-            messageSink.println(msgFailedToParseNoTopLevelObj, msg::path = origin);
-            return nullopt;
+            return parse_configuration(std::move(*conf_value_object), origin, messageSink);
         }
 
-        return parse_configuration(std::move(conf_value).object(VCPKG_LINE_INFO), origin, messageSink);
+        messageSink.println(msgFailedToParseNoTopLevelObj, msg::path = origin);
+        return nullopt;
     }
 
     Optional<Configuration> parse_configuration(const Json::Object& obj, StringView origin, MessageSink& messageSink)

--- a/src/vcpkg/configure-environment.cpp
+++ b/src/vcpkg/configure-environment.cpp
@@ -42,30 +42,32 @@ namespace
             return;
         }
 
-        auto acquired_artifacts = pparsed->get(JsonIdAcquiredArtifacts);
-        if (acquired_artifacts)
+        if (auto acquired_artifacts = pparsed->get(JsonIdAcquiredArtifacts))
         {
-            if (acquired_artifacts->is_string())
+            if (auto maybe_acquired_string = acquired_artifacts->maybe_string())
             {
-                get_global_metrics_collector().track_string(StringMetric::AcquiredArtifacts,
-                                                            acquired_artifacts->string(VCPKG_LINE_INFO));
+                get_global_metrics_collector().track_string(StringMetric::AcquiredArtifacts, *maybe_acquired_string);
             }
-            Debug::println("Acquired artifacts was not a string.");
+            else
+            {
+                Debug::println("Acquired artifacts was not a string.");
+            }
         }
         else
         {
             Debug::println("No artifacts acquired.");
         }
 
-        auto activated_artifacts = pparsed->get(JsonIdActivatedArtifacts);
-        if (activated_artifacts)
+        if (auto activated_artifacts = pparsed->get(JsonIdActivatedArtifacts))
         {
-            if (activated_artifacts->is_string())
+            if (auto maybe_activated_string = activated_artifacts->maybe_string())
             {
-                get_global_metrics_collector().track_string(StringMetric::ActivatedArtifacts,
-                                                            activated_artifacts->string(VCPKG_LINE_INFO));
+                get_global_metrics_collector().track_string(StringMetric::ActivatedArtifacts, *maybe_activated_string);
             }
-            Debug::println("Activated artifacts was not a string.");
+            else
+            {
+                Debug::println("Activated artifacts was not a string.");
+            }
         }
         else
         {

--- a/src/vcpkg/sourceparagraph.cpp
+++ b/src/vcpkg/sourceparagraph.cpp
@@ -1194,9 +1194,9 @@ namespace vcpkg
 
             if (auto configuration = obj.get(JsonIdVcpkgConfiguration))
             {
-                if (configuration->is_object())
+                if (auto configuration_object = configuration->maybe_object())
                 {
-                    spgh.vcpkg_configuration.emplace(configuration->object(VCPKG_LINE_INFO));
+                    spgh.vcpkg_configuration.emplace(*configuration_object);
                 }
                 else
                 {

--- a/src/vcpkg/spdx.cpp
+++ b/src/vcpkg/spdx.cpp
@@ -24,9 +24,9 @@ static void append_move_if_exists_and_array(Json::Array& out, Json::Object& obj,
 {
     if (auto p = obj.get(property))
     {
-        if (p->is_array())
+        if (auto arr = p->maybe_array())
         {
-            for (auto& e : p->array(VCPKG_LINE_INFO))
+            for (auto& e : *arr)
             {
                 out.push_back(std::move(e));
             }

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -435,30 +435,32 @@ namespace
         {
             auto repo = repo_to_ref_info_value.first;
             const auto& ref_info_value = repo_to_ref_info_value.second;
+            if (auto ref_info_value_object = ref_info_value.maybe_object())
+            {
+                for (auto&& reference_to_commit : *ref_info_value_object)
+                {
+                    auto reference = reference_to_commit.first;
+                    const auto& commit = reference_to_commit.second;
+                    if (auto commit_string = commit.maybe_string())
+                    {
+                        if (!is_git_commit_sha(*commit_string))
+                        {
+                            Debug::print("Lockfile value for key '", reference, "' was not a commit sha\n");
+                            return ret;
+                        }
 
-            if (!ref_info_value.is_object())
+                        ret.emplace(repo.to_string(), LockFile::EntryData{reference.to_string(), *commit_string, true});
+                        continue;
+                    }
+
+                    Debug::print("Lockfile value for key '", reference, "' was not a string\n");
+                    return ret;
+                }
+            }
+            else
             {
                 Debug::print("Lockfile value for key '", repo, "' was not an object\n");
                 return ret;
-            }
-
-            for (auto&& reference_to_commit : ref_info_value.object(VCPKG_LINE_INFO))
-            {
-                auto reference = reference_to_commit.first;
-                const auto& commit = reference_to_commit.second;
-
-                if (!commit.is_string())
-                {
-                    Debug::print("Lockfile value for key '", reference, "' was not a string\n");
-                    return ret;
-                }
-                auto sv = commit.string(VCPKG_LINE_INFO);
-                if (!is_git_commit_sha(sv))
-                {
-                    Debug::print("Lockfile value for key '", reference, "' was not a string\n");
-                    return ret;
-                }
-                ret.emplace(repo.to_string(), LockFile::EntryData{reference.to_string(), sv.to_string(), true});
             }
         }
         return ret;


### PR DESCRIPTION
Extracted from https://github.com/microsoft/vcpkg-tool/pull/1514

This avoids some check/confirm anti-patterns and discourages null-dereference prone code like `*example.get()`. Example:

https://github.com/microsoft/vcpkg-tool/blob/ad7b71c9fc939fbeda446592d41d829d02be0724/src/vcpkg/commands.set-installed.cpp#L62