### PR TITLE
Add support for visionOS platform

### DIFF
--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -1021,7 +1021,7 @@ namespace vcpkg
         }
         else if (cmake_system_name == "visionOS")
         {
-            return m_paths.scripts / "toolchains/visionos.cmake";
+            return m_paths.scripts / "toolchains/ios.cmake";
         }
         else
         {

--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -1019,6 +1019,10 @@ namespace vcpkg
         {
             return m_paths.scripts / "toolchains/windows.cmake";
         }
+        else if (cmake_system_name == "visionOS")
+        {
+            return m_paths.scripts / "toolchains/visionos.cmake";
+        }
         else
         {
             Checks::msg_exit_maybe_upgrade(VCPKG_LINE_INFO,

--- a/src/vcpkg/platform-expression.cpp
+++ b/src/vcpkg/platform-expression.cpp
@@ -35,6 +35,7 @@ namespace vcpkg::PlatformExpression
         ios,
         qnx,
         vxworks,
+        visionos,
 
         static_link,
         static_crt,
@@ -66,6 +67,7 @@ namespace vcpkg::PlatformExpression
             {"ios", Identifier::ios},
             {"qnx", Identifier::qnx},
             {"vxworks", Identifier::vxworks},
+            {"visionOS", Identifier::visionos},
             {"static", Identifier::static_link},
             {"staticcrt", Identifier::static_crt},
             {"native", Identifier::native},
@@ -572,6 +574,8 @@ namespace vcpkg::PlatformExpression
                         case Identifier::vxworks: return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "VxWorks");
                         case Identifier::wasm32: return true_if_exists_and_equal("VCPKG_TARGET_ARCHITECTURE", "wasm32");
                         case Identifier::mips64: return true_if_exists_and_equal("VCPKG_TARGET_ARCHITECTURE", "mips64");
+                        case Identifier::visionos:
+                            return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "visionOS");
                         case Identifier::static_link:
                             return true_if_exists_and_equal("VCPKG_LIBRARY_LINKAGE", "static");
                         case Identifier::static_crt: return true_if_exists_and_equal("VCPKG_CRT_LINKAGE", "static");

--- a/src/vcpkg/platform-expression.cpp
+++ b/src/vcpkg/platform-expression.cpp
@@ -67,7 +67,7 @@ namespace vcpkg::PlatformExpression
             {"ios", Identifier::ios},
             {"qnx", Identifier::qnx},
             {"vxworks", Identifier::vxworks},
-            {"visionOS", Identifier::visionos},
+            {"visionos", Identifier::visionos},
             {"static", Identifier::static_link},
             {"staticcrt", Identifier::static_crt},
             {"native", Identifier::native},


### PR DESCRIPTION
This commit adds support for visionOS as a platform.

There is a downstream set of changes in the vcpkg repo that adds a toolchain. I'm not entirely sure how to coordinate the changes but I'll open a PR in the base repo as well.