### PR TITLE
Optimize rename_or_delete to stop retrying after EXDEV

### DIFF
--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -2045,6 +2045,11 @@ namespace vcpkg
                 this->remove_all(old_path, ec);
                 return false;
             }
+            else if (ec == std::make_error_condition(std::errc::cross_device_link))
+            {
+                // If old_path and new_path are on different file systems, trying again will never help.
+                return false;
+            }
 
             std::this_thread::sleep_for(delay);
             this->rename(old_path, new_path, ec);

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -241,8 +241,8 @@ namespace
                     // either we need to make a copy or the rename failed because buildtrees and the binary
                     // cache write target are on different filesystems, copy to a sibling in that directory and rename
                     // into place
-                    // First copy to temporary location to avoid race between different instances trying to upload the
-                    // same archive, e.g. if 2 machines try to upload to a shared binary cache.
+                    // First copy to temporary location to avoid race between different vcpkg instances trying to upload
+                    // the same archive, e.g. if 2 machines try to upload to a shared binary cache.
                     m_fs.copy_file(zip_path, archive_temp_path, CopyOptions::overwrite_existing, ec);
                     if (!ec)
                     {

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -237,7 +237,7 @@ namespace
 
                 if (!can_attempt_rename || (ec && ec == std::make_error_condition(std::errc::cross_device_link)))
                 {
-                    // either we need to make a copy or the rename failed because because buildtrees and the binary
+                    // either we need to make a copy or the rename failed because buildtrees and the binary
                     // cache write target are on different filesystems, copy to a sibling in that directory and rename
                     // into place
                     m_fs.copy_file(zip_path, archive_temp_path, CopyOptions::overwrite_existing, ec);


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/45130

Please note that there is already code in place to handle `std::errc::cross_device_link` for binary caching:

https://github.com/microsoft/vcpkg-tool/blob/d092b51ab6eb219e9af393d29214eeb4ad9f4750/src/vcpkg/binarycaching.cpp#L232-L249

However, copy-and-delete was only tried after calling `fs.rename_or_delete()` which tries to move the file after increasing timeouts. I decided to not move the copy-and-delete behavior to `fs.rename_or_delete()` because the file is first copied to a temproary location in `binarycaching.cpp`.

Files on different filesystems can't be renamed:

Linux: https://man7.org/linux/man-pages/man2/rename.2.html

Windows seems to support moving files but not folders across devices: https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-movefile

`std::errc::cross_device_link`: https://en.cppreference.com/w/cpp/error/errno_macros

Stack Overflow: https://stackoverflow.com/questions/43206198/what-does-the-exdev-cross-device-link-not-permitted-error-mean