### PR TITLE
[CMakeRC] support CMake 4.0

### DIFF
--- a/cmake/CMakeRC_cmake_4.patch
+++ b/cmake/CMakeRC_cmake_4.patch
@@ -1,0 +1,23 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 432b8bf97c..0f5e51c5e8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.6)
++cmake_minimum_required(VERSION 3.6...4.0)
+ project(CMakeRC VERSION 2.0.0)
+ 
+ list(INSERT CMAKE_MODULE_PATH 0 "${PROJECT_SOURCE_DIR}/cmake")
+diff --git a/CMakeRC.cmake b/CMakeRC.cmake
+index 409136f789..5bacc60d33 100644
+--- a/CMakeRC.cmake
++++ b/CMakeRC.cmake
+@@ -34,7 +34,7 @@
+ 
+ set(_version 2.0.0)
+ 
+-cmake_minimum_required(VERSION 3.3)
++cmake_minimum_required(VERSION 3.3...4.0)
+ include(CMakeParseArguments)
+ 
+ if(COMMAND cmrc_add_resource_library)

--- a/cmake/FindCMakeRC.cmake
+++ b/cmake/FindCMakeRC.cmake
@@ -11,10 +11,12 @@ if(POLICY CMP0135)
 endif()
 
 include(FetchContent)
+find_package(Git REQUIRED)
 FetchContent_Declare(
     CMakeRC
     URL "${VCPKG_CMAKERC_URL}"
     URL_HASH "SHA512=cb69ff4545065a1a89e3a966e931a58c3f07d468d88ecec8f00da9e6ce3768a41735a46fc71af56e0753926371d3ca5e7a3f2221211b4b1cf634df860c2c997f"
+    PATCH_COMMAND "${GIT_EXECUTABLE}" apply "${CMAKE_CURRENT_LIST_DIR}/CMakeRC_cmake_4.patch"
 )
 
 if(NOT CMakeRC_FIND_REQUIRED)


### PR DESCRIPTION
Because the version of CMakeRC that vcpkg depends on is so old, it has  a `cmake_minimum_required(VERSION 3.3)`; this is not valid now that CMake 4 has come out.

There are three options for fixing this:

- just add a maximum version in a patch
- start using a later version; unfortunately, this is not possible without changing how CMakeRC is downloaded, since the last tagged version of CMakeRC is from 2018
- Just pull CMakeRC into the tree. Given that the last tagged version is from _seven_ years ago, this seems entirely reasonable, but I didn't want to do that work without someone telling me that that was what they wanted.

I chose the first option since it's the simplest one.