### PR TITLE
Always use InstallPlanAction::package_dir

### DIFF
--- a/include/vcpkg/commands.install.h
+++ b/include/vcpkg/commands.install.h
@@ -65,10 +65,6 @@ namespace vcpkg
                                           const std::vector<Path>& files,
                                           const InstallDir& destination_dir);
 
-    InstallResult install_package(const VcpkgPaths& paths,
-                                  const BinaryControlFile& binary_paragraph,
-                                  StatusParagraphs* status_db);
-
     struct CMakeUsageInfo
     {
         std::string message;

--- a/include/vcpkg/postbuildlint.h
+++ b/include/vcpkg/postbuildlint.h
@@ -4,6 +4,7 @@
 #include <vcpkg/base/fwd/messages.h>
 
 #include <vcpkg/fwd/build.h>
+#include <vcpkg/fwd/dependencies.h>
 #include <vcpkg/fwd/packagespec.h>
 #include <vcpkg/fwd/vcpkgpaths.h>
 
@@ -11,10 +12,9 @@
 
 namespace vcpkg
 {
-    size_t perform_post_build_lint_checks(const PackageSpec& spec,
+    size_t perform_post_build_lint_checks(const InstallPlanAction& action,
                                           const VcpkgPaths& paths,
                                           const PreBuildInfo& pre_build_info,
                                           const BuildInfo& build_info,
-                                          const Path& port_dir,
                                           MessageSink& msg_sink);
 }

--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -1047,13 +1047,13 @@ namespace vcpkg
             return ExtendedBuildResult{BuildResult::BuildFailed, stdoutlog, std::move(error_logs)};
         }
 
-        const BuildInfo build_info = read_build_info(fs, paths.package_dir(action.spec) / FileBuildInfo);
+        const BuildInfo build_info =
+            read_build_info(fs, action.package_dir.value_or_exit(VCPKG_LINE_INFO) / FileBuildInfo);
         size_t error_count = 0;
         {
             FileSink file_sink{fs, stdoutlog, Append::YES};
             TeeSink combo_sink{out_sink, file_sink};
-            error_count = perform_post_build_lint_checks(
-                action.spec, paths, pre_build_info, build_info, scfl.port_directory(), combo_sink);
+            error_count = perform_post_build_lint_checks(action, paths, pre_build_info, build_info, combo_sink);
         };
         if (error_count != 0 && build_options.backcompat_features == BackcompatFeatures::Prohibit)
         {

--- a/src/vcpkg/commands.install.cpp
+++ b/src/vcpkg/commands.install.cpp
@@ -217,11 +217,13 @@ namespace vcpkg
         return SortedVector<file_pack>(std::move(installed_files));
     }
 
-    InstallResult install_package(const VcpkgPaths& paths, const BinaryControlFile& bcf, StatusParagraphs* status_db)
+    static InstallResult install_package(const VcpkgPaths& paths,
+                                         const Path& package_dir,
+                                         const BinaryControlFile& bcf,
+                                         StatusParagraphs* status_db)
     {
         auto& fs = paths.get_filesystem();
         const auto& installed = paths.installed();
-        const auto package_dir = paths.package_dir(bcf.core_paragraph.spec);
         Triplet triplet = bcf.core_paragraph.spec.triplet();
         const std::vector<StatusParagraphAndAssociatedFiles> pgh_and_files =
             get_installed_files_and_upgrade(fs, installed, *status_db);
@@ -389,7 +391,8 @@ namespace vcpkg
             BuildResult code;
             if (all_dependencies_satisfied)
             {
-                const auto install_result = install_package(paths, *bcf, &status_db);
+                const auto install_result =
+                    install_package(paths, action.package_dir.value_or_exit(VCPKG_LINE_INFO), *bcf, &status_db);
                 switch (install_result)
                 {
                     case InstallResult::SUCCESS: code = BuildResult::Succeeded; break;

--- a/src/vcpkg/dependencies.cpp
+++ b/src/vcpkg/dependencies.cpp
@@ -1378,7 +1378,7 @@ namespace vcpkg
             const CMakeVars::CMakeVarProvider& m_var_provider;
             const PackageSpec& m_toplevel;
             const Triplet m_host_triplet;
-            const Path m_packages_dir;
+            const Path& m_packages_dir;
 
             struct DepSpec
             {

--- a/src/vcpkg/postbuildlint.cpp
+++ b/src/vcpkg/postbuildlint.cpp
@@ -10,6 +10,7 @@
 #include <vcpkg/base/util.h>
 
 #include <vcpkg/commands.build.h>
+#include <vcpkg/dependencies.h>
 #include <vcpkg/installedpaths.h>
 #include <vcpkg/packagespec.h>
 #include <vcpkg/postbuildlint.h>
@@ -1636,7 +1637,7 @@ namespace vcpkg
         return relative_libs;
     }
 
-    static size_t perform_all_checks_and_return_error_count(const PackageSpec& spec,
+    static size_t perform_all_checks_and_return_error_count(const InstallPlanAction& action,
                                                             const VcpkgPaths& paths,
                                                             const PreBuildInfo& pre_build_info,
                                                             const BuildInfo& build_info,
@@ -1646,8 +1647,8 @@ namespace vcpkg
     {
         const bool windows_target = Util::Vectors::contains(windows_system_names, pre_build_info.cmake_system_name);
         const auto& fs = paths.get_filesystem();
-        const auto build_dir = paths.build_dir(spec);
-        const auto package_dir = paths.package_dir(spec);
+        const auto build_dir = paths.build_dir(action.spec);
+        const auto& package_dir = action.package_dir.value_or_exit(VCPKG_LINE_INFO);
         const bool not_release_only = !pre_build_info.build_type;
 
         size_t error_count = 0;
@@ -1659,7 +1660,7 @@ namespace vcpkg
             error_count +=
                 check_for_no_files_in_cmake_helper_port_include_directory(fs, package_dir, portfile_cmake, msg_sink);
             error_count += check_for_vcpkg_port_config_in_cmake_helper_port(
-                fs, package_dir, spec.name(), portfile_cmake, msg_sink);
+                fs, package_dir, action.spec.name(), portfile_cmake, msg_sink);
         }
         else if (!policies.is_enabled(BuildPolicy::EMPTY_INCLUDE_FOLDER))
         {
@@ -1693,7 +1694,8 @@ namespace vcpkg
         }
         if (!policies.is_enabled(BuildPolicy::SKIP_COPYRIGHT_CHECK))
         {
-            error_count += check_for_copyright_file(fs, spec.name(), package_dir, build_dir, portfile_cmake, msg_sink);
+            error_count +=
+                check_for_copyright_file(fs, action.spec.name(), package_dir, build_dir, portfile_cmake, msg_sink);
         }
         if (windows_target && !policies.is_enabled(BuildPolicy::ALLOW_EXES_IN_BIN))
         {
@@ -1702,7 +1704,7 @@ namespace vcpkg
         if (!policies.is_enabled(BuildPolicy::SKIP_USAGE_INSTALL_CHECK))
         {
             error_count +=
-                check_for_usage_forgot_install(fs, port_dir, package_dir, spec.name(), portfile_cmake, msg_sink);
+                check_for_usage_forgot_install(fs, port_dir, package_dir, action.spec.name(), portfile_cmake, msg_sink);
         }
 
         std::vector<Path> relative_debug_libs =
@@ -1884,11 +1886,10 @@ namespace vcpkg
         return false;
     }
 
-    size_t perform_post_build_lint_checks(const PackageSpec& spec,
+    size_t perform_post_build_lint_checks(const InstallPlanAction& action,
                                           const VcpkgPaths& paths,
                                           const PreBuildInfo& pre_build_info,
                                           const BuildInfo& build_info,
-                                          const Path& port_dir,
                                           MessageSink& msg_sink)
     {
         auto& policies = build_info.policies;
@@ -1899,9 +1900,11 @@ namespace vcpkg
         }
 
         msg_sink.println(LocalizedString::from_raw("-- ").append(msgPerformingPostBuildValidation));
+        const auto& scfl = action.source_control_file_and_location.value_or_exit(VCPKG_LINE_INFO);
+        auto port_dir = scfl.port_directory();
         const auto portfile_cmake = port_dir / FilePortfileDotCMake;
         const size_t error_count = perform_all_checks_and_return_error_count(
-            spec, paths, pre_build_info, build_info, port_dir, portfile_cmake, msg_sink);
+            action, paths, pre_build_info, build_info, port_dir, portfile_cmake, msg_sink);
         if (error_count != 0)
         {
             msg_sink.println(Color::warning,


### PR DESCRIPTION
... rather than attempting to rederive it several times. This clears the way for several actions that want to install the same package name with different feature sets (in #802 ) to not step on each others' toes.

The remaining callers of `VcpkgPaths::package_dir` are all doing so to purge that directory when they will *not* be building it, and in #802 will need to be taught to purge everything following the disambiguating pattern used.

![all remaining callers of package_dir](https://github.com/user-attachments/assets/c8cc8c2b-e562-4b84-b1a6-d1e91de4b57b)
