### PR TITLE
windows: Fix crash when curl is used to download assets

### DIFF
--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -1162,7 +1162,10 @@ namespace vcpkg
 #endif
         // Create directory in advance, otherwise curl will create it in 750 mode on unix style file systems.
         const auto dir = download_path_part_path.parent_path();
-        fs.create_directories(dir, VCPKG_LINE_INFO);
+        if (!dir.empty())
+        {
+            fs.create_directories(dir, VCPKG_LINE_INFO);
+        }
 
         auto cmd = Command{"curl"}
                        .string_arg("--fail")


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/44832