### PR TITLE
Remove PrintUsage from BuildPackageOptions.

### DIFF
--- a/include/vcpkg/commands.build.h
+++ b/include/vcpkg/commands.build.h
@@ -72,7 +72,6 @@ namespace vcpkg
         CleanDownloads clean_downloads;
         DownloadTool download_tool;
         BackcompatFeatures backcompat_features;
-        PrintUsage print_usage;
         KeepGoing keep_going;
     };
 

--- a/include/vcpkg/commands.set-installed.h
+++ b/include/vcpkg/commands.set-installed.h
@@ -40,6 +40,7 @@ namespace vcpkg
                                            const CMakeVars::CMakeVarProvider& cmake_vars,
                                            ActionPlan action_plan,
                                            DryRun dry_run,
+                                           PrintUsage print_usage,
                                            const Optional<Path>& maybe_pkgconfig,
                                            bool include_manifest_in_github_issue);
     void command_set_installed_and_exit(const VcpkgCmdArguments& args,

--- a/src/vcpkg/commands.build-external.cpp
+++ b/src/vcpkg/commands.build-external.cpp
@@ -36,7 +36,6 @@ namespace vcpkg
             CleanDownloads::No,
             DownloadTool::Builtin,
             BackcompatFeatures::Allow,
-            PrintUsage::Yes,
         };
 
         const FullPackageSpec spec =

--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -98,7 +98,6 @@ namespace vcpkg
             CleanDownloads::No,
             DownloadTool::Builtin,
             BackcompatFeatures::Allow,
-            PrintUsage::Yes,
         };
 
         const FullPackageSpec spec =

--- a/src/vcpkg/commands.ci.cpp
+++ b/src/vcpkg/commands.ci.cpp
@@ -327,7 +327,6 @@ namespace vcpkg
             CleanDownloads::No,
             DownloadTool::Builtin,
             BackcompatFeatures::Prohibit,
-            PrintUsage::Yes,
             KeepGoing::Yes,
         };
 

--- a/src/vcpkg/commands.install.cpp
+++ b/src/vcpkg/commands.install.cpp
@@ -1271,7 +1271,7 @@ namespace vcpkg
                                               var_provider,
                                               std::move(install_plan),
                                               dry_run ? DryRun::Yes : DryRun::No,
-                                              print_cmake_usage ? PrintUsage::No : PrintUsage::Yes,
+                                              print_cmake_usage ? PrintUsage::Yes : PrintUsage::No,
                                               pkgsconfig,
                                               true);
         }

--- a/src/vcpkg/commands.upgrade.cpp
+++ b/src/vcpkg/commands.upgrade.cpp
@@ -69,7 +69,6 @@ namespace vcpkg
             CleanDownloads::No,
             DownloadTool::Builtin,
             BackcompatFeatures::Allow,
-            PrintUsage::Yes,
             keep_going,
         };
 


### PR DESCRIPTION
Extracted from https://github.com/microsoft/vcpkg-tool/pull/1514/

build_package never prints usage so the setting should not be there.