### PR TITLE
Make SPDX resource heuristics an object rather than a value.

### DIFF
--- a/include/vcpkg/commands.build.h
+++ b/include/vcpkg/commands.build.h
@@ -246,7 +246,7 @@ namespace vcpkg
         Optional<Path> abi_tag_file;
         std::vector<Path> relative_port_files;
         std::vector<std::string> relative_port_hashes;
-        std::vector<Json::Value> heuristic_resources;
+        std::vector<Json::Object> heuristic_resources;
     };
 
     void compute_all_abis(const VcpkgPaths& paths,

--- a/include/vcpkg/spdx.h
+++ b/include/vcpkg/spdx.h
@@ -27,7 +27,7 @@ namespace vcpkg
                                  View<std::string> hashes,
                                  std::string created_time,
                                  std::string document_namespace,
-                                 std::vector<Json::Value>&& resource_docs);
+                                 std::vector<Json::Object>&& resource_docs);
 
-    Json::Value run_resource_heuristics(StringView contents, StringView portRawVersion);
+    Json::Object run_resource_heuristics(StringView contents, StringView portRawVersion);
 }

--- a/src/vcpkg-test/spdx.cpp
+++ b/src/vcpkg-test/spdx.cpp
@@ -316,7 +316,7 @@ TEST_CASE ("spdx concat resources", "[spdx]")
 })json",
                             "test")
                     .value(VCPKG_LINE_INFO)
-                    .value;
+                    .value.object(VCPKG_LINE_INFO);
     auto doc2 = Json::parse(R"json(
 {
   "packages": [ "p1", "p2", "p3" ],
@@ -324,7 +324,7 @@ TEST_CASE ("spdx concat resources", "[spdx]")
 })json",
                             "test")
                     .value(VCPKG_LINE_INFO)
-                    .value;
+                    .value.object(VCPKG_LINE_INFO);
 
     const auto sbom = create_spdx_sbom(ipa, {}, {}, "now+1", "ns", {std::move(doc1), std::move(doc2)});
 

--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -922,7 +922,7 @@ namespace vcpkg
 
     static void write_sbom(const VcpkgPaths& paths,
                            const InstallPlanAction& action,
-                           std::vector<Json::Value> heuristic_resources)
+                           std::vector<Json::Object> heuristic_resources)
     {
         auto& fs = paths.get_filesystem();
         const auto& scfl = action.source_control_file_and_location.value_or_exit(VCPKG_LINE_INFO);

--- a/src/vcpkg/spdx.cpp
+++ b/src/vcpkg/spdx.cpp
@@ -82,7 +82,7 @@ static Json::Object make_resource(
     return obj;
 }
 
-Json::Value vcpkg::run_resource_heuristics(StringView contents, StringView version_text)
+Json::Object vcpkg::run_resource_heuristics(StringView contents, StringView version_text)
 {
     // These are a sequence of heuristics to enable proof-of-concept extraction of remote resources for SPDX SBOM
     // inclusion
@@ -130,7 +130,7 @@ Json::Value vcpkg::run_resource_heuristics(StringView contents, StringView versi
         packages.push_back(
             make_resource(fmt::format("SPDXRef-resource-{}", ++n), filename, std::move(url), sha, filename));
     }
-    return Json::Value::object(std::move(ret));
+    return ret;
 }
 
 std::string vcpkg::create_spdx_sbom(const InstallPlanAction& action,
@@ -138,7 +138,7 @@ std::string vcpkg::create_spdx_sbom(const InstallPlanAction& action,
                                     View<std::string> hashes,
                                     std::string created_time,
                                     std::string document_namespace,
-                                    std::vector<Json::Value>&& resource_docs)
+                                    std::vector<Json::Object>&& resource_docs)
 {
     Checks::check_exit(VCPKG_LINE_INFO, relative_paths.size() == hashes.size());
 
@@ -249,11 +249,9 @@ std::string vcpkg::create_spdx_sbom(const InstallPlanAction& action,
 
     for (auto&& rdoc : resource_docs)
     {
-        if (!rdoc.is_object()) continue;
-        auto robj = std::move(rdoc).object(VCPKG_LINE_INFO);
-        append_move_if_exists_and_array(rels, robj, JsonIdRelationships);
-        append_move_if_exists_and_array(files, robj, JsonIdFiles);
-        append_move_if_exists_and_array(packages, robj, JsonIdPackages);
+        append_move_if_exists_and_array(rels, rdoc, JsonIdRelationships);
+        append_move_if_exists_and_array(files, rdoc, JsonIdFiles);
+        append_move_if_exists_and_array(packages, rdoc, JsonIdPackages);
     }
 
     return Json::stringify(doc);


### PR DESCRIPTION
Extracted from https://github.com/microsoft/vcpkg-tool/pull/1514

We were paying to package the object up into a value, then unpackage it.