### PR TITLE
BuildLogsRecorder: Only copy new log files

### DIFF
--- a/include/vcpkg/base/files.h
+++ b/include/vcpkg/base/files.h
@@ -315,6 +315,11 @@ namespace vcpkg
         virtual void copy_symlink(const Path& source, const Path& destination, std::error_code& ec) const = 0;
         void copy_symlink(const Path& source, const Path& destination, LineInfo li) const;
 
+        virtual int64_t file_time_now() const = 0;
+
+        virtual int64_t last_write_time(const Path& target, std::error_code& ec) const = 0;
+        int64_t last_write_time(const Path& target, LineInfo li) const noexcept;
+
         using ReadOnlyFilesystem::current_path;
         virtual void current_path(const Path& new_current_path, std::error_code&) const = 0;
         void current_path(const Path& new_current_path, LineInfo li) const;

--- a/include/vcpkg/commands.build.h
+++ b/include/vcpkg/commands.build.h
@@ -42,7 +42,7 @@ namespace vcpkg
 
     struct CiBuildLogsRecorder final : IBuildLogsRecorder
     {
-        explicit CiBuildLogsRecorder(const Path& base_path_, int64_t minimum_last_write_time = 0);
+        explicit CiBuildLogsRecorder(const Path& base_path_, int64_t minimum_last_write_time);
 
         CiBuildLogsRecorder(const CiBuildLogsRecorder&) = delete;
         CiBuildLogsRecorder& operator=(const CiBuildLogsRecorder&) = delete;

--- a/include/vcpkg/commands.build.h
+++ b/include/vcpkg/commands.build.h
@@ -42,7 +42,7 @@ namespace vcpkg
 
     struct CiBuildLogsRecorder final : IBuildLogsRecorder
     {
-        explicit CiBuildLogsRecorder(const Path& base_path_);
+        explicit CiBuildLogsRecorder(const Path& base_path_, int64_t minimum_last_write_time = 0);
 
         CiBuildLogsRecorder(const CiBuildLogsRecorder&) = delete;
         CiBuildLogsRecorder& operator=(const CiBuildLogsRecorder&) = delete;
@@ -51,6 +51,7 @@ namespace vcpkg
 
     private:
         Path base_path;
+        int64_t minimum_last_write_time;
     };
 
     struct PackagesDirAssigner

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -3831,7 +3831,7 @@ namespace vcpkg
 #else // ^^^ _WIN32 // !_WIN32 vvv
             struct timespec ts;
             clock_gettime(CLOCK_REALTIME, &ts);
-            return ts.tv_sec * 1'000'000'000 + ts.tv_nsec;
+            return int64_t{ts.tv_sec} * 1'000'000'000 + ts.tv_nsec;
 #endif
         }
 
@@ -3846,9 +3846,9 @@ namespace vcpkg
             {
                 ec.clear();
 #ifdef __APPLE__
-                return s.st_mtimespec.tv_sec * 1'000'000'000 + s.st_mtimespec.tv_nsec;
+                return int64_t{s.st_mtimespec.tv_sec} * 1'000'000'000 + s.st_mtimespec.tv_nsec;
 #else
-                return s.st_mtim.tv_sec * 1'000'000'000 + s.st_mtim.tv_nsec;
+                return int64_t{s.st_mtim.tv_sec} * 1'000'000'000 + s.st_mtim.tv_nsec;
 #endif
             }
 

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -2239,6 +2239,18 @@ namespace vcpkg
         }
     }
 
+    int64_t Filesystem::last_write_time(const Path& target, vcpkg::LineInfo li) const noexcept
+    {
+        std::error_code ec;
+        auto result = this->last_write_time(target, ec);
+        if (ec)
+        {
+            exit_filesystem_call_error(li, ec, __func__, {target});
+        }
+
+        return result;
+    }
+
     void Filesystem::write_lines(const Path& file_path, const std::vector<std::string>& lines, LineInfo li) const
     {
         std::error_code ec;
@@ -3809,6 +3821,39 @@ namespace vcpkg
             {
                 ec.assign(errno, std::generic_category());
             }
+#endif // ^^^ !_WIN32
+        }
+
+        int64_t file_time_now() const override
+        {
+#if defined(_WIN32)
+            return stdfs::file_time_type::clock::now().time_since_epoch().count();
+#else // ^^^ _WIN32 // !_WIN32 vvv
+            struct timespec ts;
+            clock_gettime(CLOCK_REALTIME, &ts);
+            return ts.tv_sec * 1'000'000'000 + ts.tv_nsec;
+#endif
+        }
+
+        int64_t last_write_time(const Path& target, std::error_code& ec) const override
+        {
+#if defined(_WIN32)
+            auto result = stdfs::last_write_time(to_stdfs_path(target), ec);
+            return result.time_since_epoch().count();
+#else // ^^^ _WIN32 // !_WIN32 vvv
+            struct stat s;
+            if (::lstat(target.c_str(), &s) == 0)
+            {
+                ec.clear();
+#ifdef __APPLE__
+                return s.st_mtimespec.tv_sec * 1'000'000'000 + s.st_mtimespec.tv_nsec;
+#else
+                return s.st_mtim.tv_sec * 1'000'000'000 + s.st_mtim.tv_nsec;
+#endif
+            }
+
+            ec.assign(errno, std::generic_category());
+            return {};
 #endif // ^^^ !_WIN32
         }
 

--- a/src/vcpkg/commands.ci.cpp
+++ b/src/vcpkg/commands.ci.cpp
@@ -345,8 +345,8 @@ namespace vcpkg
                 msg::println(msgCreateFailureLogsDir, msg::path = it_failure_logs->second);
                 Path raw_path = it_failure_logs->second;
                 fs.create_directories(raw_path, VCPKG_LINE_INFO);
-                build_logs_recorder =
-                    &(build_logs_recorder_storage.emplace(fs.almost_canonical(raw_path, VCPKG_LINE_INFO)));
+                build_logs_recorder = &(build_logs_recorder_storage.emplace(
+                    fs.almost_canonical(raw_path, VCPKG_LINE_INFO), fs.file_time_now()));
             }
         }
 

--- a/src/vcpkg/commands.test-features.cpp
+++ b/src/vcpkg/commands.test-features.cpp
@@ -477,7 +477,7 @@ namespace vcpkg
             {
                 auto& logs_dir =
                     maybe_logs_dir.emplace(ci_build_log_feature_test_base_path(*build_logs_base_path, i, spec));
-                build_logs_recorder = &(feature_build_logs_recorder_storage.emplace(logs_dir));
+                build_logs_recorder = &(feature_build_logs_recorder_storage.emplace(logs_dir, fs.file_time_now()));
             }
 
             ElapsedTimer install_timer;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/pull/45070#issuecomment-2809826609 where logs from a previous run were copied into the logs folder 