### PR TITLE
Fix referring to registry ports as 'overlays'

### DIFF
--- a/azure-pipelines/end-to-end-tests-dir/e2e-registry.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/e2e-registry.ps1
@@ -86,7 +86,7 @@ try
     $out = Run-VcpkgAndCaptureOutput @commonArgs install
     Throw-IfFailed
     if ($out -match 'error: the baseline does not contain an entry for port removed' -Or
-        $out -notmatch 'The following packages will be built and installed:\s+removed:[^ ]+@1.0.0 -- [^ ]+git-trees[\\/]9b82c31964570870d27a5bb634f5b84e13f8b90a'
+        $out -notmatch 'The following packages will be built and installed:\s+removed:[^ ]+@1.0.0 -- git\+[^\n]+@9b82c31964570870d27a5bb634f5b84e13f8b90a'
         )
     {
         throw 'Baseline removed port could not be selected with overrides'

--- a/include/vcpkg/base/message-data.inc.h
+++ b/include/vcpkg/base/message-data.inc.h
@@ -1775,6 +1775,8 @@ DECLARE_MESSAGE(InstalledBy, (msg::path), "", "Installed by {path}")
 DECLARE_MESSAGE(InstalledPackages, (), "", "The following packages are already installed:")
 DECLARE_MESSAGE(InstalledRequestedPackages, (), "", "All requested packages are currently installed.")
 DECLARE_MESSAGE(InstallFailed, (msg::path, msg::error_msg), "", "failed: {path}: {error_msg}")
+DECLARE_MESSAGE(InstallingFromFilesystemRegistry, (), "", "installing from filesystem registry here")
+DECLARE_MESSAGE(InstallingFromGitRegistry, (), "", "installing from git registry")
 DECLARE_MESSAGE(InstallingOverlayPort, (), "", "installing overlay port from here")
 DECLARE_MESSAGE(InstallingPackage,
                 (msg::action_index, msg::count, msg::spec),

--- a/include/vcpkg/dependencies.h
+++ b/include/vcpkg/dependencies.h
@@ -211,7 +211,7 @@ namespace vcpkg
         LocalizedString text;
     };
 
-    FormattedPlan format_plan(const ActionPlan& action_plan, const Path& builtin_ports_dir);
+    FormattedPlan format_plan(const ActionPlan& action_plan);
 
-    FormattedPlan print_plan(const ActionPlan& action_plan, const Path& builtin_ports_dir);
+    FormattedPlan print_plan(const ActionPlan& action_plan);
 }

--- a/include/vcpkg/fwd/portfileprovider.h
+++ b/include/vcpkg/fwd/portfileprovider.h
@@ -15,5 +15,6 @@ namespace vcpkg
         Unknown,   // We have not tested yet
         Port,      // The overlay directory is itself a port
         Directory, // The overlay directory itself contains port directories
+        Builtin,   // Same as directory but we remember that it came from builtin_ports_directory
     };
 }

--- a/include/vcpkg/paragraphs.h
+++ b/include/vcpkg/paragraphs.h
@@ -41,6 +41,11 @@ namespace vcpkg::Paragraphs
     PortLoadResult try_load_port_required(const ReadOnlyFilesystem& fs,
                                           StringView port_name,
                                           const PortLocation& port_location);
+    std::string builtin_port_spdx_location(StringView port_name);
+    std::string builtin_git_tree_spdx_location(StringView git_tree);
+    PortLoadResult try_load_builtin_port_required(const ReadOnlyFilesystem& fs,
+                                                  StringView port_name,
+                                                  const Path& builtin_ports_directory);
     ExpectedL<std::unique_ptr<SourceControlFile>> try_load_project_manifest_text(StringView text,
                                                                                  StringView control_path,
                                                                                  MessageSink& warning_sink);

--- a/include/vcpkg/portfileprovider.h
+++ b/include/vcpkg/portfileprovider.h
@@ -59,8 +59,6 @@ namespace vcpkg
                                                            const ReadOnlyFilesystem& fs,
                                                            StringView port_name);
 
-        ExpectedL<Unit> load_all_port_subdirectories(const ReadOnlyFilesystem& fs);
-
         const ExpectedL<SourceControlFileAndLocation>* try_load_port_subdirectory_with_cache(
             const ReadOnlyFilesystem& fs, StringView port_name);
     };

--- a/include/vcpkg/sourceparagraph.h
+++ b/include/vcpkg/sourceparagraph.h
@@ -140,13 +140,39 @@ namespace vcpkg
         friend bool operator!=(const SourceParagraph& lhs, const SourceParagraph& rhs) { return !(lhs == rhs); }
     };
 
+    enum class PortSourceKind
+    {
+        Unknown,
+        Builtin,
+        Overlay,
+        Git,
+        Filesystem,
+    };
+
+    struct NoAssertionTag
+    {
+    };
+
+    inline constexpr NoAssertionTag no_assertion;
+
     struct PortLocation
     {
+        explicit PortLocation(const Path& port_directory, NoAssertionTag, PortSourceKind kind);
+        explicit PortLocation(Path&& port_directory, NoAssertionTag, PortSourceKind kind);
+        explicit PortLocation(const Path& port_directory, std::string&& spdx_location, PortSourceKind kind);
+        explicit PortLocation(Path&& port_directory, std::string&& spdx_location, PortSourceKind kind);
+        PortLocation(const PortLocation&) = default;
+        PortLocation(PortLocation&&) = default;
+        PortLocation& operator=(const PortLocation&) = default;
+        PortLocation& operator=(PortLocation&&) = default;
+
         Path port_directory;
 
         /// Should model SPDX PackageDownloadLocation. Empty implies NOASSERTION.
         /// See https://spdx.github.io/spdx-spec/package-information/#77-package-download-location-field
         std::string spdx_location;
+
+        PortSourceKind kind;
     };
 
     /// <summary>
@@ -218,7 +244,7 @@ namespace vcpkg
                 scf = std::make_unique<SourceControlFile>(source_control_file->clone());
             }
 
-            return SourceControlFileAndLocation{std::move(scf), control_path, spdx_location};
+            return SourceControlFileAndLocation{std::move(scf), control_path, spdx_location, kind};
         }
 
         std::unique_ptr<SourceControlFile> source_control_file;
@@ -227,6 +253,8 @@ namespace vcpkg
         /// Should model SPDX PackageDownloadLocation. Empty implies NOASSERTION.
         /// See https://spdx.github.io/spdx-spec/package-information/#77-package-download-location-field
         std::string spdx_location;
+
+        PortSourceKind kind = PortSourceKind::Unknown;
     };
 
     void print_error_message(const LocalizedString& message);

--- a/locales/messages.json
+++ b/locales/messages.json
@@ -995,6 +995,8 @@
   "_InstalledBy.comment": "An example of {path} is /foo/bar.",
   "InstalledPackages": "The following packages are already installed:",
   "InstalledRequestedPackages": "All requested packages are currently installed.",
+  "InstallingFromFilesystemRegistry": "installing from filesystem registry here",
+  "InstallingFromGitRegistry": "installing from git registry",
   "InstallingOverlayPort": "installing overlay port from here",
   "InstallingPackage": "Installing {action_index}/{count} {spec}...",
   "_InstallingPackage.comment": "An example of {action_index} is 340. An example of {count} is 42. An example of {spec} is zlib:x64-windows.",

--- a/src/vcpkg/commands.add-version.cpp
+++ b/src/vcpkg/commands.add-version.cpp
@@ -478,8 +478,7 @@ namespace vcpkg
         for (auto&& port_git_tree_entry : port_git_trees)
         {
             auto& port_name = port_git_tree_entry.file_name;
-            auto port_dir = builtin_ports_directory / port_name;
-            auto load_result = Paragraphs::try_load_port_required(fs, port_name, PortLocation{port_dir});
+            auto load_result = Paragraphs::try_load_builtin_port_required(fs, port_name, builtin_ports_directory);
             auto& maybe_scfl = load_result.maybe_scfl;
             auto scfl = maybe_scfl.get();
             if (!scfl)

--- a/src/vcpkg/commands.autocomplete.cpp
+++ b/src/vcpkg/commands.autocomplete.cpp
@@ -105,8 +105,8 @@ namespace vcpkg
                 StringView port_name{last_arg.begin(), colon};
                 StringView triplet_prefix{colon + 1, last_arg.end()};
                 // TODO: Support autocomplete for ports in --overlay-ports
-                auto maybe_port = Paragraphs::try_load_port_required(
-                    paths.get_filesystem(), port_name, PortLocation{paths.builtin_ports_directory() / port_name});
+                auto maybe_port = Paragraphs::try_load_builtin_port_required(
+                    paths.get_filesystem(), port_name, paths.builtin_ports_directory());
                 if (!maybe_port.maybe_scfl)
                 {
                     Checks::exit_success(VCPKG_LINE_INFO);

--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -1080,13 +1080,36 @@ namespace vcpkg
                            .append_raw('\n'));
         }
 
-        if (!Strings::starts_with(scfl.control_path, paths.builtin_ports_directory()))
+        switch (scfl.kind)
         {
-            msg::print(LocalizedString::from_raw(scfl.port_directory())
-                           .append_raw(": ")
-                           .append_raw(InfoPrefix)
-                           .append(msgInstallingOverlayPort)
-                           .append_raw('\n'));
+            case PortSourceKind::Unknown:
+            case PortSourceKind::Builtin:
+                // intentionally no output for these
+                break;
+            case PortSourceKind::Overlay:
+                msg::print(LocalizedString::from_raw(scfl.port_directory())
+                               .append_raw(": ")
+                               .append_raw(InfoPrefix)
+                               .append(msgInstallingOverlayPort)
+                               .append_raw('\n'));
+                break;
+            case PortSourceKind::Git:
+                msg::print(LocalizedString::from_raw(scfl.port_directory())
+                               .append_raw(": ")
+                               .append_raw(InfoPrefix)
+                               .append(msgInstallingFromGitRegistry)
+                               .append_raw(' ')
+                               .append_raw(scfl.spdx_location)
+                               .append_raw('\n'));
+                break;
+            case PortSourceKind::Filesystem:
+                msg::print(LocalizedString::from_raw(scfl.port_directory())
+                               .append_raw(": ")
+                               .append_raw(InfoPrefix)
+                               .append(msgInstallingFromFilesystemRegistry)
+                               .append_raw('\n'));
+                break;
+            default: Checks::unreachable(VCPKG_LINE_INFO);
         }
 
         const auto& abi_info = action.abi_info.value_or_exit(VCPKG_LINE_INFO);

--- a/src/vcpkg/commands.ci-verify-versions.cpp
+++ b/src/vcpkg/commands.ci-verify-versions.cpp
@@ -54,8 +54,12 @@ namespace
             return success;
         }
 
-        auto load_result =
-            Paragraphs::try_load_port_required(paths.get_filesystem(), port_name, PortLocation{*extracted_tree});
+        auto load_result = Paragraphs::try_load_port_required(
+            paths.get_filesystem(),
+            port_name,
+            PortLocation(*extracted_tree,
+                         Paragraphs::builtin_git_tree_spdx_location(version_entry.git_tree),
+                         PortSourceKind::Git));
         auto scfl = load_result.maybe_scfl.get();
         if (!scfl)
         {
@@ -534,9 +538,8 @@ namespace vcpkg
         for (auto&& tree_entry : port_git_trees)
         {
             auto& port_name = tree_entry.file_name;
-            auto port_path = paths.builtin_ports_directory() / port_name;
             auto maybe_loaded_port =
-                Paragraphs::try_load_port_required(fs, port_name, PortLocation{port_path}).maybe_scfl;
+                Paragraphs::try_load_builtin_port_required(fs, port_name, paths.builtin_ports_directory()).maybe_scfl;
             auto loaded_port = maybe_loaded_port.get();
             if (loaded_port)
             {

--- a/src/vcpkg/commands.ci.cpp
+++ b/src/vcpkg/commands.ci.cpp
@@ -472,7 +472,7 @@ namespace vcpkg
 
         if (is_dry_run)
         {
-            print_plan(action_plan, paths.builtin_ports_directory());
+            print_plan(action_plan);
             if (!not_supported_regressions.empty())
             {
                 msg::write_unlocalized_text_to_stderr(

--- a/src/vcpkg/commands.format-manifest.cpp
+++ b/src/vcpkg/commands.format-manifest.cpp
@@ -165,7 +165,8 @@ namespace vcpkg
         {
             for (const auto& dir : fs.get_directories_non_recursive(paths.builtin_ports_directory(), VCPKG_LINE_INFO))
             {
-                auto maybe_manifest = Paragraphs::try_load_port_required(fs, dir.filename(), PortLocation{dir});
+                auto maybe_manifest =
+                    Paragraphs::try_load_builtin_port_required(fs, dir.filename(), paths.builtin_ports_directory());
                 if (auto manifest = maybe_manifest.maybe_scfl.get())
                 {
                     auto original = manifest->control_path;

--- a/src/vcpkg/commands.install.cpp
+++ b/src/vcpkg/commands.install.cpp
@@ -1330,7 +1330,7 @@ namespace vcpkg
         }
 #endif // defined(_WIN32)
 
-        const auto formatted = print_plan(action_plan, paths.builtin_ports_directory());
+        const auto formatted = print_plan(action_plan);
         if (!is_recursive && formatted.has_removals)
         {
             msg::println_warning(msgPackagesToRebuildSuggestRecurse);

--- a/src/vcpkg/commands.set-installed.cpp
+++ b/src/vcpkg/commands.set-installed.cpp
@@ -229,7 +229,7 @@ namespace vcpkg
         auto status_db = database_load_collapse(fs, paths.installed());
         adjust_action_plan_to_status_db(action_plan, status_db);
 
-        print_plan(action_plan, paths.builtin_ports_directory());
+        print_plan(action_plan);
 
         if (auto p_pkgsconfig = maybe_pkgconfig.get())
         {

--- a/src/vcpkg/commands.upgrade.cpp
+++ b/src/vcpkg/commands.upgrade.cpp
@@ -193,7 +193,7 @@ namespace vcpkg
 
         Checks::check_exit(VCPKG_LINE_INFO, !action_plan.empty());
         action_plan.print_unsupported_warnings();
-        print_plan(action_plan, paths.builtin_ports_directory());
+        print_plan(action_plan);
 
         if (!no_dry_run)
         {

--- a/src/vcpkg/sourceparagraph.cpp
+++ b/src/vcpkg/sourceparagraph.cpp
@@ -133,6 +133,26 @@ namespace vcpkg
         return true;
     }
 
+    PortLocation::PortLocation(const Path& port_directory, NoAssertionTag, PortSourceKind kind)
+        : port_directory(port_directory), spdx_location(), kind(kind)
+    {
+    }
+
+    PortLocation::PortLocation(Path&& port_directory, NoAssertionTag, PortSourceKind kind)
+        : port_directory(std::move(port_directory)), spdx_location(), kind(kind)
+    {
+    }
+
+    PortLocation::PortLocation(const Path& port_directory, std::string&& spdx_location, PortSourceKind kind)
+        : port_directory(port_directory), spdx_location(std::move(spdx_location)), kind(kind)
+    {
+    }
+
+    PortLocation::PortLocation(Path&& port_directory, std::string&& spdx_location, PortSourceKind kind)
+        : port_directory(std::move(port_directory)), spdx_location(std::move(spdx_location)), kind(kind)
+    {
+    }
+
     bool operator==(const FeatureParagraph& lhs, const FeatureParagraph& rhs)
     {
         if (lhs.name != rhs.name) return false;


### PR DESCRIPTION
Related: https://github.com/microsoft/vcpkg-tool/pull/1379#discussion_r1567944235

Previously, we are loading ports from outside the builtin ports directory, so we would refer to these as 'overlays' even when they actually come from versioning / registries.

Couple of examples follow.

Before:

```
C:\Dev\vcpkg-tool\out\build\Win-x64-Debug-WithArtifacts\vcpkg-shell.ps1 install --triplet x86-windows --x-buildtrees-root=C:\Dev\work\testing\buildtrees --x-install-root=C:\Dev\work\testing\installed --x-packages-root=C:\Dev\work\testing\packages --feature-flags=registries,manifests
Detecting compiler hash for triplet x86-windows...
Compiler found: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.43.34808/bin/Hostx64/x86/cl.exe
The following packages will be built and installed:
    vcpkg-internal-e2e-test-port:x86-windows@1.0.0 -- C:\Dev\work\testing\filesystem-registry\vcpkg-internal-e2e-test-port
Restored 0 package(s) from C:\Users\bion\AppData\Local\vcpkg\archives in 554 us. Use --debug to see more details.
Installing 1/1 vcpkg-internal-e2e-test-port:x86-windows@1.0.0...
Building vcpkg-internal-e2e-test-port:x86-windows@1.0.0...
C:\Dev\work\testing\filesystem-registry\vcpkg-internal-e2e-test-port: info: installing overlay port from here
-- Skipping post-build validation due to VCPKG_POLICY_EMPTY_PACKAGE
Starting submission of vcpkg-internal-e2e-test-port:x86-windows@1.0.0 to 1 binary cache(s) in the background
Elapsed time to handle vcpkg-internal-e2e-test-port:x86-windows: 44.4 ms
vcpkg-internal-e2e-test-port:x86-windows package ABI: 44a438d915046bd3b0c94d08ee9c96cf41cc76811f01ecbfefa7974fec9b3f60
Total install time: 48 ms
Waiting for 1 remaining binary cache submissions...
Completed submission of vcpkg-internal-e2e-test-port:x86-windows@1.0.0 to 1 binary cache(s) in 28.5 ms (1/1)
```

After:

```
C:\Dev\vcpkg-tool\out\build\Win-x64-Debug-WithArtifacts\vcpkg-shell.ps1 install --triplet x86-windows --x-buildtrees-root=C:\Dev\work\testing\buildtrees --x-install-root=C:\Dev\work\testing\installed --x-packages-root=C:\Dev\work\testing\packages --feature-flags=registries,manifests
Detecting compiler hash for triplet x86-windows...
Compiler found: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.43.34808/bin/Hostx64/x86/cl.exe
The following packages will be built and installed:
    vcpkg-internal-e2e-test-port:x86-windows@1.0.0 -- C:\Dev\work\testing\filesystem-registry\vcpkg-internal-e2e-test-port
Restored 0 package(s) from C:\Users\bion\AppData\Local\vcpkg\archives in 515 us. Use --debug to see more details.
Installing 1/1 vcpkg-internal-e2e-test-port:x86-windows@1.0.0...
Building vcpkg-internal-e2e-test-port:x86-windows@1.0.0...
C:\Dev\work\testing\filesystem-registry\vcpkg-internal-e2e-test-port: info: installing from filesystem registry here
-- Skipping post-build validation due to VCPKG_POLICY_EMPTY_PACKAGE
Starting submission of vcpkg-internal-e2e-test-port:x86-windows@1.0.0 to 1 binary cache(s) in the background
Elapsed time to handle vcpkg-internal-e2e-test-port:x86-windows: 41.3 ms
vcpkg-internal-e2e-test-port:x86-windows package ABI: 44a438d915046bd3b0c94d08ee9c96cf41cc76811f01ecbfefa7974fec9b3f60
Total install time: 42.5 ms
Waiting for 1 remaining binary cache submissions...
Completed submission of vcpkg-internal-e2e-test-port:x86-windows@1.0.0 to 1 binary cache(s) in 25.9 ms (1/1)
```

Before:

```
C:\Dev\vcpkg-tool\out\build\Win-x64-Debug-WithArtifacts\vcpkg-shell.ps1 install --triplet x86-windows --x-buildtrees-root=C:\Dev\work\testing\buildtrees --x-install-root=C:\Dev\work\testing\installed --x-packages-root=C:\Dev\work\testing\packages --feature-flags=registries,manifests --dry-run
Fetching registry information from C:\Dev\work\testing\git-registry-upstream (HEAD)...
Fetching registry information from C:\Dev\work\testing\git-registry-upstream (secondary)...
Detecting compiler hash for triplet x86-windows...
Compiler found: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.43.34808/bin/Hostx64/x86/cl.exe
The following packages will be rebuilt:
    vcpkg-internal-e2e-test-port:x86-windows@1.0.0 -- C:\Dev\work\testing\registries\git-trees\f4f1e944412b441d41d45867ac36450adb1d8c40
The following packages will be built and installed:
    vcpkg-internal-e2e-test-port2:x86-windows@1.0.0 -- C:\Dev\work\testing\registries\git-trees\cf9c5d6c86dc6daac39e9f367393cd9fba768f8e

C:\Dev\vcpkg-tool\out\build\Win-x64-Debug-WithArtifacts\vcpkg-shell.ps1 install --triplet x86-windows --x-buildtrees-root=C:\Dev\work\testing\buildtrees --x-install-root=C:\Dev\work\testing\installed --x-packages-root=C:\Dev\work\testing\packages --feature-flags=registries,manifests
Fetching registry information from C:\Dev\work\testing\git-registry-upstream (HEAD)...
Fetching registry information from C:\Dev\work\testing\git-registry-upstream (secondary)...
Detecting compiler hash for triplet x86-windows...
Compiler found: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.43.34808/bin/Hostx64/x86/cl.exe
The following packages will be rebuilt:
    vcpkg-internal-e2e-test-port:x86-windows@1.0.0 -- C:\Dev\work\testing\registries\git-trees\f4f1e944412b441d41d45867ac36450adb1d8c40
The following packages will be built and installed:
    vcpkg-internal-e2e-test-port2:x86-windows@1.0.0 -- C:\Dev\work\testing\registries\git-trees\cf9c5d6c86dc6daac39e9f367393cd9fba768f8e
Restored 0 package(s) from C:\Users\bion\AppData\Local\vcpkg\archives in 549 us. Use --debug to see more details.
Removing 1/3 vcpkg-internal-e2e-test-port:x86-windows
Elapsed time to handle vcpkg-internal-e2e-test-port:x86-windows: 2.32 ms
Installing 2/3 vcpkg-internal-e2e-test-port:x86-windows@1.0.0...
Building vcpkg-internal-e2e-test-port:x86-windows@1.0.0...
C:\Dev\work\testing\registries\git-trees\f4f1e944412b441d41d45867ac36450adb1d8c40: info: installing overlay port from here
-- Skipping post-build validation due to VCPKG_POLICY_EMPTY_PACKAGE
Starting submission of vcpkg-internal-e2e-test-port:x86-windows@1.0.0 to 1 binary cache(s) in the background
Elapsed time to handle vcpkg-internal-e2e-test-port:x86-windows: 42.1 ms
vcpkg-internal-e2e-test-port:x86-windows package ABI: 9c7ce84f25005c6055554edbcfd078df68a3285c1f2dedba6e419b7a1b229977
Installing 3/3 vcpkg-internal-e2e-test-port2:x86-windows@1.0.0...
Building vcpkg-internal-e2e-test-port2:x86-windows@1.0.0...
C:\Dev\work\testing\registries\git-trees\cf9c5d6c86dc6daac39e9f367393cd9fba768f8e: info: installing overlay port from here
-- Skipping post-build validation due to VCPKG_POLICY_EMPTY_PACKAGE
Starting submission of vcpkg-internal-e2e-test-port2:x86-windows@1.0.0 to 1 binary cache(s) in the background
Elapsed time to handle vcpkg-internal-e2e-test-port2:x86-windows: 42.2 ms
vcpkg-internal-e2e-test-port2:x86-windows package ABI: 08801ac889538c8b112baad4cb38ba4d1b546059b6229f58bd17f4606f75fb17
Total install time: 89.8 ms
Completed submission of vcpkg-internal-e2e-test-port:x86-windows@1.0.0 to 1 binary cache(s) in 26.8 ms
Waiting for 1 remaining binary cache submissions...
Completed submission of vcpkg-internal-e2e-test-port2:x86-windows@1.0.0 to 1 binary cache(s) in 38.4 ms (1/1)
````

After:

```
C:\Dev\vcpkg-tool\out\build\Win-x64-Debug-WithArtifacts\vcpkg-shell.ps1 install --triplet x86-windows --x-buildtrees-root=C:\Dev\work\testing\buildtrees --x-install-root=C:\Dev\work\testing\installed --x-packages-root=C:\Dev\work\testing\packages --feature-flags=registries,manifests --dry-run
Fetching registry information from C:\Dev\work\testing\git-registry-upstream (HEAD)...
Fetching registry information from C:\Dev\work\testing\git-registry-upstream (secondary)...
Detecting compiler hash for triplet x86-windows...
Compiler found: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.43.34808/bin/Hostx64/x86/cl.exe
The following packages will be rebuilt:
    vcpkg-internal-e2e-test-port:x86-windows@1.0.0 -- git+C:\Dev\work\testing\git-registry-upstream@f4f1e944412b441d41d45867ac36450adb1d8c40
The following packages will be built and installed:
    vcpkg-internal-e2e-test-port2:x86-windows@1.0.0 -- git+C:\Dev\work\testing\git-registry-upstream@cf9c5d6c86dc6daac39e9f367393cd9fba768f8e

C:\Dev\vcpkg-tool\out\build\Win-x64-Debug-WithArtifacts\vcpkg-shell.ps1 install --triplet x86-windows --x-buildtrees-root=C:\Dev\work\testing\buildtrees --x-install-root=C:\Dev\work\testing\installed --x-packages-root=C:\Dev\work\testing\packages --feature-flags=registries,manifests
Fetching registry information from C:\Dev\work\testing\git-registry-upstream (HEAD)...
Fetching registry information from C:\Dev\work\testing\git-registry-upstream (secondary)...
Detecting compiler hash for triplet x86-windows...
Compiler found: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.43.34808/bin/Hostx64/x86/cl.exe
The following packages will be rebuilt:
    vcpkg-internal-e2e-test-port:x86-windows@1.0.0 -- git+C:\Dev\work\testing\git-registry-upstream@f4f1e944412b441d41d45867ac36450adb1d8c40
The following packages will be built and installed:
    vcpkg-internal-e2e-test-port2:x86-windows@1.0.0 -- git+C:\Dev\work\testing\git-registry-upstream@cf9c5d6c86dc6daac39e9f367393cd9fba768f8e
Restored 0 package(s) from C:\Users\bion\AppData\Local\vcpkg\archives in 498 us. Use --debug to see more details.
Removing 1/3 vcpkg-internal-e2e-test-port:x86-windows
Elapsed time to handle vcpkg-internal-e2e-test-port:x86-windows: 2.47 ms
Installing 2/3 vcpkg-internal-e2e-test-port:x86-windows@1.0.0...
Building vcpkg-internal-e2e-test-port:x86-windows@1.0.0...
C:\Dev\work\testing\registries\git-trees\f4f1e944412b441d41d45867ac36450adb1d8c40: info: installing from git registry git+C:\Dev\work\testing\git-registry-upstream@f4f1e944412b441d41d45867ac36450adb1d8c40
-- Skipping post-build validation due to VCPKG_POLICY_EMPTY_PACKAGE
Starting submission of vcpkg-internal-e2e-test-port:x86-windows@1.0.0 to 1 binary cache(s) in the background
Elapsed time to handle vcpkg-internal-e2e-test-port:x86-windows: 42.7 ms
vcpkg-internal-e2e-test-port:x86-windows package ABI: 9c7ce84f25005c6055554edbcfd078df68a3285c1f2dedba6e419b7a1b229977
Installing 3/3 vcpkg-internal-e2e-test-port2:x86-windows@1.0.0...
Building vcpkg-internal-e2e-test-port2:x86-windows@1.0.0...
C:\Dev\work\testing\registries\git-trees\cf9c5d6c86dc6daac39e9f367393cd9fba768f8e: info: installing from git registry git+C:\Dev\work\testing\git-registry-upstream@cf9c5d6c86dc6daac39e9f367393cd9fba768f8e
-- Skipping post-build validation due to VCPKG_POLICY_EMPTY_PACKAGE
Starting submission of vcpkg-internal-e2e-test-port2:x86-windows@1.0.0 to 1 binary cache(s) in the background
Elapsed time to handle vcpkg-internal-e2e-test-port2:x86-windows: 41.4 ms
vcpkg-internal-e2e-test-port2:x86-windows package ABI: 08801ac889538c8b112baad4cb38ba4d1b546059b6229f58bd17f4606f75fb17
Total install time: 92.1 ms
Completed submission of vcpkg-internal-e2e-test-port:x86-windows@1.0.0 to 1 binary cache(s) in 36.9 ms
Waiting for 1 remaining binary cache submissions...
Completed submission of vcpkg-internal-e2e-test-port2:x86-windows@1.0.0 to 1 binary cache(s) in 32.6 ms (1/1)
```