### PR TITLE
Use `GITHUB_SERVER_URL` to change GitHub API host for dependency graph submission

### DIFF
--- a/include/vcpkg/base/downloads.h
+++ b/include/vcpkg/base/downloads.h
@@ -36,6 +36,10 @@ namespace vcpkg
                                     View<std::string> headers,
                                     View<std::string> secrets);
 
+    bool send_snapshot_to_api(StringView github_api_url,
+                              StringView github_token,
+                              StringView github_repository,
+                              const Json::Object& snapshot);
     bool send_snapshot_to_api(const std::string& github_token,
                               const std::string& github_repository,
                               const Json::Object& snapshot);

--- a/include/vcpkg/base/downloads.h
+++ b/include/vcpkg/base/downloads.h
@@ -36,13 +36,10 @@ namespace vcpkg
                                     View<std::string> headers,
                                     View<std::string> secrets);
 
-    bool send_snapshot_to_api(StringView github_api_url,
-                              StringView github_token,
-                              StringView github_repository,
-                              const Json::Object& snapshot);
-    bool send_snapshot_to_api(const std::string& github_token,
-                              const std::string& github_repository,
-                              const Json::Object& snapshot);
+    bool submit_github_dependency_graph_snapshot(const Optional<std::string>& maybe_github_server_url,
+                                                 const std::string& github_token,
+                                                 const std::string& github_repository,
+                                                 const Json::Object& snapshot);
     ExpectedL<int> put_file(const ReadOnlyFilesystem&,
                             StringView url,
                             const std::vector<std::string>& secrets,

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -483,19 +483,26 @@ namespace vcpkg
                                    secrets);
     }
 
-    bool send_snapshot_to_api(const std::string& github_token,
-                              const std::string& github_repository,
-                              const Json::Object& snapshot)
-    {
-        return send_snapshot_to_api("https://api.github.com", github_token, github_repository, snapshot);
-    }
-
-    bool send_snapshot_to_api(StringView github_api_url,
-                              StringView github_token,
-                              StringView github_repository,
-                              const Json::Object& snapshot)
+    bool submit_github_dependency_graph_snapshot(const Optional<std::string>& maybe_github_server_url,
+                                                 const std::string& github_token,
+                                                 const std::string& github_repository,
+                                                 const Json::Object& snapshot)
     {
         static constexpr StringLiteral guid_marker = "fcfad8a3-bb68-4a54-ad00-dab1ff671ed2";
+
+        std::string uri;
+        if (auto github_server_url = maybe_github_server_url.get())
+        {
+            uri = *github_server_url;
+            uri.append("/api/v3");
+        }
+        else
+        {
+            uri = "https://api.github.com";
+        }
+
+        fmt::format_to(
+            std::back_inserter(uri), "/repos/{}/dependency-graph/snapshots", url_encode_spaces(github_repository));
 
         auto cmd = Command{"curl"};
         cmd.string_arg("-w").string_arg("\\n" + guid_marker.to_string() + "%{http_code}");
@@ -505,9 +512,7 @@ namespace vcpkg
         std::string res = "Authorization: Bearer " + github_token;
         cmd.string_arg("-H").string_arg(res);
         cmd.string_arg("-H").string_arg("X-GitHub-Api-Version: 2022-11-28");
-        cmd.string_arg(Strings::concat(static_cast<std::string>(github_api_url) + "/repos/",
-                                       url_encode_spaces(github_repository),
-                                       "/dependency-graph/snapshots"));
+        cmd.string_arg(uri);
         cmd.string_arg("-d").string_arg("@-");
 
         RedirectedProcessLaunchSettings settings;

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -487,6 +487,14 @@ namespace vcpkg
                               const std::string& github_repository,
                               const Json::Object& snapshot)
     {
+        return send_snapshot_to_api("https://api.github.com", github_token, github_repository, snapshot);
+    }
+
+    bool send_snapshot_to_api(StringView github_api_url,
+                              StringView github_token,
+                              StringView github_repository,
+                              const Json::Object& snapshot)
+    {
         static constexpr StringLiteral guid_marker = "fcfad8a3-bb68-4a54-ad00-dab1ff671ed2";
 
         auto cmd = Command{"curl"};
@@ -497,8 +505,9 @@ namespace vcpkg
         std::string res = "Authorization: Bearer " + github_token;
         cmd.string_arg("-H").string_arg(res);
         cmd.string_arg("-H").string_arg("X-GitHub-Api-Version: 2022-11-28");
-        cmd.string_arg(Strings::concat(
-            "https://api.github.com/repos/", url_encode_spaces(github_repository), "/dependency-graph/snapshots"));
+        cmd.string_arg(Strings::concat(static_cast<std::string>(github_api_url) + "/repos/",
+                                       url_encode_spaces(github_repository),
+                                       "/dependency-graph/snapshots"));
         cmd.string_arg("-d").string_arg("@-");
 
         RedirectedProcessLaunchSettings settings;

--- a/src/vcpkg/commands.set-installed.cpp
+++ b/src/vcpkg/commands.set-installed.cpp
@@ -200,7 +200,7 @@ namespace vcpkg
             {
                 if (args.github_server_url.has_value())
                 {
-                    s = send_snapshot_to_api(*args.github_server_url.get(),
+                    s = send_snapshot_to_api(*args.github_server_url.get() + "/api/v3",
                                              *args.github_token.get(),
                                              *args.github_repository.get(),
                                              *snapshot.get());

--- a/src/vcpkg/commands.set-installed.cpp
+++ b/src/vcpkg/commands.set-installed.cpp
@@ -194,23 +194,16 @@ namespace vcpkg
         if (paths.manifest_mode_enabled() && paths.get_feature_flags().dependency_graph)
         {
             msg::println(msgDependencyGraphCalculation);
-            auto snapshot = create_dependency_graph_snapshot(args, action_plan);
-            bool s = false;
-            if (snapshot.has_value() && args.github_token.has_value() && args.github_repository.has_value())
+            auto maybe_snapshot = create_dependency_graph_snapshot(args, action_plan);
+            auto snapshot = maybe_snapshot.get();
+            auto github_token = args.github_token.get();
+            auto github_repository = args.github_repository.get();
+            bool dependency_graph_success = false;
+            if (snapshot && github_token && github_repository)
             {
-                if (args.github_server_url.has_value())
-                {
-                    s = send_snapshot_to_api(*args.github_server_url.get() + "/api/v3",
-                                             *args.github_token.get(),
-                                             *args.github_repository.get(),
-                                             *snapshot.get());
-                }
-                else
-                {
-                    s = send_snapshot_to_api(*args.github_token.get(), *args.github_repository.get(), *snapshot.get());
-                }
-
-                if (s)
+                dependency_graph_success = submit_github_dependency_graph_snapshot(
+                    args.github_server_url, *github_token, *github_repository, *snapshot);
+                if (dependency_graph_success)
                 {
                     msg::println(msgDependencyGraphSuccess);
                 }
@@ -219,7 +212,7 @@ namespace vcpkg
                     msg::println(msgDependencyGraphFailure);
                 }
             }
-            get_global_metrics_collector().track_bool(BoolMetric::DependencyGraphSuccess, s);
+            get_global_metrics_collector().track_bool(BoolMetric::DependencyGraphSuccess, dependency_graph_success);
         }
 
         // currently (or once) installed specifications

--- a/src/vcpkg/commands.set-installed.cpp
+++ b/src/vcpkg/commands.set-installed.cpp
@@ -198,7 +198,18 @@ namespace vcpkg
             bool s = false;
             if (snapshot.has_value() && args.github_token.has_value() && args.github_repository.has_value())
             {
-                s = send_snapshot_to_api(*args.github_token.get(), *args.github_repository.get(), *snapshot.get());
+                if (args.github_server_url.has_value())
+                {
+                    s = send_snapshot_to_api(*args.github_server_url.get(),
+                                             *args.github_token.get(),
+                                             *args.github_repository.get(),
+                                             *snapshot.get());
+                }
+                else
+                {
+                    s = send_snapshot_to_api(*args.github_token.get(), *args.github_repository.get(), *snapshot.get());
+                }
+
                 if (s)
                 {
                     msg::println(msgDependencyGraphSuccess);


### PR DESCRIPTION

## Description

I was trying to use `dependencygraph` feature in my company, and found the following GitHub Action step was not updating the dependency of the repository.

```yaml
# example GitHub Actions step
- name: "Run vcpkg(install)"
  run: vcpkg install --triplet "x64-windows"
  env:
    GITHUB_TOKEN: ${{ secrets.GHE_ACCESS_TOKEN }}
    VCPKG_FEATURE_FLAGS: "...,dependencygraph"
```

With `--debug`, I found the curl has failed with bad credential.

```log
[DEBUG] 1032: CreateProcessW(curl -w "\nfcfad8a3-bb68-4a54-ad00-dab1ff671ed2%{http_code}" -X POST -H "Accept: application/vnd.github+json" -H "Authorization: ***" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/luncliff/experiment-repo/dependency-graph/snapshots -d @-)
[DEBUG] 1032: Unexpected WriteFileEx partial success: 7A
[DEBUG]   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
[DEBUG]                                  Dload  Upload   Total   Spent    Left  Speed
[DEBUG] 
[DEBUG]   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
[DEBUG] 100 21560  100   109  100 21451    179  35337 --:--:-- --:--:-- --:--:-- 35933
[DEBUG] {
[DEBUG]   "message": "Bad credentials",
[DEBUG]   "documentation_url": "https://docs.github.com/rest",
[DEBUG]   "status": "401"
[DEBUG] }
[DEBUG] 
[DEBUG] 1032: cmd_execute_and_stream_data() returned 0 after   649546 us
```

Simply because the repository was in the GitHub Enterprise, not in the github.com.

## Changes

* Add another version of `send_snapshot_to_api` function and use it if `args.github_server_url` is detected

I suggest using `GITHUB_SERVER_URL` environment variable for changing the GitHub API host

```yaml
# example GitHub Actions step
- name: "Run vcpkg(install)"
  run: vcpkg install --triplet "x64-windows"
  env:
    GITHUB_SERVER_URL: "https://git.example.com" # API to "https://git.example.com/api/v3/..."
    GITHUB_TOKEN: ${{ secrets.GHE_ACCESS_TOKEN }}
    VCPKG_FEATURE_FLAGS: "...,dependencygraph"
```

After change, the debug message would be like this in the GitHub Enterprise server (3.12)

```log
[DEBUG] 1011: CreateProcessW(curl -w "\nfcfad8a3-bb68-4a54-ad00-dab1ff671ed2%{http_code}" -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ghp_..." -H "X-GitHub-Api-Version: 2022-11-28" https://git.example.com/api/v3/repos/luncliff/experiment-repo/dependency-graph/snapshots -d @-)
[DEBUG]   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
[DEBUG]                                  Dload  Upload   Total   Spent    Left  Speed
[DEBUG] 
[DEBUG]   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
[DEBUG]   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
[DEBUG] 100   860    0     0  100   860      0    738  0:00:01  0:00:01 --:--:--   742
[DEBUG] 100  1024  100   164  100   860     77    405  0:00:02  0:00:02 --:--:--   484
[DEBUG] {
[DEBUG]   "id": 5238,
[DEBUG]   "created_at": "2024-12-03T09:28:55.815Z",
[DEBUG]   "result": "SUCCESS",
[DEBUG]   "message": "Dependency results for the repo have been successfully updated."
[DEBUG] }
[DEBUG] 
[DEBUG] 1011: cmd_execute_and_stream_data() returned 0 after  2153075 us
```

## References

* https://github.com/microsoft/vcpkg-tool/pull/989
* https://devblogs.microsoft.com/cppblog/vcpkg-integration-with-the-github-dependency-graph/
* https://docs.github.com/en/enterprise-server@3.12/rest/dependency-graph/dependency-submission?apiVersion=2022-11-28#create-a-snapshot-of-dependencies-for-a-repository

