### PR TITLE
Improve invalid feature name reporting

### DIFF
--- a/azure-pipelines/e2e-assets/format-manifest-malformed/bad-feature-name.json
+++ b/azure-pipelines/e2e-assets/format-manifest-malformed/bad-feature-name.json
@@ -1,0 +1,15 @@
+{
+  "name": "bad-feature-name",
+  "version": "0",
+  "features": {
+    "a": {
+      "description": "Feature A"
+    },
+    "b_required": {
+      "description": "This feature has an invalid name"
+    },
+    "c": {
+      "description": "Feature C"
+    }
+  }
+}

--- a/azure-pipelines/end-to-end-tests-dir/format-manifest.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/format-manifest.ps1
@@ -18,6 +18,11 @@ $testProjects | % {
     }
 }
 
+$output = Run-VcpkgAndCaptureOutput @commonArgs format-manifest "$PSScriptRoot/../e2e-assets/format-manifest-malformed/bad-feature-name.json"
+Throw-IfNotFailed
+$expected = "bad-feature-name.json: error: $.features.b_required (a feature): features must be lowercase alphanumeric+hyphens, and not one of the reserved names"
+Throw-IfNonContains -Expected $expected -Actual $output
+
 Write-Trace "test re-serializing every manifest"
 $manifestDir = "$TestingRoot/manifest-dir"
 Copy-Item -Path "$env:VCPKG_ROOT/ports" -Destination $manifestDir -recurse -Force -Filter vcpkg.json

--- a/include/vcpkg/base/jsonreader.h
+++ b/include/vcpkg/base/jsonreader.h
@@ -46,6 +46,7 @@ namespace vcpkg::Json
         void add_expected_type_error(const LocalizedString& expected_type);
         void add_extra_field_error(const LocalizedString& type, StringView fields, StringView suggestion = {});
         void add_generic_error(const LocalizedString& type, StringView message);
+        void add_field_name_error(const LocalizedString& type, StringView field, StringView message);
 
         void add_warning(LocalizedString type, StringView msg);
 

--- a/src/vcpkg/base/json.cpp
+++ b/src/vcpkg/base/json.cpp
@@ -1492,6 +1492,12 @@ namespace vcpkg::Json
                                .append_raw(message));
     }
 
+    void Reader::add_field_name_error(const LocalizedString& type, StringView field, StringView message)
+    {
+        PathGuard guard{m_path, field};
+        add_generic_error(type, message);
+    }
+
     void Reader::check_for_unexpected_fields(const Object& obj,
                                              View<StringLiteral> valid_fields,
                                              const LocalizedString& type_name)

--- a/src/vcpkg/sourceparagraph.cpp
+++ b/src/vcpkg/sourceparagraph.cpp
@@ -1108,7 +1108,8 @@ namespace vcpkg
                 }
                 if (!Json::IdentifierDeserializer::is_ident(pr.first))
                 {
-                    r.add_generic_error(type_name(), msg::format(msgInvalidFeature));
+                    r.add_field_name_error(
+                        FeatureDeserializer::instance.type_name(), pr.first, msg::format(msgInvalidFeature));
                     continue;
                 }
                 std::unique_ptr<FeatureParagraph> v;


### PR DESCRIPTION
When a feature name is invalid, report the error as part of the feature name rather than as part of the overall features block.

Before and after demonstration:

```
PS C:\Dev\vcpkg-tool\out\build\Win-x64-Debug-WithArtifacts> type C:\Dev\vcpkg-tool\azure-pipelines\e2e-ports\vcpkg-requires-feature\vcpkg.json
{
  "name": "vcpkg-requires-feature",
  "version": "0",
  "features": {
    "a": {
      "description": "Feature A"
    },
    "b": {
      "description": "Feature B"
    },
    "b_required": {
      "description": "This feature needs to be turned on for the port to build"
    },
    "c": {
      "description": "Feature C"
    }
  }
}
PS C:\Dev\vcpkg-tool\out\build\Win-x64-Debug-WithArtifacts> C:\Dev\vcpkg\vcpkg.exe format-manifest C:\Dev\vcpkg-tool\azure-pipelines\e2e-ports\vcpkg-requires-feature\vcpkg.json
C:\Dev\vcpkg-tool\azure-pipelines\e2e-ports\vcpkg-requires-feature\vcpkg.json: error: $.features (a set of features): features must be lowercase alphanumeric+hyphens, and not one of the reserved names
PS C:\Dev\vcpkg-tool\out\build\Win-x64-Debug-WithArtifacts> .\vcpkg.exe format-manifest C:\Dev\vcpkg-tool\azure-pipelines\e2e-ports\vcpkg-requires-feature\vcpkg.json
C:\Dev\vcpkg-tool\azure-pipelines\e2e-ports\vcpkg-requires-feature\vcpkg.json: error: $.features.b_required (a feature): features must be lowercase alphanumeric+hyphens, and not one of the reserved names
PS C:\Dev\vcpkg-tool\out\build\Win-x64-Debug-WithArtifacts>
```