### PR TITLE
Merge cascaded failure feature dependencies together.

### DIFF
--- a/azure-pipelines/e2e-ports/vcpkg-depends-on-fail/portfile.cmake
+++ b/azure-pipelines/e2e-ports/vcpkg-depends-on-fail/portfile.cmake
@@ -1,0 +1,1 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/azure-pipelines/e2e-ports/vcpkg-depends-on-fail/vcpkg.json
+++ b/azure-pipelines/e2e-ports/vcpkg-depends-on-fail/vcpkg.json
@@ -1,0 +1,27 @@
+{
+  "name": "vcpkg-depends-on-fail",
+  "version": "0",
+  "dependencies": [
+    {
+      "name": "vcpkg-fail-if-depended-upon",
+      "default-features": false,
+      "features": [
+        "a"
+      ]
+    }
+  ],
+  "features": {
+    "x": {
+      "description": "feature x",
+      "dependencies": [
+        {
+          "name": "vcpkg-fail-if-depended-upon",
+          "default-features": false,
+          "features": [
+            "b"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/azure-pipelines/e2e-ports/vcpkg-fail-if-depended-upon/vcpkg.json
+++ b/azure-pipelines/e2e-ports/vcpkg-fail-if-depended-upon/vcpkg.json
@@ -1,4 +1,18 @@
 {
   "name": "vcpkg-fail-if-depended-upon",
-  "version": "0"
+  "version": "0",
+  "default-features": [
+    "is-a-default-feature"
+  ],
+  "features": {
+    "a": {
+      "description": "feature a"
+    },
+    "b": {
+      "description": "feature b"
+    },
+    "is-a-default-feature": {
+      "description": "this is a default feature"
+    }
+  }
 }

--- a/azure-pipelines/end-to-end-tests-dir/build-test-ports.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/build-test-ports.ps1
@@ -82,3 +82,15 @@ if ($firstMatch -lt 0) {
 } elseif ($output.IndexOf($expected, $firstMatch + 1) -ge 0) {
     throw 'Duplicated bad license'
 }
+
+Refresh-TestRoot
+$output = Run-VcpkgAndCaptureOutput @commonArgs --x-builtin-ports-root="$PSScriptRoot/../e2e-ports" install 'vcpkg-depends-on-fail[x]' --keep-going
+Throw-IfNotFailed
+$expected = @"
+Building vcpkg-depends-on-fail[core,x]:$($Triplet)@0...
+error: building vcpkg-depends-on-fail:$($Triplet) failed with: CASCADED_DUE_TO_MISSING_DEPENDENCIES
+  due to the following missing dependencies:
+    vcpkg-fail-if-depended-upon[a,b,core]:$($Triplet)
+"@
+
+Throw-IfNonContains -Expected $expected -Actual $output

--- a/include/vcpkg/commands.build.h
+++ b/include/vcpkg/commands.build.h
@@ -184,11 +184,11 @@ namespace vcpkg
     {
         explicit ExtendedBuildResult(BuildResult code);
         explicit ExtendedBuildResult(BuildResult code, vcpkg::Path stdoutlog, std::vector<std::string>&& error_logs);
-        ExtendedBuildResult(BuildResult code, std::vector<FeatureSpec>&& unmet_deps);
+        ExtendedBuildResult(BuildResult code, std::vector<FullPackageSpec>&& unmet_deps);
         ExtendedBuildResult(BuildResult code, std::unique_ptr<BinaryControlFile>&& bcf);
 
         BuildResult code;
-        std::vector<FeatureSpec> unmet_dependencies;
+        std::vector<FullPackageSpec> unmet_dependencies;
         std::unique_ptr<BinaryControlFile> binary_control_file;
         Optional<vcpkg::Path> stdoutlog;
         std::vector<std::string> error_logs;

--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -1591,8 +1591,10 @@ namespace vcpkg
                 return {BuildResult::CascadedDueToMissingDependencies,
                         Util::fmap(std::move(missing_fspecs),
                                    [](std::pair<PackageSpec, std::set<std::string>>&& missing_features) {
-                                       return FeatureSpec{std::move(missing_features.first),
-                                                          Strings::join(",", missing_features.second)};
+                                       return FullPackageSpec{
+                                           std::move(missing_features.first),
+                                           InternalFeatureSet{std::make_move_iterator(missing_features.second.begin()),
+                                                              std::make_move_iterator(missing_features.second.end())}};
                                    })};
             }
 
@@ -2193,7 +2195,7 @@ namespace vcpkg
         : code(code), binary_control_file(std::move(bcf))
     {
     }
-    ExtendedBuildResult::ExtendedBuildResult(BuildResult code, std::vector<FeatureSpec>&& unmet_deps)
+    ExtendedBuildResult::ExtendedBuildResult(BuildResult code, std::vector<FullPackageSpec>&& unmet_deps)
         : code(code), unmet_dependencies(std::move(unmet_deps))
     {
     }

--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -1571,14 +1571,14 @@ namespace vcpkg
         auto& spec = action.spec;
         const std::string& name = action.source_control_file_and_location.value_or_exit(VCPKG_LINE_INFO).to_name();
 
-        std::vector<FeatureSpec> missing_fspecs;
+        std::map<PackageSpec, std::set<std::string>> missing_fspecs;
         for (const auto& kv : action.feature_dependencies)
         {
             for (const FeatureSpec& fspec : kv.second)
             {
                 if (!status_db.is_installed(fspec) && !(fspec.port() == name && fspec.triplet() == spec.triplet()))
                 {
-                    missing_fspecs.emplace_back(fspec);
+                    missing_fspecs[fspec.spec()].insert(fspec.feature());
                 }
             }
         }
@@ -1588,7 +1588,12 @@ namespace vcpkg
         {
             if (!all_dependencies_satisfied)
             {
-                return {BuildResult::CascadedDueToMissingDependencies, std::move(missing_fspecs)};
+                return {BuildResult::CascadedDueToMissingDependencies,
+                        Util::fmap(std::move(missing_fspecs),
+                                   [](std::pair<PackageSpec, std::set<std::string>>&& missing_features) {
+                                       return FeatureSpec{std::move(missing_features.first),
+                                                          Strings::join(",", missing_features.second)};
+                                   })};
             }
 
             // assert that all_dependencies_satisfied is accurate above by checking that they're all installed


### PR DESCRIPTION
Before:

```
.\vcpkg.exe install vcpkg-depends-on-fail[x] --overlay-ports C:\Dev\vcpkg-tool\azure-pipelines\e2e-ports --keep-going --binarysource clear
[...]
error: building vcpkg-depends-on-fail:x64-windows failed with: CASCADED_DUE_TO_MISSING_DEPENDENCIES
  due to the following missing dependencies:
    vcpkg-fail-if-depended-upon[a]:x64-windows
    vcpkg-fail-if-depended-upon[core]:x64-windows
    vcpkg-fail-if-depended-upon[b]:x64-windows
    vcpkg-fail-if-depended-upon[core]:x64-windows
```

After:

```
.\vcpkg.exe install vcpkg-depends-on-fail[x] --overlay-ports C:\Dev\vcpkg-tool\azure-pipelines\e2e-ports --keep-going --binarysource clear
[...]
error: building vcpkg-depends-on-fail:x64-windows failed with: CASCADED_DUE_TO_MISSING_DEPENDENCIES
  due to the following missing dependencies:
    vcpkg-fail-if-depended-upon[a,b,core]:x64-windows
```

I discovered this upon seeing that there is a duplicate implementation here I'm removing: https://github.com/microsoft/vcpkg-tool/blob/d3138cbc5d6088012516a53bc6546b6b756414b3/src/vcpkg/commands.test-features.cpp#L496