### PR TITLE
test-features: Wait for async complete of binary cache at end of command

### DIFF
--- a/src/vcpkg/commands.test-features.cpp
+++ b/src/vcpkg/commands.test-features.cpp
@@ -506,6 +506,8 @@ namespace vcpkg
             fs.write_contents_and_dirs(raw_path, content, VCPKG_LINE_INFO);
         }
 
+        binary_cache.wait_for_async_complete_and_join();
+
         Checks::exit_success(VCPKG_LINE_INFO);
     }
 }


### PR DESCRIPTION
I somehow missed that as a stealth merge conflict 