### PR TITLE
[spdx] Add installed package files to SPDX SBOM file

### DIFF
--- a/include/vcpkg/base/contractual-constants.h
+++ b/include/vcpkg/base/contractual-constants.h
@@ -578,6 +578,7 @@ namespace vcpkg
     inline constexpr StringLiteral AbiTagPostBuildChecks = "post_build_checks";
     inline constexpr StringLiteral AbiTagPowershell = "powershell";
     inline constexpr StringLiteral AbiTagPublicAbiOverride = "public_abi_override";
+    inline constexpr StringLiteral AbiTagSbomInfo = "sbom_info";
 
     inline constexpr StringLiteral StatusDeinstall = "deinstall";
     inline constexpr StringLiteral StatusError = "error";

--- a/include/vcpkg/base/contractual-constants.h
+++ b/include/vcpkg/base/contractual-constants.h
@@ -125,7 +125,6 @@ namespace vcpkg
     // would use in other contexts.
     inline constexpr StringLiteral SpdxCCZero = "CC0-1.0";
     inline constexpr StringLiteral SpdxChecksumValue = "checksumValue";
-    inline constexpr StringLiteral SpdxContainedBy = "CONTAINED_BY";
     inline constexpr StringLiteral SpdxContains = "CONTAINS";
     inline constexpr StringLiteral SpdxCopyrightText = "copyrightText";
     inline constexpr StringLiteral SpdxCreationInfo = "creationInfo";
@@ -135,7 +134,6 @@ namespace vcpkg
     inline constexpr StringLiteral SpdxDownloadLocation = "downloadLocation";
     inline constexpr StringLiteral SpdxElementId = "spdxElementId";
     inline constexpr StringLiteral SpdxFileName = "fileName";
-    inline constexpr StringLiteral SpdxGeneratedFrom = "GENERATED_FROM";
     inline constexpr StringLiteral SpdxGenerates = "GENERATES";
     inline constexpr StringLiteral SpdxLicenseConcluded = "licenseConcluded";
     inline constexpr StringLiteral SpdxLicenseDeclared = "licenseDeclared";

--- a/include/vcpkg/spdx.h
+++ b/include/vcpkg/spdx.h
@@ -22,6 +22,8 @@ namespace vcpkg
     /// @param action Install action to be represented by this manifest
     /// @param relative_paths Must contain relative paths of all files in the port directory (from the port directory)
     /// @param hashes Must contain ordered hashes of `relative_paths`
+    /// @param relative_package_files Must contain relative paths of all files in the package directory
+    /// @param package_hashes Must contain ordered hashes of `relative_package_files`
     /// @param created_time SPDX creation time in YYYY-MM-DDThh:mm:ssZ format
     /// @param document_namespace Universally unique URI representing this SPDX document. See
     /// https://spdx.github.io/spdx-spec/document-creation-information/#65-spdx-document-namespace-field
@@ -30,6 +32,8 @@ namespace vcpkg
     std::string create_spdx_sbom(const InstallPlanAction& action,
                                  View<Path> relative_paths,
                                  View<std::string> hashes,
+                                 View<Path> relative_package_files,
+                                 View<std::string> package_hashes,
                                  std::string created_time,
                                  std::string document_namespace,
                                  std::vector<Json::Object>&& resource_docs);

--- a/src/vcpkg-test/spdx.cpp
+++ b/src/vcpkg-test/spdx.cpp
@@ -381,6 +381,8 @@ TEST_CASE ("spdx maximum serialization", "[spdx]")
         create_spdx_sbom(ipa,
                          std::vector<Path>{"vcpkg.json", "portfile.cmake", "patches/patch1.diff"},
                          std::vector<std::string>{"vcpkg.json-hash", "portfile.cmake-hash", "patch1.diff-hash"},
+                         std::vector<Path>{"include/zlib.h", "lib/zlib.lib"},
+                         std::vector<std::string>{"zlib-header-hash", "zlib-lib-hash"},
                          "now",
                          "https://test-document-namespace",
                          {});
@@ -408,42 +410,32 @@ TEST_CASE ("spdx maximum serialization", "[spdx]")
     {
       "spdxElementId": "SPDXRef-port",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-file-0"
+      "relatedSpdxElement": "SPDXRef-port-file-0"
     },
     {
-      "spdxElementId": "SPDXRef-port",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-file-1"
-    },
-    {
-      "spdxElementId": "SPDXRef-port",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-file-2"
-    },
-    {
-      "spdxElementId": "SPDXRef-binary",
-      "relationshipType": "GENERATED_FROM",
-      "relatedSpdxElement": "SPDXRef-port"
-    },
-    {
-      "spdxElementId": "SPDXRef-file-0",
-      "relationshipType": "CONTAINED_BY",
-      "relatedSpdxElement": "SPDXRef-port"
-    },
-    {
-      "spdxElementId": "SPDXRef-file-0",
+      "spdxElementId": "SPDXRef-port-file-0",
       "relationshipType": "DEPENDENCY_MANIFEST_OF",
       "relatedSpdxElement": "SPDXRef-port"
     },
     {
-      "spdxElementId": "SPDXRef-file-1",
-      "relationshipType": "CONTAINED_BY",
-      "relatedSpdxElement": "SPDXRef-port"
+      "spdxElementId": "SPDXRef-port",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-port-file-1"
     },
     {
-      "spdxElementId": "SPDXRef-file-2",
-      "relationshipType": "CONTAINED_BY",
-      "relatedSpdxElement": "SPDXRef-port"
+      "spdxElementId": "SPDXRef-port",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-port-file-2"
+    },
+    {
+      "spdxElementId": "SPDXRef-binary",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-binary-file-0"
+    },
+    {
+      "spdxElementId": "SPDXRef-binary",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-binary-file-1"
     }
   ],
   "packages": [
@@ -474,7 +466,7 @@ TEST_CASE ("spdx maximum serialization", "[spdx]")
   "files": [
     {
       "fileName": "./vcpkg.json",
-      "SPDXID": "SPDXRef-file-0",
+      "SPDXID": "SPDXRef-port-file-0",
       "checksums": [
         {
           "algorithm": "SHA256",
@@ -486,7 +478,7 @@ TEST_CASE ("spdx maximum serialization", "[spdx]")
     },
     {
       "fileName": "./portfile.cmake",
-      "SPDXID": "SPDXRef-file-1",
+      "SPDXID": "SPDXRef-port-file-1",
       "checksums": [
         {
           "algorithm": "SHA256",
@@ -498,11 +490,35 @@ TEST_CASE ("spdx maximum serialization", "[spdx]")
     },
     {
       "fileName": "./patches/patch1.diff",
-      "SPDXID": "SPDXRef-file-2",
+      "SPDXID": "SPDXRef-port-file-2",
       "checksums": [
         {
           "algorithm": "SHA256",
           "checksumValue": "patch1.diff-hash"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./include/zlib.h",
+      "SPDXID": "SPDXRef-binary-file-0",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "zlib-header-hash"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./lib/zlib.lib",
+      "SPDXID": "SPDXRef-binary-file-1",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "zlib-lib-hash"
         }
       ],
       "licenseConcluded": "NOASSERTION",
@@ -537,6 +553,8 @@ TEST_CASE ("spdx minimum serialization", "[spdx]")
     const auto sbom = create_spdx_sbom(ipa,
                                        std::vector<Path>{"vcpkg.json", "portfile.cmake"},
                                        std::vector<std::string>{"hash-vcpkg.json", "hash-portfile.cmake"},
+                                       {},
+                                       {},
                                        "now+1",
                                        "https://test-document-namespace-2",
                                        {});
@@ -564,32 +582,17 @@ TEST_CASE ("spdx minimum serialization", "[spdx]")
     {
       "spdxElementId": "SPDXRef-port",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-file-0"
+      "relatedSpdxElement": "SPDXRef-port-file-0"
     },
     {
-      "spdxElementId": "SPDXRef-port",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-file-1"
-    },
-    {
-      "spdxElementId": "SPDXRef-binary",
-      "relationshipType": "GENERATED_FROM",
-      "relatedSpdxElement": "SPDXRef-port"
-    },
-    {
-      "spdxElementId": "SPDXRef-file-0",
-      "relationshipType": "CONTAINED_BY",
-      "relatedSpdxElement": "SPDXRef-port"
-    },
-    {
-      "spdxElementId": "SPDXRef-file-0",
+      "spdxElementId": "SPDXRef-port-file-0",
       "relationshipType": "DEPENDENCY_MANIFEST_OF",
       "relatedSpdxElement": "SPDXRef-port"
     },
     {
-      "spdxElementId": "SPDXRef-file-1",
-      "relationshipType": "CONTAINED_BY",
-      "relatedSpdxElement": "SPDXRef-port"
+      "spdxElementId": "SPDXRef-port",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-port-file-1"
     }
   ],
   "packages": [
@@ -617,7 +620,7 @@ TEST_CASE ("spdx minimum serialization", "[spdx]")
   "files": [
     {
       "fileName": "./vcpkg.json",
-      "SPDXID": "SPDXRef-file-0",
+      "SPDXID": "SPDXRef-port-file-0",
       "checksums": [
         {
           "algorithm": "SHA256",
@@ -629,7 +632,7 @@ TEST_CASE ("spdx minimum serialization", "[spdx]")
     },
     {
       "fileName": "./portfile.cmake",
-      "SPDXID": "SPDXRef-file-1",
+      "SPDXID": "SPDXRef-port-file-1",
       "checksums": [
         {
           "algorithm": "SHA256",
@@ -681,7 +684,7 @@ TEST_CASE ("spdx concat resources", "[spdx]")
                     .value(VCPKG_LINE_INFO)
                     .value.object(VCPKG_LINE_INFO);
 
-    const auto sbom = create_spdx_sbom(ipa, {}, {}, "now+1", "ns", {std::move(doc1), std::move(doc2)});
+    const auto sbom = create_spdx_sbom(ipa, {}, {}, {}, {}, "now+1", "ns", {std::move(doc1), std::move(doc2)});
 
     auto expected = Json::parse(R"json(
 {
@@ -702,11 +705,6 @@ TEST_CASE ("spdx concat resources", "[spdx]")
       "spdxElementId": "SPDXRef-port",
       "relationshipType": "GENERATES",
       "relatedSpdxElement": "SPDXRef-binary"
-    },
-    {
-      "spdxElementId": "SPDXRef-binary",
-      "relationshipType": "GENERATED_FROM",
-      "relatedSpdxElement": "SPDXRef-port"
     },
     "r1",
     "r2",
@@ -810,7 +808,7 @@ TEST_CASE ("spdx license parse edge cases", "[spdx]")
   "files": [
     {
       "fileName": "./vcpkg.json",
-      "SPDXID": "SPDXRef-file-0",
+      "SPDXID": "SPDXRef-port-file-0",
       "checksums": [
         {
           "algorithm": "SHA256",
@@ -822,7 +820,7 @@ TEST_CASE ("spdx license parse edge cases", "[spdx]")
     },
     {
       "fileName": "./portfile.cmake",
-      "SPDXID": "SPDXRef-file-1",
+      "SPDXID": "SPDXRef-port-file-1",
       "checksums": [
         {
           "algorithm": "SHA256",
@@ -892,7 +890,7 @@ TEST_CASE ("spdx license parse edge cases", "[spdx]")
   "files": [
     {
       "fileName": "./vcpkg.json",
-      "SPDXID": "SPDXRef-file-0",
+      "SPDXID": "SPDXRef-port-file-0",
       "checksums": [
         {
           "algorithm": "SHA256",
@@ -904,7 +902,7 @@ TEST_CASE ("spdx license parse edge cases", "[spdx]")
     },
     {
       "fileName": "./portfile.cmake",
-      "SPDXID": "SPDXRef-file-1",
+      "SPDXID": "SPDXRef-port-file-1",
       "checksums": [
         {
           "algorithm": "SHA256",
@@ -974,7 +972,7 @@ TEST_CASE ("spdx license parse edge cases", "[spdx]")
   "files": [
     {
       "fileName": "./vcpkg.json",
-      "SPDXID": "SPDXRef-file-0",
+      "SPDXID": "SPDXRef-port-file-0",
       "checksums": [
         {
           "algorithm": "SHA256",
@@ -986,7 +984,7 @@ TEST_CASE ("spdx license parse edge cases", "[spdx]")
     },
     {
       "fileName": "./portfile.cmake",
-      "SPDXID": "SPDXRef-file-1",
+      "SPDXID": "SPDXRef-port-file-1",
       "checksums": [
         {
           "algorithm": "SHA256",
@@ -1056,7 +1054,7 @@ TEST_CASE ("spdx license parse edge cases", "[spdx]")
   "files": [
     {
       "fileName": "./vcpkg.json",
-      "SPDXID": "SPDXRef-file-0",
+      "SPDXID": "SPDXRef-port-file-0",
       "checksums": [
         {
           "algorithm": "SHA256",
@@ -1068,7 +1066,7 @@ TEST_CASE ("spdx license parse edge cases", "[spdx]")
     },
     {
       "fileName": "./portfile.cmake",
-      "SPDXID": "SPDXRef-file-1",
+      "SPDXID": "SPDXRef-port-file-1",
       "checksums": [
         {
           "algorithm": "SHA256",
@@ -1147,7 +1145,7 @@ TEST_CASE ("spdx license parse edge cases", "[spdx]")
   "files": [
     {
       "fileName": "./vcpkg.json",
-      "SPDXID": "SPDXRef-file-0",
+      "SPDXID": "SPDXRef-port-file-0",
       "checksums": [
         {
           "algorithm": "SHA256",
@@ -1159,7 +1157,7 @@ TEST_CASE ("spdx license parse edge cases", "[spdx]")
     },
     {
       "fileName": "./portfile.cmake",
-      "SPDXID": "SPDXRef-file-1",
+      "SPDXID": "SPDXRef-port-file-1",
       "checksums": [
         {
           "algorithm": "SHA256",
@@ -1240,7 +1238,7 @@ TEST_CASE ("spdx license parse edge cases", "[spdx]")
   "files": [
     {
       "fileName": "./vcpkg.json",
-      "SPDXID": "SPDXRef-file-0",
+      "SPDXID": "SPDXRef-port-file-0",
       "checksums": [
         {
           "algorithm": "SHA256",
@@ -1252,7 +1250,7 @@ TEST_CASE ("spdx license parse edge cases", "[spdx]")
     },
     {
       "fileName": "./portfile.cmake",
-      "SPDXID": "SPDXRef-file-1",
+      "SPDXID": "SPDXRef-port-file-1",
       "checksums": [
         {
           "algorithm": "SHA256",
@@ -1343,7 +1341,7 @@ TEST_CASE ("spdx license parse edge cases", "[spdx]")
   "files": [
     {
       "fileName": "./vcpkg.json",
-      "SPDXID": "SPDXRef-file-0",
+      "SPDXID": "SPDXRef-port-file-0",
       "checksums": [
         {
           "algorithm": "SHA256",
@@ -1355,7 +1353,7 @@ TEST_CASE ("spdx license parse edge cases", "[spdx]")
     },
     {
       "fileName": "./portfile.cmake",
-      "SPDXID": "SPDXRef-file-1",
+      "SPDXID": "SPDXRef-port-file-1",
       "checksums": [
         {
           "algorithm": "SHA256",

--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -1471,6 +1471,7 @@ namespace vcpkg
 
         abi_tag_entries.emplace_back(AbiTagPortsDotCMake, paths.get_ports_cmake_hash().to_string());
         abi_tag_entries.emplace_back(AbiTagPostBuildChecks, "2");
+        abi_tag_entries.emplace_back(AbiTagSbomInfo, "1");
         InternalFeatureSet sorted_feature_list = action.feature_list;
         // Check that no "default" feature is present. Default features must be resolved before attempting to calculate
         // a package ABI, so the "default" should not have made it here.

--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -1055,14 +1055,29 @@ namespace vcpkg
 
         const auto now = CTime::now_string();
         const auto& abi = action.abi_info.value_or_exit(VCPKG_LINE_INFO);
+        const auto& package_dir = action.package_dir.value_or_exit(VCPKG_LINE_INFO);
 
-        const auto json_path =
-            action.package_dir.value_or_exit(VCPKG_LINE_INFO) / FileShare / action.spec.name() / FileVcpkgSpdxJson;
-        fs.write_contents_and_dirs(
-            json_path,
-            create_spdx_sbom(
-                action, abi.relative_port_files, abi.relative_port_hashes, now, doc_ns, std::move(heuristic_resources)),
-            VCPKG_LINE_INFO);
+        const auto json_path = package_dir / FileShare / action.spec.name() / FileVcpkgSpdxJson;
+        // Gather all the files in the package directory
+        // Note: For packages with many files, this sequential hashing may be slow
+        const auto relative_package_files =
+            fs.get_regular_files_recursive_lexically_proximate(package_dir, VCPKG_LINE_INFO);
+        std::vector<std::string> package_hashes;
+        for (const auto& file : relative_package_files)
+        {
+            auto hash = Hash::get_file_hash(fs, package_dir / file, Hash::Algorithm::Sha256);
+            package_hashes.push_back(hash.value_or_exit(VCPKG_LINE_INFO));
+        }
+        fs.write_contents_and_dirs(json_path,
+                                   create_spdx_sbom(action,
+                                                    abi.relative_port_files,
+                                                    abi.relative_port_hashes,
+                                                    relative_package_files,
+                                                    package_hashes,
+                                                    now,
+                                                    doc_ns,
+                                                    std::move(heuristic_resources)),
+                                   VCPKG_LINE_INFO);
     }
 
     static ExtendedBuildResult do_build_package(const VcpkgCmdArguments& args,


### PR DESCRIPTION
Also remove repetition of relationships. These are no longer present in v3 of the SPDX spec. Keeping these relationships would also make the SBOM very noisy.