### PR TITLE
Add platform support for Solaris and illumos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -431,6 +431,10 @@ elseif(NOT MSVC)
     target_compile_options(vcpkglib PRIVATE -include "${CMAKE_CURRENT_SOURCE_DIR}/include/pch.h")
 endif()
 
+if(CMAKE_HOST_SOLARIS)
+    target_link_libraries(vcpkglib PRIVATE socket)
+endif()
+
 if(ANDROID AND CMAKE_SYSTEM_VERSION LESS "28")
     # pkg install libandroid-spawn
     target_link_libraries(vcpkglib PRIVATE android-spawn)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -431,7 +431,7 @@ elseif(NOT MSVC)
     target_compile_options(vcpkglib PRIVATE -include "${CMAKE_CURRENT_SOURCE_DIR}/include/pch.h")
 endif()
 
-if(CMAKE_HOST_SOLARIS)
+if(CMAKE_SYSTEM_NAME STREQUAL "SunOS")
     target_link_libraries(vcpkglib PRIVATE socket)
 endif()
 

--- a/docs/vcpkg-tools.schema.json
+++ b/docs/vcpkg-tools.schema.json
@@ -22,7 +22,7 @@
           "os": {
             "type": "string",
             "description": "The platform where the record is valid.",
-            "enum": [ "windows", "osx", "linux", "freebsd", "openbsd" ]
+            "enum": [ "windows", "osx", "linux", "freebsd", "openbsd", "solaris" ]
           },
           "version": {
             "type": "string",

--- a/include/vcpkg/tools.test.h
+++ b/include/vcpkg/tools.test.h
@@ -47,6 +47,7 @@ namespace vcpkg
         Linux,
         FreeBsd,
         OpenBsd,
+        Solaris,
     };
 
     Optional<ToolOs> to_tool_os(StringView os) noexcept;

--- a/src/vcpkg-test/tools.cpp
+++ b/src/vcpkg-test/tools.cpp
@@ -255,7 +255,7 @@ TEST_CASE ("parse_tool_data errors", "[tools]")
     REQUIRE(!invalid_os.has_value());
     CHECK(
         "invalid_os.json: error: $.tools[0].os (a tool data operating system): Invalid tool operating system: notanos. "
-        "Expected one of: windows, osx, linux, freebsd, openbsd" == invalid_os.error());
+        "Expected one of: windows, osx, linux, freebsd, openbsd, solaris" == invalid_os.error());
 
     auto invalid_version = parse_tool_data(R"(
 {

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -3363,7 +3363,8 @@ namespace vcpkg
             }
 
             auto mkdir_error = errno;
-            if (mkdir_error == EEXIST)
+            // mkdir returns ENOSYS on Solaris/illumos autofs mount points
+            if (mkdir_error == EEXIST || mkdir_error == ENOSYS)
             {
                 struct stat s;
                 if (::stat(new_directory, &s) == 0)

--- a/src/vcpkg/base/system.cpp
+++ b/src/vcpkg/base/system.cpp
@@ -769,6 +769,8 @@ namespace vcpkg
         return "freebsd";
 #elif defined(__OpenBSD__)
         return "openbsd";
+#elif defined(__SVR4) && defined(__sun)
+        return "solaris";
 #elif defined(__ANDROID__)
         return "android";
 #elif defined(__linux__)

--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -26,6 +26,12 @@ extern char** environ;
 #include <sys/wait.h>
 #endif
 
+#if defined(__SVR4) && defined(__sun)
+extern char** environ;
+#include <stdio.h>
+#include <unistd.h>
+#endif
+
 #if defined(_WIN32)
 #include <Psapi.h>
 #include <TlHelp32.h>
@@ -249,6 +255,13 @@ namespace vcpkg
         char* exePath(realpath(argv[0], buf));
         Checks::check_exit(VCPKG_LINE_INFO, exePath != nullptr, "Could not determine current executable path.");
         return Path(exePath);
+#elif defined(__SVR4) && defined(__sun)
+        char procpath[PATH_MAX];
+        (void)snprintf(procpath, sizeof(procpath), "/proc/%d/path/a.out", getpid());
+        char buf[PATH_MAX];
+        auto written = readlink(procpath, buf, sizeof(buf));
+        Checks::check_exit(VCPKG_LINE_INFO, written != -1, "Could not determine current executable path.");
+        return Path(buf, written);
 #else /* LINUX */
         char buf[1024 * 4] = {};
         auto written = readlink("/proc/self/exe", buf, sizeof(buf));

--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -995,7 +995,7 @@ namespace vcpkg
         {
             return m_paths.scripts / "toolchains/openbsd.cmake";
         }
-        else if (cmake_system_name == "Solaris")
+        else if (cmake_system_name == "SunOS")
         {
             return m_paths.scripts / "toolchains/solaris.cmake";
         }

--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -995,6 +995,10 @@ namespace vcpkg
         {
             return m_paths.scripts / "toolchains/openbsd.cmake";
         }
+        else if (cmake_system_name == "Solaris")
+        {
+            return m_paths.scripts / "toolchains/solaris.cmake";
+        }
         else if (cmake_system_name == "Android")
         {
             return m_paths.scripts / "toolchains/android.cmake";

--- a/src/vcpkg/platform-expression.cpp
+++ b/src/vcpkg/platform-expression.cpp
@@ -562,7 +562,7 @@ namespace vcpkg::PlatformExpression
                         case Identifier::linux: return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "Linux");
                         case Identifier::freebsd: return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "FreeBSD");
                         case Identifier::openbsd: return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "OpenBSD");
-                        case Identifier::solaris: return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "Solaris");
+                        case Identifier::solaris: return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "SunOS");
                         case Identifier::osx: return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "Darwin");
                         case Identifier::uwp:
                             return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "WindowsStore");

--- a/src/vcpkg/platform-expression.cpp
+++ b/src/vcpkg/platform-expression.cpp
@@ -27,6 +27,7 @@ namespace vcpkg::PlatformExpression
         linux,
         freebsd,
         openbsd,
+        solaris,
         osx,
         uwp,
         xbox,
@@ -58,6 +59,7 @@ namespace vcpkg::PlatformExpression
             {"linux", Identifier::linux},
             {"freebsd", Identifier::freebsd},
             {"openbsd", Identifier::openbsd},
+            {"solaris", Identifier::solaris},
             {"osx", Identifier::osx},
             {"uwp", Identifier::uwp},
             {"xbox", Identifier::xbox},
@@ -560,6 +562,7 @@ namespace vcpkg::PlatformExpression
                         case Identifier::linux: return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "Linux");
                         case Identifier::freebsd: return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "FreeBSD");
                         case Identifier::openbsd: return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "OpenBSD");
+                        case Identifier::solaris: return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "Solaris");
                         case Identifier::osx: return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "Darwin");
                         case Identifier::uwp:
                             return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "WindowsStore");

--- a/src/vcpkg/tools.cpp
+++ b/src/vcpkg/tools.cpp
@@ -38,6 +38,7 @@ namespace
         {"linux", ToolOs::Linux},
         {"freebsd", ToolOs::FreeBsd},
         {"openbsd", ToolOs::OpenBsd},
+        {"solaris", ToolOs::Solaris},
     };
 }
 
@@ -176,6 +177,8 @@ namespace vcpkg
         auto data = get_raw_tool_data(tool_data_table, tool, hp, ToolOs::FreeBsd);
 #elif defined(__OpenBSD__)
         auto data = get_raw_tool_data(tool_data_table, tool, hp, ToolOs::OpenBsd);
+#elif defined(__SVR4) && defined(__sun)
+        auto data = get_raw_tool_data(tool_data_table, tool, hp, ToolOs::Solaris);
 #else
         return nullopt;
 #endif


### PR DESCRIPTION
This adds support for building and using vcpkg-tool on Solaris and illumos systems. The intent is to get the rest of vcpkg working. The majority of the work is in the `vcpkg::get_user_mac_hash` implementation using interfaces available in Solaris 8 and later. Tests pass with clang 18 on illumos/amd64.