### PR TITLE
Remove trailing '/' from environment HTTP_PROXY variable fixes #45678

### DIFF
--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -354,8 +354,14 @@ namespace vcpkg
             auto maybe_https_proxy_env = get_environment_variable(EnvironmentVariableHttpsProxy);
             if (auto p_https_proxy = maybe_https_proxy_env.get())
             {
-                std::wstring env_proxy_settings = Strings::to_utf16(*p_https_proxy);
-                if (env_proxy_settings.back() == '/') env_proxy_settings.pop_back();
+                StringView p_https_proxy_view = *p_https_proxy;
+                if (p_https_proxy_view.size() != 0 && p_https_proxy_view.back() == '/')
+                {
+                    // remove trailing slash
+                    p_https_proxy_view = p_https_proxy_view.substr(0, p_https_proxy_view.size() - 1);
+                }
+
+                std::wstring env_proxy_settings = Strings::to_utf16(p_https_proxy_view);
                 WINHTTP_PROXY_INFO proxy;
                 proxy.dwAccessType = WINHTTP_ACCESS_TYPE_NAMED_PROXY;
                 proxy.lpszProxy = env_proxy_settings.data();

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -355,6 +355,7 @@ namespace vcpkg
             if (auto p_https_proxy = maybe_https_proxy_env.get())
             {
                 std::wstring env_proxy_settings = Strings::to_utf16(*p_https_proxy);
+                if (env_proxy_settings.back() == '/') env_proxy_settings.pop_back();
                 WINHTTP_PROXY_INFO proxy;
                 proxy.dwAccessType = WINHTTP_ACCESS_TYPE_NAMED_PROXY;
                 proxy.lpszProxy = env_proxy_settings.data();


### PR DESCRIPTION
fixes setting HTTTP<S>_PROXY environment variable with a trailing '/' results in no ability to download #45678