### PR TITLE
Change subprocesses to normal priority (#42715)

### DIFF
--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -833,7 +833,7 @@ namespace
                             nullptr,
                             nullptr,
                             bInheritHandles,
-                            IDLE_PRIORITY_CLASS | CREATE_UNICODE_ENVIRONMENT | EXTENDED_STARTUPINFO_PRESENT |
+                            NORMAL_PRIORITY_CLASS | CREATE_UNICODE_ENVIRONMENT | EXTENDED_STARTUPINFO_PRESENT |
                                 dwCreationFlags,
                             call_environment,
                             working_directory_arg,


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/42715

The priority was changed to normal to NORMAL_PRIORITY_CLASS so vcpkg can perform its tasks (building, zipping, etc) much faster.
