### PR TITLE
x-feature-test: Only enforce cascades in baseline when used with --all

### DIFF
--- a/azure-pipelines/end-to-end-tests-prelude.ps1
+++ b/azure-pipelines/end-to-end-tests-prelude.ps1
@@ -269,6 +269,20 @@ function Throw-IfNonEndsWith {
     }
 }
 
+function Throw-IfContains {
+    Param(
+        [string]$Actual,
+        [string]$Expected
+    )
+    if ($Actual.Contains($Expected)) {
+        Set-Content -Value $Expected -LiteralPath "$TestingRoot/expected.txt"
+        Set-Content -Value $Actual -LiteralPath "$TestingRoot/actual.txt"
+        git diff --no-index -- "$TestingRoot/expected.txt" "$TestingRoot/actual.txt"
+        Write-Stack
+        throw "Expected '$Expected' to not be in '$Actual'"
+    }
+}
+
 function Throw-IfNonContains {
     Param(
         [string]$Actual,

--- a/include/vcpkg/ci-feature-baseline.h
+++ b/include/vcpkg/ci-feature-baseline.h
@@ -23,7 +23,8 @@ namespace vcpkg
 
     enum class CiFeatureBaselineOutcome
     {
-        Pass,
+        ImplicitPass,
+        ExplicitPass,
         PortMarkedFail,
         PortMarkedCascade,
         FeatureFail,

--- a/src/vcpkg/ci-feature-baseline.cpp
+++ b/src/vcpkg/ci-feature-baseline.cpp
@@ -389,9 +389,17 @@ namespace vcpkg
                     }
                 }
             }
+
+            if (auto pstate = baseline->state.get())
+            {
+                if (pstate->value == CiFeatureBaselineState::Pass)
+                {
+                    return Located<CiFeatureBaselineOutcome>{SourceLoc{}, CiFeatureBaselineOutcome::ExplicitPass};
+                }
+            }
         }
 
-        return Located<CiFeatureBaselineOutcome>{SourceLoc{}, CiFeatureBaselineOutcome::Pass};
+        return Located<CiFeatureBaselineOutcome>{SourceLoc{}, CiFeatureBaselineOutcome::ImplicitPass};
     }
 
     StringLiteral to_string_literal(CiFeatureBaselineState state)


### PR DESCRIPTION
We don't want to enforce the cascade list for the curated registry.

See also:
* https://github.com/microsoft/vcpkg/pull/45176#issuecomment-2826401801
* https://github.com/microsoft/vcpkg/pull/45270