### PR TITLE
Fix try_load_port to match its documented interface.

### DIFF
--- a/include/vcpkg/paragraphs.h
+++ b/include/vcpkg/paragraphs.h
@@ -35,7 +35,7 @@ namespace vcpkg::Paragraphs
     // If an error occurs, the Expected will be in the error state.
     // Otherwise, if the port is known, the maybe_scfl.get()->source_control_file contains the loaded port information.
     // Otherwise, maybe_scfl.get()->source_control_file is nullptr.
-    PortLoadResult try_load_port(const ReadOnlyFilesystem& fs, StringView port_name, const PortLocation& port_location);
+    PortLoadResult try_load_port(const ReadOnlyFilesystem& fs, const PortLocation& port_location);
     // Identical to try_load_port, but the port unknown condition is mapped to an error.
     PortLoadResult try_load_port_required(const ReadOnlyFilesystem& fs,
                                           StringView port_name,

--- a/src/vcpkg/paragraphs.cpp
+++ b/src/vcpkg/paragraphs.cpp
@@ -386,7 +386,7 @@ namespace vcpkg::Paragraphs
         });
     }
 
-    PortLoadResult try_load_port(const ReadOnlyFilesystem& fs, StringView port_name, const PortLocation& port_location)
+    PortLoadResult try_load_port(const ReadOnlyFilesystem& fs, const PortLocation& port_location)
     {
         StatsTimer timer(g_load_ports_stats);
 
@@ -441,34 +441,34 @@ namespace vcpkg::Paragraphs
                                   std::string{}};
         }
 
-        if (fs.exists(port_location.port_directory, IgnoreErrors{}))
-        {
-            return PortLoadResult{LocalizedString::from_raw(port_location.port_directory)
-                                      .append_raw(": ")
-                                      .append_raw(ErrorPrefix)
-                                      .append(msgPortMissingManifest2, msg::package_name = port_name),
-                                  std::string{}};
-        }
-
-        return PortLoadResult{LocalizedString::from_raw(port_location.port_directory)
-                                  .append_raw(": ")
-                                  .append_raw(ErrorPrefix)
-                                  .append(msgPortDoesNotExist, msg::package_name = port_name),
-                              std::string{}};
+        return PortLoadResult{SourceControlFileAndLocation{}, std::string{}};
     }
 
     PortLoadResult try_load_port_required(const ReadOnlyFilesystem& fs,
                                           StringView port_name,
                                           const PortLocation& port_location)
     {
-        auto load_result = try_load_port(fs, port_name, port_location);
+        auto load_result = try_load_port(fs, port_location);
         auto maybe_res = load_result.maybe_scfl.get();
         if (maybe_res)
         {
             auto res = maybe_res->source_control_file.get();
             if (!res)
             {
-                load_result.maybe_scfl = msg::format_error(msgPortDoesNotExist, msg::package_name = port_name);
+                if (fs.exists(port_location.port_directory, IgnoreErrors{}))
+                {
+                    load_result.maybe_scfl = LocalizedString::from_raw(port_location.port_directory)
+                                                 .append_raw(": ")
+                                                 .append_raw(ErrorPrefix)
+                                                 .append(msgPortMissingManifest2, msg::package_name = port_name);
+                }
+                else
+                {
+                    load_result.maybe_scfl = LocalizedString::from_raw(port_location.port_directory)
+                                                 .append_raw(": ")
+                                                 .append_raw(ErrorPrefix)
+                                                 .append(msgPortDoesNotExist, msg::package_name = port_name);
+                }
             }
         }
 

--- a/src/vcpkg/registries.cpp
+++ b/src/vcpkg/registries.cpp
@@ -497,7 +497,7 @@ namespace
             return m_scfls.get_lazy(path, [&, this]() {
                 std::string spdx_location = "git+https://github.com/Microsoft/vcpkg#ports/";
                 spdx_location.append(port_name.data(), port_name.size());
-                return Paragraphs::try_load_port(m_fs, port_name, PortLocation{path, std::move(spdx_location)})
+                return Paragraphs::try_load_port_required(m_fs, port_name, PortLocation{path, std::move(spdx_location)})
                     .maybe_scfl;
             });
         }


### PR DESCRIPTION
The last two paths in try_load_port translated a nonexistent port directory or missing CONTROL file into errors, which is the try_load_port_required interface. No path returned the "nullptr scfl" result.

The only caller of try_load_port in registries.cpp therefore clearly wanted the "_required" behavior.