### PR TITLE
Update clang-format to 20.1.x.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,4 @@
 BasedOnStyle: WebKit
-Language: Cpp
-Standard: Cpp11
 
 UseTab: Never
 IndentWidth: 4
@@ -75,3 +73,8 @@ IncludeCategories:
     Priority: 6
   - Regex: '^<[a-z0-9_]*>$' # C++ standard library
     Priority: 7
+
+---
+
+Language: Cpp
+Standard: c++17

--- a/include/vcpkg/base/diagnostics.h
+++ b/include/vcpkg/base/diagnostics.h
@@ -311,9 +311,8 @@ namespace vcpkg
 
     // The overload for functors that return Optional<T>
     template<class Fn, class... Args>
-    auto adapt_context_to_expected(Fn functor, Args&&... args)
-        -> ExpectedL<
-            typename AdaptContextUnwrapOptional<std::invoke_result_t<Fn, BufferedDiagnosticContext&, Args...>>::type>
+    auto adapt_context_to_expected(Fn functor, Args&&... args) -> ExpectedL<
+        typename AdaptContextUnwrapOptional<std::invoke_result_t<Fn, BufferedDiagnosticContext&, Args...>>::type>
     {
         using Unwrapper = AdaptContextUnwrapOptional<std::invoke_result_t<Fn, BufferedDiagnosticContext&, Args...>>;
         using ReturnType = ExpectedL<typename Unwrapper::type>;
@@ -381,9 +380,8 @@ namespace vcpkg
 
     // The overload for functors that return std::unique_ptr<T>
     template<class Fn, class... Args>
-    auto adapt_context_to_expected(Fn functor, Args&&... args)
-        -> ExpectedL<
-            typename AdaptContextDetectUniquePtr<std::invoke_result_t<Fn, BufferedDiagnosticContext&, Args...>>::type>
+    auto adapt_context_to_expected(Fn functor, Args&&... args) -> ExpectedL<
+        typename AdaptContextDetectUniquePtr<std::invoke_result_t<Fn, BufferedDiagnosticContext&, Args...>>::type>
     {
         using ReturnType = ExpectedL<
             typename AdaptContextDetectUniquePtr<std::invoke_result_t<Fn, BufferedDiagnosticContext&, Args...>>::type>;

--- a/src/vcpkg-test/json.cpp
+++ b/src/vcpkg-test/json.cpp
@@ -11,7 +11,7 @@
 template<size_t Sz>
 static auto u8_string_to_char_string(const char8_t (&literal)[Sz]) -> const char (&)[Sz]
 {
-    return reinterpret_cast<const char(&)[Sz]>(literal);
+    return reinterpret_cast<const char (&)[Sz]>(literal);
 }
 
 #define U8_STR(s) (u8_string_to_char_string(u8"" s))

--- a/src/vcpkg/base/json.cpp
+++ b/src/vcpkg/base/json.cpp
@@ -72,7 +72,7 @@ namespace vcpkg::Json
 
         private:
             template<class T>
-            ValueImpl& internal_assign(ValueKind vk, T ValueImpl::*mp, ValueImpl& other) noexcept
+            ValueImpl& internal_assign(ValueKind vk, T ValueImpl::* mp, ValueImpl& other) noexcept
             {
                 if (tag == vk)
                 {

--- a/src/vcpkg/base/system.cpp
+++ b/src/vcpkg/base/system.cpp
@@ -208,8 +208,8 @@ namespace vcpkg
         const HMODULE hKernel32 = ::GetModuleHandleW(L"kernel32.dll");
         if (hKernel32)
         {
-            BOOL(__stdcall* const isWow64Process2)
-            (HANDLE /* hProcess */, USHORT* /* pProcessMachine */, USHORT* /*pNativeMachine*/) =
+            BOOL(__stdcall* const isWow64Process2)(
+                HANDLE /* hProcess */, USHORT* /* pProcessMachine */, USHORT* /*pNativeMachine*/) =
                 reinterpret_cast<decltype(isWow64Process2)>(::GetProcAddress(hKernel32, "IsWow64Process2"));
             if (isWow64Process2)
             {


### PR DESCRIPTION
This got updated underneath us in GitHub Actions. For example, #1718 doesn't touch C++ files at all but still fails.