### PR TITLE
Change subprocesses to run at normal priority (#42715)

### DIFF
--- a/include/vcpkg/base/contractual-constants.h
+++ b/include/vcpkg/base/contractual-constants.h
@@ -546,6 +546,7 @@ namespace vcpkg
     inline constexpr StringLiteral EnvironmentVariableVcpkgForceSystemBinaries = "VCPKG_FORCE_SYSTEM_BINARIES";
     inline constexpr StringLiteral EnvironmentVariableVcpkgKeepEnvVars = "VCPKG_KEEP_ENV_VARS";
     inline constexpr StringLiteral EnvironmentVariableVcpkgMaxConcurrency = "VCPKG_MAX_CONCURRENCY";
+    inline constexpr StringLiteral EnvironmentVariableVcpkgSubprocessPriority = "VCPKG_SUBPROCESS_PRIORITY";
     inline constexpr StringLiteral EnvironmentVariableVcpkgNoCi = "VCPKG_NO_CI";
     inline constexpr StringLiteral EnvironmentVariableVcpkgNuGetRepository = "VCPKG_NUGET_REPOSITORY";
     inline constexpr StringLiteral EnvironmentVariableVcpkgOverlayPorts = "VCPKG_OVERLAY_PORTS";

--- a/include/vcpkg/base/message-data.inc.h
+++ b/include/vcpkg/base/message-data.inc.h
@@ -1147,6 +1147,11 @@ DECLARE_MESSAGE(EnvInvalidMaxConcurrency,
                 (msg::env_var, msg::value),
                 "{value} is the invalid value of an environment variable",
                 "{env_var} is {value}, must be > 0")
+DECLARE_MESSAGE(EnvInvalidPriority,
+                (msg::env_var, msg::value),
+                "'{value} is a user-supplied value for {env_var} environment variable.'",
+                "invalid value \"{value}\" for {env_var}."
+                "Valid values are '', 'IDLE', 'BELOW_NORMAL', 'NORMAL', 'ABOVE_NORMAL', 'HIGH' and 'REALTIME'")
 DECLARE_MESSAGE(EnvStrFailedToExtract, (), "", "could not expand the environment string:")
 DECLARE_MESSAGE(EnvPlatformNotSupported, (), "", "Build environment commands are not supported on this platform")
 DECLARE_MESSAGE(EnvVarMustBeAbsolutePath, (msg::path, msg::env_var), "", "{env_var} ({path}) was not an absolute path")

--- a/include/vcpkg/base/system.h
+++ b/include/vcpkg/base/system.h
@@ -62,6 +62,10 @@ namespace vcpkg
     const Optional<Path>& get_program_files_platform_bitness();
 
     unsigned int get_concurrency();
+    
+#if defined(_WIN32)
+    DWORD get_subprocess_priority();
+#endif
 
     Optional<CPUArchitecture> guess_visual_studio_prompt_target_architecture();
 }

--- a/include/vcpkg/base/system.h
+++ b/include/vcpkg/base/system.h
@@ -62,7 +62,7 @@ namespace vcpkg
     const Optional<Path>& get_program_files_platform_bitness();
 
     unsigned int get_concurrency();
-    
+
 #if defined(_WIN32)
     DWORD get_subprocess_priority();
 #endif

--- a/locales/messages.json
+++ b/locales/messages.json
@@ -676,6 +676,8 @@
   "EndOfStringInCodeUnit": "found end of string in middle of code point",
   "EnvInvalidMaxConcurrency": "{env_var} is {value}, must be > 0",
   "_EnvInvalidMaxConcurrency.comment": "{value} is the invalid value of an environment variable An example of {env_var} is VCPKG_DEFAULT_TRIPLET.",
+  "EnvInvalidPriority": "invalid value \"{value}\" for {env_var}.Valid values are '', 'IDLE', 'BELOW_NORMAL', 'NORMAL', 'ABOVE_NORMAL', 'HIGH' and 'REALTIME'",
+  "_EnvInvalidPriority.comment": "'{value} is a user-supplied value for {env_var} environment variable.' An example of {env_var} is VCPKG_DEFAULT_TRIPLET.",
   "EnvPlatformNotSupported": "Build environment commands are not supported on this platform",
   "EnvStrFailedToExtract": "could not expand the environment string:",
   "EnvVarMustBeAbsolutePath": "{env_var} ({path}) was not an absolute path",

--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -818,6 +818,8 @@ namespace
             call_environment = environment_block.data();
         }
 
+        DWORD dwPriority = get_subprocess_priority();
+
         // Leaking process information handle 'process_info.proc_info.hProcess'
         // /analyze can't tell that we transferred ownership here
         VCPKG_MSVC_WARNING(suppress : 6335)
@@ -826,7 +828,7 @@ namespace
                             nullptr,
                             nullptr,
                             bInheritHandles,
-                            IDLE_PRIORITY_CLASS | CREATE_UNICODE_ENVIRONMENT | EXTENDED_STARTUPINFO_PRESENT |
+                            dwPriority | CREATE_UNICODE_ENVIRONMENT | EXTENDED_STARTUPINFO_PRESENT |
                                 dwCreationFlags,
                             call_environment,
                             working_directory_arg,

--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -828,8 +828,7 @@ namespace
                             nullptr,
                             nullptr,
                             bInheritHandles,
-                            dwPriority | CREATE_UNICODE_ENVIRONMENT | EXTENDED_STARTUPINFO_PRESENT |
-                                dwCreationFlags,
+                            dwPriority | CREATE_UNICODE_ENVIRONMENT | EXTENDED_STARTUPINFO_PRESENT | dwCreationFlags,
                             call_environment,
                             working_directory_arg,
                             &startup_info.StartupInfo,


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/42715

The priority was changed to NORMAL_PRIORITY_CLASS so vcpkg can perform its tasks (building, zipping, etc) much faster.