### PR TITLE
Fix --clean-after-build + async push_success

### DIFF
--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -2534,11 +2534,6 @@ namespace vcpkg
                 return;
             }
         }
-
-        if (clean_packages == CleanPackages::Yes)
-        {
-            m_fs.remove_all(action.package_dir.value_or_exit(VCPKG_LINE_INFO), VCPKG_LINE_INFO);
-        }
     }
 
     void BinaryCache::print_updates() { m_bg_msg_sink.print_published(); }


### PR DESCRIPTION
Probably stealth merge conflict in https://github.com/microsoft/vcpkg-tool/pull/908 and/or probably my fault.

Note that this is now done here:

https://github.com/microsoft/vcpkg-tool/blob/390d2f5b9d5e2f8fc5a19cb4dc594e00cae5842c/src/vcpkg/binarycaching.cpp#L2595-L2598