### PR TITLE
Remove "Store success" message.

### DIFF
--- a/azure-pipelines/end-to-end-tests-dir/asset-caching.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/asset-caching.ps1
@@ -71,8 +71,7 @@ $expected = @(
 "A suitable version of cmake was not found \(required v[0-9\.]+\)\.",
 "Trying to download cmake-[0-9.]+-[^.]+\.(zip|tar\.gz) using asset cache file://$assetCacheRegex/[0-9a-f]+"
 "Asset cache miss; trying authoritative source https://github\.com/Kitware/CMake/releases/download/[^ ]+",
-"Successfully downloaded cmake-[0-9.]+-[^.]+\.(zip|tar\.gz), storing to file://$assetCacheRegex/[0-9a-f]+",
-"Store success"
+"Successfully downloaded cmake-[0-9.]+-[^.]+\.(zip|tar\.gz), storing to file://$assetCacheRegex/[0-9a-f]+"
 ) -join "`n"
 
 if (-not ($actual -match $expected)) {
@@ -281,7 +280,6 @@ $expected = @(
 "^Trying to download example3\.html using asset cache file://$assetCacheRegex/[0-9a-z]+",
 "Asset cache miss; trying authoritative source https://example\.com",
 "Successfully downloaded example3\.html, storing to file://$assetCacheRegex/[0-9a-f]+",
-"Store success",
 "$"
 ) -join "`n"
 
@@ -344,7 +342,6 @@ $expected = @(
 "^Trying to download example3\.html using asset cache file://$assetCacheRegex/[0-9a-z]+",
 "Asset cache miss; trying authoritative source https://example\.com",
 "Successfully downloaded example3\.html, storing to file://$assetCacheRegex/[0-9a-z]+",
-"Store success",
 "$"
 ) -join "`n"
 

--- a/include/vcpkg/base/message-data.inc.h
+++ b/include/vcpkg/base/message-data.inc.h
@@ -293,7 +293,6 @@ DECLARE_MESSAGE(AssetCacheScriptFailedToWriteCorrectHash,
                 (),
                 "",
                 "the asset cache script returned success but the resulting file has an unexpected hash")
-DECLARE_MESSAGE(AssetCacheSuccesfullyStored, (), "", "Store success")
 DECLARE_MESSAGE(AssetSourcesArg, (), "", "Asset caching sources. See 'vcpkg help assetcaching'")
 DECLARE_MESSAGE(ASemanticVersionString, (), "", "a semantic version string")
 DECLARE_MESSAGE(ASetOfFeatures, (), "", "a set of features")

--- a/locales/messages.json
+++ b/locales/messages.json
@@ -204,7 +204,6 @@
   "_AssetCacheScriptNeedsSha.comment": "{value} is the script template the user supplied to x-script An example of {url} is https://github.com/microsoft/vcpkg.",
   "AssetCacheScriptNeedsUrl": "the script template {value} requires a URL, but no URL is known for attempted download of {sha}",
   "_AssetCacheScriptNeedsUrl.comment": "{value} is the script template the user supplied to x-script An example of {sha} is eb32643dd2164c72b8a660ef52f1e701bb368324ae461e12d70d6a9aefc0c9573387ee2ed3828037ed62bb3e8f566416a2d3b3827a3928f0bff7c29f7662293e.",
-  "AssetCacheSuccesfullyStored": "Store success",
   "AssetSourcesArg": "Asset caching sources. See 'vcpkg help assetcaching'",
   "AttemptingToSetBuiltInBaseline": "attempting to set builtin-baseline in vcpkg.json while overriding the default-registry in vcpkg-configuration.json.\nthe default-registry from vcpkg-configuration.json will be used.",
   "AuthenticationMayRequireManualAction": "One or more {vendor} credential providers requested manual action. Add the binary source 'interactive' to allow interactivity.",

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -886,13 +886,7 @@ namespace vcpkg
                               View<std::string> headers,
                               const Path& file)
     {
-        if (store_to_asset_cache_impl(context, raw_url, sanitized_url, method, headers, file))
-        {
-            context.statusln(msg::format(msgAssetCacheSuccesfullyStored));
-            return true;
-        }
-
-        return false;
+        return store_to_asset_cache_impl(context, raw_url, sanitized_url, method, headers, file);
     }
 
     std::string format_url_query(StringView base_url, View<std::string> query_params)

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -819,12 +819,12 @@ namespace vcpkg
         return false;
     }
 
-    static bool store_to_asset_cache_impl(DiagnosticContext& context,
-                                          StringView raw_url,
-                                          const SanitizedUrl& sanitized_url,
-                                          StringLiteral method,
-                                          View<std::string> headers,
-                                          const Path& file)
+    bool store_to_asset_cache(DiagnosticContext& context,
+                              StringView raw_url,
+                              const SanitizedUrl& sanitized_url,
+                              StringLiteral method,
+                              View<std::string> headers,
+                              const Path& file)
     {
         static constexpr StringLiteral guid_marker = "9a1db05f-a65d-419b-aa72-037fb4d0672e";
 
@@ -877,16 +877,6 @@ namespace vcpkg
         }
 
         return true;
-    }
-
-    bool store_to_asset_cache(DiagnosticContext& context,
-                              StringView raw_url,
-                              const SanitizedUrl& sanitized_url,
-                              StringLiteral method,
-                              View<std::string> headers,
-                              const Path& file)
-    {
-        return store_to_asset_cache_impl(context, raw_url, sanitized_url, method, headers, file);
     }
 
     std::string format_url_query(StringView base_url, View<std::string> query_params)


### PR DESCRIPTION
The message is currently shows when storing to an asset cache
```
Asset cache miss; trying authoritative source https://github.com/tbeu/matio/archive/v1.5.28.tar.gz
Successfully downloaded tbeu-matio-v1.5.28.tar.gz, storing to https://s3.hilton.rwth-aachen.de/assetcache/358318a249e22f5228516309d267593b8da9005de015dc0f59645fbfd7a5001e10be9144f32437acc2f6921d952e03adbaf8b9ca5b6620e191346bb569c04780
Store success
```
or when using a http binary cache
```
Store success
Completed submission of unicorn:arm64-osx@2.1.1 to 2 binary cache(s) in 15 s
Store success
Completed submission of unqlite:arm64-osx@1.1.9#2 to 2 binary cache(s) in 462 ms
Store success
Completed submission of utfz:arm64-osx@1.2#4 to 2 binary cache(s) in 231 ms
Store success
Completed submission of vcpkg-cmake-get-vars:arm64-osx@2024-09-22 to 2 binary cache(s) in 148 ms
```

In both situations (at least in the second) the message is imho unnecessary since I expect success until a error is printed.