### PR TITLE
Fix GitHub Actions Cache setting an incorrect Content-Range header

### DIFF
--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -923,6 +923,7 @@ namespace
 
             size_t upload_count = 0;
             auto cache_size = m_fs.file_size(zip_path, VCPKG_LINE_INFO);
+            if (cache_size == 0) return upload_count;
 
             if (auto cacheId = reserve_cache_entry(request.spec.name(), abi, cache_size))
             {
@@ -930,7 +931,7 @@ namespace
                     m_token_header,
                     m_accept_header.to_string(),
                     "Content-Type: application/octet-stream",
-                    "Content-Range: bytes 0-" + std::to_string(cache_size) + "/*",
+                    fmt::format("Content-Range: bytes 0-{}/{}", cache_size - 1, cache_size),
                 };
 
                 PrintingDiagnosticContext pdc{msg_sink};


### PR DESCRIPTION
I recently tried to use the `VCPKG_BINARY_SOURCES` setting to set `clear;x-gha,readwrite` in our GitHub Actions workflow and couldn't get vcpkg to upload to the cache successfully. Proxying vcpkg I noticed that the Content-Range header was off by one causing the cache server to return:

```http
HTTP/2 400 Bad Request
Content-Length: 295
Content-Type: application/json; charset=utf-8
Date: Wed, 15 Jan 2025 02:35:10 GMT
Server: Kestrel
Cache-Control: no-store,no-cache
Pragma: no-cache
...
X-Frame-Options: SAMEORIGIN

{"$id":"1","innerException":null,"message":"The size of the content did not match the Content-Range header","typeName":"Microsoft.Azure.DevOps.ArtifactCache.WebApi.InvalidChunkException, Microsoft.Azure.DevOps.ArtifactCache.WebApi","typeKey":"InvalidChunkException","errorCode":0,"eventId":3000}
```

Manually correcting the value and then sealing the cache with the POST request containing the `size` field resulted in the package being correctly cached. I'm not sure why users of the GitHub Actions binary caching feature in vcpkg haven't run into this on GitHub.com and haven't had the time to see if GitHub.com handles this case differently but it does work on GitHub Enterprise Server.