### PR TITLE
Update upload-artifact to v4.

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -65,7 +65,7 @@ jobs:
             exit 1
           }
       - name: 'Publish Format and Messages File Diff'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure() && steps.diff.outcome == 'failure'
         with:
           name: format.patch


### PR DESCRIPTION
Resolves failures like:
https://github.com/microsoft/vcpkg-tool/pull/1568/checks

Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/