### PR TITLE
Try to improve ubuntu test lab reliability

### DIFF
--- a/azure-pipelines/end-to-end-tests-prelude.ps1
+++ b/azure-pipelines/end-to-end-tests-prelude.ps1
@@ -190,6 +190,7 @@ function Set-EmptyTestPort {
         [string]$PortsRoot,
         [switch]$Malformed
     )
+    Write-Host "Setting $Name to $Version#$PortVersion @ $PortsRoot"
 
     $portDir = Join-Path $PortsRoot $Name
 
@@ -214,6 +215,7 @@ function Set-EmptyTestPort {
     $json += "`n}`n"
 
     Set-Content -Value $json -LiteralPath (Join-Path $portDir 'vcpkg.json') -Encoding Ascii -NoNewline
+    git -C $PortsRoot status
 }
 
 function Throw-IfNonEqual {

--- a/src/vcpkg/base/git.cpp
+++ b/src/vcpkg/base/git.cpp
@@ -209,12 +209,12 @@ namespace vcpkg
 
     bool git_add_with_index(DiagnosticContext& context, const Path& git_exe, const Path& index_file, const Path& target)
     {
-        Command cmd(git_exe);
-        cmd.string_arg("-c").string_arg("core.autocrlf=false").string_arg("-c").string_arg("core.untrackedCache=false");
         RedirectedProcessLaunchSettings launch_settings;
         launch_settings.working_directory.emplace(target);
         auto& environment = launch_settings.environment.emplace();
         environment.add_entry("GIT_INDEX_FILE", index_file);
+        Command cmd(git_exe);
+        cmd.string_arg("-c").string_arg("core.autocrlf=false");
         cmd.string_arg("add");
         cmd.string_arg("-A");
         cmd.string_arg(".");


### PR DESCRIPTION
PR testing in https://github.com/microsoft/vcpkg-tool/pull/1616 passed twice but now CI is failing because git isn't detecting changes.

I don't know exactly why, but issuing a random `git status` after editing the files seems to fix it. I'm guessing it's some sort of race on Ubuntu when mtime doesn't move forward by 1 second that is confusing git, which normally only has 1 second resolution; but I really have no idea.