### PR TITLE
tls12-download.exe: Enforce that the signing cert uses SHA-2.

### DIFF
--- a/src/tls12-download.c
+++ b/src/tls12-download.c
@@ -373,6 +373,17 @@ int __stdcall entry()
     wtfi.hFile = out_file;
     wtfi.pgKnownSubject = 0;
 
+    // CERT_STRONG_SIGN_PARA + WINTRUST_SIGNATURE_SETTINGS tell WinVerifyTrust that only SHA-2 certificates are
+    // acceptable.
+    CERT_STRONG_SIGN_PARA cssp = {0};
+    cssp.cbSize = sizeof(cssp);
+    cssp.dwInfoChoice = CERT_STRONG_SIGN_OID_INFO_CHOICE;
+    cssp.pszOID = szOID_CERT_STRONG_SIGN_OS_1;
+
+    WINTRUST_SIGNATURE_SETTINGS wtss = {0};
+    wtss.cbStruct = sizeof(wtss);
+    wtss.pCryptoPolicy = &cssp;
+
     WINTRUST_DATA wtd = {0};
     wtd.cbStruct = sizeof(wtd);
     wtd.dwUIChoice = WTD_UI_NONE;
@@ -381,6 +392,7 @@ int __stdcall entry()
     wtd.pFile = &wtfi;
     wtd.dwStateAction = WTD_STATEACTION_VERIFY;
     wtd.dwProvFlags = WTD_REVOCATION_CHECK_CHAIN;
+    wtd.pSignatureSettings = &wtss;
 
     GUID wt_policy_guid = WINTRUST_ACTION_GENERIC_VERIFY_V2;
 


### PR DESCRIPTION
Resolves https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2342038 and https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2342019

Demonstration:

https://live.sysinternals.com/RootkitRevealer.exe was released in 2006 and thus can't have a SHA-2 cert. https://live.sysinternals.com/autoruns.exe  was released in 2020 and therefore has a SHA-2 cert.

```
PS D:\vcpkg-tool\out\build\Win-x64-Debug-WithArtifacts> .\tls12-download.exe
Usage: tls12-download.exe DOMAIN RELATIVE-PATH OUT-FILE
PS D:\vcpkg-tool\out\build\Win-x64-Debug-WithArtifacts> .\tls12-download.exe live.sysinternals.com /RootkitRevealer.exe out.exe
Downloading https://live.sysinternals.com/RootkitRevealer.exe -> out.exe... done.
Validating signature... failed! 0x80096002 Deleted!
```

We failed to download RootkitRevealer.exe, this is good

```
PS D:\vcpkg-tool\out\build\Win-x64-Debug-WithArtifacts> .\tls12-download.exe live.sysinternals.com /autoruns.exe out.exe
Downloading https://live.sysinternals.com/autoruns.exe -> out.exe... done.
Validating signature... done.
```

But we can still download autoruns.

Demonstrating the certificate chains in the above test. Note the sha1RSA algorithms in the older app:

```
PS D:\vcpkg-tool\out\build\Win-x64-Debug-WithArtifacts> curl -L -o bad.exe https://live.sysinternals.com/RootkitRevealer.exe
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  326k  100  326k    0     0  3419k      0 --:--:-- --:--:-- --:--:-- 3514k
PS D:\vcpkg-tool\out\build\Win-x64-Debug-WithArtifacts> C:\Users\bion\Downloads\sigcheck64.exe -i bad.exe

Sigcheck v2.90 - File version and signature viewer
Copyright (C) 2004-2022 Mark Russinovich
Sysinternals - www.sysinternals.com

D:\vcpkg-tool\out\build\Win-x64-Debug-WithArtifacts\bad.exe:
        Verified:       Signed
        Link date:      3:15 PM 8/15/2006
        Signing date:   1:07 PM 11/1/2006
        Catalog:        D:\vcpkg-tool\out\build\Win-x64-Debug-WithArtifacts\bad.exe
        Signers:
           Microsoft Corporation
                Cert Status:    This certificate or one of the certificates in the certificate chain is not time valid.
                Valid Usage:    Code Signing
                Cert Issuer:    Microsoft Code Signing PCA
                Serial Number:  61 46 9E CB 00 04 00 00 00 65
                Thumbprint:     564E01066387F26C912010D06BD78D3CF1E845AB
                Algorithm:      sha1RSA
                Valid from:     11:43 AM 4/4/2006
                Valid to:       11:53 AM 10/4/2007
           Microsoft Code Signing PCA
                Cert Status:    This certificate or one of the certificates in the certificate chain is not time valid.
                Valid Usage:    Code Signing
                Cert Issuer:    Microsoft Root Authority
                Serial Number:  6A 0B 99 4F C0 00 1D AB 11 DA C4 02 A1 66 27 BA
                Thumbprint:     D07EA64088A80085F01BD40AA4EAD82F470482A6
                Algorithm:      sha1RSA
                Valid from:     9:44 AM 4/4/2006
                Valid to:       11:00 PM 4/25/2012
           Microsoft Root Authority
                Cert Status:    This certificate or one of the certificates in the certificate chain is not time valid.
                Valid Usage:    All
                Cert Issuer:    Microsoft Root Authority
                Serial Number:  00 C1 00 8B 3C 3C 88 11 D1 3E F6 63 EC DF 40
                Thumbprint:     A43489159A520F0D93D032CCAF37E7FE20A8B419
                Algorithm:      md5RSA
                Valid from:     11:00 PM 1/9/1997
                Valid to:       11:00 PM 12/30/2020
        Counter Signers:
           VeriSign Time Stamping Services Signer
                Cert Status:    This certificate or one of the certificates in the certificate chain is not time valid., The revocation status of the certificate or one of the certificates in the certificate chain is unknown., Error 65536 (0x10000), The revocation status of the certificate or one of the certificates in the certificate chain is either offline or stale.
                Valid Usage:    Timestamp Signing
                Cert Issuer:    VeriSign Time Stamping Services CA
                Serial Number:  0D E9 2B F0 D4 D8 29 88 18 32 05 09 5E 9A 76 88
                Thumbprint:     817E78267300CB0FE5D631357851DB366123A690
                Algorithm:      sha1RSA
                Valid from:     4:00 PM 12/3/2003
                Valid to:       3:59 PM 12/3/2008
           VeriSign Time Stamping Services CA
                Cert Status:    This certificate or one of the certificates in the certificate chain is not time valid.
                Valid Usage:    Timestamp Signing
                Cert Issuer:    Thawte Timestamping CA
                Serial Number:  47 BF 19 95 DF 8D 52 46 43 F7 DB 6D 48 0D 31 A4
                Thumbprint:     F46AC0C6EFBB8C6A14F55F09E2D37DF4C0DE012D
                Algorithm:      sha1RSA
                Valid from:     4:00 PM 12/3/2003
                Valid to:       3:59 PM 12/3/2013
           Thawte Timestamping CA
                Cert Status:    This certificate or one of the certificates in the certificate chain is not time valid.
                Valid Usage:    Timestamp Signing
                Cert Issuer:    Thawte Timestamping CA
                Serial Number:  00
                Thumbprint:     BE36A4562FB2EE05DBB3D32323ADF445084ED656
                Algorithm:      md5RSA
                Valid from:     4:00 PM 12/31/1996
                Valid to:       3:59 PM 12/31/2020
        Company:        Sysinternals - www.sysinternals.com
        Description:    Rootkit detection utility
        Product:        Sysinternals Rootkitrevealer
        Prod version:   1.70
        File version:   1.70
        MachineType:    32-bit
PS D:\vcpkg-tool\out\build\Win-x64-Debug-WithArtifacts> C:\Users\bion\Downloads\sigcheck64.exe -i out.exe

Sigcheck v2.90 - File version and signature viewer
Copyright (C) 2004-2022 Mark Russinovich
Sysinternals - www.sysinternals.com

D:\vcpkg-tool\out\build\Win-x64-Debug-WithArtifacts\out.exe:
        Verified:       Signed
        Link date:      2:45 AM 2/1/2024
        Signing date:   2:45 AM 2/1/2024
        Catalog:        D:\vcpkg-tool\out\build\Win-x64-Debug-WithArtifacts\out.exe
        Signers:
           Microsoft Corporation
                Cert Status:    This certificate or one of the certificates in the certificate chain is not time valid.
                Valid Usage:    Microsoft Publisher, Code Signing
                Cert Issuer:    Microsoft Code Signing PCA 2011
                Serial Number:  33 00 00 03 AF 30 40 0E 4C A3 4D 05 41 00 00 00 00 03 AF
                Thumbprint:     C2048FB509F1C37A8C3E9EC6648118458AA01780
                Algorithm:      sha256RSA
                Valid from:     11:09 AM 11/16/2023
                Valid to:       11:09 AM 11/14/2024
           Microsoft Code Signing PCA 2011
                Cert Status:    Valid
                Valid Usage:    All
                Cert Issuer:    Microsoft Root Certificate Authority 2011
                Serial Number:  61 0E 90 D2 00 00 00 00 00 03
                Thumbprint:     F252E794FE438E35ACE6E53762C0A234A2C52135
                Algorithm:      sha256RSA
                Valid from:     12:59 PM 7/8/2011
                Valid to:       1:09 PM 7/8/2026
           Microsoft Root Certificate Authority 2011
                Cert Status:    Valid
                Valid Usage:    All
                Cert Issuer:    Microsoft Root Certificate Authority 2011
                Serial Number:  3F 8B C8 B5 FC 9F B2 96 43 B5 69 D6 6C 42 E1 44
                Thumbprint:     8F43288AD272F3103B6FB1428485EA3014C0BCFE
                Algorithm:      sha256RSA
                Valid from:     2:05 PM 3/22/2011
                Valid to:       2:13 PM 3/22/2036
        Counter Signers:
           Microsoft Time-Stamp Service
                Cert Status:    This certificate or one of the certificates in the certificate chain is not time valid.
                Valid Usage:    Timestamp Signing
                Cert Issuer:    Microsoft Time-Stamp PCA 2010
                Serial Number:  33 00 00 01 D1 B2 5B 40 28 6C 2E D2 45 00 01 00 00 01 D1
                Thumbprint:     47258D85BFE1A12D0B510D1DAF23305A4AFFFB2C
                Algorithm:      sha256RSA
                Valid from:     11:12 AM 5/25/2023
                Valid to:       11:12 AM 2/1/2024
           Microsoft Time-Stamp PCA 2010
                Cert Status:    Valid
                Valid Usage:    Timestamp Signing
                Cert Issuer:    Microsoft Root Certificate Authority 2010
                Serial Number:  33 00 00 00 15 C5 E7 6B 9E 02 9B 49 99 00 00 00 00 00 15
                Thumbprint:     36056A5662DCADECF82CC14C8B80EC5E0BCC59A6
                Algorithm:      sha256RSA
                Valid from:     10:22 AM 9/30/2021
                Valid to:       10:32 AM 9/30/2030
           Microsoft Root Certificate Authority 2010
                Cert Status:    Valid
                Valid Usage:    All
                Cert Issuer:    Microsoft Root Certificate Authority 2010
                Serial Number:  28 CC 3A 25 BF BA 44 AC 44 9A 9B 58 6B 43 39 AA
                Thumbprint:     3B1EFD3A66EA28B16697394703A72CA340A05BD5
                Algorithm:      sha256RSA
                Valid from:     1:57 PM 6/23/2010
                Valid to:       2:04 PM 6/23/2035
        Company:        Sysinternals - www.sysinternals.com
        Description:    Autostart program viewer
        Product:        Sysinternals autoruns
        Prod version:   14.11
        File version:   14.11
        MachineType:    32-bit
```