### PR TITLE
Add manifest-info.json to record manifest path in vcpkg_installed

### DIFF
--- a/azure-pipelines/end-to-end-tests-dir/manifests.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/manifests.ps1
@@ -119,6 +119,23 @@ Write-Trace "test nameless manifest features: default-features, features = []"
 Run-Vcpkg install @manifestDirArgs
 Throw-IfNotFailed
 
+Write-Trace "Checking for manifest_info.json in vcpkg_installed directory"
+# Define the install root based on the actual install path
+$installRoot = "/Users/javiermatos/dev/vcpkg-tool/work/testing/installed"
+$installedDir = Join-Path -Path $installRoot -ChildPath "vcpkg"
+$manifestInfoPath = Join-Path -Path $installedDir -ChildPath "manifest_info.json"
+
+# Check if manifest_info.json exists
+if (Test-Path -Path $manifestInfoPath) {
+    Write-Trace "manifest_info.json found at: $manifestInfoPath"
+    $manifestInfoContent = Get-Content -Path $manifestInfoPath -Raw
+    Write-Trace "Contents of manifest_info.json:"
+    Write-Trace $manifestInfoContent
+} else {
+    Write-Trace "manifest_info.json not found in vcpkg_installed directory!"
+    Throw "manifest_info.json missing from $installedDir"
+}
+
 Write-Trace "test nameless manifest features: no-default-features, features = []"
 Run-Vcpkg install @manifestDirArgs --x-no-default-features
 Throw-IfFailed

--- a/azure-pipelines/end-to-end-tests-dir/manifests.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/manifests.ps1
@@ -8,7 +8,7 @@ $manifestDirArgs = $commonArgs + @("--x-manifest-root=$manifestDir")
 $noDefaultFeatureArgs = $manifestDirArgs + @('--x-no-default-features')
 
 $vcpkgDir = Join-Path -Path $installRoot -ChildPath "vcpkg"
-$manifestInfoPath = Join-Path -Path $vcpkgDir -ChildPath "manifest_info.json"
+$manifestInfoPath = Join-Path -Path $vcpkgDir -ChildPath "manifest-info.json"
 function feature {
     @{
         'description' = '';

--- a/azure-pipelines/end-to-end-tests-dir/manifests.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/manifests.ps1
@@ -7,6 +7,8 @@ $commonArgs += @("--x-builtin-ports-root=$PSScriptRoot/../e2e-ports")
 $manifestDirArgs = $commonArgs + @("--x-manifest-root=$manifestDir")
 $noDefaultFeatureArgs = $manifestDirArgs + @('--x-no-default-features')
 
+$vcpkgDir = Join-Path -Path $installRoot -ChildPath "vcpkg"
+$manifestInfoPath = Join-Path -Path $vcpkgDir -ChildPath "manifest_info.json"
 function feature {
     @{
         'description' = '';
@@ -53,13 +55,18 @@ Throw-IfNotFailed
 Write-Trace "test manifest features: no-default-features, features = []"
 Run-Vcpkg install @manifestDirArgs --x-no-default-features
 Throw-IfFailed
+Test-ManifestInfo -ManifestInfoPath $ManifestInfoPath -VcpkgDir $vcpkgDir -ManifestRoot $manifestDir
+
 Write-Trace "test manifest features: default-features, features = [core]"
 Run-Vcpkg install @manifestDirArgs --x-feature=core
 Throw-IfFailed
+Test-ManifestInfo -ManifestInfoPath $ManifestInfoPath -VcpkgDir $vcpkgDir -ManifestRoot $manifestDir
+
 # test having both
 Write-Trace "test manifest features: no-default-features, features = [core]"
 Run-Vcpkg install @manifestDirArgs --x-no-default-features --x-feature=core
 Throw-IfFailed
+Test-ManifestInfo -ManifestInfoPath $ManifestInfoPath -VcpkgDir $vcpkgDir -ManifestRoot $manifestDir
 
 Write-Trace "test manifest features: no-default-features, features = [default-fail]"
 Run-Vcpkg install @manifestDirArgs --x-no-default-features --x-feature=default-fail
@@ -71,26 +78,38 @@ Throw-IfNotFailed
 Write-Trace "test manifest features: no-default-features, features = [copied-feature]"
 Run-Vcpkg install @noDefaultFeatureArgs --x-feature=copied-feature
 Throw-IfFailed
+Test-ManifestInfo -ManifestInfoPath $ManifestInfoPath -VcpkgDir $vcpkgDir -ManifestRoot $manifestDir
+
 Write-Trace "test manifest features: no-default-features, features = [copied-feature, copied-feature]"
 Run-Vcpkg install @noDefaultFeatureArgs --x-feature=copied-feature --x-feature=copied-feature
 Throw-IfFailed
+Test-ManifestInfo -ManifestInfoPath $ManifestInfoPath -VcpkgDir $vcpkgDir -ManifestRoot $manifestDir
 
 Write-Trace "test manifest features: no-default-features, features = [multiple-dep-1, multiple-dep-2]"
 Run-Vcpkg install @noDefaultFeatureArgs --x-feature=multiple-dep-1 --x-feature=multiple-dep-2
 Throw-IfFailed
+Test-ManifestInfo -ManifestInfoPath $ManifestInfoPath -VcpkgDir $vcpkgDir -ManifestRoot $manifestDir
 
 Write-Trace "test manifest features: no-default-features, features = [no-default-features-1]"
 Run-Vcpkg install @noDefaultFeatureArgs --x-feature=no-default-features-1
 Throw-IfFailed
+Test-ManifestInfo -ManifestInfoPath $ManifestInfoPath -VcpkgDir $vcpkgDir -ManifestRoot $manifestDir
+
 Write-Trace "test manifest features: no-default-features, features = [no-default-features-2]"
 Run-Vcpkg install @noDefaultFeatureArgs --x-feature=no-default-features-2
 Throw-IfFailed
+Test-ManifestInfo -ManifestInfoPath $ManifestInfoPath -VcpkgDir $vcpkgDir -ManifestRoot $manifestDir
+
 Write-Trace "test manifest features: no-default-features, features = [no-default-features-1,no-default-features-3]"
 Run-Vcpkg install @noDefaultFeatureArgs --x-feature=no-default-features-1 --x-feature=no-default-features-3
 Throw-IfFailed
+Test-ManifestInfo -ManifestInfoPath $ManifestInfoPath -VcpkgDir $vcpkgDir -ManifestRoot $manifestDir
+
 Write-Trace "test manifest features: no-default-features, features = [no-default-features-3]"
 Run-Vcpkg install @noDefaultFeatureArgs --x-feature=no-default-features-3
 Throw-IfFailed
+Test-ManifestInfo -ManifestInfoPath $ManifestInfoPath -VcpkgDir $vcpkgDir -ManifestRoot $manifestDir
+
 
 $vcpkgJson = @{
     'default-features' = @( 'default-fail' );
@@ -119,37 +138,26 @@ Write-Trace "test nameless manifest features: default-features, features = []"
 Run-Vcpkg install @manifestDirArgs
 Throw-IfNotFailed
 
-Write-Trace "Checking for manifest_info.json in vcpkg_installed directory"
-# Define the install root based on the actual install path
-$installRoot = "/Users/javiermatos/dev/vcpkg-tool/work/testing/installed"
-$installedDir = Join-Path -Path $installRoot -ChildPath "vcpkg"
-$manifestInfoPath = Join-Path -Path $installedDir -ChildPath "manifest_info.json"
-
-# Check if manifest_info.json exists
-if (Test-Path -Path $manifestInfoPath) {
-    Write-Trace "manifest_info.json found at: $manifestInfoPath"
-    $manifestInfoContent = Get-Content -Path $manifestInfoPath -Raw
-    Write-Trace "Contents of manifest_info.json:"
-    Write-Trace $manifestInfoContent
-} else {
-    Write-Trace "manifest_info.json not found in vcpkg_installed directory!"
-    Throw "manifest_info.json missing from $installedDir"
-}
-
 Write-Trace "test nameless manifest features: no-default-features, features = []"
 Run-Vcpkg install @manifestDirArgs --x-no-default-features
 Throw-IfFailed
+Test-ManifestInfo -ManifestInfoPath $ManifestInfoPath -VcpkgDir $vcpkgDir -ManifestRoot $manifestDir
+
 Write-Trace "test nameless manifest features: default-features, features = [core]"
 Run-Vcpkg install @manifestDirArgs --x-feature=core
 Throw-IfFailed
+Test-ManifestInfo -ManifestInfoPath $ManifestInfoPath -VcpkgDir $vcpkgDir -ManifestRoot $manifestDir
+
 # test having both
 Write-Trace "test nameless manifest features: no-default-features, features = [core]"
 Run-Vcpkg install @manifestDirArgs --x-no-default-features --x-feature=core
 Throw-IfFailed
+Test-ManifestInfo -ManifestInfoPath $ManifestInfoPath -VcpkgDir $vcpkgDir -ManifestRoot $manifestDir
 
 Write-Trace "test nameless manifest features: no-default-features, features = [default-fail]"
 Run-Vcpkg install @manifestDirArgs --x-no-default-features --x-feature=default-fail
 Throw-IfNotFailed
+
 Write-Trace "test nameless manifest features: default-features, features = [core, default-fail]"
 Run-Vcpkg install @manifestDirArgs --x-feature=core --x-feature=default-fail
 Throw-IfNotFailed
@@ -157,20 +165,27 @@ Throw-IfNotFailed
 Write-Trace "test nameless manifest features: no-default-features, features = [copied-feature]"
 Run-Vcpkg install @noDefaultFeatureArgs --x-feature=copied-feature
 Throw-IfFailed
+Test-ManifestInfo -ManifestInfoPath $ManifestInfoPath -VcpkgDir $vcpkgDir -ManifestRoot $manifestDir
+
 Write-Trace "test nameless manifest features: no-default-features, features = [copied-feature, copied-feature]"
 Run-Vcpkg install @noDefaultFeatureArgs --x-feature=copied-feature --x-feature=copied-feature
 Throw-IfFailed
+Test-ManifestInfo -ManifestInfoPath $ManifestInfoPath -VcpkgDir $vcpkgDir -ManifestRoot $manifestDir
 
 Write-Trace "test nameless manifest features: no-default-features, features = [multiple-dep-1, multiple-dep-2]"
 Run-Vcpkg install @noDefaultFeatureArgs --x-feature=multiple-dep-1 --x-feature=multiple-dep-2
 Throw-IfFailed
+Test-ManifestInfo -ManifestInfoPath $ManifestInfoPath -VcpkgDir $vcpkgDir -ManifestRoot $manifestDir
 
 Write-Trace "test nameless manifest features: no-default-features, features = [no-default-features-1]"
 Run-Vcpkg install @noDefaultFeatureArgs --x-feature=no-default-features-1
 Throw-IfFailed
+Test-ManifestInfo -ManifestInfoPath $ManifestInfoPath -VcpkgDir $vcpkgDir -ManifestRoot $manifestDir
+
 Write-Trace "test nameless manifest features: no-default-features, features = [no-default-features-2]"
 Run-Vcpkg install @noDefaultFeatureArgs --x-feature=no-default-features-2
 Throw-IfFailed
+Test-ManifestInfo -ManifestInfoPath $ManifestInfoPath -VcpkgDir $vcpkgDir -ManifestRoot $manifestDir
 
 $vcpkgJson = @{
     'name' = "manifest-test";
@@ -198,10 +213,12 @@ Set-Content -Path "$manifestDir/manifest-test/vcpkg.json" `
 Write-Trace "test manifest features: self-reference, features = [a]"
 Run-Vcpkg install @manifestDirArgs --x-feature=a
 Throw-IfFailed
+Test-ManifestInfo -ManifestInfoPath $ManifestInfoPath -VcpkgDir $vcpkgDir -ManifestRoot $manifestDir
 
 Write-Trace "test manifest features: self-reference, features = [a], with overlay"
 Run-Vcpkg install @manifestDirArgs --x-feature=a "--overlay-ports=$manifestDir/manifest-test"
 Throw-IfFailed
+Test-ManifestInfo -ManifestInfoPath $ManifestInfoPath -VcpkgDir $vcpkgDir -ManifestRoot $manifestDir
 
 Write-Trace "test manifest install with specific package names fails"
 $output = Run-VcpkgAndCaptureOutput install @manifestDirArgs vcpkg-empty-port
@@ -211,6 +228,8 @@ Throw-IfNonContains -Expected 'error: In manifest mode, `vcpkg install` does not
 Write-Trace "test manifest install with specific package names forced to classic mode succeeds"
 $output = Run-VcpkgAndCaptureOutput install @manifestDirArgs --classic vcpkg-empty-port
 Throw-IfFailed
+Test-ManifestInfo -ManifestInfoPath $ManifestInfoPath -VcpkgDir $vcpkgDir -ManifestRoot $manifestDir
+
 $expected = @"
 The following packages will be built and installed:
     vcpkg-empty-port:

--- a/azure-pipelines/end-to-end-tests-dir/overlays.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/overlays.ps1
@@ -1,5 +1,8 @@
 . $PSScriptRoot/../end-to-end-tests-prelude.ps1
 
+$vcpkgDir = Join-Path -Path $installRoot -ChildPath "vcpkg"
+$manifestInfoPath = Join-Path -Path $vcpkgDir -ChildPath "manifest_info.json"
+
 # Tests a simple project with overlay ports and triplets configured on a vcpkg-configuration.json file
 Copy-Item -Recurse -LiteralPath @(
     "$PSScriptRoot/../e2e-projects/overlays-project-with-config",
@@ -16,6 +19,7 @@ Run-Vcpkg install --x-manifest-root=$manifestRoot `
     --x-install-root=$installRoot `
     --triplet fancy-triplet
 Throw-IfFailed
+Test-ManifestInfo -ManifestInfoPath $ManifestInfoPath -VcpkgDir $vcpkgDir -ManifestRoot $manifestRoot
 
 # Tests overlays configured in env and cli on a project with configuration embedded on the manifest file
 $manifestRoot = "$TestingRoot/overlays-project-config-embedded"
@@ -26,6 +30,7 @@ Run-Vcpkg install --x-manifest-root=$manifestRoot `
     --x-install-root=$installRoot `
     --triplet fancy-config-embedded-triplet
 Throw-IfFailed
+Test-ManifestInfo -ManifestInfoPath $ManifestInfoPath -VcpkgDir $vcpkgDir -ManifestRoot $manifestRoot
 
 # Config with bad paths
 $manifestRoot = "$TestingRoot/overlays-bad-paths"

--- a/azure-pipelines/end-to-end-tests-dir/overlays.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/overlays.ps1
@@ -1,7 +1,7 @@
 . $PSScriptRoot/../end-to-end-tests-prelude.ps1
 
 $vcpkgDir = Join-Path -Path $installRoot -ChildPath "vcpkg"
-$manifestInfoPath = Join-Path -Path $vcpkgDir -ChildPath "manifest_info.json"
+$manifestInfoPath = Join-Path -Path $vcpkgDir -ChildPath "manifest-info.json"
 
 # Tests a simple project with overlay ports and triplets configured on a vcpkg-configuration.json file
 Copy-Item -Recurse -LiteralPath @(

--- a/azure-pipelines/end-to-end-tests-prelude.ps1
+++ b/azure-pipelines/end-to-end-tests-prelude.ps1
@@ -273,13 +273,13 @@ function Test-ManifestInfo {
     )
 
     if (-not (Test-Path $ManifestInfoPath)) {
-        Throw "manifest_info.json missing from $VcpkgDir"
+        Throw "manifest-info.json missing from $VcpkgDir"
     }
 
     $manifestInfoContent = Get-Content $ManifestInfoPath -Raw | ConvertFrom-Json
 
-    if ($manifestInfoContent.manifest_path -ne (Join-Path -Path $ManifestRoot -ChildPath "vcpkg.json")) {
-        Throw "Mismatch in manifest_path. Expected: $ManifestRoot, Found: $($manifestInfoContent.manifest_path)"
+    if ($manifestInfoContent.'manifest-path' -ne (Join-Path -Path $ManifestRoot -ChildPath "vcpkg.json")) {
+        Throw "Mismatch in manifest-path. Expected: $ManifestRoot, Found: $($manifestInfoContent.'manifest-path')"
     }
 }
 

--- a/azure-pipelines/end-to-end-tests-prelude.ps1
+++ b/azure-pipelines/end-to-end-tests-prelude.ps1
@@ -265,4 +265,22 @@ function Throw-IfNonContains {
     }
 }
 
+function Test-ManifestInfo {
+    param (
+        [string]$ManifestInfoPath,
+        [string]$VcpkgDir,
+        [string]$ManifestRoot
+    )
+
+    if (-not (Test-Path $ManifestInfoPath)) {
+        Throw "manifest_info.json missing from $VcpkgDir"
+    }
+
+    $manifestInfoContent = Get-Content $ManifestInfoPath -Raw | ConvertFrom-Json
+
+    if ($manifestInfoContent.manifest_path -ne (Join-Path -Path $ManifestRoot -ChildPath "vcpkg.json")) {
+        Throw "Mismatch in manifest_path. Expected: $ManifestRoot, Found: $($manifestInfoContent.manifest_path)"
+    }
+}
+
 Refresh-TestRoot

--- a/docs/manifest-info.schema.json
+++ b/docs/manifest-info.schema.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg-manifest-info.schema.json",
+    "type": "object",
+    "properties": {
+      "manifest-path": {
+        "description": "Identifies the path of the vcpkg manifest file that produced this installed tree.",
+        "type": "string"
+      }
+    },
+    "additionalProperties": true,
+    "required": [ "manifest-path" ]
+  }

--- a/docs/manifest-info.schema.json
+++ b/docs/manifest-info.schema.json
@@ -1,13 +1,15 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg-manifest-info.schema.json",
-    "type": "object",
-    "properties": {
-      "manifest-path": {
-        "description": "Identifies the path of the vcpkg manifest file that produced this installed tree.",
-        "type": "string"
-      }
-    },
-    "additionalProperties": true,
-    "required": [ "manifest-path" ]
-  }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg-manifest-info.schema.json",
+  "type": "object",
+  "properties": {
+    "manifest-path": {
+      "description": "Identifies the path of the vcpkg manifest file that produced this installed tree.",
+      "type": "string"
+    }
+  },
+  "additionalProperties": true,
+  "required": [
+    "manifest-path"
+  ]
+}

--- a/include/vcpkg/base/contractual-constants.h
+++ b/include/vcpkg/base/contractual-constants.h
@@ -362,7 +362,7 @@ namespace vcpkg
     inline constexpr StringLiteral FileVcpkgConfigurationDotJson = "vcpkg-configuration.json";
     inline constexpr StringLiteral FileVcpkgDotJson = "vcpkg.json";
     inline constexpr StringLiteral FileVcpkgLock = "vcpkg-lock.json";
-    inline constexpr StringLiteral FileManifestInfo = "manifest_info.json";
+    inline constexpr StringLiteral FileManifestInfo = "manifest-info.json";
     inline constexpr StringLiteral FileVcpkgPathTxt = "vcpkg.path.txt";
     inline constexpr StringLiteral FileVcpkgPortConfig = "vcpkg-port-config.cmake";
     inline constexpr StringLiteral FileVcpkgSpdxJson = "vcpkg.spdx.json";

--- a/include/vcpkg/base/contractual-constants.h
+++ b/include/vcpkg/base/contractual-constants.h
@@ -362,6 +362,7 @@ namespace vcpkg
     inline constexpr StringLiteral FileVcpkgConfigurationDotJson = "vcpkg-configuration.json";
     inline constexpr StringLiteral FileVcpkgDotJson = "vcpkg.json";
     inline constexpr StringLiteral FileVcpkgLock = "vcpkg-lock.json";
+    inline constexpr StringLiteral FileManifestInfo = "manifest_info.json";
     inline constexpr StringLiteral FileVcpkgPathTxt = "vcpkg.path.txt";
     inline constexpr StringLiteral FileVcpkgPortConfig = "vcpkg-port-config.cmake";
     inline constexpr StringLiteral FileVcpkgSpdxJson = "vcpkg.spdx.json";

--- a/src/vcpkg/commands.set-installed.cpp
+++ b/src/vcpkg/commands.set-installed.cpp
@@ -193,23 +193,6 @@ namespace vcpkg
             }
         }
 
-        if (auto manifest = paths.get_manifest().get())
-        {
-            Json::Object manifest_info;
-            manifest_info.insert("manifest_path", Json::Value::string(manifest->path));
-            
-            if (const auto installed_paths = paths.maybe_installed().get())
-            {
-                const auto json_file_path = installed_paths->vcpkg_dir() / "manifest_info.json";
-
-                const auto json_contents = Json::stringify(manifest_info, Json::JsonStyle::with_spaces(4));
-
-                fs.write_contents(json_file_path, json_contents, VCPKG_LINE_INFO);
-
-                Debug::print("Manifest JSON written to: ", json_file_path, "\nContents:\n", json_contents);
-            }
-        }
-
         if (paths.manifest_mode_enabled() && paths.get_feature_flags().dependency_graph)
         {
             msg::println(msgDependencyGraphCalculation);
@@ -293,6 +276,23 @@ namespace vcpkg
                 {
                     install_print_usage_information(it->get()->package, printed_usages, fs, paths.installed());
                 }
+            }
+        }
+
+        if (auto manifest = paths.get_manifest().get())
+        {
+            Json::Object manifest_info;
+            manifest_info.insert("manifest_path", Json::Value::string(manifest->path));
+            
+            if (const auto installed_paths = paths.maybe_installed().get())
+            {
+                const auto json_file_path = installed_paths->vcpkg_dir() / "manifest_info.json";
+
+                const auto json_contents = Json::stringify(manifest_info, Json::JsonStyle::with_spaces(4));
+                
+                fs.write_contents(json_file_path, json_contents, VCPKG_LINE_INFO);
+
+                Debug::print("Manifest JSON written to: ", json_file_path, "\nContents:\n", json_contents);
             }
         }
 

--- a/src/vcpkg/commands.set-installed.cpp
+++ b/src/vcpkg/commands.set-installed.cpp
@@ -282,16 +282,11 @@ namespace vcpkg
         {
             Json::Object manifest_info;
             manifest_info.insert("manifest_path", Json::Value::string(manifest->path));
-
             if (const auto installed_paths = paths.maybe_installed().get())
             {
-                const auto json_file_path = installed_paths->vcpkg_dir() / "manifest_info.json";
-
-                const auto json_contents = Json::stringify(manifest_info, Json::JsonStyle::with_spaces(4));
-
+                const auto json_file_path = installed_paths->vcpkg_dir() / FileManifestInfo;
+                const auto json_contents = Json::stringify(manifest_info, Json::JsonStyle::with_spaces(2));
                 fs.write_contents(json_file_path, json_contents, VCPKG_LINE_INFO);
-
-                Debug::print("Manifest JSON written to: ", json_file_path, "\nContents:\n", json_contents);
             }
         }
 

--- a/src/vcpkg/commands.set-installed.cpp
+++ b/src/vcpkg/commands.set-installed.cpp
@@ -8,14 +8,13 @@
 #include <vcpkg/commands.install.h>
 #include <vcpkg/commands.set-installed.h>
 #include <vcpkg/input.h>
+#include <vcpkg/installedpaths.h>
 #include <vcpkg/metrics.h>
 #include <vcpkg/portfileprovider.h>
 #include <vcpkg/registries.h>
 #include <vcpkg/vcpkgcmdarguments.h>
 #include <vcpkg/vcpkglib.h>
 #include <vcpkg/vcpkgpaths.h>
-#include <vcpkg/installedpaths.h>
-
 
 using namespace vcpkg;
 
@@ -283,13 +282,13 @@ namespace vcpkg
         {
             Json::Object manifest_info;
             manifest_info.insert("manifest_path", Json::Value::string(manifest->path));
-            
+
             if (const auto installed_paths = paths.maybe_installed().get())
             {
                 const auto json_file_path = installed_paths->vcpkg_dir() / "manifest_info.json";
 
                 const auto json_contents = Json::stringify(manifest_info, Json::JsonStyle::with_spaces(4));
-                
+
                 fs.write_contents(json_file_path, json_contents, VCPKG_LINE_INFO);
 
                 Debug::print("Manifest JSON written to: ", json_file_path, "\nContents:\n", json_contents);

--- a/src/vcpkg/commands.set-installed.cpp
+++ b/src/vcpkg/commands.set-installed.cpp
@@ -193,6 +193,23 @@ namespace vcpkg
             }
         }
 
+        if (auto manifest = paths.get_manifest().get())
+        {
+            Json::Object manifest_info;
+            manifest_info.insert("manifest_path", Json::Value::string(manifest->path));
+            
+            if (const auto installed_paths = paths.maybe_installed().get())
+            {
+                const auto json_file_path = installed_paths->vcpkg_dir() / "manifest_info.json";
+
+                const auto json_contents = Json::stringify(manifest_info, Json::JsonStyle::with_spaces(4));
+
+                fs.write_contents(json_file_path, json_contents, VCPKG_LINE_INFO);
+
+                Debug::print("Manifest JSON written to: ", json_file_path, "\nContents:\n", json_contents);
+            }
+        }
+
         if (paths.manifest_mode_enabled() && paths.get_feature_flags().dependency_graph)
         {
             msg::println(msgDependencyGraphCalculation);
@@ -276,27 +293,6 @@ namespace vcpkg
                 {
                     install_print_usage_information(it->get()->package, printed_usages, fs, paths.installed());
                 }
-            }
-        }
-
-        if (auto manifest = paths.get_manifest().get())
-        {
-            Json::Object manifest_info;
-            manifest_info.insert("manifest_path", Json::Value::string(manifest->path));
-
-            if (const auto installed_paths = paths.maybe_installed().get())
-            {
-                const auto json_file_path = installed_paths->vcpkg_dir() / "manifest_info.json";
-
-                const auto json_contents = Json::stringify(manifest_info, Json::JsonStyle::with_spaces(4));
-
-                fs.write_contents(json_file_path, json_contents, VCPKG_LINE_INFO);
-
-                Debug::print("Manifest JSON written to: ", json_file_path, "\nContents:\n", json_contents);
-            }
-            else
-            {
-                Debug::print("No installed paths are available.\n");
             }
         }
 

--- a/src/vcpkg/commands.set-installed.cpp
+++ b/src/vcpkg/commands.set-installed.cpp
@@ -281,7 +281,7 @@ namespace vcpkg
         if (auto manifest = paths.get_manifest().get())
         {
             Json::Object manifest_info;
-            manifest_info.insert("manifest_path", Json::Value::string(manifest->path));
+            manifest_info.insert("manifest-path", Json::Value::string(manifest->path));
             if (const auto installed_paths = paths.maybe_installed().get())
             {
                 const auto json_file_path = installed_paths->vcpkg_dir() / FileManifestInfo;

--- a/src/vcpkg/commands.set-installed.cpp
+++ b/src/vcpkg/commands.set-installed.cpp
@@ -278,16 +278,16 @@ namespace vcpkg
             }
         }
 
-        if (auto manifest = paths.get_manifest().get())
+        const auto manifest = paths.get_manifest().get();
+        const auto installed_paths = paths.maybe_installed().get();
+        if (manifest && installed_paths)
         {
+            // See docs/manifest-info.schema.json
             Json::Object manifest_info;
             manifest_info.insert("manifest-path", Json::Value::string(manifest->path));
-            if (const auto installed_paths = paths.maybe_installed().get())
-            {
-                const auto json_file_path = installed_paths->vcpkg_dir() / FileManifestInfo;
-                const auto json_contents = Json::stringify(manifest_info);
-                fs.write_contents(json_file_path, json_contents, VCPKG_LINE_INFO);
-            }
+            const auto json_file_path = installed_paths->vcpkg_dir() / FileManifestInfo;
+            const auto json_contents = Json::stringify(manifest_info);
+            fs.write_contents(json_file_path, json_contents, VCPKG_LINE_INFO);
         }
 
         Checks::exit_success(VCPKG_LINE_INFO);

--- a/src/vcpkg/commands.set-installed.cpp
+++ b/src/vcpkg/commands.set-installed.cpp
@@ -14,6 +14,8 @@
 #include <vcpkg/vcpkgcmdarguments.h>
 #include <vcpkg/vcpkglib.h>
 #include <vcpkg/vcpkgpaths.h>
+#include <vcpkg/installedpaths.h>
+
 
 using namespace vcpkg;
 
@@ -274,6 +276,27 @@ namespace vcpkg
                 {
                     install_print_usage_information(it->get()->package, printed_usages, fs, paths.installed());
                 }
+            }
+        }
+
+        if (auto manifest = paths.get_manifest().get())
+        {
+            Json::Object manifest_info;
+            manifest_info.insert("manifest_path", Json::Value::string(manifest->path));
+
+            if (const auto installed_paths = paths.maybe_installed().get())
+            {
+                const auto json_file_path = installed_paths->vcpkg_dir() / "manifest_info.json";
+
+                const auto json_contents = Json::stringify(manifest_info, Json::JsonStyle::with_spaces(4));
+
+                fs.write_contents(json_file_path, json_contents, VCPKG_LINE_INFO);
+
+                Debug::print("Manifest JSON written to: ", json_file_path, "\nContents:\n", json_contents);
+            }
+            else
+            {
+                Debug::print("No installed paths are available.\n");
             }
         }
 

--- a/src/vcpkg/commands.set-installed.cpp
+++ b/src/vcpkg/commands.set-installed.cpp
@@ -285,7 +285,7 @@ namespace vcpkg
             if (const auto installed_paths = paths.maybe_installed().get())
             {
                 const auto json_file_path = installed_paths->vcpkg_dir() / FileManifestInfo;
-                const auto json_contents = Json::stringify(manifest_info, Json::JsonStyle::with_spaces(2));
+                const auto json_contents = Json::stringify(manifest_info);
                 fs.write_contents(json_file_path, json_contents, VCPKG_LINE_INFO);
             }
         }


### PR DESCRIPTION
This PR introduces the generation of a manifest_info.json file in the vcpkg_installed directory for projects using a manifest (vcpkg.json). This file contains the absolute path to the manifest file that was used to generate the corresponding vcpkg_installed tree.

https://devdiv.visualstudio.com/DevDiv/_backlogs/backlog/Vcpkg%20Package%20Manager/Stories?System.AssignedTo=javiermat%40microsoft.com&System.State=Active%2CIn%20Progress%2CProposed%2CCommitted&workitem=2253211