### PR TITLE
binarycaching: also don't restore file times on windows

### DIFF
--- a/include/vcpkg/base/files.h
+++ b/include/vcpkg/base/files.h
@@ -320,6 +320,9 @@ namespace vcpkg
         virtual int64_t last_write_time(const Path& target, std::error_code& ec) const = 0;
         int64_t last_write_time(const Path& target, LineInfo li) const noexcept;
 
+        virtual void last_write_time(const Path& target, int64_t new_time, std::error_code& ec) const = 0;
+        void last_write_time(const Path& target, int64_t new_time, LineInfo li) const noexcept;
+
         using ReadOnlyFilesystem::current_path;
         virtual void current_path(const Path& new_current_path, std::error_code&) const = 0;
         void current_path(const Path& new_current_path, LineInfo li) const;

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -329,6 +329,16 @@ namespace
                 const auto& zip_path = zip_paths[i].value_or_exit(VCPKG_LINE_INFO);
                 if (job_results[j])
                 {
+#ifdef _WIN32
+                    // On windows the ziptool does restore file times, we don't want that because this breaks file time
+                    // based change detection.
+                    const auto& pkg_path = actions[i]->package_dir.value_or_exit(VCPKG_LINE_INFO);
+                    auto now = m_fs.file_time_now();
+                    for (auto&& path : m_fs.get_files_recursive(pkg_path, VCPKG_LINE_INFO))
+                    {
+                        m_fs.last_write_time(path, now, VCPKG_LINE_INFO);
+                    }
+#endif
                     Debug::print("Restored ", zip_path.path, '\n');
                     out_status[i] = RestoreResult::restored;
                 }


### PR DESCRIPTION
This fixes https://github.com/microsoft/vcpkg/issues/33714, but for windows. 7zip restores file times by default and there is no way to disable it.

This currently breaks our build at work. We use grpc and the generated headers has to match with the version of grpc that is currently in use. We use the following target but it is not triggered since the last modification date of the restored grpc tool (ProtocExe) is older than the headers:
```xml
<Target Name="GrpcGenerateCode" BeforeTargets="ClCompile"
	Inputs="@(NormalizedProtoFile);$(ProtocExe)"
	Outputs="@(_GrpcGeneratedHeaders);@(_GrpcGeneratedSources)">
    ...
</Target>
```
After this PR it worked as expected. 