### PR TITLE
Add C:\Windows\System32\OpenSSH to PATH for git-for-windows using external OpenSSH

### DIFF
--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -545,7 +545,9 @@ namespace vcpkg
                         system32_env,
                         "\\Wbem;",
                         system32_env,
-                        "\\WindowsPowerShell\\v1.0\\");
+                        "\\WindowsPowerShell\\v1.0\\;",
+                        system32_env,
+                        "\\OpenSSH\\");
 
         std::vector<std::string> env_strings = {
             "ALLUSERSPROFILE",


### PR DESCRIPTION
Otherwise, vcpkg_from_git with ssh protocol would fail with messages:
error: cannot spawn ssh: No such file or directory 
fatal: unable to fork