### PR TITLE
Ensure x-script's SHA is tolower'd.

### DIFF
--- a/azure-pipelines/e2e-ports/vcpkg-test-x-script/portfile.cmake
+++ b/azure-pipelines/e2e-ports/vcpkg-test-x-script/portfile.cmake
@@ -2,6 +2,7 @@
 vcpkg_download_distfile(
     SOURCE_PATH
     URLS https://example.com/hello-world.txt
+    # This must stay uppercase to check that the SHA512 is properly tolower'd when it gets passed to x-script
     SHA512 09E1E2A84C92B56C8280F4A1203C7CFFD61B162CFE987278D4D6BE9AFBF38C0E8934CDADF83751F4E99D111352BFFEFC958E5A4852C8A7A29C95742CE59288A8
     FILENAME hello-world.txt
 )

--- a/src/test-script-asset-cache.c
+++ b/src/test-script-asset-cache.c
@@ -5,6 +5,7 @@
 #include <string.h>
 
 static const char expected_uri[] = "https://example.com/hello-world.txt";
+// Note that this checks that the SHA is properly tolower'd
 static const char expected_sha[] = "09e1e2a84c92b56c8280f4a1203c7cffd61b162cfe987278d4d6be9afbf38c0e8934cdadf83751f4e99"
                                    "d111352bffefc958e5a4852c8a7a29c95742ce59288a8";
 

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -1050,7 +1050,8 @@ namespace vcpkg
                 {
                     const auto download_path_part_path = download_path + fmt::format(".{}.part", get_process_id());
                     const auto escaped_url = Command(urls[0]).extract();
-                    const auto escaped_sha512 = Command(*hash).extract();
+                    auto escaped_sha512 = Command(*hash).extract();
+                    Strings::inplace_ascii_to_lowercase(escaped_sha512);
                     const auto escaped_dpath = Command(download_path_part_path).extract();
                     Command cmd;
                     cmd.raw_arg(api_stable_format(*script, [&](std::string& out, StringView key) {

--- a/src/vcpkg/commands.download.cpp
+++ b/src/vcpkg/commands.download.cpp
@@ -82,7 +82,6 @@ namespace vcpkg
             {
                 Checks::msg_exit_with_error(VCPKG_LINE_INFO, msgImproperShaLength, msg::value = *p);
             }
-            Strings::inplace_ascii_to_lowercase(p->data(), p->data() + p->size());
         }
 
         return sha;


### PR DESCRIPTION
A large customer took a dependency on our happening to use lowercase SHA512s most of the time, and were broken when recent changes to vcpkgTools.xml contained capitalized SHA512s. This change always lowercases the SHA before invoking the x-script.