### PR TITLE
Disable -Wno-dangling-reference on GCC 13.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,11 @@ else()
 
         string(APPEND CMAKE_C_FLAGS " -Wall -Wextra -Wpedantic -Wno-unknown-pragmas -Wno-missing-field-initializers ${DECL_WARNING}")
         string(APPEND CMAKE_CXX_FLAGS " -Wall -Wextra -Wpedantic -Wno-unknown-pragmas -Wno-missing-field-initializers -Wno-redundant-move ${DECL_WARNING}")
+
+        if(VCPKG_COMPILER STREQUAL "gcc" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13 AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14)
+            # -Wno-dangling-reference results from https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107532 :(
+            string(APPEND CMAKE_CXX_FLAGS " -Wno-dangling-reference")
+        endif()
     endif()
 
     if(VCPKG_WARNINGS_AS_ERRORS)


### PR DESCRIPTION
Our Optional<T&> and Expected<T&> trip over the false positive described in https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107532 , where there are temporary Optional or Expecteds that return references to things outside of their own lifetime that trip the warning.

(I tried to edit vcpkg-tool on Ubuntu 24.04 which comes with GCC 13, triggering this)