### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 15684: Build ID 12078116

### DIFF
--- a/locales/messages.cs.json
+++ b/locales/messages.cs.json
@@ -113,7 +113,6 @@
   "AppliedUserIntegration": "Pro tento kořen vcpkg byla použita integrace na úrovni uživatele.",
   "ApplocalProcessing": "nasazování závislostí",
   "ArtifactsBootstrapFailed": "vcpkg-artifacts není nainstalovaný a nelze jej spustit.",
-  "ArtifactsNotInstalledReadonlyRoot": "vcpkg-artifacts není nainstalovaný a nedá se nainstalovat, protože se předpokládá, že VCPKG_ROOT je jen pro čtení. Tento problém můžete vyřešit přeinstalací balíčku vcpkg pomocí one-lineru.",
   "ArtifactsOptionIncompatibility": "--{option} nemá žádný vliv na artefakt hledání.",
   "ArtifactsOptionJson": "Úplná cesta k souboru JSON, kde se zaznamenávají proměnné prostředí a další vlastnosti",
   "ArtifactsOptionMSBuildProps": "Úplná cesta k souboru, do kterého se zapíší vlastnosti nástroje MSBuild.",

--- a/locales/messages.de.json
+++ b/locales/messages.de.json
@@ -113,7 +113,6 @@
   "AppliedUserIntegration": "Die benutzerweite Integration für diesen vcpkg-Stamm wurde angewendet.",
   "ApplocalProcessing": "Bereitstellen von Abhängigkeiten",
   "ArtifactsBootstrapFailed": "vcpkg-artifacts ist nicht installiert und konnte nicht mit dem Bootstrapping ausgeführt werden.",
-  "ArtifactsNotInstalledReadonlyRoot": "vcpkg-artifacts ist nicht installiert und kann nicht installiert werden, da VCPKG_ROOT als schreibgeschützt angenommen wird. Dieses Problem kann möglicherweise durch erneutes Installieren von vcpkg mithilfe des One Liners behoben werden.",
   "ArtifactsOptionIncompatibility": "--{option} hat keine Auswirkungen auf \"Artefakt suchen\".",
   "ArtifactsOptionJson": "Vollständiger Pfad zur JSON-Datei, in der Umgebungsvariablen und andere Eigenschaften aufgezeichnet werden.",
   "ArtifactsOptionMSBuildProps": "Vollständiger Pfad zu der Datei, in die MSBuild-Eigenschaften geschrieben werden",

--- a/locales/messages.es.json
+++ b/locales/messages.es.json
@@ -113,7 +113,6 @@
   "AppliedUserIntegration": "Integración aplicada en todo el usuario para esta raíz vcpkg.",
   "ApplocalProcessing": "implementar dependencias",
   "ArtifactsBootstrapFailed": "vcpkg-artifacts no está instalado y no se pudo arrancar.",
-  "ArtifactsNotInstalledReadonlyRoot": "vcpkg-artifacts no está instalado y no se puede instalar porque se supone que VCPKG_ROOT es de solo lectura. La reinstalación de vcpkg mediante el \"un liner\" puede solucionar este problema.",
   "ArtifactsOptionIncompatibility": "--{option} no tiene ningún efecto en la búsqueda de artefactos.",
   "ArtifactsOptionJson": "Ruta de acceso completa al archivo JSON donde se registran las variables de entorno y otras propiedades",
   "ArtifactsOptionMSBuildProps": "Ruta de acceso completa al archivo en el que se escribirán las propiedades de MSBuild",

--- a/locales/messages.fr.json
+++ b/locales/messages.fr.json
@@ -113,7 +113,6 @@
   "AppliedUserIntegration": "Intégration à l’échelle de l’utilisateur appliquée pour cette racine vcpkg.",
   "ApplocalProcessing": "déploiement de dépendances",
   "ArtifactsBootstrapFailed": "vcpkg-artifacts n’est pas installé et n’a pas pu être lancé.",
-  "ArtifactsNotInstalledReadonlyRoot": "vcpkg-artifacts n’est pas installé et ne peut pas être installé, car VCPKG_ROOT est supposé être en lecture seule. La réinstallation de vcpkg à l’aide du « one-pack » peut résoudre ce problème.",
   "ArtifactsOptionIncompatibility": "--{option} n’a aucun effet sur la recherche d’artefact.",
   "ArtifactsOptionJson": "Chemin d’accès complet au fichier JSON où les variables d’environnement et d’autres propriétés sont enregistrées",
   "ArtifactsOptionMSBuildProps": "Chemin d’accès complet au fichier, dans lequel les propriétés MSBuild seront écrites",

--- a/locales/messages.it.json
+++ b/locales/messages.it.json
@@ -113,7 +113,6 @@
   "AppliedUserIntegration": "Integrazione a livello di utente applicata per questa radice vcpkg.",
   "ApplocalProcessing": "distribuzione delle dipendenze",
   "ArtifactsBootstrapFailed": "Vcpkg-artifacts non è installato e non ne è stato possibile eseguire il bootstrap.",
-  "ArtifactsNotInstalledReadonlyRoot": "vcpkg-artifacts non è installato e non può essere installato perché si presuppone che VCPKG_ROOT sia di sola lettura. La reinstallazione di vcpkg con 'one liner' potrebbe risolvere il problema.",
   "ArtifactsOptionIncompatibility": "--{option} non ha alcun effetto sulla ricerca dell'artefatto.",
   "ArtifactsOptionJson": "Percorso completo del file JSON in cui vengono registrate le variabili di ambiente e altre proprietà",
   "ArtifactsOptionMSBuildProps": "Percorso completo del file in cui verranno scritte le proprietà di MSBuild",

--- a/locales/messages.ja.json
+++ b/locales/messages.ja.json
@@ -113,7 +113,6 @@
   "AppliedUserIntegration": "この vcpkg ルートにユーザー全体の統合を適用しました。",
   "ApplocalProcessing": "依存関係を配置しています",
   "ArtifactsBootstrapFailed": "vckpg-artifacts がインストールされておらず、ブートストラップできませんでした。",
-  "ArtifactsNotInstalledReadonlyRoot": "vcpkg-artifacts がインストールされておらず、VCPKG_ROOT が読み取り専用と見なされているためインストールできません。'one liner' を使用して vcpkg を再インストールすればこの問題を解決できる可能性があります。",
   "ArtifactsOptionIncompatibility": "--{option} は成果物の検索には影響しません。",
   "ArtifactsOptionJson": "環境変数とその他のプロパティが記録される JSON ファイルへの完全パス",
   "ArtifactsOptionMSBuildProps": "MSBuild プロパティが書き込まれるファイルへの完全なパス",

--- a/locales/messages.ko.json
+++ b/locales/messages.ko.json
@@ -113,7 +113,6 @@
   "AppliedUserIntegration": "이 vcpkg 루트에 대한 사용자 차원의 통합을 적용했습니다.",
   "ApplocalProcessing": "종속성을 배포하는 중",
   "ArtifactsBootstrapFailed": "vcpkg-artifacts가 설치되어 있지 않으며 부트스트랩할 수 없습니다.",
-  "ArtifactsNotInstalledReadonlyRoot": "vcpkg-artifacts가 설치되어 있지 않으며, VCPKG_ROOT가 읽기 전용으로 간주되어 vcpkg-artifacts를 설치할 수 없습니다. 'one liner'를 사용하여 vcpkg를 다시 설치하여 이 문제를 해결할 수 있습니다.",
   "ArtifactsOptionIncompatibility": "--{option}은(는) 아티팩트 찾기에 영향을 주지 않습니다.",
   "ArtifactsOptionJson": "환경 변수 및 기타 속성이 기록되는 JSON 파일의 전체 경로",
   "ArtifactsOptionMSBuildProps": "MSBuild 속성이 기록될 파일의 전체 경로",

--- a/locales/messages.pl.json
+++ b/locales/messages.pl.json
@@ -113,7 +113,6 @@
   "AppliedUserIntegration": "Zastosowano integrację na poziomie użytkownika dla tego katalogu głównego menedżera vcpkg.",
   "ApplocalProcessing": "wdrażanie zależności",
   "ArtifactsBootstrapFailed": "Element vcpkg-artifacts nie jest zainstalowany i nie można go uruchomić.",
-  "ArtifactsNotInstalledReadonlyRoot": "Element vcpkg-artifacts nie jest zainstalowany i nie można go zainstalować, ponieważ zakłada się, że VCPKG_ROOT jest tylko do odczytu. Ponowne zainstalowanie programu vcpkg przy użyciu polecenia „one liner” może rozwiązać ten problem.",
   "ArtifactsOptionIncompatibility": "Opcja --{option} nie ma wpływu na znajdowanie artefaktu.",
   "ArtifactsOptionJson": "Pełna ścieżka do pliku JSON, w którym są rejestrowane zmienne środowiskowe i inne właściwości",
   "ArtifactsOptionMSBuildProps": "Pełna ścieżka do pliku, w którym zostaną zapisane właściwości programu MSBuild",

--- a/locales/messages.pt-BR.json
+++ b/locales/messages.pt-BR.json
@@ -113,7 +113,6 @@
   "AppliedUserIntegration": "Integração aplicada para todo o usuário para esta raiz vcpkg.",
   "ApplocalProcessing": "implantando dependências",
   "ArtifactsBootstrapFailed": "vcpkg-artifacts não está instalado e não pôde ser inicializado.",
-  "ArtifactsNotInstalledReadonlyRoot": "vcpkg-artifacts não está instalado e não pode ser instalado porque VCPKG_ROOT é considerado somente leitura. A reinstalação do vcpkg usando o 'one liner' pode corrigir esse problema.",
   "ArtifactsOptionIncompatibility": "--{option} não tem efeito em localizar artefato.",
   "ArtifactsOptionJson": "Caminho completo para o arquivo JSON no qual as variáveis de ambiente e outras propriedades são registradas",
   "ArtifactsOptionMSBuildProps": "Caminho completo para o arquivo no qual as propriedades do MSBuild serão gravadas.",

--- a/locales/messages.ru.json
+++ b/locales/messages.ru.json
@@ -113,7 +113,6 @@
   "AppliedUserIntegration": "Применена общепользовательская интеграция для этого корня vcpkg.",
   "ApplocalProcessing": "развертывание зависимостей",
   "ArtifactsBootstrapFailed": "vcpkg-артефакты не установлены и не могут использоваться для начальной загрузки.",
-  "ArtifactsNotInstalledReadonlyRoot": "vcpkg-артефакты не установлены, и их невозможно установить, так как предполагается, что VCPKG_ROOT доступен только для чтения. Переустановка vcpkg с помощью \"one liner\" может устранить эту проблему.",
   "ArtifactsOptionIncompatibility": "--{option} не влияет на поиск артефакта.",
   "ArtifactsOptionJson": "Полный путь к файлу JSON, в котором записаны переменные среды и другие свойства",
   "ArtifactsOptionMSBuildProps": "Полный путь к файлу, в который будут записаны свойства MSBuild",

--- a/locales/messages.tr.json
+++ b/locales/messages.tr.json
@@ -113,7 +113,6 @@
   "AppliedUserIntegration": "Bu vcpkg kökü için kullanıcı genelinde tümleştirme uygulandı.",
   "ApplocalProcessing": "bağımlılıkları dağıtılıyor",
   "ArtifactsBootstrapFailed": "Vcpkg yapıtları yüklü değil ve önyükleme yapılamadı.",
-  "ArtifactsNotInstalledReadonlyRoot": "Vcpkg yapıtları yüklü değil ve VCPKG_ROOT salt okunur varsayıldığından yüklenemiyor. Vcpkg paket yöneticisinin 'tek satırlık' kod kullanılarak yeniden yüklenmesi bu sorunu çözebilir.",
   "ArtifactsOptionIncompatibility": "--{option}, yapıtı bulma üzerinde hiçbir etkiye sahip değildir.",
   "ArtifactsOptionJson": "Ortam değişkenlerinin ve diğer özelliklerin kaydedildiği JSON dosyasının tam yolu",
   "ArtifactsOptionMSBuildProps": "MSBuild özelliklerinin yazılacağı dosyanın tam yolu",

--- a/locales/messages.zh-Hans.json
+++ b/locales/messages.zh-Hans.json
@@ -113,7 +113,6 @@
   "AppliedUserIntegration": "已为此 vcpkg 根应用用户范围的集成。",
   "ApplocalProcessing": "正在部署依赖项",
   "ArtifactsBootstrapFailed": "vcpkg-artifacts 未安装，无法启动。",
-  "ArtifactsNotInstalledReadonlyRoot": "未安装 vcpkg-artifacts，也无法安装，因为假定 VCPKG_ROOT 是只读的。使用“一行代码”重新安装 vcpkg 可能会解决此问题。",
   "ArtifactsOptionIncompatibility": "--{option} 对查找项目没有影响。",
   "ArtifactsOptionJson": "记录环境变量和其他属性的 JSON 文件的完整路径",
   "ArtifactsOptionMSBuildProps": "将写入 MSBuild 属性的文件的完整路径",

--- a/locales/messages.zh-Hant.json
+++ b/locales/messages.zh-Hant.json
@@ -113,7 +113,6 @@
   "AppliedUserIntegration": "已為此 vcpkg 根目錄套用整個使用者整合。",
   "ApplocalProcessing": "部署相依性",
   "ArtifactsBootstrapFailed": "未安裝 vcpkg-artifacts，因此無法啟動載入。",
-  "ArtifactsNotInstalledReadonlyRoot": "未安裝 vcpkg-artifacts，而且無法安裝，因為 VCPKG_ROOT 假設為唯讀。使用 'one liner' 重新安裝 vcpkg 可能可以修正此問題。",
   "ArtifactsOptionIncompatibility": "--{option} 對尋找成品不會影響。",
   "ArtifactsOptionJson": "記錄環境變數和其他屬性之 JSON 檔案的完整路徑",
   "ArtifactsOptionMSBuildProps": "將寫入 MSBuild 屬性之檔案的完整路徑",


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.