### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 15684: Build ID 11966727

### DIFF
--- a/locales/messages.cs.json
+++ b/locales/messages.cs.json
@@ -1180,7 +1180,7 @@
   "WhileParsingVersionsForPort": "při parsování verzí pro {package_name} z {path}",
   "WhileRunningAssetCacheScriptCommandLine": "při spuštění příkazového řádku skriptu mezipaměti prostředků",
   "WhileValidatingVersion": "při ověřování verze: {version}",
-  "WindowsEnvMustAlwaysBePresent": "Expected {env_var} to be always set on Windows.",
+  "WindowsEnvMustAlwaysBePresent": "Očekává se, že proměnná {env_var} bude ve Windows vždy nastavená.",
   "WindowsOnlyCommand": "Tento příkaz podporuje jenom Windows.",
   "WroteNuGetPkgConfInfo": "Do {path} se zapsaly informace o konfiguraci balíčku NuGet",
   "FatalTheRootFolder$CannotBeCreated": "Závažné: Kořenovou složku ${p0} nejde vytvořit",

--- a/locales/messages.de.json
+++ b/locales/messages.de.json
@@ -1180,7 +1180,7 @@
   "WhileParsingVersionsForPort": "beim Parsen von Versionen für das Paket {package_name} aus {path}",
   "WhileRunningAssetCacheScriptCommandLine": "während der Ausführung der Skriptbefehlszeile für den Ressourcencache",
   "WhileValidatingVersion": "beim Überprüfen der Version: {version}",
-  "WindowsEnvMustAlwaysBePresent": "Expected {env_var} to be always set on Windows.",
+  "WindowsEnvMustAlwaysBePresent": "Es wurde erwartet, dass die {env_var}-Umgebungsvariable immer unter Windows festgelegt ist.",
   "WindowsOnlyCommand": "Dieser Befehl unterstützt nur Windows.",
   "WroteNuGetPkgConfInfo": "NuGet-Paketkonfigurationsinformationen wurden in {path} geschrieben.",
   "FatalTheRootFolder$CannotBeCreated": "Schwerwiegend: Der Stammordner \"${p0}\" kann nicht erstellt werden.",

--- a/locales/messages.es.json
+++ b/locales/messages.es.json
@@ -1180,7 +1180,7 @@
   "WhileParsingVersionsForPort": "al analizar las versiones de {package_name} desde {path}",
   "WhileRunningAssetCacheScriptCommandLine": "al ejecutar la línea de comandos del script de caché de recursos",
   "WhileValidatingVersion": "al validar la versión: {version}",
-  "WindowsEnvMustAlwaysBePresent": "Expected {env_var} to be always set on Windows.",
+  "WindowsEnvMustAlwaysBePresent": "Se esperaba que {env_var} estuviera siempre activado en Windows.",
   "WindowsOnlyCommand": "Este comando solo admite Windows.",
   "WroteNuGetPkgConfInfo": "Se escribió la información de configuración del paquete NuGet en {path}",
   "FatalTheRootFolder$CannotBeCreated": "Irrecuperable: no se puede crear la carpeta raíz \"${p0}\"",

--- a/locales/messages.fr.json
+++ b/locales/messages.fr.json
@@ -1180,7 +1180,7 @@
   "WhileParsingVersionsForPort": "lors de l’analyse des versions de {package_name} à partir de {path}",
   "WhileRunningAssetCacheScriptCommandLine": "lors de l’exécution de la ligne de commande du script du cache de ressources",
   "WhileValidatingVersion": "lors de la validation de la version : {version}",
-  "WindowsEnvMustAlwaysBePresent": "Expected {env_var} to be always set on Windows.",
+  "WindowsEnvMustAlwaysBePresent": "La variable d’environnement {env_var} prévue doit toujours être définie sur Windows.",
   "WindowsOnlyCommand": "Cette commande prend uniquement en charge Windows.",
   "WroteNuGetPkgConfInfo": "A écrit les informations de configuration du package NuGet dans {path}",
   "FatalTheRootFolder$CannotBeCreated": "Irrécupérable : impossible de créer le dossier racine « ${p0} »",

--- a/locales/messages.it.json
+++ b/locales/messages.it.json
@@ -1180,7 +1180,7 @@
   "WhileParsingVersionsForPort": "durante l'analisi delle versioni per {package_name} da {path}",
   "WhileRunningAssetCacheScriptCommandLine": "durante l'esecuzione della riga di comando dello script della cache degli asset",
   "WhileValidatingVersion": "durante la convalida della versione: {version}",
-  "WindowsEnvMustAlwaysBePresent": "Expected {env_var} to be always set on Windows.",
+  "WindowsEnvMustAlwaysBePresent": "È previsto che la variabile di ambiente {env_var} sia sempre impostata in Windows.",
   "WindowsOnlyCommand": "Questo comando supporta solo Windows.",
   "WroteNuGetPkgConfInfo": "Le informazioni di configurazione del pacchetto NuGet sono stata scritte in {path}.",
   "FatalTheRootFolder$CannotBeCreated": "Errore irreversibile: non è possibile creare la cartella radice '${p0}'",

--- a/locales/messages.ja.json
+++ b/locales/messages.ja.json
@@ -1180,7 +1180,7 @@
   "WhileParsingVersionsForPort": "{path} からの {package_name} のバージョンの解析中",
   "WhileRunningAssetCacheScriptCommandLine": "資産キャッシュ スクリプトコマンド ラインの実行中",
   "WhileValidatingVersion": "バージョンの検証中に: {version}",
-  "WindowsEnvMustAlwaysBePresent": "Expected {env_var} to be always set on Windows.",
+  "WindowsEnvMustAlwaysBePresent": "{env_var} は常に Windows で設定される必要があります。",
   "WindowsOnlyCommand": "このコマンドは Windows のみをサポートします。",
   "WroteNuGetPkgConfInfo": "NuGet パッケージ構成情報を {path} に書き込みました",
   "FatalTheRootFolder$CannotBeCreated": "致命的エラー: ルート フォルダー '${p0}' を作成できません",

--- a/locales/messages.ko.json
+++ b/locales/messages.ko.json
@@ -1180,7 +1180,7 @@
   "WhileParsingVersionsForPort": "{path}에서 {package_name}의 버전을 구문 분석하는 동안",
   "WhileRunningAssetCacheScriptCommandLine": "자산 캐시 스크립트 명령줄을 실행하는 동안",
   "WhileValidatingVersion": "{version} 버전 유효성을 검사하는 동안",
-  "WindowsEnvMustAlwaysBePresent": "Expected {env_var} to be always set on Windows.",
+  "WindowsEnvMustAlwaysBePresent": "Windows에서는 {env_var}이(가) 항상 설정되어 있어야 합니다.",
   "WindowsOnlyCommand": "이 명령은 Windows만 지원합니다.",
   "WroteNuGetPkgConfInfo": "NuGet 패키지 구성 정보를 {path}에 기록함",
   "FatalTheRootFolder$CannotBeCreated": "치명적: 루트 폴더 '${p0}'을(를) 만들 수 없습니다.",

--- a/locales/messages.pl.json
+++ b/locales/messages.pl.json
@@ -1180,7 +1180,7 @@
   "WhileParsingVersionsForPort": "podczas analizowania wersji dla pakietu {package_name} ze ścieżki {path}",
   "WhileRunningAssetCacheScriptCommandLine": "podczas uruchamiania wiersza polecenia skryptu pamięci podręcznej zasobów",
   "WhileValidatingVersion": "podczas walidacji wersji: {version}",
-  "WindowsEnvMustAlwaysBePresent": "Expected {env_var} to be always set on Windows.",
+  "WindowsEnvMustAlwaysBePresent": "Oczekiwano, że element {env_var} będzie zawsze ustawiony w systemie Windows.",
   "WindowsOnlyCommand": "To polecenie obsługuje tylko system Windows.",
   "WroteNuGetPkgConfInfo": "Zapisano informacje o konfiguracji pakietu NuGet w ścieżce {path}",
   "FatalTheRootFolder$CannotBeCreated": "Krytyczny: nie można utworzyć folderu głównego „${p0}”",

--- a/locales/messages.pt-BR.json
+++ b/locales/messages.pt-BR.json
@@ -1180,7 +1180,7 @@
   "WhileParsingVersionsForPort": "ao analisar versões para {package_name} de {path}",
   "WhileRunningAssetCacheScriptCommandLine": "ao executar a linha de comando do script do cache de ativos",
   "WhileValidatingVersion": "ao validar a versão: {version}",
-  "WindowsEnvMustAlwaysBePresent": "Expected {env_var} to be always set on Windows.",
+  "WindowsEnvMustAlwaysBePresent": "Espera-se que {env_var} sempre seja definido no Windows.",
   "WindowsOnlyCommand": "Este comando oferece suporte apenas ao Windows.",
   "WroteNuGetPkgConfInfo": "Escreveu as informações de configuração do pacote NuGet para {path}",
   "FatalTheRootFolder$CannotBeCreated": "Fatal: não é possível criar a pasta raiz \"${p0}\"",

--- a/locales/messages.ru.json
+++ b/locales/messages.ru.json
@@ -1180,7 +1180,7 @@
   "WhileParsingVersionsForPort": "при анализе версий для {package_name} из {path}",
   "WhileRunningAssetCacheScriptCommandLine": "при выполнении командной строки сценария кэша ресурсов",
   "WhileValidatingVersion": "при проверке версии: {version}",
-  "WindowsEnvMustAlwaysBePresent": "Expected {env_var} to be always set on Windows.",
+  "WindowsEnvMustAlwaysBePresent": "Ожидалось, что {env_var} всегда будет настроено в Windows.",
   "WindowsOnlyCommand": "Эта команда поддерживает только Windows.",
   "WroteNuGetPkgConfInfo": "Сведения о конфигурации пакета NuGet записаны в {path}",
   "FatalTheRootFolder$CannotBeCreated": "Неустранимая ошибка: не удается создать корневую папку \"${p0}\"",

--- a/locales/messages.tr.json
+++ b/locales/messages.tr.json
@@ -1180,7 +1180,7 @@
   "WhileParsingVersionsForPort": "{path} öğesinden {package_name} için sürümler ayrıştırılırken",
   "WhileRunningAssetCacheScriptCommandLine": "varlık önbelleği betiği komut satırı çalıştırılırken",
   "WhileValidatingVersion": "sürüm doğrulanırken: {version}",
-  "WindowsEnvMustAlwaysBePresent": "Expected {env_var} to be always set on Windows.",
+  "WindowsEnvMustAlwaysBePresent": "{env_var} ortam değişkeninin her zaman Windows'ta ayarlanması bekleniyor.",
   "WindowsOnlyCommand": "Bu komut yalnızca Windows'u destekler.",
   "WroteNuGetPkgConfInfo": "NuGet paketi yapılandırma bilgilerini {path} öğesine yazdı",
   "FatalTheRootFolder$CannotBeCreated": "Önemli: '${p0}' kök klasörü oluşturulamıyor",

--- a/locales/messages.zh-Hans.json
+++ b/locales/messages.zh-Hans.json
@@ -1180,7 +1180,7 @@
   "WhileParsingVersionsForPort": "分析来自 {path} 的 {package_name} 版本时",
   "WhileRunningAssetCacheScriptCommandLine": "运行资产缓存脚本命令行时",
   "WhileValidatingVersion": "验证版本: {version} 时",
-  "WindowsEnvMustAlwaysBePresent": "Expected {env_var} to be always set on Windows.",
+  "WindowsEnvMustAlwaysBePresent": "应始终在 Windows 上设置 {env_var}。",
   "WindowsOnlyCommand": "此命令仅支持 Windows。",
   "WroteNuGetPkgConfInfo": "已将 NuGet 包配置信息写入 {path}",
   "FatalTheRootFolder$CannotBeCreated": "严重: 无法创建根文件夹“${p0}”",

--- a/locales/messages.zh-Hant.json
+++ b/locales/messages.zh-Hant.json
@@ -1180,7 +1180,7 @@
   "WhileParsingVersionsForPort": "當剖析來自 {path} 的 {package_name} 版本時",
   "WhileRunningAssetCacheScriptCommandLine": "執行資產快取腳本命令行時",
   "WhileValidatingVersion": "驗證版本時: {version}",
-  "WindowsEnvMustAlwaysBePresent": "Expected {env_var} to be always set on Windows.",
+  "WindowsEnvMustAlwaysBePresent": "應一律在 Windows 上設定 {env_var}。",
   "WindowsOnlyCommand": "這個命令只支援 Windows。",
   "WroteNuGetPkgConfInfo": "已將 NuGet 套件設定資訊寫入 {path}。",
   "FatalTheRootFolder$CannotBeCreated": "嚴重: 無法建立根資料夾 '${p0}'",


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.