### PR TITLE
Always pass an absolute path to x-script destinations.

### DIFF
--- a/azure-pipelines/end-to-end-tests-dir/asset-caching.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/asset-caching.ps1
@@ -8,7 +8,7 @@ Throw-IfFailed
 Run-Vcpkg @commonArgs fetch ninja
 Throw-IfFailed
 Remove-Item env:VCPKG_FORCE_DOWNLOADED_BINARIES
-Remove-Item (Join-Path $DefaultDownloadsRoot 'hello-world.txt')
+Remove-Item (Join-Path $DefaultDownloadsRoot 'hello-world.txt') -ErrorActionPreference SilentlyContinue
 Run-Vcpkg @commonArgs install vcpkg-test-x-script --x-binarysource=clear "--overlay-ports=$PSScriptRoot/../e2e-ports" "--x-asset-sources=x-script,$TestScriptAssetCacheExe {url} {sha512} {dst};x-block-origin"
 Throw-IfFailed
 

--- a/azure-pipelines/end-to-end-tests-dir/asset-caching.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/asset-caching.ps1
@@ -3,12 +3,13 @@
 # Testing x-script
 Refresh-TestRoot
 $env:VCPKG_FORCE_DOWNLOADED_BINARIES = "ON"
-Run-Vcpkg -TestArgs ($commonArgs + @('fetch', 'cmake'))
+Run-Vcpkg @commonArgs fetch cmake
 Throw-IfFailed
-Run-Vcpkg -TestArgs ($commonArgs + @('fetch', 'ninja'))
+Run-Vcpkg @commonArgs fetch ninja
 Throw-IfFailed
 Remove-Item env:VCPKG_FORCE_DOWNLOADED_BINARIES
-Run-Vcpkg -TestArgs ($commonArgs + @("install", "vcpkg-test-x-script", "--x-binarysource=clear", "--overlay-ports=$PSScriptRoot/../e2e-ports", "--x-asset-sources=x-script,$TestScriptAssetCacheExe {url} {sha512} {dst};x-block-origin"))
+Remove-Item (Join-Path $DefaultDownloadsRoot 'hello-world.txt')
+Run-Vcpkg @commonArgs install vcpkg-test-x-script --x-binarysource=clear "--overlay-ports=$PSScriptRoot/../e2e-ports" "--x-asset-sources=x-script,$TestScriptAssetCacheExe {url} {sha512} {dst};x-block-origin"
 Throw-IfFailed
 
 $env:VCPKG_FORCE_DOWNLOADED_BINARIES = "ON"
@@ -16,7 +17,7 @@ $assetCacheRegex = [regex]::Escape($AssetCache)
 
 # Testing asset cache miss (not configured) + x-block-origin enabled
 Refresh-TestRoot
-$actual = Run-VcpkgAndCaptureOutput -TestArgs ($commonArgs + @("fetch", "cmake", "--x-asset-sources=clear;x-block-origin", "--downloads-root=$DownloadsRoot"))
+$actual = Run-VcpkgAndCaptureOutput @commonArgs fetch cmake "--x-asset-sources=clear;x-block-origin" "--downloads-root=$TestDownloadsRoot"
 Throw-IfNotFailed
 $expected = @(
 "A suitable version of cmake was not found \(required v[0-9.]+\)\.",
@@ -29,7 +30,7 @@ if (-not ($actual -match $expected)) {
 }
 
 # Testing asset cache miss (not configured) + x-block-origin disabled
-$actual = Run-VcpkgAndCaptureOutput -TestArgs ($commonArgs + @("fetch", "cmake", "--x-asset-sources=clear;", "--downloads-root=$DownloadsRoot"))
+$actual = Run-VcpkgAndCaptureOutput @commonArgs fetch cmake "--x-asset-sources=clear;" "--downloads-root=$TestDownloadsRoot"
 Throw-IfFailed
 $expected = @(
 "A suitable version of cmake was not found \(required v[0-9.]+\)\.",
@@ -43,7 +44,7 @@ if (-not ($actual -match $expected)) {
 
 # Testing asset cache miss (configured) + x-block-origin enabled
 Refresh-TestRoot
-$actual = Run-VcpkgAndCaptureOutput -TestArgs ($commonArgs + @("fetch", "cmake", "--x-asset-sources=x-azurl,file://$AssetCache,,readwrite;x-block-origin", "--downloads-root=$DownloadsRoot"))
+$actual = Run-VcpkgAndCaptureOutput @commonArgs fetch cmake "--x-asset-sources=x-azurl,file://$AssetCache,,readwrite;x-block-origin" "--downloads-root=$TestDownloadsRoot"
 Throw-IfNotFailed
 $expected = @(
 "A suitable version of cmake was not found \(required v[0-9.]+\)\.",
@@ -67,7 +68,7 @@ if (-not ($actual -match $expected)) {
 
 # Testing asset cache miss (configured) + x-block-origin disabled
 Refresh-TestRoot
-$actual = Run-VcpkgAndCaptureOutput -TestArgs ($commonArgs + @("fetch", "cmake", "--x-asset-sources=x-azurl,file://$AssetCache,,readwrite;", "--downloads-root=$DownloadsRoot"))
+$actual = Run-VcpkgAndCaptureOutput @commonArgs fetch cmake "--x-asset-sources=x-azurl,file://$AssetCache,,readwrite;" "--downloads-root=$TestDownloadsRoot"
 Throw-IfFailed
 $expected = @(
 "A suitable version of cmake was not found \(required v[0-9\.]+\)\.",
@@ -81,9 +82,9 @@ if (-not ($actual -match $expected)) {
 }
 
 # Testing asset cache hit
-Refresh-Downloads
-Run-Vcpkg -TestArgs ($commonArgs + @('remove', 'vcpkg-internal-e2e-test-port'))
-$actual = Run-VcpkgAndCaptureOutput -TestArgs ($commonArgs + @("fetch", "cmake", "--x-asset-sources=x-azurl,file://$AssetCache,,readwrite;", "--downloads-root=$DownloadsRoot"))
+Refresh-TestDownloads
+Run-Vcpkg @commonArgs remove vcpkg-internal-e2e-test-port
+$actual = Run-VcpkgAndCaptureOutput @commonArgs fetch cmake "--x-asset-sources=x-azurl,file://$AssetCache,,readwrite;" "--downloads-root=$TestDownloadsRoot"
 
 $expected = @(
 "A suitable version of cmake was not found \(required v[0-9\.]+\)\.",
@@ -113,7 +114,7 @@ $expected = @(
 "$"
 ) -join "`n"
 
-$actual = Run-VcpkgAndCaptureOutput -TestArgs ($commonArgs + @("x-download", "$downloadsRoot/example3.html", "--sha512", "d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73a", "--url", "https://localhost:1234/foobar.html"))
+$actual = Run-VcpkgAndCaptureOutput @commonArgs x-download "$TestDownloadsRoot/example3.html" --sha512 d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73a --url https://localhost:1234/foobar.html
 Throw-IfNotFailed
 if (-not ($actual -match $expected)) {
     throw "Failure: azurl (no), x-block-origin (no), asset-cache (n/a), download (fail)"
@@ -138,7 +139,7 @@ $expected = @(
 "$"
 ) -join "`n"
 
-$actual = Run-VcpkgAndCaptureOutput -TestArgs ($commonArgs + @("x-download", "$downloadsRoot/example3.html", "--sha512", "D06B93C883F8126A04589937A884032DF031B05518EED9D433EFB6447834DF2596AEBD500D69B8283E5702D988ED49655AE654C1683C7A4AE58BFA6B92F2B73A", "--url", "https://localhost:1234/foobar.html", "--url", "https://localhost:1235/baz.html"))
+$actual = Run-VcpkgAndCaptureOutput @commonArgs x-download "$TestDownloadsRoot/example3.html" --sha512 D06B93C883F8126A04589937A884032DF031B05518EED9D433EFB6447834DF2596AEBD500D69B8283E5702D988ED49655AE654C1683C7A4AE58BFA6B92F2B73A --url https://localhost:1234/foobar.html --url https://localhost:1235/baz.html
 Throw-IfNotFailed
 if (-not ($actual -match $expected)) {
     throw "Failure: azurl (no), x-block-origin (no), asset-cache (n/a), download (fail)"
@@ -155,7 +156,7 @@ $expected = @(
 "$"
 ) -join "`n"
 
-$actual = Run-VcpkgAndCaptureOutput -TestArgs ($commonArgs + @("x-download", "$downloadsRoot/example3.html", "--sha512", "d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73b", "--url", "https://example.com"))
+$actual = Run-VcpkgAndCaptureOutput @commonArgs x-download "$TestDownloadsRoot/example3.html" --sha512 d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73b --url https://example.com
 Throw-IfNotFailed
 if (-not ($actual -match $expected)) {
     throw "Failure: azurl (no), x-block-origin (no), asset-cache (n/a), download (sha-mismatch)"
@@ -170,7 +171,7 @@ $expected = @(
 "$"
 ) -join "`n"
 
-$actual = Run-VcpkgAndCaptureOutput -TestArgs ($commonArgs + @("x-download", "$downloadsRoot/example3.html", "--sha512", "d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73a", "--url", "https://example.com"))
+$actual = Run-VcpkgAndCaptureOutput @commonArgs x-download "$TestDownloadsRoot/example3.html" --sha512 d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73a --url https://example.com
 Throw-IfFailed
 if (-not ($actual -match $expected)) {
     throw "Failure: azurl (no), x-block-origin (no), asset-cache (n/a), download (succeed)"
@@ -190,7 +191,7 @@ if ($IsWindows) {
     "$"
     ) -join "`n"
 
-    $actual = Run-VcpkgAndCaptureOutput -TestArgs ($commonArgs + @("x-download", "$downloadsRoot/example3.html", "--sha512", "d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73a", "--url", "https://nonexistent.example.com", "--url", "https://example.com"))
+    $actual = Run-VcpkgAndCaptureOutput @commonArgs x-download "$TestDownloadsRoot/example3.html" --sha512 d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73a --url https://nonexistent.example.com --url https://example.com
     Throw-IfFailed
     if (-not ($actual -match $expected)) {
         throw "Failure: azurl (no), x-block-origin (no), asset-cache (n/a), download (succeed)"
@@ -209,7 +210,7 @@ $expected = @(
 "$"
 ) -join "`n"
 
-$actual = Run-VcpkgAndCaptureOutput -TestArgs ($commonArgs + @("x-download", "$downloadsRoot/example3.html", "--sha512", "d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73a", "--url", "https://nonexistent.example.com", "--url", "https://example.com", "--header", "Cache-Control: no-cache"))
+$actual = Run-VcpkgAndCaptureOutput @commonArgs x-download "$TestDownloadsRoot/example3.html" --sha512 d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73a --url https://nonexistent.example.com --url https://example.com --header "Cache-Control: no-cache"
 Throw-IfFailed
 if (-not ($actual -match $expected)) {
     throw "Failure: azurl (no), x-block-origin (no), asset-cache (n/a), download (succeed)"
@@ -223,7 +224,7 @@ $expected = @(
 "error: there were no asset cache hits, and x-block-origin blocks trying the authoritative source https://example\.com",
 "$"
 ) -join "`n"
-$actual = Run-VcpkgAndCaptureOutput -TestArgs ($commonArgs + @("x-download", "$downloadsRoot/example3.html", "--sha512", "d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73a", "--url", "https://example.com", "--x-asset-sources=clear;x-block-origin"))
+$actual = Run-VcpkgAndCaptureOutput @commonArgs  x-download "$TestDownloadsRoot/example3.html" --sha512 d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73a --url https://example.com "--x-asset-sources=clear;x-block-origin"
 Throw-IfNotFailed
  if (-not ($actual -match $expected)) {
     throw "Failure: azurl (no), x-block-origin (yes), asset-cache (n/a), download (n/a)"
@@ -250,7 +251,7 @@ $expected = @(
 "$"
 ) -join "`n"
 
-$actual = Run-VcpkgAndCaptureOutput -TestArgs ($commonArgs + @("x-download", "$downloadsRoot/example3.html", "--sha512", "D06B93C883F8126A04589937A884032DF031B05518EED9D433EFB6447834DF2596AEBD500D69B8283E5702D988ED49655AE654C1683C7A4AE58BFA6B92F2B73A", "--url", "https://localhost:1234/foobar.html", "--x-asset-sources=x-azurl,file://$AssetCache,,readwrite"))
+$actual = Run-VcpkgAndCaptureOutput @commonArgs x-download "$TestDownloadsRoot/example3.html" --sha512 D06B93C883F8126A04589937A884032DF031B05518EED9D433EFB6447834DF2596AEBD500D69B8283E5702D988ED49655AE654C1683C7A4AE58BFA6B92F2B73A --url https://localhost:1234/foobar.html "--x-asset-sources=x-azurl,file://$AssetCache,,readwrite"
 Throw-IfNotFailed
 if (-not ($actual -match $expected)) {
     throw "Failure: azurl (yes), x-block-origin (no), asset-cache (miss), download (fail)"
@@ -259,16 +260,16 @@ if (-not ($actual -match $expected)) {
 # azurl (yes), x-block-origin (no), asset-cache (hit), download (n/a)
 # Expected: Download success message, asset cache named, nothing about x-block-origin
 Refresh-TestRoot
-Run-Vcpkg -TestArgs ($commonArgs + @("x-download", "$downloadsRoot/example3.html", "--sha512", "d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73a", "--url", "https://example.com", "--x-asset-sources=x-azurl,file://$AssetCache,,readwrite"))
+Run-Vcpkg @commonArgs x-download "$TestDownloadsRoot/example3.html" --sha512 d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73a --url https://example.com "--x-asset-sources=x-azurl,file://$AssetCache,,readwrite"
 Throw-IfFailed
-Remove-Item "$downloadsRoot/example3.html"
+Remove-Item "$TestDownloadsRoot/example3.html"
 $expected = @(
 "^Trying to download example3\.html using asset cache file://$assetCacheRegex/[0-9a-z]+",
 "Download successful! Asset cache hit, did not try authoritative source https://example\.com",
 "$"
 ) -join "`n"
 
-$actual = Run-VcpkgAndCaptureOutput -TestArgs ($commonArgs + @("x-download", "$downloadsRoot/example3.html", "--sha512", "d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73a", "--url", "https://example.com", "--x-asset-sources=x-azurl,file://$AssetCache,,readwrite"))
+$actual = Run-VcpkgAndCaptureOutput @commonArgs x-download "$TestDownloadsRoot/example3.html" --sha512 d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73a --url https://example.com "--x-asset-sources=x-azurl,file://$AssetCache,,readwrite"
 Throw-IfFailed
 if (-not ($actual -match $expected)) {
     throw "Success: azurl (yes), x-block-origin (no), asset-cache (hit), download (n/a)"
@@ -276,7 +277,7 @@ if (-not ($actual -match $expected)) {
 
 # azurl (yes), x-block-origin (no), asset-cache (hash mismatch), download (success)
 # Expected: Asset cache named, nothing about x-block-origin
-Remove-Item "$downloadsRoot/example3.html"
+Remove-Item "$TestDownloadsRoot/example3.html"
 Set-Content -Path "$AssetCache/d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73a" -Encoding Ascii -NoNewline -Value "The wrong hash content"
 $expected = @(
 "^Trying to download example3\.html using asset cache file://$assetCacheRegex/[0-9a-z]+",
@@ -285,7 +286,7 @@ $expected = @(
 "$"
 ) -join "`n"
 
-$actual = Run-VcpkgAndCaptureOutput -TestArgs ($commonArgs + @("x-download", "$downloadsRoot/example3.html", "--sha512", "d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73a", "--url", "https://example.com", "--x-asset-sources=x-azurl,file://$AssetCache,,readwrite"))
+$actual = Run-VcpkgAndCaptureOutput @commonArgs x-download "$TestDownloadsRoot/example3.html" --sha512 d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73a --url https://example.com "--x-asset-sources=x-azurl,file://$AssetCache,,readwrite"
 Throw-IfFailed
 if (-not ($actual -match $expected)) {
     throw "Success: azurl (yes), x-block-origin (no), asset-cache (hit), download (n/a)"
@@ -311,7 +312,7 @@ $expected = @(
 "note: Actual  : d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73a",
 "$"
 ) -join "`n"
-$actual = Run-VcpkgAndCaptureOutput -TestArgs ($commonArgs + @("x-download", "$downloadsRoot/example3.html", "--sha512", "d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73b", "--url", "https://example.com", "--x-asset-sources=x-azurl,file://$AssetCache,,readwrite"))
+$actual = Run-VcpkgAndCaptureOutput @commonArgs x-download "$TestDownloadsRoot/example3.html" --sha512 d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73b --url https://example.com "--x-asset-sources=x-azurl,file://$AssetCache,,readwrite"
 Throw-IfNotFailed
 if (-not ($actual -match $expected)) {
     throw "Failure: azurl (yes), x-block-origin (no), asset-cache (sha-mismatch), download (sha-mismatch)"
@@ -331,7 +332,7 @@ $expected = @(
 "note: Actual  : d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73a",
 "$"
 ) -join "`n"
-$actual = Run-VcpkgAndCaptureOutput -TestArgs ($commonArgs + @("x-download", "$downloadsRoot/example3.html", "--sha512", "d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73b", "--url", "https://example.com", "--x-asset-sources=x-azurl,file://$AssetCache,,readwrite"))
+$actual = Run-VcpkgAndCaptureOutput @commonArgs x-download "$TestDownloadsRoot/example3.html" --sha512 d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73b --url https://example.com "--x-asset-sources=x-azurl,file://$AssetCache,,readwrite"
 Throw-IfNotFailed
 if (-not ($actual -match $expected)) {
     throw "Failure: azurl (yes), x-block-origin (no), asset-cache (sha-mismatch), download (sha-mismatch)"
@@ -347,7 +348,7 @@ $expected = @(
 "$"
 ) -join "`n"
 
-$actual = Run-VcpkgAndCaptureOutput -TestArgs ($commonArgs + @("x-download", "$downloadsRoot/example3.html", "--sha512", "d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73a", "--url", "https://example.com", "--x-asset-sources=x-azurl,file://$AssetCache,,readwrite"))
+$actual = Run-VcpkgAndCaptureOutput @commonArgs x-download "$TestDownloadsRoot/example3.html" --sha512 d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73a --url https://example.com "--x-asset-sources=x-azurl,file://$AssetCache,,readwrite"
 Throw-IfFailed
 if (-not ($actual -match $expected)) {
     throw "Success: azurl (yes), x-block-origin (no), asset-cache (miss), download (succeed)"
@@ -373,7 +374,7 @@ $expected = @(
 "$"
 ) -join "`n"
 
-$actual = Run-VcpkgAndCaptureOutput -TestArgs ($commonArgs + @("x-download", "$downloadsRoot/example3.html", "--sha512", "d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73a", "--url", "https://example.com", "--url", "https://alternate.example.com", "--x-asset-sources=x-azurl,file://$AssetCache,,readwrite;x-block-origin"))
+$actual = Run-VcpkgAndCaptureOutput @commonArgs x-download "$TestDownloadsRoot/example3.html" --sha512 d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73a --url https://example.com --url https://alternate.example.com "--x-asset-sources=x-azurl,file://$AssetCache,,readwrite;x-block-origin"
 Throw-IfNotFailed
 if (-not ($actual -match $expected)) {
     throw "Failure: azurl (yes), x-block-origin (yes), asset-cache (miss), download (n/a)"
@@ -387,10 +388,10 @@ $expected = @(
 "Download successful! Asset cache hit, did not try authoritative source https://example\.com, or https://alternate\.example\.com",
 "$"
 ) -join "`n"
-Run-Vcpkg -TestArgs ($commonArgs + @("x-download", "$downloadsRoot/example3.html", "--sha512", "d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73a", "--url", "https://example.com", "--x-asset-sources=x-azurl,file://$AssetCache,,readwrite"))
+Run-Vcpkg @commonArgs x-download "$TestDownloadsRoot/example3.html" --sha512 d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73a --url https://example.com "--x-asset-sources=x-azurl,file://$AssetCache,,readwrite"
 Throw-IfFailed
-Remove-Item "$downloadsRoot/example3.html"
-$actual = Run-VcpkgAndCaptureOutput -TestArgs ($commonArgs + @("x-download", "$downloadsRoot/example3.html", "--sha512", "d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73a", "--url", "https://example.com", "--url", "https://alternate.example.com", "--x-asset-sources=x-azurl,file://$AssetCache,,readwrite;x-block-origin"))
+Remove-Item "$TestDownloadsRoot/example3.html"
+$actual = Run-VcpkgAndCaptureOutput @commonArgs x-download "$TestDownloadsRoot/example3.html" --sha512 d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73a --url https://example.com --url https://alternate.example.com "--x-asset-sources=x-azurl,file://$AssetCache,,readwrite;x-block-origin"
 Throw-IfFailed
 if (-not ($actual -match $expected)) {
     throw "Success: azurl (yes), x-block-origin (yes), asset-cache (hit), download (n/a)"
@@ -406,7 +407,7 @@ $expected = @(
 "error: there were no asset cache hits, and x-block-origin blocks trying the authoritative source https://example\.com",
 "$"
 ) -join "`n"
-$actual = Run-VcpkgAndCaptureOutput -TestArgs ($commonArgs + @("x-download", "$downloadsRoot/example3.html", "--url", "https://example.com", "--sha512", "d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73a"))
+$actual = Run-VcpkgAndCaptureOutput @commonArgs x-download "$TestDownloadsRoot/example3.html" --url https://example.com --sha512 d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73a
 Throw-IfNotFailed
 if (-not ($actual -match $expected)) {
     throw "Failure: azurl (no), x-block-origin (yes), asset-cache (hit), download (n/a)"
@@ -422,7 +423,7 @@ $expected = @(
 "error: there were no asset cache hits, and x-block-origin blocks trying the authoritative source https://example\.com",
 "$"
 ) -join "`n"
-$actual = Run-VcpkgAndCaptureOutput -TestArgs ($commonArgs + @("x-download", "$downloadsRoot/example3.html", "--url", "https://example.com", "--sha512", "d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73a"))
+$actual = Run-VcpkgAndCaptureOutput @commonArgs x-download "$TestDownloadsRoot/example3.html" --url https://example.com --sha512 d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73a
 Throw-IfNotFailed
 if (-not ($actual -match $expected)) {
     throw "Failure: azurl (no), x-block-origin (yes), asset-cache (hit), download (n/a)"
@@ -440,7 +441,7 @@ $expected = @(
 "error: there were no asset cache hits, and x-block-origin blocks trying the authoritative source https://example\.com",
 "$"
 ) -join "`n"
-$actual = Run-VcpkgAndCaptureOutput -TestArgs ($commonArgs + @("x-download", "$downloadsRoot/example3.html", "--url", "https://example.com", "--sha512", "d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73a"))
+$actual = Run-VcpkgAndCaptureOutput @commonArgs x-download "$TestDownloadsRoot/example3.html" --url https://example.com --sha512 d06b93c883f8126a04589937a884032df031b05518eed9d433efb6447834df2596aebd500d69b8283e5702d988ed49655ae654c1683c7a4ae58bfa6b92f2b73a
 Throw-IfNotFailed
 if (-not ($actual -match $expected)) {
     throw "Failure: azurl (no), x-block-origin (yes), asset-cache (hit), download (n/a)"
@@ -454,7 +455,7 @@ $expected = @(
 "$"
 ) -join "`n"
 $env:X_VCPKG_ASSET_SOURCES = "clear;x-script,$TestScriptAssetCacheExe {url} {sha512} {dst};x-block-origin"
-$actual = Run-VcpkgAndCaptureOutput -TestArgs ($commonArgs + @("x-download", "$downloadsRoot/example3.html", "--url", "https://example.com/hello-world.txt", "--sha512", "09e1e2a84c92b56c8280f4a1203c7cffd61b162cfe987278d4d6be9afbf38c0e8934cdadf83751f4e99d111352bffefc958e5a4852c8a7a29c95742ce59288a8"))
+$actual = Run-VcpkgAndCaptureOutput @commonArgs x-download "$TestDownloadsRoot/example3.html" --url https://example.com/hello-world.txt --sha512 09e1e2a84c92b56c8280f4a1203c7cffd61b162cfe987278d4d6be9afbf38c0e8934cdadf83751f4e99d111352bffefc958e5a4852c8a7a29c95742ce59288a8
 Throw-IfFailed
 if (-not ($actual -match $expected)) {
     throw "Success: x-script download success message"
@@ -474,7 +475,7 @@ $expected = @(
 "$"
 ) -join "`n"
 
-$actual = Run-VcpkgAndCaptureOutput -TestArgs ($commonArgs + @("x-download", "$downloadsRoot/download-result.txt", "--sha512", "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", "--url", $downloadTargetUrl))
+$actual = Run-VcpkgAndCaptureOutput @commonArgs x-download "$TestDownloadsRoot/download-result.txt" --sha512 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 --url $downloadTargetUrl
 Throw-IfNotFailed
 if (-not ($actual -match $expected)) {
     throw "Failure: zero sha"
@@ -490,7 +491,7 @@ $expected = @(
 "$"
 ) -join "`n"
 
-$actual = Run-VcpkgAndCaptureOutput -TestArgs ($commonArgs + @("x-download", "$downloadsRoot/download-result.txt", "--sha512", "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", "--url", $downloadTargetUrl))
+$actual = Run-VcpkgAndCaptureOutput @commonArgs x-download "$TestDownloadsRoot/download-result.txt" --sha512 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 --url $downloadTargetUrl
 Throw-IfNotFailed
 if (-not ($actual -match $expected)) {
     throw "Failure: zero sha + x-script"
@@ -506,9 +507,8 @@ $expected = @(
 "$"
 ) -join "`n"
 
-$actual = Run-VcpkgAndCaptureOutput -TestArgs ($commonArgs + @("x-download", "$downloadsRoot/download-result.txt", "--sha512", "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", "--url", $downloadTargetUrl))
+$actual = Run-VcpkgAndCaptureOutput @commonArgs x-download "$TestDownloadsRoot/download-result.txt" --sha512 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 --url $downloadTargetUrl
 Throw-IfNotFailed
 if (-not ($actual -match $expected)) {
     throw "Failure: bad replacement"
 }
-

--- a/azure-pipelines/end-to-end-tests-dir/asset-caching.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/asset-caching.ps1
@@ -8,7 +8,11 @@ Throw-IfFailed
 Run-Vcpkg @commonArgs fetch ninja
 Throw-IfFailed
 Remove-Item env:VCPKG_FORCE_DOWNLOADED_BINARIES
-Remove-Item (Join-Path $DefaultDownloadsRoot 'hello-world.txt') -ErrorActionPreference SilentlyContinue
+$helloPath = Join-Path $DefaultDownloadsRoot 'hello-world.txt'
+if (Test-Path $helloPath) {
+    Remove-Item $helloPath
+}
+
 Run-Vcpkg @commonArgs install vcpkg-test-x-script --x-binarysource=clear "--overlay-ports=$PSScriptRoot/../e2e-ports" "--x-asset-sources=x-script,$TestScriptAssetCacheExe {url} {sha512} {dst};x-block-origin"
 Throw-IfFailed
 

--- a/azure-pipelines/end-to-end-tests-dir/clean-after-build.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/clean-after-build.ps1
@@ -1,80 +1,66 @@
 . $PSScriptRoot/../end-to-end-tests-prelude.ps1
 
-$downloadsRoot = Join-Path $TestingRoot 'downloads'
-
 $CurrentTest = "Clean After Build"
 
 $InstalledHeader = Join-Path $installRoot "$Triplet/include/vcpkg-clean-after-build-test-port.h"
-$DownloadedFile = Join-Path $downloadsRoot 'clean_after_build_test.txt'
+$DownloadedFile = Join-Path $TestDownloadsRoot 'clean_after_build_test.txt'
 $PackageRoot = Join-Path $packagesRoot "vcpkg-clean-after-build-test-port_$Triplet"
 $PackageSrc = Join-Path $buildtreesRoot "vcpkg-clean-after-build-test-port/src"
 
 $installTestPortArgs = `
-  @("install", "vcpkg-clean-after-build-test-port", "--no-binarycaching", "--downloads-root=$downloadsRoot", "--x-builtin-ports-root=$PSScriptRoot/../e2e-ports")
+  @("install", "vcpkg-clean-after-build-test-port", "--no-binarycaching", "--downloads-root=$TestDownloadsRoot", "--x-builtin-ports-root=$PSScriptRoot/../e2e-ports")
 
 Refresh-TestRoot
-Run-Vcpkg -TestArgs ($commonArgs + $installTestPortArgs)
+Run-Vcpkg @commonArgs @installTestPortArgs
 Require-FileExists $InstalledHeader
 Require-FileExists $DownloadedFile
 Require-FileExists $PackageRoot
 Require-FileExists $PackageSrc
 
 Refresh-TestRoot
-Run-Vcpkg -TestArgs ($commonArgs + $installTestPortArgs + @("--clean-packages-after-build"))
+Run-Vcpkg @commonArgs @installTestPortArgs --clean-packages-after-build
 Require-FileExists $InstalledHeader
 Require-FileExists $DownloadedFile
 Require-FileNotExists $PackageRoot
 Require-FileExists $PackageSrc
 
 Refresh-TestRoot
-Run-Vcpkg -TestArgs ($commonArgs + $installTestPortArgs + @("--clean-buildtrees-after-build"))
+Run-Vcpkg @commonArgs @installTestPortArgs --clean-buildtrees-after-build
 Require-FileExists $InstalledHeader
 Require-FileExists $DownloadedFile
 Require-FileExists $PackageRoot
 Require-FileNotExists $PackageSrc
 
 Refresh-TestRoot
-Run-Vcpkg -TestArgs ($commonArgs + $installTestPortArgs + @(
-    "--clean-packages-after-build",
-    "--clean-buildtrees-after-build"
-    ))
+Run-Vcpkg @commonArgs @installTestPortArgs --clean-packages-after-build --clean-buildtrees-after-build
 Require-FileExists $InstalledHeader
 Require-FileExists $DownloadedFile
 Require-FileNotExists $PackageRoot
 Require-FileNotExists $PackageSrc
 
 Refresh-TestRoot
-Run-Vcpkg -TestArgs ($commonArgs + $installTestPortArgs + @("--clean-buildtrees-after-build"))
+Run-Vcpkg @commonArgs @installTestPortArgs --clean-buildtrees-after-build
 Require-FileExists $InstalledHeader
 Require-FileExists $DownloadedFile
 Require-FileExists $PackageRoot
 Require-FileNotExists $PackageSrc
 
 Refresh-TestRoot
-Run-Vcpkg -TestArgs ($commonArgs + $installTestPortArgs + @(
-    "--clean-downloads-after-build",
-    "--clean-packages-after-build",
-    "--clean-buildtrees-after-build"
-    ))
+Run-Vcpkg @commonArgs @installTestPortArgs --clean-downloads-after-build --clean-packages-after-build --clean-buildtrees-after-build
 Require-FileExists $InstalledHeader
 Require-FileNotExists $DownloadedFile
 Require-FileNotExists $PackageRoot
 Require-FileNotExists $PackageSrc
 
 Refresh-TestRoot
-Run-Vcpkg -TestArgs ($commonArgs + $installTestPortArgs + @("--clean-after-build"))
+Run-Vcpkg @commonArgs @installTestPortArgs --clean-after-build
 Require-FileExists $InstalledHeader
 Require-FileNotExists $DownloadedFile
 Require-FileNotExists $PackageRoot
 Require-FileNotExists $PackageSrc
 
 Refresh-TestRoot
-Run-Vcpkg -TestArgs ($commonArgs + $installTestPortArgs + @(
-    "--clean-after-build",
-    "--clean-downloads-after-build",
-    "--clean-packages-after-build",
-    "--clean-buildtrees-after-build"
-    ))
+Run-Vcpkg @commonArgs @installTestPortArgs --clean-after-build --clean-downloads-after-build --clean-packages-after-build --clean-buildtrees-after-build
 Require-FileExists $InstalledHeader
 Require-FileNotExists $DownloadedFile
 Require-FileNotExists $PackageRoot

--- a/azure-pipelines/end-to-end-tests-prelude.ps1
+++ b/azure-pipelines/end-to-end-tests-prelude.ps1
@@ -6,7 +6,7 @@ $NuGetRoot = Join-Path $TestingRoot 'nuget'
 $NuGetRoot2 = Join-Path $TestingRoot 'nuget2'
 $ArchiveRoot = Join-Path $TestingRoot 'archives'
 $VersionFilesRoot = Join-Path $TestingRoot 'version-test'
-$DownloadsRoot = Join-Path $TestingRoot 'downloads'
+$TestDownloadsRoot = Join-Path $TestingRoot 'downloads'
 $AssetCache = Join-Path $TestingRoot 'asset-cache'
 
 $directoryArgs = @(
@@ -26,6 +26,12 @@ $gitConfigOptions = @(
   '-c', 'core.autocrlf=false'
 )
 
+if (Test-Path env:VCPKG_DOWNLOADS) {
+    $DefaultDownloadsRoot = $env:VCPKG_DOWNLOADS
+} else {
+    $DefaultDownloadsRoot = Join-Path $VcpkgRoot 'downloads'
+}
+
 $unusedStdoutFile = Join-Path $WorkingRoot 'unused-stdout.txt'
 $stderrFile = Join-Path $WorkingRoot 'last-stderr.txt'
 
@@ -35,13 +41,13 @@ function Refresh-TestRoot {
     Remove-Item -Recurse -Force $TestingRoot -ErrorAction SilentlyContinue
     New-Item -ItemType Directory -Force $TestingRoot | Out-Null
     New-Item -ItemType Directory -Force $NuGetRoot | Out-Null
-    New-Item -ItemType Directory -Force $DownloadsRoot | Out-Null
+    New-Item -ItemType Directory -Force $TestDownloadsRoot | Out-Null
     New-Item -ItemType Directory -Force $AssetCache | Out-Null
 }
 
-function Refresh-Downloads{
-    Remove-Item -Recurse -Force $DownloadsRoot -ErrorAction SilentlyContinue
-    New-Item -ItemType Directory -Force $DownloadsRoot | Out-Null
+function Refresh-TestDownloads {
+    Remove-Item -Recurse -Force $TestDownloadsRoot -ErrorAction SilentlyContinue
+    New-Item -ItemType Directory -Force $TestDownloadsRoot | Out-Null
 }
 
 function Write-Stack {

--- a/src/test-script-asset-cache.c
+++ b/src/test-script-asset-cache.c
@@ -31,7 +31,23 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    FILE* fp = fopen(argv[3], "wb");
+    char* destination = argv[3];
+#if defined(_WIN32)
+    if (!((destination[0] >= 'A' && destination[0] <= 'Z') || (destination[0] >= 'a' && destination[0] <= 'z')) ||
+        destination[1] != ':' || (destination[2] != '/' && destination[2] != '\\'))
+    {
+        printf("Bad argument 3; expected path be absolute, got %s\n", destination);
+        return 1;
+    }
+#else
+    if (destination[0] != '/')
+    {
+        printf("Bad argument 3; expected path be absolute, got %s\n", destination);
+        return 1;
+    }
+#endif
+
+    FILE* fp = fopen(destination, "wb");
     if (!fp)
     {
         puts("fopen failed");

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -1440,7 +1440,8 @@ namespace vcpkg
         }
 
         context.statusln(msg::format(msgAssetCacheConsultScript, msg::path = display_path));
-        const auto download_path_part_path = fmt::format("{}.{}.part", download_path, get_process_id());
+        const auto download_path_part_path =
+            fmt::format("{}.{}.part", fs.absolute(download_path, VCPKG_LINE_INFO), get_process_id());
         Lazy<std::string> escaped_url;
         const auto escaped_dpath = Command(download_path_part_path).extract();
         auto maybe_raw_command = api_stable_format(context, *script, [&](std::string& out, StringView key) {


### PR DESCRIPTION
Resolves a report that we broke Terrapin Retrieval Tool in https://github.com/microsoft/vcpkg-tool/pull/1618