### PR TITLE
--clean-buildtrees-after-build: Only clean on success 

### DIFF
--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -1209,7 +1209,7 @@ namespace vcpkg
     {
         auto result = do_build_package(args, paths, host_triplet, build_options, action, all_dependencies_satisfied);
 
-        if (build_options.clean_buildtrees == CleanBuildtrees::Yes)
+        if (build_options.clean_buildtrees == CleanBuildtrees::Yes && result.code == BuildResult::Succeeded)
         {
             auto& fs = paths.get_filesystem();
             // Will keep the logs, which are regular files


### PR DESCRIPTION
This helps debugging build failures since the buildtrees folder is not removed in that case.