### PR TITLE
Emit an error for duplicate overrides.

### DIFF
--- a/azure-pipelines/e2e-ports/broken-manifests/broken-duplicate-overrides/portfile.cmake
+++ b/azure-pipelines/e2e-ports/broken-manifests/broken-duplicate-overrides/portfile.cmake
@@ -1,0 +1,1 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/azure-pipelines/e2e-ports/broken-manifests/broken-duplicate-overrides/vcpkg.json
+++ b/azure-pipelines/e2e-ports/broken-manifests/broken-duplicate-overrides/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "broken-duplicate-overrides",
+  "version": "1",
+  "dependencies": [
+    "zlib"
+  ],
+  "overrides": [
+    {
+      "name": "zlib",
+      "version": "1.2.13"
+    },
+    {
+      "name": "zlib",
+      "version": "1.3.1"
+    }
+  ]
+}

--- a/azure-pipelines/end-to-end-tests-dir/build-test-ports.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/build-test-ports.ps1
@@ -30,7 +30,7 @@ Throw-IfFailed
 
 $output = Run-VcpkgAndCaptureOutput @commonArgs --overlay-ports="$PSScriptRoot/../e2e-ports/broken-manifests" install broken-duplicate-overrides
 Throw-IfNotFailed
-if ($output -notmatch "vcpkg\.json: error: \$\.overrides\[1\] \(an override\): zlib already has a declared override") {
+if ($output -notmatch "vcpkg\.json: error: \$\.overrides\[1\] \(an override\): zlib already has an override") {
     throw 'Did not detect duplicate override'
 }
 

--- a/azure-pipelines/end-to-end-tests-dir/build-test-ports.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/build-test-ports.ps1
@@ -28,6 +28,12 @@ Throw-IfFailed
 Run-Vcpkg @commonArgs --overlay-ports="$PSScriptRoot/../e2e-ports" --overlay-ports="$PSScriptRoot/../e2e-ports/broken-manifests" install control-file
 Throw-IfFailed
 
+$output = Run-VcpkgAndCaptureOutput @commonArgs --overlay-ports="$PSScriptRoot/../e2e-ports/broken-manifests" install broken-duplicate-overrides
+Throw-IfNotFailed
+if ($output -notmatch "vcpkg\.json: error: \$\.overrides\[1\] \(an override\): zlib already has a declared override") {
+    throw 'Did not detect duplicate override'
+}
+
 $output = Run-VcpkgAndCaptureOutput @commonArgs --overlay-ports="$PSScriptRoot/../e2e-ports/broken-manifests" install broken-no-name
 Throw-IfNotFailed
 if ($output -notmatch "missing required field 'name'") {

--- a/include/vcpkg/base/jsonreader.h
+++ b/include/vcpkg/base/jsonreader.h
@@ -18,12 +18,8 @@ namespace vcpkg::Json
         using type = Type;
         virtual LocalizedString type_name() const = 0;
 
-    private:
-        friend struct Reader;
         Optional<Type> visit(Reader&, const Value&) const;
         Optional<Type> visit(Reader&, const Object&) const;
-
-    public:
         virtual Optional<Type> visit_null(Reader&) const;
         virtual Optional<Type> visit_boolean(Reader&, bool) const;
         virtual Optional<Type> visit_integer(Reader& r, int64_t i) const;
@@ -33,14 +29,11 @@ namespace vcpkg::Json
         virtual Optional<Type> visit_object(Reader&, const Object&) const;
         virtual View<StringLiteral> valid_fields() const noexcept;
 
-        virtual ~IDeserializer() = default;
-
     protected:
         IDeserializer() = default;
-        IDeserializer(const IDeserializer&) = default;
-        IDeserializer& operator=(const IDeserializer&) = default;
-        IDeserializer(IDeserializer&&) = default;
-        IDeserializer& operator=(IDeserializer&&) = default;
+        IDeserializer(const IDeserializer&) = delete;
+        IDeserializer& operator=(const IDeserializer&) = delete;
+        ~IDeserializer() = default;
     };
 
     struct Reader
@@ -64,9 +57,6 @@ namespace vcpkg::Json
         StringView origin() const noexcept;
 
     private:
-        template<class Type>
-        friend struct IDeserializer;
-
         std::vector<LocalizedString> m_errors;
         std::vector<LocalizedString> m_warnings;
         struct JsonPathElement
@@ -168,19 +158,8 @@ namespace vcpkg::Json
             }
         }
 
-        template<class Type>
-        Optional<Type> visit(const Value& value, const IDeserializer<Type>& visitor)
-        {
-            return visitor.visit(*this, value);
-        }
-        template<class Type>
-        Optional<Type> visit(const Object& value, const IDeserializer<Type>& visitor)
-        {
-            return visitor.visit(*this, value);
-        }
-
-        template<class Type>
-        Optional<std::vector<Type>> array_elements(const Array& arr, const IDeserializer<Type>& visitor)
+        template<class Type, class Fn>
+        Optional<std::vector<Type>> array_elements_fn(const Array& arr, const IDeserializer<Type>& visitor, Fn callback)
         {
             Optional<std::vector<Type>> result{std::vector<Type>()};
             auto& result_vec = *result.get();
@@ -189,7 +168,7 @@ namespace vcpkg::Json
             for (size_t i = 0; i < arr.size(); ++i)
             {
                 m_path.back().index = static_cast<int64_t>(i);
-                auto opt = visitor.visit(*this, arr[i]);
+                auto opt = callback(*this, visitor, arr[i]);
                 if (auto parsed = opt.get())
                 {
                     if (success)
@@ -206,6 +185,15 @@ namespace vcpkg::Json
             }
 
             return result;
+        }
+
+        template<class Type>
+        Optional<std::vector<Type>> array_elements(const Array& arr, const IDeserializer<Type>& visitor)
+        {
+            return array_elements_fn(
+                arr, visitor, [](Reader& this_, const IDeserializer<Type>& visitor, const Json::Value& value) {
+                    return visitor.visit(this_, value);
+                });
         }
 
         static uint64_t get_reader_stats();

--- a/include/vcpkg/base/message-data.inc.h
+++ b/include/vcpkg/base/message-data.inc.h
@@ -1124,6 +1124,7 @@ DECLARE_MESSAGE(DownloadWinHttpError,
                 (msg::system_api, msg::exit_code, msg::url),
                 "",
                 "{url}: {system_api} failed with exit code {exit_code}.")
+DECLARE_MESSAGE(DuplicateDependencyOverride, (msg::package_name), "", "{package_name} already has a declared override")
 DECLARE_MESSAGE(DuplicatedKeyInObj,
                 (msg::value),
                 "{value} is a json property/object",

--- a/include/vcpkg/base/message-data.inc.h
+++ b/include/vcpkg/base/message-data.inc.h
@@ -1124,7 +1124,7 @@ DECLARE_MESSAGE(DownloadWinHttpError,
                 (msg::system_api, msg::exit_code, msg::url),
                 "",
                 "{url}: {system_api} failed with exit code {exit_code}.")
-DECLARE_MESSAGE(DuplicateDependencyOverride, (msg::package_name), "", "{package_name} already has a declared override")
+DECLARE_MESSAGE(DuplicateDependencyOverride, (msg::package_name), "", "{package_name} already has an override")
 DECLARE_MESSAGE(DuplicatedKeyInObj,
                 (msg::value),
                 "{value} is a json property/object",

--- a/include/vcpkg/configuration.h
+++ b/include/vcpkg/configuration.h
@@ -89,7 +89,7 @@ namespace vcpkg
         Optional<Configuration> config;
     };
 
-    Json::IDeserializer<Configuration>& get_configuration_deserializer();
+    extern const Json::IDeserializer<Configuration>& configuration_deserializer;
     // Parse configuration from a file containing a valid vcpkg-configuration.json file
     Optional<Configuration> parse_configuration(StringView contents,
                                                 StringView origin,

--- a/include/vcpkg/registries-parsing.h
+++ b/include/vcpkg/registries-parsing.h
@@ -1,0 +1,43 @@
+#pragma once
+#include <vcpkg/base/jsonreader.h>
+
+#include <vcpkg/registries.h>
+
+namespace vcpkg
+{
+    struct FilesystemVersionDbEntryDeserializer final : Json::IDeserializer<FilesystemVersionDbEntry>
+    {
+        LocalizedString type_name() const override;
+        View<StringLiteral> valid_fields() const noexcept override;
+        Optional<FilesystemVersionDbEntry> visit_object(Json::Reader& r, const Json::Object& obj) const override;
+        FilesystemVersionDbEntryDeserializer(const Path& root) : registry_root(root) { }
+
+    private:
+        Path registry_root;
+    };
+
+    struct FilesystemVersionDbEntryArrayDeserializer final : Json::IDeserializer<std::vector<FilesystemVersionDbEntry>>
+    {
+        virtual LocalizedString type_name() const override;
+        virtual Optional<std::vector<FilesystemVersionDbEntry>> visit_array(Json::Reader& r,
+                                                                            const Json::Array& arr) const override;
+        FilesystemVersionDbEntryArrayDeserializer(const Path& root) : underlying{root} { }
+
+    private:
+        FilesystemVersionDbEntryDeserializer underlying;
+    };
+
+    struct GitVersionDbEntryDeserializer final : Json::IDeserializer<GitVersionDbEntry>
+    {
+        LocalizedString type_name() const override;
+        View<StringLiteral> valid_fields() const noexcept override;
+        Optional<GitVersionDbEntry> visit_object(Json::Reader& r, const Json::Object& obj) const override;
+    };
+
+    struct GitVersionDbEntryArrayDeserializer final : Json::IDeserializer<std::vector<GitVersionDbEntry>>
+    {
+        virtual LocalizedString type_name() const override;
+        virtual Optional<std::vector<GitVersionDbEntry>> visit_array(Json::Reader& r,
+                                                                     const Json::Array& arr) const override;
+    };
+}

--- a/include/vcpkg/registries.h
+++ b/include/vcpkg/registries.h
@@ -217,8 +217,4 @@ namespace vcpkg
     // No match is 0, exact match is SIZE_MAX, wildcard match is the length of the pattern.
     // Note that the * is included in the match size to distinguish from 0 == no match.
     size_t package_pattern_match(StringView name, StringView pattern);
-
-    std::unique_ptr<Json::IDeserializer<std::vector<GitVersionDbEntry>>> make_git_version_db_deserializer();
-    std::unique_ptr<Json::IDeserializer<std::vector<FilesystemVersionDbEntry>>> make_filesystem_version_db_deserializer(
-        const Path& root);
 }

--- a/locales/messages.json
+++ b/locales/messages.json
@@ -653,7 +653,7 @@
   "DownloadingVcpkgStandaloneBundle": "Downloading standalone bundle {version}.",
   "_DownloadingVcpkgStandaloneBundle.comment": "An example of {version} is 1.3.8.",
   "DownloadingVcpkgStandaloneBundleLatest": "Downloading latest standalone bundle.",
-  "DuplicateDependencyOverride": "{package_name} already has a declared override",
+  "DuplicateDependencyOverride": "{package_name} already has an override",
   "_DuplicateDependencyOverride.comment": "An example of {package_name} is zlib.",
   "DuplicatePackagePattern": "Package \"{package_name}\" is duplicated.",
   "_DuplicatePackagePattern.comment": "An example of {package_name} is zlib.",

--- a/locales/messages.json
+++ b/locales/messages.json
@@ -653,6 +653,8 @@
   "DownloadingVcpkgStandaloneBundle": "Downloading standalone bundle {version}.",
   "_DownloadingVcpkgStandaloneBundle.comment": "An example of {version} is 1.3.8.",
   "DownloadingVcpkgStandaloneBundleLatest": "Downloading latest standalone bundle.",
+  "DuplicateDependencyOverride": "{package_name} already has a declared override",
+  "_DuplicateDependencyOverride.comment": "An example of {package_name} is zlib.",
   "DuplicatePackagePattern": "Package \"{package_name}\" is duplicated.",
   "_DuplicatePackagePattern.comment": "An example of {package_name} is zlib.",
   "DuplicatePackagePatternFirstOcurrence": "First declared in:",

--- a/src/vcpkg-test/configmetadata.cpp
+++ b/src/vcpkg-test/configmetadata.cpp
@@ -40,7 +40,7 @@ static Configuration parse_test_configuration(StringView text)
     auto object = Json::parse_object(text, origin).value_or_exit(VCPKG_LINE_INFO);
 
     Json::Reader reader(origin);
-    auto parsed_config_opt = reader.visit(object, get_configuration_deserializer());
+    auto parsed_config_opt = configuration_deserializer.visit(reader, object);
     REQUIRE(reader.errors().empty());
 
     return std::move(parsed_config_opt).value_or_exit(VCPKG_LINE_INFO);
@@ -60,7 +60,7 @@ static void check_errors(const std::string& config_text, const std::string& expe
     auto object = Json::parse_object(config_text, origin).value_or_exit(VCPKG_LINE_INFO);
 
     Json::Reader reader(origin);
-    auto parsed_config_opt = reader.visit(object, get_configuration_deserializer());
+    auto parsed_config_opt = configuration_deserializer.visit(reader, object);
     REQUIRE(!reader.errors().empty());
 
     CHECK_LINES(Strings::join("\n", reader.errors()), expected_errors);

--- a/src/vcpkg/registries.cpp
+++ b/src/vcpkg/registries.cpp
@@ -11,7 +11,7 @@
 #include <vcpkg/documentation.h>
 #include <vcpkg/metrics.h>
 #include <vcpkg/paragraphs.h>
-#include <vcpkg/registries.h>
+#include <vcpkg/registries-parsing.h>
 #include <vcpkg/sourceparagraph.h>
 #include <vcpkg/vcpkgpaths.h>
 #include <vcpkg/versiondeserializers.h>
@@ -41,157 +41,8 @@ namespace
 
         static const RegistryPathStringDeserializer instance;
     };
+
     const RegistryPathStringDeserializer RegistryPathStringDeserializer::instance;
-
-    struct GitVersionDbEntryDeserializer final : Json::IDeserializer<GitVersionDbEntry>
-    {
-        LocalizedString type_name() const override;
-        View<StringLiteral> valid_fields() const noexcept override;
-        Optional<GitVersionDbEntry> visit_object(Json::Reader& r, const Json::Object& obj) const override;
-    };
-
-    LocalizedString GitVersionDbEntryDeserializer::type_name() const { return msg::format(msgAVersionDatabaseEntry); }
-    View<StringLiteral> GitVersionDbEntryDeserializer::valid_fields() const noexcept
-    {
-        static constexpr StringLiteral fields[] = {VCPKG_SCHEMED_DESERIALIZER_FIELDS, JsonIdGitTree};
-        return fields;
-    }
-
-    Optional<GitVersionDbEntry> GitVersionDbEntryDeserializer::visit_object(Json::Reader& r,
-                                                                            const Json::Object& obj) const
-    {
-        GitVersionDbEntry ret;
-        ret.version = visit_required_schemed_version(type_name(), r, obj);
-        r.required_object_field(type_name(), obj, JsonIdGitTree, ret.git_tree, GitTreeStringDeserializer::instance);
-        return ret;
-    }
-
-    struct GitVersionDbEntryArrayDeserializer final : Json::IDeserializer<std::vector<GitVersionDbEntry>>
-    {
-        virtual LocalizedString type_name() const override;
-        virtual Optional<std::vector<GitVersionDbEntry>> visit_array(Json::Reader& r,
-                                                                     const Json::Array& arr) const override;
-
-    private:
-        GitVersionDbEntryDeserializer underlying;
-    };
-    LocalizedString GitVersionDbEntryArrayDeserializer::type_name() const { return msg::format(msgAnArrayOfVersions); }
-
-    Optional<std::vector<GitVersionDbEntry>> GitVersionDbEntryArrayDeserializer::visit_array(
-        Json::Reader& r, const Json::Array& arr) const
-    {
-        return r.array_elements(arr, underlying);
-    }
-
-    struct FilesystemVersionDbEntryDeserializer final : Json::IDeserializer<FilesystemVersionDbEntry>
-    {
-        LocalizedString type_name() const override;
-        View<StringLiteral> valid_fields() const noexcept override;
-        Optional<FilesystemVersionDbEntry> visit_object(Json::Reader& r, const Json::Object& obj) const override;
-        FilesystemVersionDbEntryDeserializer(const Path& root) : registry_root(root) { }
-
-    private:
-        Path registry_root;
-    };
-
-    LocalizedString FilesystemVersionDbEntryDeserializer::type_name() const
-    {
-        return msg::format(msgAVersionDatabaseEntry);
-    }
-    View<StringLiteral> FilesystemVersionDbEntryDeserializer::valid_fields() const noexcept
-    {
-        static constexpr StringLiteral fields[] = {VCPKG_SCHEMED_DESERIALIZER_FIELDS, JsonIdPath};
-        return fields;
-    }
-
-    Optional<FilesystemVersionDbEntry> FilesystemVersionDbEntryDeserializer::visit_object(Json::Reader& r,
-                                                                                          const Json::Object& obj) const
-    {
-        FilesystemVersionDbEntry ret;
-        ret.version = visit_required_schemed_version(type_name(), r, obj);
-
-        std::string path_res;
-        r.required_object_field(type_name(), obj, JsonIdPath, path_res, RegistryPathStringDeserializer::instance);
-        if (!Strings::starts_with(path_res, "$/"))
-        {
-            r.add_generic_error(msg::format(msgARegistryPath), msg::format(msgARegistryPathMustStartWithDollar));
-            return nullopt;
-        }
-
-        if (Strings::contains(path_res, '\\') || Strings::contains(path_res, "//"))
-        {
-            r.add_generic_error(msg::format(msgARegistryPath),
-                                msg::format(msgARegistryPathMustBeDelimitedWithForwardSlashes));
-            return nullopt;
-        }
-
-        auto first = path_res.begin();
-        const auto last = path_res.end();
-        for (std::string::iterator candidate;; first = candidate)
-        {
-            candidate = std::find(first, last, '/');
-            if (candidate == last)
-            {
-                break;
-            }
-
-            ++candidate;
-            if (candidate == last)
-            {
-                break;
-            }
-
-            if (*candidate != '.')
-            {
-                continue;
-            }
-
-            ++candidate;
-            if (candidate == last || *candidate == '/')
-            {
-                r.add_generic_error(msg::format(msgARegistryPath), msg::format(msgARegistryPathMustNotHaveDots));
-                return nullopt;
-            }
-
-            if (*candidate != '.')
-            {
-                first = candidate;
-                continue;
-            }
-
-            ++candidate;
-            if (candidate == last || *candidate == '/')
-            {
-                r.add_generic_error(msg::format(msgARegistryPath), msg::format(msgARegistryPathMustNotHaveDots));
-                return nullopt;
-            }
-        }
-
-        ret.p = registry_root / StringView{path_res}.substr(2);
-
-        return ret;
-    }
-
-    struct FilesystemVersionDbEntryArrayDeserializer final : Json::IDeserializer<std::vector<FilesystemVersionDbEntry>>
-    {
-        virtual LocalizedString type_name() const override;
-        virtual Optional<std::vector<FilesystemVersionDbEntry>> visit_array(Json::Reader& r,
-                                                                            const Json::Array& arr) const override;
-        FilesystemVersionDbEntryArrayDeserializer(const Path& root) : underlying{root} { }
-
-    private:
-        FilesystemVersionDbEntryDeserializer underlying;
-    };
-    LocalizedString FilesystemVersionDbEntryArrayDeserializer::type_name() const
-    {
-        return msg::format(msgAnArrayOfVersions);
-    }
-
-    Optional<std::vector<FilesystemVersionDbEntry>> FilesystemVersionDbEntryArrayDeserializer::visit_array(
-        Json::Reader& r, const Json::Array& arr) const
-    {
-        return r.array_elements(arr, underlying);
-    }
 
     using Baseline = std::map<std::string, Version, std::less<>>;
 
@@ -1748,14 +1599,116 @@ namespace vcpkg
         return std::make_unique<FilesystemRegistry>(fs, std::move(path), std::move(baseline));
     }
 
-    std::unique_ptr<Json::IDeserializer<std::vector<GitVersionDbEntry>>> make_git_version_db_deserializer()
+    LocalizedString FilesystemVersionDbEntryDeserializer::type_name() const
     {
-        return std::make_unique<GitVersionDbEntryArrayDeserializer>();
+        return msg::format(msgAVersionDatabaseEntry);
+    }
+    View<StringLiteral> FilesystemVersionDbEntryDeserializer::valid_fields() const noexcept
+    {
+        static constexpr StringLiteral fields[] = {VCPKG_SCHEMED_DESERIALIZER_FIELDS, JsonIdPath};
+        return fields;
     }
 
-    std::unique_ptr<Json::IDeserializer<std::vector<FilesystemVersionDbEntry>>> make_filesystem_version_db_deserializer(
-        const Path& root)
+    Optional<FilesystemVersionDbEntry> FilesystemVersionDbEntryDeserializer::visit_object(Json::Reader& r,
+                                                                                          const Json::Object& obj) const
     {
-        return std::make_unique<FilesystemVersionDbEntryArrayDeserializer>(root);
+        FilesystemVersionDbEntry ret;
+        ret.version = visit_required_schemed_version(type_name(), r, obj);
+
+        std::string path_res;
+        r.required_object_field(type_name(), obj, JsonIdPath, path_res, RegistryPathStringDeserializer::instance);
+        if (!Strings::starts_with(path_res, "$/"))
+        {
+            r.add_generic_error(msg::format(msgARegistryPath), msg::format(msgARegistryPathMustStartWithDollar));
+            return nullopt;
+        }
+
+        if (Strings::contains(path_res, '\\') || Strings::contains(path_res, "//"))
+        {
+            r.add_generic_error(msg::format(msgARegistryPath),
+                                msg::format(msgARegistryPathMustBeDelimitedWithForwardSlashes));
+            return nullopt;
+        }
+
+        auto first = path_res.begin();
+        const auto last = path_res.end();
+        for (std::string::iterator candidate;; first = candidate)
+        {
+            candidate = std::find(first, last, '/');
+            if (candidate == last)
+            {
+                break;
+            }
+
+            ++candidate;
+            if (candidate == last)
+            {
+                break;
+            }
+
+            if (*candidate != '.')
+            {
+                continue;
+            }
+
+            ++candidate;
+            if (candidate == last || *candidate == '/')
+            {
+                r.add_generic_error(msg::format(msgARegistryPath), msg::format(msgARegistryPathMustNotHaveDots));
+                return nullopt;
+            }
+
+            if (*candidate != '.')
+            {
+                first = candidate;
+                continue;
+            }
+
+            ++candidate;
+            if (candidate == last || *candidate == '/')
+            {
+                r.add_generic_error(msg::format(msgARegistryPath), msg::format(msgARegistryPathMustNotHaveDots));
+                return nullopt;
+            }
+        }
+
+        ret.p = registry_root / StringView{path_res}.substr(2);
+
+        return ret;
+    }
+
+    LocalizedString FilesystemVersionDbEntryArrayDeserializer::type_name() const
+    {
+        return msg::format(msgAnArrayOfVersions);
+    }
+
+    Optional<std::vector<FilesystemVersionDbEntry>> FilesystemVersionDbEntryArrayDeserializer::visit_array(
+        Json::Reader& r, const Json::Array& arr) const
+    {
+        return r.array_elements(arr, underlying);
+    }
+
+    LocalizedString GitVersionDbEntryDeserializer::type_name() const { return msg::format(msgAVersionDatabaseEntry); }
+    View<StringLiteral> GitVersionDbEntryDeserializer::valid_fields() const noexcept
+    {
+        static constexpr StringLiteral fields[] = {VCPKG_SCHEMED_DESERIALIZER_FIELDS, JsonIdGitTree};
+        return fields;
+    }
+
+    Optional<GitVersionDbEntry> GitVersionDbEntryDeserializer::visit_object(Json::Reader& r,
+                                                                            const Json::Object& obj) const
+    {
+        GitVersionDbEntry ret;
+        ret.version = visit_required_schemed_version(type_name(), r, obj);
+        r.required_object_field(type_name(), obj, JsonIdGitTree, ret.git_tree, GitTreeStringDeserializer::instance);
+        return ret;
+    }
+
+    LocalizedString GitVersionDbEntryArrayDeserializer::type_name() const { return msg::format(msgAnArrayOfVersions); }
+
+    Optional<std::vector<GitVersionDbEntry>> GitVersionDbEntryArrayDeserializer::visit_array(
+        Json::Reader& r, const Json::Array& arr) const
+    {
+        return r.array_elements(arr, GitVersionDbEntryDeserializer());
     }
 }

--- a/src/vcpkg/tools.cpp
+++ b/src/vcpkg/tools.cpp
@@ -120,7 +120,7 @@ namespace vcpkg
         return Json::parse_object(contents, origin)
             .then([&](Json::Object&& as_object) -> ExpectedL<std::vector<ToolDataEntry>> {
                 Json::Reader r(origin);
-                auto maybe_tool_data = r.visit(as_object, ToolDataFileDeserializer::instance);
+                auto maybe_tool_data = ToolDataFileDeserializer::instance.visit(r, as_object);
                 if (!r.errors().empty() || !r.warnings().empty())
                 {
                     return r.join();


### PR DESCRIPTION
Also makes Json::IDeserializer no longer need a virtual dtor.

Before (first one wins):
```
PS D:\test> type vcpkg.json
{
  "dependencies": [
    "zlib"
  ],
  "overrides": [{"name": "zlib", "version": "1.2.13"}, {"name": "zlib", "version": "1.3.1"}]
}

[...]

Installing 2/2 zlib:x64-windows@1.2.13...
Building zlib:x64-windows@1.2.13...
C:\Users\bion\AppData\Local\vcpkg\registries\git-trees\ad5a49006f73b45b715299515f31164131b51982: info: installing overlay port from here
-- Using cached madler-zlib-v1.2.13.tar.gz.
-- Extracting source D:/vcpkg-downloads/madler-zlib-v1.2.13.tar.gz
-- Applying patch 0001-Prevent-invalid-inclusions-when-HAVE_-is-set-to-0.patch
-- Applying patch 0002-skip-building-examples.patch
-- Applying patch 0003-build-static-or-shared-not-both.patch
-- Applying patch 0004-android-and-mingw-fixes.patch
-- Using source at D:/vcpkg/buildtrees/zlib/src/v1.2.13-f30d2a168d.clean
-- Found external ninja('1.12.1').
-- Configuring x64-windows
-- Building x64-windows-dbg
-- Building x64-windows-rel
-- Installing: D:/vcpkg/packages/zlib_x64-windows/share/zlib/vcpkg-cmake-wrapper.cmake
-- Fixing pkgconfig file: D:/vcpkg/packages/zlib_x64-windows/lib/pkgconfig/zlib.pc
-- Using cached msys2-mingw-w64-x86_64-pkgconf-1~2.3.0-1-any.pkg.tar.zst.
-- Using cached msys2-msys2-runtime-3.5.4-2-x86_64.pkg.tar.zst.
-- Using msys root at D:/vcpkg-downloads/tools/msys2/21caed2f81ec917b
-- Fixing pkgconfig file: D:/vcpkg/packages/zlib_x64-windows/debug/lib/pkgconfig/zlib.pc
-- Installing: D:/vcpkg/packages/zlib_x64-windows/share/zlib/copyright
-- Performing post-build validation
Stored binaries in 1 destinations in 93.9 ms.
Elapsed time to handle zlib:x64-windows: 3.7 s
zlib:x64-windows package ABI: a858cb84557b70b9fa3b3934233ce9667bef3fcf11c99b00070f799cc44bff14
Total install time: 3.7 s
The package zlib is compatible with built-in CMake targets:

    find_package(ZLIB REQUIRED)
    target_link_libraries(main PRIVATE ZLIB::ZLIB)

```

After: (an error)

```
D:\test\vcpkg.json: error: $.overrides[1] (an override): zlib already has an override
note: Extended documentation available at 'https://learn.microsoft.com/vcpkg/users/manifests?WT.mc_id=vcpkg_inproduct_cli'.
```

Resolves https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1665249