### PR TITLE
Fixed packaged build with external CMakeRC

### DIFF
--- a/cmake/FindCMakeRC.cmake
+++ b/cmake/FindCMakeRC.cmake
@@ -1,5 +1,10 @@
 option(VCPKG_DEPENDENCY_CMAKERC "CMake-based C++ resource compiler" OFF)
 
+if(VCPKG_DEPENDENCY_CMAKERC)
+    find_package(CMakeRC CONFIG REQUIRED)
+    return()
+endif()
+
 # This option exists to allow the URI to be replaced with a Microsoft-internal URI in official
 # builds which have restricted internet access; see azure-pipelines/signing.yml
 # Note that the SHA512 is the same, so vcpkg-tool contributors need not be concerned that we built
@@ -18,13 +23,8 @@ FetchContent_Declare(
     URL_HASH "SHA512=cb69ff4545065a1a89e3a966e931a58c3f07d468d88ecec8f00da9e6ce3768a41735a46fc71af56e0753926371d3ca5e7a3f2221211b4b1cf634df860c2c997f"
     PATCH_COMMAND "${GIT_EXECUTABLE}" apply "${CMAKE_CURRENT_LIST_DIR}/CMakeRC_cmake_4.patch"
 )
+FetchContent_MakeAvailable(CMakeRC)
 
 if(NOT CMakeRC_FIND_REQUIRED)
     message(FATAL_ERROR "CMakeRC must be REQUIRED")
-endif()
-
-if(VCPKG_DEPENDENCY_CMAKERC)
-    find_package(CMakeRC CONFIG REQUIRED)
-else()
-    FetchContent_MakeAvailable(CMakeRC)
 endif()


### PR DESCRIPTION
Require Git only if the `VCPKG_DEPENDENCY_CMAKERC` option is disabled.

This will fix the build with the packaged version of CMakeRC after #1632:
```
CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:233 (message):
  Could NOT find Git (missing: GIT_EXECUTABLE)
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:603 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake/Modules/FindGit.cmake:128 (find_package_handle_standard_args)
  cmake/FindCMakeRC.cmake:14 (find_package)
  CMakeLists.txt:197 (find_package)
-- Configuring incomplete, errors occurred!
```

With this fix it builds correctly:
```
Wrote: /builddir/build/RPMS/vcpkg-2025.04.07-2.fc43.x86_64.rpm
Wrote: /builddir/build/RPMS/vcpkg-debugsource-2025.04.07-2.fc43.x86_64.rpm
Wrote: /builddir/build/RPMS/vcpkg-debuginfo-2025.04.07-2.fc43.x86_64.rpm
```