### PR TITLE
Use azcopy for uploading large artifacts

### DIFF
--- a/include/vcpkg/base/downloads.h
+++ b/include/vcpkg/base/downloads.h
@@ -116,6 +116,11 @@ namespace vcpkg
                               const Path& file_to_put,
                               StringView sha512);
 
+    bool azcopy_to_asset_cache(DiagnosticContext& context,
+                               StringView raw_url,
+                               const SanitizedUrl& sanitized_url,
+                               const Path& file);
+
     Optional<unsigned long long> try_parse_curl_max5_size(StringView sv);
 
     struct CurlProgressData

--- a/include/vcpkg/base/message-data.inc.h
+++ b/include/vcpkg/base/message-data.inc.h
@@ -330,6 +330,10 @@ DECLARE_MESSAGE(AVersionDatabaseEntry, (), "", "a version database entry")
 DECLARE_MESSAGE(AVersionObject, (), "", "a version object")
 DECLARE_MESSAGE(AVersionOfAnyType, (), "", "a version of any type")
 DECLARE_MESSAGE(AVersionConstraint, (), "", "a version constraint")
+DECLARE_MESSAGE(AzcopyFailedToPutBlob,
+                (msg::exit_code, msg::url, msg::value),
+                "azcopy is the name of a program.",
+                "azcopy failed to upload a file to {url} with exit code {exit_code} and http code {value}.")
 DECLARE_MESSAGE(AzUrlAssetCacheRequiresBaseUrl,
                 (),
                 "",

--- a/include/vcpkg/base/message-data.inc.h
+++ b/include/vcpkg/base/message-data.inc.h
@@ -332,7 +332,7 @@ DECLARE_MESSAGE(AVersionOfAnyType, (), "", "a version of any type")
 DECLARE_MESSAGE(AVersionConstraint, (), "", "a version constraint")
 DECLARE_MESSAGE(AzcopyFailedToPutBlob,
                 (msg::exit_code, msg::url, msg::value),
-                "azcopy is the name of a program.",
+                "azcopy is the name of a program. {value} is an HTTP status code.",
                 "azcopy failed to upload a file to {url} with exit code {exit_code} and http code {value}.")
 DECLARE_MESSAGE(AzUrlAssetCacheRequiresBaseUrl,
                 (),

--- a/include/vcpkg/binarycaching.h
+++ b/include/vcpkg/binarycaching.h
@@ -148,6 +148,8 @@ namespace vcpkg
         std::vector<UrlTemplate> url_templates_to_get;
         std::vector<UrlTemplate> url_templates_to_put;
 
+        std::vector<UrlTemplate> azblob_templates_to_put;
+
         std::vector<std::string> gcs_read_prefixes;
         std::vector<std::string> gcs_write_prefixes;
 

--- a/locales/messages.json
+++ b/locales/messages.json
@@ -211,6 +211,8 @@
   "AvailableHelpTopics": "Available help topics:",
   "AzUrlAssetCacheRequiresBaseUrl": "unexpected arguments: asset config 'azurl' requires a base url",
   "AzUrlAssetCacheRequiresLessThanFour": "unexpected arguments: asset config 'azurl' requires fewer than 4 arguments",
+  "AzcopyFailedToPutBlob": "azcopy failed to upload a file to {url} with exit code {exit_code} and http code {value}.",
+  "_AzcopyFailedToPutBlob.comment": "azcopy is the name of a program. {value} is an HTTP status code. An example of {exit_code} is 127. An example of {url} is https://github.com/microsoft/vcpkg.",
   "BaselineConflict": "Specifying vcpkg-configuration.default-registry in a manifest file conflicts with built-in baseline.\nPlease remove one of these conflicting settings.",
   "BaselineGitShowFailed": "while checking out baseline from commit '{commit_sha}', failed to `git show` versions/baseline.json. This may be fixed by fetching commits with `git fetch`.",
   "_BaselineGitShowFailed.comment": "An example of {commit_sha} is 7cfad47ae9f68b183983090afd6337cd60fd4949.",

--- a/src/vcpkg-test/configparser.cpp
+++ b/src/vcpkg-test/configparser.cpp
@@ -459,8 +459,9 @@ TEST_CASE ("BinaryConfigParser azblob provider", "[binaryconfigparser]")
 
         REQUIRE(state.binary_cache_providers == std::set<StringLiteral>{{"azblob"}, {"default"}});
         CHECK(state.url_templates_to_get.empty());
-        CHECK(state.url_templates_to_put.size() == 1);
-        CHECK(state.url_templates_to_put.front().url_template == "https://azure/container/{sha}.zip?sas");
+        CHECK(state.url_templates_to_put.empty());
+        CHECK(state.azblob_templates_to_put.size() == 1);
+        CHECK(state.azblob_templates_to_put.front().url_template == "https://azure/container/{sha}.zip?sas");
         REQUIRE(state.secrets == std::vector<std::string>{"sas"});
         REQUIRE(!state.archives_to_write.empty());
     }
@@ -471,8 +472,9 @@ TEST_CASE ("BinaryConfigParser azblob provider", "[binaryconfigparser]")
         REQUIRE(state.binary_cache_providers == std::set<StringLiteral>{{"azblob"}, {"default"}});
         CHECK(state.url_templates_to_get.size() == 1);
         CHECK(state.url_templates_to_get.front().url_template == "https://azure/container/{sha}.zip?sas");
-        CHECK(state.url_templates_to_put.size() == 1);
-        CHECK(state.url_templates_to_put.front().url_template == "https://azure/container/{sha}.zip?sas");
+        CHECK(state.url_templates_to_put.empty());
+        CHECK(state.azblob_templates_to_put.size() == 1);
+        CHECK(state.azblob_templates_to_put.front().url_template == "https://azure/container/{sha}.zip?sas");
         REQUIRE(state.secrets == std::vector<std::string>{"sas"});
         REQUIRE(!state.archives_to_read.empty());
         REQUIRE(!state.archives_to_write.empty());

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -1721,9 +1721,8 @@ namespace vcpkg
         // See examples of console output in asset-caching.ps1
 
         // Note: no secrets for the input URLs
-        std::vector<SanitizedUrl> sanitized_urls = Util::fmap(raw_urls, [&](const std::string& url) {
-            return SanitizedUrl{url, {}};
-        });
+        std::vector<SanitizedUrl> sanitized_urls =
+            Util::fmap(raw_urls, [&](const std::string& url) { return SanitizedUrl{url, {}}; });
         const auto last_sanitized_url = sanitized_urls.end();
         bool can_read_asset_cache = false;
         if (asset_cache_settings.m_read_url_template.has_value() && maybe_sha512)

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -883,6 +883,43 @@ namespace vcpkg
         return true;
     }
 
+    bool azcopy_to_asset_cache(DiagnosticContext& context,
+                               StringView raw_url,
+                               const SanitizedUrl& sanitized_url,
+                               const Path& file)
+    {
+        auto azcopy_cmd = Command{"azcopy"};
+        azcopy_cmd.string_arg("copy");
+        azcopy_cmd.string_arg("--from-to").string_arg("LocalBlob");
+        azcopy_cmd.string_arg("--log-level").string_arg("NONE");
+        azcopy_cmd.string_arg(file);
+        azcopy_cmd.string_arg(raw_url.to_string());
+
+        int code = 0;
+        auto res = cmd_execute_and_stream_lines(context, azcopy_cmd, [&code](StringView line) {
+            static constexpr StringLiteral response_marker = "RESPONSE ";
+            if (line.starts_with(response_marker))
+            {
+                code = std::strtol(line.data() + response_marker.size(), nullptr, 10);
+            }
+        });
+
+        auto pres = res.get();
+        if (!pres)
+        {
+            return false;
+        }
+
+        if (*pres != 0)
+        {
+            context.report_error(msg::format(
+                msgAzcopyFailedToPutBlob, msg::exit_code = *pres, msg::url = sanitized_url, msg::value = code));
+            return false;
+        }
+
+        return true;
+    }
+
     std::string format_url_query(StringView base_url, View<std::string> query_params)
     {
         if (query_params.empty())
@@ -1684,8 +1721,9 @@ namespace vcpkg
         // See examples of console output in asset-caching.ps1
 
         // Note: no secrets for the input URLs
-        std::vector<SanitizedUrl> sanitized_urls =
-            Util::fmap(raw_urls, [&](const std::string& url) { return SanitizedUrl{url, {}}; });
+        std::vector<SanitizedUrl> sanitized_urls = Util::fmap(raw_urls, [&](const std::string& url) {
+            return SanitizedUrl{url, {}};
+        });
         const auto last_sanitized_url = sanitized_urls.end();
         bool can_read_asset_cache = false;
         if (asset_cache_settings.m_read_url_template.has_value() && maybe_sha512)

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -503,6 +503,57 @@ namespace
         std::vector<std::string> m_secrets;
     };
 
+    struct AzureBlobPutBinaryProvider : IWriteBinaryProvider
+    {
+        AzureBlobPutBinaryProvider(const Filesystem& fs,
+                                   std::vector<UrlTemplate>&& urls,
+                                   const std::vector<std::string>& secrets)
+            : m_fs(fs), m_urls(std::move(urls)), m_secrets(secrets)
+        {
+        }
+
+        size_t push_success(const BinaryPackageWriteInfo& request, MessageSink& msg_sink) override
+        {
+            if (!request.zip_path) return 0;
+
+            const auto& zip_path = *request.zip_path.get();
+
+            size_t count_stored = 0;
+            const auto file_size = m_fs.file_size(zip_path, VCPKG_LINE_INFO);
+            if (file_size == 0) return count_stored;
+
+            // cf.
+            // https://learn.microsoft.com/en-us/rest/api/storageservices/understanding-block-blobs--append-blobs--and-page-blobs?toc=%2Fazure%2Fstorage%2Fblobs%2Ftoc.json
+            constexpr size_t max_single_write = 5000000000;
+            bool use_azcopy = file_size > max_single_write;
+
+            PrintingDiagnosticContext pdc{msg_sink};
+            WarningDiagnosticContext wdc{pdc};
+
+            for (auto&& templ : m_urls)
+            {
+                auto url = templ.instantiate_variables(request);
+                auto maybe_success =
+                    use_azcopy
+                        ? azcopy_to_asset_cache(wdc, url, SanitizedUrl{url, m_secrets}, zip_path)
+                        : store_to_asset_cache(wdc, url, SanitizedUrl{url, m_secrets}, "PUT", templ.headers, zip_path);
+                if (maybe_success)
+                {
+                    count_stored++;
+                }
+            }
+            return count_stored;
+        }
+
+        bool needs_nuspec_data() const override { return false; }
+        bool needs_zip_file() const override { return true; }
+
+    private:
+        const Filesystem& m_fs;
+        std::vector<UrlTemplate> m_urls;
+        std::vector<std::string> m_secrets;
+    };
+
     struct NuGetSource
     {
         StringLiteral option;
@@ -1674,7 +1725,9 @@ namespace
                         segments[0].first);
                 }
 
-                if (!Strings::starts_with(segments[1].second, "https://"))
+                if (!Strings::starts_with(segments[1].second, "https://") &&
+                    // Allow unencrypted Azurite for testing (not reflected in error msg)
+                    !Strings::starts_with(segments[1].second, "http://127.0.0.1"))
                 {
                     return add_error(msg::format(msgInvalidArgumentRequiresBaseUrl,
                                                  msg::base_url = "https://",
@@ -1715,7 +1768,7 @@ namespace
                 if (read) state->url_templates_to_get.push_back(url_template);
                 auto headers = azure_blob_headers();
                 url_template.headers.assign(headers.begin(), headers.end());
-                if (write) state->url_templates_to_put.push_back(url_template);
+                if (write) state->azblob_templates_to_put.push_back(url_template);
 
                 state->binary_cache_providers.insert("azblob");
             }
@@ -2492,6 +2545,11 @@ namespace vcpkg
             {
                 m_config.write.push_back(
                     std::make_unique<FilesWriteBinaryProvider>(fs, std::move(s.archives_to_write)));
+            }
+            if (!s.azblob_templates_to_put.empty())
+            {
+                m_config.write.push_back(
+                    std::make_unique<AzureBlobPutBinaryProvider>(fs, std::move(s.azblob_templates_to_put), s.secrets));
             }
             if (!s.url_templates_to_put.empty())
             {


### PR DESCRIPTION
Alternative to #1658.

Curl is still used for artifacts below the max single write limit (5 GB) and for all downloads. Fetching and uploading azcopy via vcpkg-tools.json (https://github.com/microsoft/vcpkg/pull/45461/commits/c178e5494f9c9a4beaf76f28b09a5ec1b0df1b5f) doesn't need azcopy.