### PR TITLE
[vcpkg] Add semantic handling for nuget_version with two-segment versions

### DIFF
--- a/src/vcpkg/commands.export.cpp
+++ b/src/vcpkg/commands.export.cpp
@@ -506,7 +506,13 @@ namespace
         if (opts.nuget)
         {
             const auto nuget_id = opts.maybe_nuget_id.value_or(raw_exported_dir_path.filename().to_string());
-            const auto nuget_version = opts.maybe_nuget_version.value_or("1.0.0");
+            std::string template_nuget_version = opts.maybe_nuget_version.value_or("1.0.0");
+            if (std::count(template_nuget_version.begin(), template_nuget_version.end(), '.') == 1)
+            {
+                // If the version is in the format "X.Y", make it "X.Y.0" for NuGet's semantic versioning.
+                template_nuget_version += ".0";
+            }
+            const auto nuget_version = template_nuget_version;
             const auto nuget_description = opts.maybe_nuget_description.value_or("Vcpkg NuGet export");
 
             msg::println(msgCreatingNugetPackage);


### PR DESCRIPTION
**Description:**

This PR introduces a minor enhancement to handle the `nuget_version` field more effectively when exporting NuGet packages. Specifically:

- If the provided nuget_version has only one period (.), such as 1.2, it will be automatically transformed into 1.2.0 to align with NuGet's semantic versioning.
- Versions already adhering to full semantic versioning (e.g., 1.2.1) or other formats remain unchanged.

**Reason for Change:**

- NuGet requires fully qualified semantic versions. While NuGet itself will raise an error for invalid version formats (e.g., 1.2.), this change preemptively adjusts common cases like 1.2 to avoid such errors and improve the user experience.

**Changes Made:**

- Modified the nuget_version handling logic to append .0 if only one period is found in the version string.

**Testing:**

- Manually tested scenarios with:
  - 1.2 → transformed to 1.2.0
  - 1.2.1 → remains unchanged 
- Invalid formats like 1.2. → left as-is, allowing NuGet to handle errors as expected.
![nuget](https://github.com/user-attachments/assets/a64e7b59-cbcc-4ce9-be1a-5bd05a817c50)


**Impact:**
This change ensures better alignment with NuGet's versioning requirements and reduces common user errors when specifying a version.

Fix vcpkg issue: https://github.com/microsoft/vcpkg/issues/18543
@GreyCat Could you please test this PR? :) 

cc @BillyONeal 