### PR TITLE
Suppress meaningless CodeQL warning.

### DIFF
--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -1443,6 +1443,7 @@ namespace vcpkg
         Debug::print(fmt::format("{}: system({})\n", debug_id, real_command_line));
         fflush(nullptr);
 
+        // CodeQL [cpp/uncontrolled-process-operation]: This is intended to run whatever process the user supplies.
         return system(real_command_line.c_str());
 #endif
     }


### PR DESCRIPTION
The warning is intended to detect accidentally running malicious code where a value rather than code is expected, for example the 'shellshock' bug. If we were trying to communicate what should be sanitized data between processes this warning would be appropriate, but this is used for things like `vcpkg env` which is intended to run arbitrary user-supplied shell input.

It's possible that there are places in vcpkg which would use this function inappropriately; effectively, the analysis needs to bubble up to the code that calls the execute_process\* family, but CodeQL doesn't appear to understand this.