### PR TITLE
Preserve permissions using upkg

### DIFF
--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -1330,12 +1330,12 @@ namespace
         ExpectedL<Unit> publish(const AzureUpkgSource& src,
                                 StringView package_name,
                                 StringView package_version,
-                                const Path& package_dir,
+                                const Path& zip_path,
                                 StringView description,
                                 MessageSink& sink) const
         {
             Command cmd = base_cmd(src, package_name, package_version, "publish");
-            cmd.string_arg("--description").string_arg(description).string_arg("--path").string_arg(package_dir);
+            cmd.string_arg("--description").string_arg(description).string_arg("--path").string_arg(zip_path);
             return run_az_artifacts_cmd(cmd, sink);
         }
 
@@ -1378,10 +1378,12 @@ namespace
             size_t count_stored = 0;
             auto ref = make_feedref(request, "");
             std::string package_description = "Cached package for " + ref.id;
+
+            const Path& zip_path = request.zip_path.value_or_exit(VCPKG_LINE_INFO);
             for (auto&& write_src : m_sources)
             {
                 auto res = m_azure_tool.publish(
-                    write_src, ref.id, ref.version, request.package_dir, package_description, msg_sink);
+                    write_src, ref.id, ref.version, zip_path, package_description, msg_sink);
                 if (res)
                 {
                     count_stored++;
@@ -1396,7 +1398,7 @@ namespace
         }
 
         bool needs_nuspec_data() const override { return false; }
-        bool needs_zip_file() const override { return false; }
+        bool needs_zip_file() const override { return true; }
 
     private:
         AzureUpkgTool m_azure_tool;

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -1446,10 +1446,6 @@ namespace
                 {
                     out_zips[i].emplace(std::move(zip_path), RemoveWhen::always);
                 }
-                else
-                {
-                    out_zips[i] = nullopt;
-                }
             }
         }
 
@@ -2424,7 +2420,7 @@ namespace vcpkg
             }
 
             if (!s.archives_to_read.empty() || !s.url_templates_to_get.empty() || !s.gcs_read_prefixes.empty() ||
-                !s.aws_read_prefixes.empty() || !s.cos_read_prefixes.empty() || s.gha_read)
+                !s.aws_read_prefixes.empty() || !s.cos_read_prefixes.empty() || s.gha_read || !s.upkg_templates_to_get.empty())
             {
                 ZipTool zip_tool;
                 zip_tool.setup(tools, out_sink);
@@ -2463,15 +2459,13 @@ namespace vcpkg
                     const auto& token = *args.actions_runtime_token.get();
                     m_config.read.push_back(std::make_unique<GHABinaryProvider>(zip_tool, fs, buildtrees, url, token));
                 }
-
-                if (!s.upkg_templates_to_get.empty())
+                
+                for (auto&& src : s.upkg_templates_to_get)
                 {
-                    for (auto&& src : s.upkg_templates_to_get)
-                    {
-                        m_config.read.push_back(std::make_unique<AzureUpkgGetBinaryProvider>(
-                            zip_tool, fs, tools, out_sink, std::move(src), buildtrees));
-                    }
+                    m_config.read.push_back(std::make_unique<AzureUpkgGetBinaryProvider>(
+                        zip_tool, fs, tools, out_sink, std::move(src), buildtrees));
                 }
+
                 if (!s.upkg_templates_to_put.empty())
                 {
                     m_config.write.push_back(std::make_unique<AzureUpkgPutBinaryProvider>(

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -1322,7 +1322,6 @@ namespace
                                  const Path& download_path,
                                  MessageSink& sink) const
         {
-
             Command cmd = base_cmd(src, package_name, package_version, "download");
             cmd.string_arg("--path").string_arg(download_path);
             return run_az_artifacts_cmd(cmd, sink);
@@ -1383,8 +1382,8 @@ namespace
             const Path& zip_path = request.zip_path.value_or_exit(VCPKG_LINE_INFO);
             for (auto&& write_src : m_sources)
             {
-                auto res = m_azure_tool.publish(
-                    write_src, ref.id, ref.version, zip_path, package_description, msg_sink);
+                auto res =
+                    m_azure_tool.publish(write_src, ref.id, ref.version, zip_path, package_description, msg_sink);
                 if (res)
                 {
                     count_stored++;
@@ -1408,8 +1407,17 @@ namespace
 
     struct AzureUpkgGetBinaryProvider : public ZipReadBinaryProvider
     {
-        AzureUpkgGetBinaryProvider(ZipTool zip, const Filesystem& fs, const ToolCache& cache, MessageSink& sink, const AzureUpkgSource& source, const Path& buildtrees)
-            : ZipReadBinaryProvider(std::move(zip), fs), m_azure_tool(cache, sink), m_sink(sink), m_source(std::move(source)), m_buildtrees(buildtrees)
+        AzureUpkgGetBinaryProvider(ZipTool zip,
+                                   const Filesystem& fs,
+                                   const ToolCache& cache,
+                                   MessageSink& sink,
+                                   const AzureUpkgSource& source,
+                                   const Path& buildtrees)
+            : ZipReadBinaryProvider(std::move(zip), fs)
+            , m_azure_tool(cache, sink)
+            , m_sink(sink)
+            , m_source(std::move(source))
+            , m_buildtrees(buildtrees)
         {
         }
 
@@ -1422,8 +1430,7 @@ namespace
             return msg::format(msgRestoredPackagesFromAZUPKG, msg::count = count, msg::elapsed = ElapsedTime(elapsed));
         }
 
-        void acquire_zips(View<const InstallPlanAction*> actions,
-            Span<Optional<ZipResource>> out_zips) const override
+        void acquire_zips(View<const InstallPlanAction*> actions, Span<Optional<ZipResource>> out_zips) const override
         {
             for (size_t i = 0; i < actions.size(); ++i)
             {
@@ -1443,15 +1450,14 @@ namespace
                 {
                     out_zips[i] = nullopt;
                 }
+            }
         }
-}
 
     private:
         AzureUpkgTool m_azure_tool;
         MessageSink& m_sink;
         AzureUpkgSource m_source;
         const Path& m_buildtrees;
-
     };
 
     ExpectedL<Path> default_cache_path_impl()
@@ -2514,8 +2520,8 @@ namespace vcpkg
                 zip_tool.setup(tools, out_sink);
                 for (auto&& src : s.upkg_templates_to_get)
                 {
-                    m_config.read.push_back(
-                        std::make_unique<AzureUpkgGetBinaryProvider>(zip_tool, fs, tools, out_sink, std::move(src), buildtrees));
+                    m_config.read.push_back(std::make_unique<AzureUpkgGetBinaryProvider>(
+                        zip_tool, fs, tools, out_sink, std::move(src), buildtrees));
                 }
             }
             if (!s.upkg_templates_to_put.empty())

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -335,7 +335,7 @@ namespace
             {
                 m_fs.remove(r.path, IgnoreErrors{});
             }
-        }
+        }   
 
         // For every action denoted by actions, at corresponding indicies in out_zips, stores a ZipResource indicating
         // the downloaded location.
@@ -1439,18 +1439,20 @@ namespace
                 const auto ref = make_feedref(info, "");
 
                 Path temp_dir = m_buildtrees / fmt::format("upkg_download_{}", info.package_abi);
-                Path zip_path = temp_dir / fmt::format("{}.zip", ref.id);
+                Path zip_path_temp = temp_dir / fmt::format("{}.zip", ref.id);
+                Path final_zip_path = m_buildtrees / fmt::format("{}.zip", ref.id);
 
                 const auto result = m_azure_tool.download(m_source, ref.id, ref.version, temp_dir, m_sink);
-                if (result.has_value() && m_fs.exists(zip_path, IgnoreErrors{}))
+                if (result.has_value() && m_fs.exists(zip_path_temp, IgnoreErrors{}))
                 {
-                    out_zips[i].emplace(std::move(zip_path), RemoveWhen::always);
+                    m_fs.rename(zip_path_temp, final_zip_path, VCPKG_LINE_INFO);
+                    out_zips[i].emplace(std::move(final_zip_path), RemoveWhen::always);
                 }
                 else
                 {
                     msg::println_warning(result.error());
                 }
-                // RemoveWhen mechanism is insufficient since there is now an extra temporary directory 
+                 
                 if (m_fs.exists(temp_dir, IgnoreErrors{}))
                 {
                     m_fs.remove(temp_dir, VCPKG_LINE_INFO);

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -2477,12 +2477,11 @@ namespace vcpkg
                     const auto& token = *args.actions_runtime_token.get();
                     m_config.read.push_back(std::make_unique<GHABinaryProvider>(zip_tool, fs, buildtrees, url, token));
                 }
-
-                if (!s.upkg_templates_to_put.empty())
-                {
-                    m_config.write.push_back(std::make_unique<AzureUpkgPutBinaryProvider>(
-                        tools, out_sink, std::move(s.upkg_templates_to_put)));
-                }
+            }
+            if (!s.upkg_templates_to_put.empty())
+            {
+                m_config.write.push_back(std::make_unique<AzureUpkgPutBinaryProvider>(
+                    tools, out_sink, std::move(s.upkg_templates_to_put)));
             }
             if (!s.archives_to_write.empty())
             {

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -1439,13 +1439,13 @@ namespace
                 const auto ref = make_feedref(info, "");
 
                 Path temp_dir = m_buildtrees / fmt::format("upkg_download_{}", info.package_abi);
-                Path zip_path_temp = temp_dir / fmt::format("{}.zip", ref.id);
+                Path temp_zip_path = temp_dir / fmt::format("{}.zip", ref.id);
                 Path final_zip_path = m_buildtrees / fmt::format("{}.zip", ref.id);
 
                 const auto result = m_azure_tool.download(m_source, ref.id, ref.version, temp_dir, m_sink);
-                if (result.has_value() && m_fs.exists(zip_path_temp, IgnoreErrors{}))
+                if (result.has_value() && m_fs.exists(temp_zip_path, IgnoreErrors{}))
                 {
-                    m_fs.rename(zip_path_temp, final_zip_path, VCPKG_LINE_INFO);
+                    m_fs.rename(temp_zip_path, final_zip_path, VCPKG_LINE_INFO);
                     out_zips[i].emplace(std::move(final_zip_path), RemoveWhen::always);
                 }
                 else

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -1446,6 +1446,10 @@ namespace
                 {
                     out_zips[i].emplace(std::move(zip_path), RemoveWhen::always);
                 }
+                else
+                {
+                    msg::println_warning(result.error());
+                }
             }
         }
 

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -335,7 +335,7 @@ namespace
             {
                 m_fs.remove(r.path, IgnoreErrors{});
             }
-        }   
+        }
 
         // For every action denoted by actions, at corresponding indicies in out_zips, stores a ZipResource indicating
         // the downloaded location.
@@ -1452,7 +1452,7 @@ namespace
                 {
                     msg::println_warning(result.error());
                 }
-                 
+
                 if (m_fs.exists(temp_dir, IgnoreErrors{}))
                 {
                     m_fs.remove(temp_dir, VCPKG_LINE_INFO);

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -2463,6 +2463,20 @@ namespace vcpkg
                     const auto& token = *args.actions_runtime_token.get();
                     m_config.read.push_back(std::make_unique<GHABinaryProvider>(zip_tool, fs, buildtrees, url, token));
                 }
+
+                if (!s.upkg_templates_to_get.empty())
+                {
+                    for (auto&& src : s.upkg_templates_to_get)
+                    {
+                        m_config.read.push_back(std::make_unique<AzureUpkgGetBinaryProvider>(
+                            zip_tool, fs, tools, out_sink, std::move(src), buildtrees));
+                    }
+                }
+                if (!s.upkg_templates_to_put.empty())
+                {
+                    m_config.write.push_back(
+                        std::make_unique<AzureUpkgPutBinaryProvider>(tools, out_sink, std::move(s.upkg_templates_to_put)));
+                }
             }
             if (!s.archives_to_write.empty())
             {
@@ -2512,22 +2526,6 @@ namespace vcpkg
                     m_config.write.push_back(std::make_unique<NugetBinaryPushProvider>(
                         nuget_base, std::move(s.sources_to_write), std::move(s.configs_to_write)));
                 }
-            }
-
-            if (!s.upkg_templates_to_get.empty())
-            {
-                ZipTool zip_tool;
-                zip_tool.setup(tools, out_sink);
-                for (auto&& src : s.upkg_templates_to_get)
-                {
-                    m_config.read.push_back(std::make_unique<AzureUpkgGetBinaryProvider>(
-                        zip_tool, fs, tools, out_sink, std::move(src), buildtrees));
-                }
-            }
-            if (!s.upkg_templates_to_put.empty())
-            {
-                m_config.write.push_back(
-                    std::make_unique<AzureUpkgPutBinaryProvider>(tools, out_sink, std::move(s.upkg_templates_to_put)));
             }
         }
 

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -2474,8 +2474,8 @@ namespace vcpkg
                 }
                 if (!s.upkg_templates_to_put.empty())
                 {
-                    m_config.write.push_back(
-                        std::make_unique<AzureUpkgPutBinaryProvider>(tools, out_sink, std::move(s.upkg_templates_to_put)));
+                    m_config.write.push_back(std::make_unique<AzureUpkgPutBinaryProvider>(
+                        tools, out_sink, std::move(s.upkg_templates_to_put)));
                 }
             }
             if (!s.archives_to_write.empty())

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -2453,17 +2453,17 @@ namespace vcpkg
                         std::make_unique<ObjectStorageProvider>(zip_tool, fs, buildtrees, std::move(prefix), cos_tool));
                 }
 
+                for (auto&& src : s.upkg_templates_to_get)
+                {
+                    m_config.read.push_back(std::make_unique<AzureUpkgGetBinaryProvider>(
+                        zip_tool, fs, tools, out_sink, std::move(src), buildtrees));
+                }
+
                 if (s.gha_read)
                 {
                     const auto& url = *args.actions_cache_url.get();
                     const auto& token = *args.actions_runtime_token.get();
                     m_config.read.push_back(std::make_unique<GHABinaryProvider>(zip_tool, fs, buildtrees, url, token));
-                }
-                
-                for (auto&& src : s.upkg_templates_to_get)
-                {
-                    m_config.read.push_back(std::make_unique<AzureUpkgGetBinaryProvider>(
-                        zip_tool, fs, tools, out_sink, std::move(src), buildtrees));
                 }
 
                 if (!s.upkg_templates_to_put.empty())

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -2480,8 +2480,8 @@ namespace vcpkg
             }
             if (!s.upkg_templates_to_put.empty())
             {
-                m_config.write.push_back(std::make_unique<AzureUpkgPutBinaryProvider>(
-                    tools, out_sink, std::move(s.upkg_templates_to_put)));
+                m_config.write.push_back(
+                    std::make_unique<AzureUpkgPutBinaryProvider>(tools, out_sink, std::move(s.upkg_templates_to_put)));
             }
             if (!s.archives_to_write.empty())
             {

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -2424,7 +2424,8 @@ namespace vcpkg
             }
 
             if (!s.archives_to_read.empty() || !s.url_templates_to_get.empty() || !s.gcs_read_prefixes.empty() ||
-                !s.aws_read_prefixes.empty() || !s.cos_read_prefixes.empty() || s.gha_read || !s.upkg_templates_to_get.empty())
+                !s.aws_read_prefixes.empty() || !s.cos_read_prefixes.empty() || s.gha_read ||
+                !s.upkg_templates_to_get.empty())
             {
                 ZipTool zip_tool;
                 zip_tool.setup(tools, out_sink);

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -1450,6 +1450,11 @@ namespace
                 {
                     msg::println_warning(result.error());
                 }
+                // RemoveWhen mechanism is insufficient since there is now an extra temporary directory 
+                if (m_fs.exists(temp_dir, IgnoreErrors{}))
+                {
+                    m_fs.remove(temp_dir, VCPKG_LINE_INFO);
+                }
             }
         }
 


### PR DESCRIPTION
Initial install:
￼
![image](https://github.com/user-attachments/assets/fbe1b87e-bbaa-4fff-836c-27a32557b5a7)

 After cache download:
￼
![image](https://github.com/user-attachments/assets/d610757d-925b-4011-8d55-d192385517e6)

Permissions not preserved!

Changing to zip contents…
 Original Install: 
￼
![image](https://github.com/user-attachments/assets/6c4aeed4-3df2-4079-8951-f4d7d85f4f30)

**Observe the write permissions.**
 Installing from binary cache:
￼
![image](https://github.com/user-attachments/assets/7b7db97c-7ec5-4e5e-8d65-005425eb64dd)

Permissions preserved!
