### PR TITLE
Don't emit the 'vs prompt' warning when targeting arm64ec from an arm64 developer command prompt.

### DIFF
--- a/src/vcpkg/commands.install.cpp
+++ b/src/vcpkg/commands.install.cpp
@@ -1306,20 +1306,19 @@ namespace vcpkg
 #if defined(_WIN32)
         const auto maybe_common_triplet = Util::common_projection(
             action_plan.install_actions, [](const InstallPlanAction& to_install) { return to_install.spec.triplet(); });
-        if (maybe_common_triplet)
+        if (auto common_triplet = maybe_common_triplet.get())
         {
-            const auto& common_triplet = maybe_common_triplet.value_or_exit(VCPKG_LINE_INFO);
-            const auto maybe_common_arch = common_triplet.guess_architecture();
-            if (maybe_common_arch)
+            const auto maybe_common_arch = common_triplet->guess_architecture();
+            if (auto common_arch = maybe_common_arch.get())
             {
                 const auto maybe_vs_prompt = guess_visual_studio_prompt_target_architecture();
-                if (maybe_vs_prompt)
+                if (auto vs_prompt = maybe_vs_prompt.get())
                 {
-                    const auto common_arch = maybe_common_arch.value_or_exit(VCPKG_LINE_INFO);
-                    const auto vs_prompt = maybe_vs_prompt.value_or_exit(VCPKG_LINE_INFO);
-                    if (common_arch != vs_prompt)
+                    if (*common_arch != *vs_prompt &&
+                        !(*common_arch == CPUArchitecture::ARM64EC && *vs_prompt == CPUArchitecture::ARM64))
                     {
-                        msg::println_warning(msgVcpkgInVsPrompt, msg::value = vs_prompt, msg::triplet = common_triplet);
+                        msg::println_warning(
+                            msgVcpkgInVsPrompt, msg::value = *vs_prompt, msg::triplet = common_triplet);
                     }
                 }
             }

--- a/src/vcpkg/commands.install.cpp
+++ b/src/vcpkg/commands.install.cpp
@@ -1314,11 +1314,14 @@ namespace vcpkg
                 const auto maybe_vs_prompt = guess_visual_studio_prompt_target_architecture();
                 if (auto vs_prompt = maybe_vs_prompt.get())
                 {
+                    // There is no "Developer Command Prompt for ARM64EC". ARM64EC and ARM64 use the same developer
+                    // command prompt, and compiler toolset version. The only difference is adding a /arm64ec switch to
+                    // the build
                     if (*common_arch != *vs_prompt &&
                         !(*common_arch == CPUArchitecture::ARM64EC && *vs_prompt == CPUArchitecture::ARM64))
                     {
                         msg::println_warning(
-                            msgVcpkgInVsPrompt, msg::value = *vs_prompt, msg::triplet = common_triplet);
+                            msgVcpkgInVsPrompt, msg::value = *vs_prompt, msg::triplet = *common_triplet);
                     }
                 }
             }


### PR DESCRIPTION
Partial response to https://github.com/microsoft/vcpkg/issues/40158