### PR TITLE
Check errno after waitpid for EINTR

### DIFF
--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -1227,7 +1227,11 @@ namespace
             if (pid != -1)
             {
                 int status;
-                const auto child = waitpid(pid, &status, 0);
+                pid_t child;
+                do
+                {
+                    child = waitpid(pid, &status, 0);
+                } while (child == -1 && errno == EINTR);
                 if (child != pid)
                 {
                     context.report_system_error("waitpid", errno);


### PR DESCRIPTION
For me, this fixed debugging with lldb under macOS on AppleSilicon.

This is also a general pattern found other code bases, including well-established
code bases like the dpkg source code:
  - https://git.dpkg.org/cgit/dpkg/dpkg.git/tree/utils/start-stop-daemon.c?h=1.22.15#n564
  - v1.22.15 is the latest version at time of commit

Note that the above link actually compares the return value of waitpid
against all negative values (`child < 0`). This was made to pacify
static anlyzers in commit 5601b476929a896e1ab67e66e1192d5a90346e75 and
is not any more correct than comparison against the documented return
value of `-1` for error.
  - https://git.dpkg.org/cgit/dpkg/dpkg.git/commit/?id=5601b476929a896e1ab67e66e1192d5a90346e75