### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 15684: Build ID 12087130

### DIFF
--- a/locales/messages.cs.json
+++ b/locales/messages.cs.json
@@ -221,7 +221,7 @@
   "CiBaselineIndependentRegression": "REGRESE: Nezávislá specifikace {spec} selhala s {build_result}.",
   "CiBaselineRegression": "REGRESE: Akce {spec} selhala s výsledkem: {build_result}. Pokud se to očekávalo, přidejte {spec}=fail do cesty {path}.",
   "CiBaselineRegressionHeader": "REGRESE:",
-  "CiBaselineRegressionNoPath": "REGRESSION: {spec} failed with {build_result}.",
+  "CiBaselineRegressionNoPath": "REGRESE: Akce {spec} selhala s výsledkem: {build_result}.",
   "CiBaselineUnexpectedFail": "REGRESSION: {spec} je označen jako neúspěšný, ale pro {triplet} se nepodporuje.",
   "CiBaselineUnexpectedFailCascade": "REGRESE: {spec} je označena jako neúspěšná, ale jedna závislost se pro {triplet} nepodporuje.",
   "CiBaselineUnexpectedPass": "PŘEDÁVÁNÍ, ODEBRAT ZE SEZNAMU SELHÁNÍ: {spec} ({path}).",

--- a/locales/messages.de.json
+++ b/locales/messages.de.json
@@ -221,7 +221,7 @@
   "CiBaselineIndependentRegression": "REGRESSION: Fehler bei unabhängigem {spec} mit {build_result}.",
   "CiBaselineRegression": "REGRESSION: {spec} ist mit {build_result} fehlgeschlagen. Falls erwartet, fügen Sie {spec}=fail zu {path} hinzu.",
   "CiBaselineRegressionHeader": "REGRESSIONEN:",
-  "CiBaselineRegressionNoPath": "REGRESSION: {spec} failed with {build_result}.",
+  "CiBaselineRegressionNoPath": "REGRESSION: Fehler bei {spec} mit {build_result}.",
   "CiBaselineUnexpectedFail": "REGRESSION: {spec} ist als Fehler markiert, wird aber für {triplet} nicht unterstützt.",
   "CiBaselineUnexpectedFailCascade": "REGRESSION: {spec} ist als Fehler markiert, aber eine Abhängigkeit wird für {triplet} nicht unterstützt.",
   "CiBaselineUnexpectedPass": "BESTANDEN, VON DER FEHLERLISTE ENTFERNEN: {spec} ({Pfad}).",

--- a/locales/messages.es.json
+++ b/locales/messages.es.json
@@ -221,7 +221,7 @@
   "CiBaselineIndependentRegression": "REGRESIÓN: error de {spec} independiente con {build_result}.",
   "CiBaselineRegression": "REGRESSION: error de {spec} con {build_result}. Si estaba previsto, añada {spec}=fail a {path}.",
   "CiBaselineRegressionHeader": "REGRESIONES:",
-  "CiBaselineRegressionNoPath": "REGRESSION: {spec} failed with {build_result}.",
+  "CiBaselineRegressionNoPath": "REGRESIÓN: error de {spec} con {build_result}.",
   "CiBaselineUnexpectedFail": "REGRESIÓN: {spec} está marcado como error, pero no se admite para {triplet}.",
   "CiBaselineUnexpectedFailCascade": "REGRESIÓN: {spec} está marcado como error, pero no se admite una dependencia para {triplet}.",
   "CiBaselineUnexpectedPass": "PASANDO, QUITAR DE LA LISTA DE ERRORES: {spec} ({path}).",

--- a/locales/messages.fr.json
+++ b/locales/messages.fr.json
@@ -221,7 +221,7 @@
   "CiBaselineIndependentRegression": "RÉGRESSION : échec de la {spec} indépendante avec {build_result}.",
   "CiBaselineRegression": "RÉGRESSION : {spec} a échoué avec {build_result}. Si prévu, ajoutez {spec}=échec de la {path}.",
   "CiBaselineRegressionHeader": "RÉGRESSIONS :",
-  "CiBaselineRegressionNoPath": "REGRESSION: {spec} failed with {build_result}.",
+  "CiBaselineRegressionNoPath": "RÉGRESSION : {spec} a échoué avec {build_result}.",
   "CiBaselineUnexpectedFail": "RÉGRESSION : {spec} est marqué comme échec mais n’est pas pris en charge pour {triplet}.",
   "CiBaselineUnexpectedFailCascade": "REGRESSION : {spec} est marqué comme échec, mais une dépendance n’est pas prise en charge pour {triplet}.",
   "CiBaselineUnexpectedPass": "RÉUSSITE, SUPPRESSION DE LA LISTE D’ÉCHEC : {spec} ({path}).",

--- a/locales/messages.ja.json
+++ b/locales/messages.ja.json
@@ -221,7 +221,7 @@
   "CiBaselineIndependentRegression": "回帰: 独立した {spec} が {build_result} で失敗しました。",
   "CiBaselineRegression": "回帰: {spec} は {build_result} で失敗しました。必要な場合は、{spec}=fail を {path} に追加します。",
   "CiBaselineRegressionHeader": "回帰:",
-  "CiBaselineRegressionNoPath": "REGRESSION: {spec} failed with {build_result}.",
+  "CiBaselineRegressionNoPath": "回帰: {spec} は {build_result} で失敗しました。",
   "CiBaselineUnexpectedFail": "回帰: {spec} は失敗とマークされていますが、{triplet} ではサポートされていません。",
   "CiBaselineUnexpectedFailCascade": "回帰: {spec} は失敗とマークされていますが、1 つの依存関係が {triplet} ではサポートされていません。",
   "CiBaselineUnexpectedPass": "成功、失敗リストから削除: {spec} ({path})。",

--- a/locales/messages.ko.json
+++ b/locales/messages.ko.json
@@ -221,7 +221,7 @@
   "CiBaselineIndependentRegression": "회귀: {build_result}(으)로 독립 {spec}이(가) 실패했습니다.",
   "CiBaselineRegression": "회귀: {spec}이(가) {build_result}(으)로 실패했습니다. 필요한 경우 {spec}=fail를 {path}에 추가합니다.",
   "CiBaselineRegressionHeader": "회귀:",
-  "CiBaselineRegressionNoPath": "REGRESSION: {spec} failed with {build_result}.",
+  "CiBaselineRegressionNoPath": "회귀: {spec}이(가) {build_result}(으)로 실패했습니다.",
   "CiBaselineUnexpectedFail": "회귀: {spec}이(가) 실패로 표시되었지만 {triplet}에는 지원되지 않습니다.",
   "CiBaselineUnexpectedFailCascade": "회귀: {spec}이(가) 실패로 표시되었지만 {triplet}에 대해 하나의 종속성이 지원되지 않습니다.",
   "CiBaselineUnexpectedPass": "통과, FAIL LIST에서 제거: {spec}({path}).",

--- a/locales/messages.pt-BR.json
+++ b/locales/messages.pt-BR.json
@@ -221,7 +221,7 @@
   "CiBaselineIndependentRegression": "REGRESSÃO: {spec} independente falhou com {build_result}.",
   "CiBaselineRegression": "REGRESSÃO: {spec} falhou com {build_result}. Se esperado, adicione {spec}=falha ao {path}.",
   "CiBaselineRegressionHeader": "REGRESSÕES:",
-  "CiBaselineRegressionNoPath": "REGRESSION: {spec} failed with {build_result}.",
+  "CiBaselineRegressionNoPath": "REGRESSÃO: {spec} falhou com {build_result}.",
   "CiBaselineUnexpectedFail": "REGRESSÃO: {spec} está marcada como falha, mas não tem suporte para {triplet}.",
   "CiBaselineUnexpectedFailCascade": "REGRESSÃO: {spec} está marcada como falha, mas uma dependência não possui suporte para {triplet}.",
   "CiBaselineUnexpectedPass": "PASSANDO, REMOVER DA LISTA DE FALHA: {spec} ({path}).",

--- a/locales/messages.ru.json
+++ b/locales/messages.ru.json
@@ -221,7 +221,7 @@
   "CiBaselineIndependentRegression": "РЕГРЕССИЯ: сбой независимого объекта {spec} с {build_result}.",
   "CiBaselineRegression": "РЕГРЕССИЯ: {spec} с ошибкой {build_result}. Если требуется, добавьте {spec}=fail в {path}.",
   "CiBaselineRegressionHeader": "РЕГРЕССИИ:",
-  "CiBaselineRegressionNoPath": "REGRESSION: {spec} failed with {build_result}.",
+  "CiBaselineRegressionNoPath": "РЕГРЕССИЯ: сбой {spec} с {build_result}.",
   "CiBaselineUnexpectedFail": "РЕГРЕССИЯ: {spec} помечен как сбой, но не поддерживается для {triplet}.",
   "CiBaselineUnexpectedFailCascade": "РЕГРЕССИЯ: {spec} помечен как сбой, но одна зависимость не поддерживается для {triplet}.",
   "CiBaselineUnexpectedPass": "ПЕРЕДАЧА, УДАЛЕНИЕ ИЗ СПИСКА СБОЕВ: {spec} ({path}).",

--- a/locales/messages.tr.json
+++ b/locales/messages.tr.json
@@ -221,7 +221,7 @@
   "CiBaselineIndependentRegression": "REGRESSION: Bağımsız {spec}, {build_result} ile başarısız oldu.",
   "CiBaselineRegression": "GERİLEME: {spec}, {build_result} ile başarısız oldu. Bekleniyorsa, {spec}=fail öğesini {path} yoluna ekleyin.",
   "CiBaselineRegressionHeader": "GERİLEMELER:",
-  "CiBaselineRegressionNoPath": "REGRESSION: {spec} failed with {build_result}.",
+  "CiBaselineRegressionNoPath": "REGRESYON: {spec} {build_result} ile başarısız oldu.",
   "CiBaselineUnexpectedFail": "REGRESYON: {spec} başarısız olarak işaretlenmiş ancak {triplet} için desteklenmiyor.",
   "CiBaselineUnexpectedFailCascade": "REGRESYON: {spec} başarısız olarak işaretlenmiş ancak bir bağımlılık {triplet} için desteklenmiyor.",
   "CiBaselineUnexpectedPass": "GEÇİRİLİYOR, HATA LİSTESİNDEN KALDIR: {spec} ({path}).",

--- a/locales/messages.zh-Hant.json
+++ b/locales/messages.zh-Hant.json
@@ -221,7 +221,7 @@
   "CiBaselineIndependentRegression": "迴歸: 獨立 {spec} 失敗，發生 {build_result}。",
   "CiBaselineRegression": "迴歸: {spec} 失敗，{build_result}。如果預期，將 {spec}=fail 新增到 {path}。",
   "CiBaselineRegressionHeader": "迴歸:",
-  "CiBaselineRegressionNoPath": "REGRESSION: {spec} failed with {build_result}.",
+  "CiBaselineRegressionNoPath": "建置: {spec} 失敗，原因: {build_result}。",
   "CiBaselineUnexpectedFail": "迴歸: {spec} 標示為失敗，但 {triplet} 不支援。",
   "CiBaselineUnexpectedFailCascade": "迴歸: {spec} 標示為失敗，但 {triplet} 不支援一個相依性。",
   "CiBaselineUnexpectedPass": "通過，從失敗清單移除: {spec} ({path})。",


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.