### PR TITLE
Don't track curl progress when performing bulk operations

### DIFF
--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -688,7 +688,7 @@ namespace vcpkg
             prefix_cmd.raw_arg(prefixArgs);
         }
 
-        prefix_cmd.string_arg("--retry").string_arg("3").string_arg("-L").string_arg("-w").string_arg(
+        prefix_cmd.string_arg("--retry").string_arg("3").string_arg("-L").string_arg("-sS").string_arg("-w").string_arg(
             GUID_MARKER "%{http_code} %{exitcode} %{errormsg}\\n");
 #undef GUID_MARKER
 


### PR DESCRIPTION
Curl writes progress information to stderr and write-out strings to stdout. Vcpkg uses single pipe for both stdout and stdin, so it's possible that the output will be garbled.
We don't really need progress information here, only error messages.