### PR TITLE
Use Azure Blob block lists for x-azblob caching

### DIFF
--- a/include/vcpkg/base/downloads.h
+++ b/include/vcpkg/base/downloads.h
@@ -116,6 +116,16 @@ namespace vcpkg
                               const Path& file_to_put,
                               StringView sha512);
 
+    bool store_to_azblob_cache(DiagnosticContext& context,
+                               const Filesystem& fs,
+                               StringView raw_url,
+                               const SanitizedUrl& sanitized_url,
+                               View<std::string> headers,
+                               const Path& file,
+                               size_t file_size,
+                               size_t max_single_write,
+                               size_t block_size);
+
     Optional<unsigned long long> try_parse_curl_max5_size(StringView sv);
 
     struct CurlProgressData

--- a/include/vcpkg/binarycaching.h
+++ b/include/vcpkg/binarycaching.h
@@ -148,6 +148,8 @@ namespace vcpkg
         std::vector<UrlTemplate> url_templates_to_get;
         std::vector<UrlTemplate> url_templates_to_put;
 
+        std::vector<UrlTemplate> azblob_templates_to_put;
+
         std::vector<std::string> gcs_read_prefixes;
         std::vector<std::string> gcs_write_prefixes;
 

--- a/src/vcpkg-test/configparser.cpp
+++ b/src/vcpkg-test/configparser.cpp
@@ -459,8 +459,9 @@ TEST_CASE ("BinaryConfigParser azblob provider", "[binaryconfigparser]")
 
         REQUIRE(state.binary_cache_providers == std::set<StringLiteral>{{"azblob"}, {"default"}});
         CHECK(state.url_templates_to_get.empty());
-        CHECK(state.url_templates_to_put.size() == 1);
-        CHECK(state.url_templates_to_put.front().url_template == "https://azure/container/{sha}.zip?sas");
+        CHECK(state.url_templates_to_put.empty());
+        CHECK(state.azblob_templates_to_put.size() == 1);
+        CHECK(state.azblob_templates_to_put.front().url_template == "https://azure/container/{sha}.zip?sas");
         REQUIRE(state.secrets == std::vector<std::string>{"sas"});
         REQUIRE(!state.archives_to_write.empty());
     }
@@ -471,8 +472,9 @@ TEST_CASE ("BinaryConfigParser azblob provider", "[binaryconfigparser]")
         REQUIRE(state.binary_cache_providers == std::set<StringLiteral>{{"azblob"}, {"default"}});
         CHECK(state.url_templates_to_get.size() == 1);
         CHECK(state.url_templates_to_get.front().url_template == "https://azure/container/{sha}.zip?sas");
-        CHECK(state.url_templates_to_put.size() == 1);
-        CHECK(state.url_templates_to_put.front().url_template == "https://azure/container/{sha}.zip?sas");
+        CHECK(state.url_templates_to_put.empty());
+        CHECK(state.azblob_templates_to_put.size() == 1);
+        CHECK(state.azblob_templates_to_put.front().url_template == "https://azure/container/{sha}.zip?sas");
         REQUIRE(state.secrets == std::vector<std::string>{"sas"});
         REQUIRE(!state.archives_to_read.empty());
         REQUIRE(!state.archives_to_write.empty());

--- a/src/vcpkg-test/downloads.cpp
+++ b/src/vcpkg-test/downloads.cpp
@@ -2,8 +2,22 @@
 
 #include <vcpkg/base/downloads.h>
 #include <vcpkg/base/expected.h>
+#include <vcpkg/base/system.h>
+#include <vcpkg/base/util.h>
+
+#include <random>
+#include <type_traits>
 
 using namespace vcpkg;
+
+#define CHECK_EC_ON_FILE(file, ec)                                                                                     \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        if (ec)                                                                                                        \
+        {                                                                                                              \
+            FAIL((file).native() << ": " << (ec).message());                                                           \
+        }                                                                                                              \
+    } while (0)
 
 TEST_CASE ("parse_split_url_view", "[downloads]")
 {
@@ -312,4 +326,139 @@ TEST_CASE ("url_encode_spaces", "[downloads]")
             "https://example.com/a%20space/b?query=value&query2=value2");
     REQUIRE(url_encode_spaces("https://example.com/a  space/b?query=value&query2=value2") ==
             "https://example.com/a%20%20space/b?query=value&query2=value2");
+}
+
+/*
+ * To run this test:
+ * - Set environment variables VCPKG_TEST_AZBLOB_URL and VCPKG_TEST_AZBLOB_SAS.
+ *   (Use Azurite for a local test environment.)
+ * - Run 'vcpkg-test azblob [-s]'.
+ */
+TEST_CASE ("azblob", "[.][azblob]")
+{
+    auto maybe_url = vcpkg::get_environment_variable("VCPKG_TEST_AZBLOB_URL");
+    REQUIRE(maybe_url.has_value());
+    std::string url = maybe_url.value_or_exit(VCPKG_LINE_INFO);
+    REQUIRE(!url.empty());
+
+    if (url.back() != '/') url += '/';
+
+    auto maybe_sas = vcpkg::get_environment_variable("VCPKG_TEST_AZBLOB_SAS");
+    REQUIRE(maybe_sas.has_value());
+    const std::string sas = maybe_sas.value_or_exit(VCPKG_LINE_INFO);
+
+    REQUIRE(!sas.empty());
+    REQUIRE(sas[0] != '?');
+
+    auto& fs = real_filesystem;
+    auto temp_dir = Test::base_temporary_directory() / "azblob";
+    fs.remove_all(temp_dir, VCPKG_LINE_INFO);
+
+    std::error_code ec;
+    fs.create_directories(temp_dir, ec);
+    CHECK_EC_ON_FILE(temp_dir, ec);
+
+    const char* data = "0123456789\nabcdefghij\n";
+    const auto data_size = strlen(data);
+    const auto block_size = (data_size - 1) / 2; // 3 blocks
+
+    auto data_filepath = temp_dir / "data";
+    CAPTURE(data_filepath);
+    fs.write_contents(data_filepath, data, ec);
+    CHECK_EC_ON_FILE(data_filepath, ec);
+
+    auto rnd = Strings::b32_encode(std::mt19937_64()());
+    std::vector<std::pair<std::string, Path>> url_pairs;
+    {
+        auto plain_put_filename = "plain_put_" + rnd;
+        auto plain_put_url = url + plain_put_filename + '?' + sas;
+        url_pairs.emplace_back(plain_put_url, temp_dir / plain_put_filename);
+
+        FullyBufferedDiagnosticContext diagnostics{};
+        auto plain_put_success = store_to_asset_cache(
+            diagnostics, plain_put_url, SanitizedUrl{url, {}}, "PUT", azure_blob_headers(), data_filepath);
+        INFO(diagnostics.to_string());
+        CHECK(plain_put_success);
+    }
+
+    {
+        auto single_write_filename = "single_write_" + rnd;
+        auto single_write_url = url + single_write_filename + '?' + sas;
+        url_pairs.emplace_back(single_write_url, temp_dir / single_write_filename);
+
+        FullyBufferedDiagnosticContext diagnostics{};
+        auto single_write_success = store_to_azblob_cache(diagnostics,
+                                                          fs,
+                                                          single_write_url,
+                                                          SanitizedUrl{url, {}},
+                                                          azure_blob_headers(),
+                                                          data_filepath,
+                                                          data_size,
+                                                          data_size,
+                                                          1);
+        INFO(diagnostics.to_string());
+        CHECK(single_write_success);
+    }
+
+    auto block_list_filename = "block_list_" + rnd;
+    auto block_list_url = url + block_list_filename + '?' + sas;
+    url_pairs.emplace_back(block_list_url, temp_dir / block_list_filename);
+    {
+        FullyBufferedDiagnosticContext diagnostics{};
+        auto block_list_success = store_to_azblob_cache(diagnostics,
+                                                        fs,
+                                                        block_list_url,
+                                                        SanitizedUrl{url, {}},
+                                                        azure_blob_headers(),
+                                                        data_filepath,
+                                                        data_size,
+                                                        block_size,
+                                                        block_size);
+        INFO(diagnostics.to_string());
+        CHECK(block_list_success);
+    }
+
+    {
+        FullyBufferedDiagnosticContext diagnostics{};
+        auto results = download_files_no_cache(diagnostics, url_pairs, azure_blob_headers(), {});
+        INFO(diagnostics.to_string());
+        CHECK(results == std::vector<int>{200, 200, 200});
+    }
+
+    for (auto& download : url_pairs)
+    {
+        auto download_filepath = download.second;
+        CAPTURE(download_filepath);
+        CHECK(fs.read_contents(download_filepath, VCPKG_LINE_INFO) == data);
+    }
+
+    auto block_list_urls = Util::fmap(url_pairs, [](auto url_pair) {
+        url_pair.first += "&comp=blocklist";
+        url_pair.second += ".blocklist";
+        return url_pair;
+    });
+    {
+        FullyBufferedDiagnosticContext diagnostics{};
+        auto results = download_files_no_cache(diagnostics, block_list_urls, azure_blob_headers(), {});
+        INFO(diagnostics.to_string());
+        CHECK(results == std::vector<int>{200, 200, 200});
+    }
+
+    for (auto& download : block_list_urls)
+    {
+        auto block_list_filepath = download.second;
+        CAPTURE(block_list_filepath);
+        auto block_list = fs.read_contents(block_list_filepath, VCPKG_LINE_INFO);
+        CAPTURE(block_list);
+        int count = 0;
+        for (std::string::size_type pos = block_list.find("<Block>"); pos != std::string::npos;
+             pos = block_list.find("<Block>", pos + 7))
+            ++count;
+        if (Strings::starts_with(download.first, block_list_url))
+            CHECK(count == 3);
+        else
+            CHECK(count == 0);
+    }
+
+    fs.remove_all(temp_dir, VCPKG_LINE_INFO);
 }

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -503,6 +503,62 @@ namespace
         std::vector<std::string> m_secrets;
     };
 
+    struct AzureBlobPutBinaryProvider : IWriteBinaryProvider
+    {
+        AzureBlobPutBinaryProvider(const Filesystem& fs,
+                                   std::vector<UrlTemplate>&& urls,
+                                   const std::vector<std::string>& secrets)
+            : m_fs(fs), m_urls(std::move(urls)), m_secrets(secrets)
+        {
+        }
+
+        size_t push_success(const BinaryPackageWriteInfo& request, MessageSink& msg_sink) override
+        {
+            if (!request.zip_path) return 0;
+
+            const auto& zip_path = *request.zip_path.get();
+
+            size_t count_stored = 0;
+            const auto cache_size = m_fs.file_size(zip_path, VCPKG_LINE_INFO);
+            if (cache_size == 0) return count_stored;
+
+            // cf.
+            // https://learn.microsoft.com/en-us/rest/api/storageservices/understanding-block-blobs--append-blobs--and-page-blobs?toc=%2Fazure%2Fstorage%2Fblobs%2Ftoc.json
+            constexpr size_t max_single_write = 5000000000;
+            constexpr size_t max_block_size = 4000000000;
+
+            PrintingDiagnosticContext pdc{msg_sink};
+            WarningDiagnosticContext wdc{pdc};
+
+            for (auto&& templ : m_urls)
+            {
+                auto url = templ.instantiate_variables(request);
+                auto maybe_success = store_to_azblob_cache(wdc,
+                                                           m_fs,
+                                                           url,
+                                                           SanitizedUrl{url, m_secrets},
+                                                           templ.headers,
+                                                           zip_path,
+                                                           cache_size,
+                                                           max_single_write,
+                                                           max_block_size);
+                if (maybe_success)
+                {
+                    count_stored++;
+                }
+            }
+            return count_stored;
+        }
+
+        bool needs_nuspec_data() const override { return false; }
+        bool needs_zip_file() const override { return true; }
+
+    private:
+        const Filesystem& m_fs;
+        std::vector<UrlTemplate> m_urls;
+        std::vector<std::string> m_secrets;
+    };
+
     struct NuGetSource
     {
         StringLiteral option;
@@ -1674,7 +1730,9 @@ namespace
                         segments[0].first);
                 }
 
-                if (!Strings::starts_with(segments[1].second, "https://"))
+                if (!Strings::starts_with(segments[1].second, "https://") &&
+                    // Allow unencrypted Azurite for testing (not reflected in error msg)
+                    !Strings::starts_with(segments[1].second, "http://127.0.0.1"))
                 {
                     return add_error(msg::format(msgInvalidArgumentRequiresBaseUrl,
                                                  msg::base_url = "https://",
@@ -1715,7 +1773,7 @@ namespace
                 if (read) state->url_templates_to_get.push_back(url_template);
                 auto headers = azure_blob_headers();
                 url_template.headers.assign(headers.begin(), headers.end());
-                if (write) state->url_templates_to_put.push_back(url_template);
+                if (write) state->azblob_templates_to_put.push_back(url_template);
 
                 state->binary_cache_providers.insert("azblob");
             }
@@ -2492,6 +2550,11 @@ namespace vcpkg
             {
                 m_config.write.push_back(
                     std::make_unique<FilesWriteBinaryProvider>(fs, std::move(s.archives_to_write)));
+            }
+            if (!s.azblob_templates_to_put.empty())
+            {
+                m_config.write.push_back(
+                    std::make_unique<AzureBlobPutBinaryProvider>(fs, std::move(s.azblob_templates_to_put), s.secrets));
             }
             if (!s.url_templates_to_put.empty())
             {


### PR DESCRIPTION
Alternative to #1643.

For artifacts up to app. the maximum single write size (5 GiB), uses plain HTTP PUT as before.  

For larger artitfacts, supports up to 10 blocks of max block size (4 GiB). This can handle artifacts up to 40 GiB. This limitation could be pushed by adding more pregenerated block IDs or by adding base64 encoding.  

The splitting and block listing upload is done in a single curl invocation with a sequence of multiple jobs.

A manual test in vcpkg-test covers existing and new behavior by using lower max single write size and block size. The test can be executed locally after setting up Azurite. (FTR Azurite might also be used in CI.)

All testing was done locally with Azurite. Testing in vcpkg CI can be the next step after a first review.