### PR TITLE
Improve resiliency of concurrent use the downloads directory.

### DIFF
--- a/include/vcpkg/archives.h
+++ b/include/vcpkg/archives.h
@@ -36,12 +36,7 @@ namespace vcpkg
                          MessageSink& status_sink,
                          const Path& archive,
                          const Path& to_path);
-    // set `to_path` to `archive` contents.
-    void set_directory_to_archive_contents(const Filesystem& fs,
-                                           const ToolCache& tools,
-                                           MessageSink& status_sink,
-                                           const Path& archive,
-                                           const Path& to_path);
+    // extract `archive` to a sibling temporary subdirectory of `to_path` and returns that path
     Path extract_archive_to_temp_subdirectory(const Filesystem& fs,
                                               const ToolCache& tools,
                                               MessageSink& status_sink,

--- a/include/vcpkg/base/files.h
+++ b/include/vcpkg/base/files.h
@@ -250,11 +250,12 @@ namespace vcpkg
         // Traditionally used to interact with downloads, or git tree cache, where multiple
         // instances of vcpkg may be trying to do the same action at the same time.
         //
-        // Returns whether the rename actually happened.
+        // Returns whether the rename actually happened. Note that `rename` has 'replace if exists' behavior for files
+        // but not directories, so if old_path and new_path are files, this function always returns true.
         //
         // If `old_path` and `new_path` resolve to the same file, the behavior is undefined.
-        bool rename_cas_like(const Path& old_path, const Path& new_path, std::error_code& ec) const;
-        bool rename_cas_like(const Path& old_path, const Path& new_path, LineInfo li) const;
+        bool rename_or_delete(const Path& old_path, const Path& new_path, std::error_code& ec) const;
+        bool rename_or_delete(const Path& old_path, const Path& new_path, LineInfo li) const;
 
         virtual void rename_or_copy(const Path& old_path,
                                     const Path& new_path,

--- a/include/vcpkg/base/files.h
+++ b/include/vcpkg/base/files.h
@@ -246,6 +246,16 @@ namespace vcpkg
         void rename_with_retry(const Path& old_path, const Path& new_path, std::error_code& ec) const;
         void rename_with_retry(const Path& old_path, const Path& new_path, LineInfo li) const;
 
+        // Rename old_path -> new_path, but consider new_path already existing as acceptable.
+        // Traditionally used to interact with downloads, or git tree cache, where multiple
+        // instances of vcpkg may be trying to do the same action at the same time.
+        //
+        // Returns whether the rename actually happened.
+        //
+        // If `old_path` and `new_path` resolve to the same file, the behavior is undefined.
+        bool rename_cas_like(const Path& old_path, const Path& new_path, std::error_code& ec) const;
+        bool rename_cas_like(const Path& old_path, const Path& new_path, LineInfo li) const;
+
         virtual void rename_or_copy(const Path& old_path,
                                     const Path& new_path,
                                     StringLiteral temp_suffix,

--- a/src/vcpkg-test/files.cpp
+++ b/src/vcpkg-test/files.cpp
@@ -947,9 +947,9 @@ TEST_CASE ("rename", "[files]")
         REQUIRE(!fs.exists(temp_dir_b, VCPKG_LINE_INFO));
     }
 
-    // try rename_cas_like directory, target does not exist
+    // try rename_or_delete directory, target does not exist
     {
-        REQUIRE(fs.rename_cas_like(temp_dir_a, temp_dir_b, VCPKG_LINE_INFO));
+        REQUIRE(fs.rename_or_delete(temp_dir_a, temp_dir_b, VCPKG_LINE_INFO));
         REQUIRE(!fs.exists(temp_dir_a, VCPKG_LINE_INFO));
         REQUIRE(fs.read_contents(temp_dir_b_file, VCPKG_LINE_INFO) == text_file_contents);
 
@@ -959,13 +959,13 @@ TEST_CASE ("rename", "[files]")
         REQUIRE(!fs.exists(temp_dir_b, VCPKG_LINE_INFO));
     }
 
-    // try rename_cas_like directory, target exists
+    // try rename_or_delete directory, target exists
     {
         fs.create_directory(temp_dir_b, VCPKG_LINE_INFO);
         fs.write_contents(temp_dir_b_file, text_file_contents, VCPKG_LINE_INFO);
 
         // Note that the VCPKG_LINE_INFO overload implicitly tests that ec got cleared
-        REQUIRE(!fs.rename_cas_like(temp_dir_a, temp_dir_b, VCPKG_LINE_INFO));
+        REQUIRE(!fs.rename_or_delete(temp_dir_a, temp_dir_b, VCPKG_LINE_INFO));
         REQUIRE(!fs.exists(temp_dir_a, VCPKG_LINE_INFO));
         REQUIRE(fs.read_contents(temp_dir_b_file, VCPKG_LINE_INFO) == text_file_contents);
 
@@ -975,10 +975,10 @@ TEST_CASE ("rename", "[files]")
         REQUIRE(!fs.exists(temp_dir_b, VCPKG_LINE_INFO));
     }
 
-    // try rename_cas_like file, target does not exist
+    // try rename_or_delete file, target does not exist
     {
         fs.create_directory(temp_dir_b, VCPKG_LINE_INFO);
-        REQUIRE(fs.rename_cas_like(temp_dir_a_file, temp_dir_b_file, VCPKG_LINE_INFO));
+        REQUIRE(fs.rename_or_delete(temp_dir_a_file, temp_dir_b_file, VCPKG_LINE_INFO));
         REQUIRE(!fs.exists(temp_dir_a_file, VCPKG_LINE_INFO));
         REQUIRE(fs.read_contents(temp_dir_b_file, VCPKG_LINE_INFO) == text_file_contents);
 
@@ -989,14 +989,14 @@ TEST_CASE ("rename", "[files]")
         fs.remove(temp_dir_b, VCPKG_LINE_INFO);
     }
 
-    // try rename_cas_like file, target exists
+    // try rename_or_delete file, target exists
     {
         fs.create_directory(temp_dir_b, VCPKG_LINE_INFO);
         fs.write_contents(temp_dir_b_file, text_file_contents, VCPKG_LINE_INFO);
         // Note that the VCPKG_LINE_INFO overload implicitly tests that ec got cleared
         // Also note that POSIX rename() will just delete the target like we want by itself so
         // this returns true.
-        REQUIRE(fs.rename_cas_like(temp_dir_a_file, temp_dir_b_file, VCPKG_LINE_INFO));
+        REQUIRE(fs.rename_or_delete(temp_dir_a_file, temp_dir_b_file, VCPKG_LINE_INFO));
         REQUIRE(!fs.exists(temp_dir_a_file, VCPKG_LINE_INFO));
         REQUIRE(fs.read_contents(temp_dir_b_file, VCPKG_LINE_INFO) == text_file_contents);
 

--- a/src/vcpkg-test/files.cpp
+++ b/src/vcpkg-test/files.cpp
@@ -914,7 +914,7 @@ TEST_CASE ("copy_file", "[files]")
     CHECK_EC_ON_FILE(temp_dir, ec);
 }
 
-TEST_CASE("rename", "[files]")
+TEST_CASE ("rename", "[files]")
 {
     urbg_t urbg;
 

--- a/src/vcpkg-test/files.cpp
+++ b/src/vcpkg-test/files.cpp
@@ -29,7 +29,10 @@ namespace
 {
     using urbg_t = std::mt19937_64;
 
-    std::string get_random_filename(urbg_t& urbg) { return Strings::b32_encode(urbg()); }
+    std::string get_random_filename(urbg_t& urbg, StringLiteral tag)
+    {
+        return Strings::b32_encode(urbg()).append(tag.data(), tag.size());
+    }
 
     bool is_valid_symlink_failure(const std::error_code& ec) noexcept
     {
@@ -131,7 +134,7 @@ namespace
             CHECK_EC_ON_FILE(base, ec);
             for (unsigned int i = 0; i < 5; ++i)
             {
-                create_directory_tree(urbg, fs, base / get_random_filename(urbg), remaining_depth - 1);
+                create_directory_tree(urbg, fs, base / get_random_filename(urbg, "_tree"), remaining_depth - 1);
             }
 
 #if !defined(_WIN32)
@@ -177,7 +180,7 @@ namespace
 
         auto& fs = setup();
 
-        auto temp_dir = base_temporary_directory() / get_random_filename(urbg);
+        auto temp_dir = base_temporary_directory() / get_random_filename(urbg, "_enum");
         INFO("temp dir is: " << temp_dir.native());
 
         const auto target_root = temp_dir / "target";
@@ -619,7 +622,7 @@ TEST_CASE ("remove readonly", "[files]")
 
     auto& fs = setup();
 
-    auto temp_dir = base_temporary_directory() / get_random_filename(urbg);
+    auto temp_dir = base_temporary_directory() / get_random_filename(urbg, "_remove_readonly");
     INFO("temp dir is: " << temp_dir.native());
 
     fs.create_directory(temp_dir, VCPKG_LINE_INFO);
@@ -672,7 +675,7 @@ TEST_CASE ("remove all", "[files]")
 
     auto& fs = setup();
 
-    auto temp_dir = base_temporary_directory() / get_random_filename(urbg);
+    auto temp_dir = base_temporary_directory() / get_random_filename(urbg, "_remove_all");
     INFO("temp dir is: " << temp_dir.native());
 
     create_directory_tree(urbg, fs, temp_dir);
@@ -692,7 +695,7 @@ TEST_CASE ("remove all symlinks", "[files]")
 
     auto& fs = setup();
 
-    auto temp_dir = base_temporary_directory() / get_random_filename(urbg);
+    auto temp_dir = base_temporary_directory() / get_random_filename(urbg, "_remove_all_symlinks");
     INFO("temp dir is: " << temp_dir.native());
 
     const auto target_root = temp_dir / "target";
@@ -840,7 +843,7 @@ TEST_CASE ("copy_file", "[files]")
 
     auto& fs = setup();
 
-    auto temp_dir = base_temporary_directory() / get_random_filename(urbg);
+    auto temp_dir = base_temporary_directory() / get_random_filename(urbg, "_copy_file");
     INFO("temp dir is: " << temp_dir.native());
 
     fs.create_directory(temp_dir, VCPKG_LINE_INFO);
@@ -920,7 +923,7 @@ TEST_CASE ("rename", "[files]")
 
     auto& fs = setup();
 
-    auto temp_dir = base_temporary_directory() / get_random_filename(urbg);
+    auto temp_dir = base_temporary_directory() / get_random_filename(urbg, "_rename");
     INFO("temp dir is: " << temp_dir.native());
 
     static constexpr StringLiteral FileTxt = "file.txt";
@@ -1014,7 +1017,7 @@ TEST_CASE ("copy_symlink", "[files]")
 
     auto& fs = setup();
 
-    auto temp_dir = base_temporary_directory() / get_random_filename(urbg);
+    auto temp_dir = base_temporary_directory() / get_random_filename(urbg, "_copy_symlink");
     INFO("temp dir is: " << temp_dir.native());
 
     fs.create_directory(temp_dir, VCPKG_LINE_INFO);
@@ -1174,7 +1177,7 @@ TEST_CASE ("remove all -- benchmarks", "[files][!benchmark]")
             temp_dirs.resize(meter.runs());
 
             std::generate(begin(temp_dirs), end(temp_dirs), [&] {
-                Path temp_dir = base_temporary_directory() / get_random_filename(urbg);
+                Path temp_dir = base_temporary_directory() / get_random_filename(urbg, "_remove_all_bench");
                 create_directory_tree(urbg, fs, temp_dir, max_depth);
                 return temp_dir;
             });

--- a/src/vcpkg/archives.cpp
+++ b/src/vcpkg/archives.cpp
@@ -310,18 +310,6 @@ namespace vcpkg
                                msg::path = archive);
     }
 
-    void set_directory_to_archive_contents(const Filesystem& fs,
-                                           const ToolCache& tools,
-                                           MessageSink& status_sink,
-                                           const Path& archive,
-                                           const Path& to_path)
-
-    {
-        fs.remove_all(to_path, VCPKG_LINE_INFO);
-        Path to_path_partial = extract_archive_to_temp_subdirectory(fs, tools, status_sink, archive, to_path);
-        fs.rename_with_retry(to_path_partial, to_path, VCPKG_LINE_INFO);
-    }
-
     bool ZipTool::compress_directory_to_zip(DiagnosticContext& context,
                                             const Filesystem& fs,
                                             const Path& source,

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -2008,10 +2008,10 @@ namespace vcpkg
         }
     }
 
-    bool Filesystem::rename_cas_like(const Path& old_path, const Path& new_path, LineInfo li) const
+    bool Filesystem::rename_or_delete(const Path& old_path, const Path& new_path, LineInfo li) const
     {
         std::error_code ec;
-        bool result = this->rename_cas_like(old_path, new_path, ec);
+        bool result = this->rename_or_delete(old_path, new_path, ec);
         if (ec)
         {
             exit_filesystem_call_error(li, ec, __func__, {old_path, new_path});
@@ -2020,7 +2020,7 @@ namespace vcpkg
         return result;
     }
 
-    bool Filesystem::rename_cas_like(const Path& old_path, const Path& new_path, std::error_code& ec) const
+    bool Filesystem::rename_or_delete(const Path& old_path, const Path& new_path, std::error_code& ec) const
     {
         this->rename(old_path, new_path, ec);
         using namespace std::chrono_literals;

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -2008,6 +2008,44 @@ namespace vcpkg
         }
     }
 
+    bool Filesystem::rename_cas_like(const Path& old_path, const Path& new_path, LineInfo li) const
+    {
+        std::error_code ec;
+        bool result = this->rename_cas_like(old_path, new_path, ec);
+        if (ec)
+        {
+            exit_filesystem_call_error(li, ec, __func__, {old_path, new_path});
+        }
+
+        return result;
+    }
+
+    bool Filesystem::rename_cas_like(const Path& old_path, const Path& new_path, std::error_code& ec) const
+    {
+        this->rename(old_path, new_path, ec);
+        using namespace std::chrono_literals;
+        for (const auto& delay : {10ms, 100ms, 1000ms, 10000ms})
+        {
+            if (!ec)
+            {
+                return true;
+            }
+            else if (ec == std::make_error_condition(std::errc::directory_not_empty) ||
+                     ec == std::make_error_condition(std::errc::file_exists) || this->exists(new_path, ec))
+            {
+                // either the rename failed with a target already exists error, or the target explicitly exists,
+                // assume another process 'won' the 'CAS'.
+                this->remove_all(old_path, ec);
+                return false;
+            }
+
+            std::this_thread::sleep_for(delay);
+            this->rename(old_path, new_path, ec);
+        }
+
+        return false;
+    }
+
     bool Filesystem::remove(const Path& target, LineInfo li) const
     {
         std::error_code ec;

--- a/src/vcpkg/tools.cpp
+++ b/src/vcpkg/tools.cpp
@@ -871,12 +871,14 @@ namespace vcpkg
             if (tool_data.is_archive)
             {
                 status_sink.println(Color::none, msgExtractingTool, msg::tool_name = tool_data.name);
-                set_directory_to_archive_contents(fs, *this, status_sink, download_path, tool_dir_path);
+                Path to_path_partial =
+                    extract_archive_to_temp_subdirectory(fs, *this, status_sink, download_path, tool_dir_path);
+                fs.rename_cas_like(to_path_partial, tool_dir_path, IgnoreErrors{});
             }
             else
             {
                 fs.create_directories(exe_path.parent_path(), IgnoreErrors{});
-                fs.rename(download_path, exe_path, IgnoreErrors{});
+                fs.rename_cas_like(download_path, exe_path, IgnoreErrors{});
             }
 
             if (!fs.exists(exe_path, IgnoreErrors{}))

--- a/src/vcpkg/tools.cpp
+++ b/src/vcpkg/tools.cpp
@@ -873,12 +873,12 @@ namespace vcpkg
                 status_sink.println(Color::none, msgExtractingTool, msg::tool_name = tool_data.name);
                 Path to_path_partial =
                     extract_archive_to_temp_subdirectory(fs, *this, status_sink, download_path, tool_dir_path);
-                fs.rename_cas_like(to_path_partial, tool_dir_path, IgnoreErrors{});
+                fs.rename_or_delete(to_path_partial, tool_dir_path, IgnoreErrors{});
             }
             else
             {
                 fs.create_directories(exe_path.parent_path(), IgnoreErrors{});
-                fs.rename_cas_like(download_path, exe_path, IgnoreErrors{});
+                fs.rename_or_delete(download_path, exe_path, IgnoreErrors{});
             }
 
             if (!fs.exists(exe_path, IgnoreErrors{}))

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -1199,12 +1199,6 @@ namespace vcpkg
             return format_filesystem_call_error(ec, "create_directory", {git_tree_temp});
         }
 
-        fs.remove_all(destination, ec);
-        if (ec)
-        {
-            return format_filesystem_call_error(ec, "remove_all", {destination});
-        }
-
         auto git_archive = git_cmd_builder(dot_git_dir, git_tree_temp)
                                .string_arg("read-tree")
                                .string_arg("-m")
@@ -1232,11 +1226,11 @@ namespace vcpkg
             return error;
         }
 
-        fs.rename_with_retry(git_tree_temp, destination, ec);
+        fs.rename_cas_like(git_tree_temp, destination, ec);
         if (ec)
         {
             return error_prefix().append(
-                format_filesystem_call_error(ec, "rename_with_retry", {git_tree_temp, destination}));
+                format_filesystem_call_error(ec, "rename_cas_like", {git_tree_temp, destination}));
         }
 
         fs.remove(git_tree_index, IgnoreErrors{});

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -1226,11 +1226,11 @@ namespace vcpkg
             return error;
         }
 
-        fs.rename_cas_like(git_tree_temp, destination, ec);
+        fs.rename_or_delete(git_tree_temp, destination, ec);
         if (ec)
         {
             return error_prefix().append(
-                format_filesystem_call_error(ec, "rename_cas_like", {git_tree_temp, destination}));
+                format_filesystem_call_error(ec, "rename_or_delete", {git_tree_temp, destination}));
         }
 
         fs.remove(git_tree_index, IgnoreErrors{});


### PR DESCRIPTION
This *might* workaround some failures reported by internal customers.