### PR TITLE
Adopt macOS 14 for PR and Release builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
             preset: linux-ci
           - os: ubuntu-24.04-arm
             preset: linux-arm64-ci
-          - os: macos-13
+          - os: macos-14
             preset: macos-ci
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120

--- a/azure-pipelines/signing.yml
+++ b/azure-pipelines/signing.yml
@@ -205,7 +205,7 @@ extends:
         - arch_independent
         pool:
           name: Azure Pipelines
-          vmImage: macOS-13
+          vmImage: macOS-14
           os: macOS
         variables:
           VCPKG_STANDALONE_BUNDLE_SHA: $[ dependencies.arch_independent.outputs['shas.VCPKG_STANDALONE_BUNDLE_SHA'] ]


### PR DESCRIPTION
Notably, this switches us to Apple Silicon for both test and build labs, which should hopefully speed up test runs and/or reduce wait time for getting a machine to run the tests.