### PR TITLE
Update binarycaching.cpp to workaround change in azure devops response

### DIFF
--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -684,7 +684,8 @@ namespace
                                          msg::vendor = "NuGet",
                                          msg::url = docs::troubleshoot_binary_cache_url);
                     }
-                    else if (res.output.find("for example \"-ApiKey AzureDevOps\"") != std::string::npos)
+                    else if (res.output.find("for example \"-ApiKey AzureDevOps\"") != std::string::npos ||
+                             res.output.find("for example \"-ApiKey **api-key-removed**\"") != std::string::npos)
                     {
                         auto real_cmd = cmd;
                         real_cmd.string_arg("-ApiKey").string_arg("AzureDevOps");


### PR DESCRIPTION
Upfront:
- win11 64bit/32bit
- cmake 4.0.2
- vcpkg with cmake integration

When I start cmake for my project it first starts to check the vcpkg-configuration, download and build whats needed. For each dependent package it creates a nuget package, which is uploaded to _cache_ in azure devops. Recently that upload didn't work anymore. After some deep dive it turned out that the azure devops returns a different string in _bad request_ response.
Previously it contained the string `for example "-ApiKey AzureDevOps". It has changed to `for example "-ApiKey **api-key-removed**".

Checking the source of vcpkg.exe revealed a place in binarycaching.cpp that has a _workaround_ to play nicely with azure devops. The PR extends the corresponding part in binarycaching.cpp.

Note, I am not an expert for vcpkg or azure devops. There are possible other options to fix that.