### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 15684: Build ID 12253873

### DIFF
--- a/locales/messages.cs.json
+++ b/locales/messages.cs.json
@@ -279,7 +279,7 @@
   "CmdExportEmptyPlan": "Odmítnutí vytvořit export nulových balíčků. Před exportem nainstalujte balíčky.",
   "CmdExportExample1": "vcpkg export <port names> [--nuget] [--directory=out_dir]",
   "CmdExportOpt7Zip": "Exportuje do souboru 7zip (.7z).",
-  "CmdExportOptDereferenceSymlinks": "Copies symlinks as regular files and directories in the exported results",
+  "CmdExportOptDereferenceSymlinks": "Zkopíruje symbolické odkazy jako běžné soubory a adresáře v exportovaných výsledcích.",
   "CmdExportOptDryRun": "Ve skutečnosti neexportuje",
   "CmdExportOptInstalled": "Exportuje všechny nainstalované balíčky",
   "CmdExportOptNuget": "Exportuje balíček NuGet",

--- a/locales/messages.de.json
+++ b/locales/messages.de.json
@@ -279,7 +279,7 @@
   "CmdExportEmptyPlan": "Es wird abgelehnt, einen Export von Nullpaketen zu erstellen. Installieren Sie Pakete vor dem Exportieren.",
   "CmdExportExample1": "vcpkg export <port names> [--nuget] [--output-dir=out_dir]",
   "CmdExportOpt7Zip": "Exportiert in eine 7zip(.7z)-Datei.",
-  "CmdExportOptDereferenceSymlinks": "Copies symlinks as regular files and directories in the exported results",
+  "CmdExportOptDereferenceSymlinks": "Kopiert Symlinks als reguläre Dateien und Verzeichnisse in den exportierten Ergebnissen.",
   "CmdExportOptDryRun": "Exportiert nicht wirklich",
   "CmdExportOptInstalled": "Exportiert alle installierten Pakete.",
   "CmdExportOptNuget": "Exportiert ein NuGet-Paket",

--- a/locales/messages.es.json
+++ b/locales/messages.es.json
@@ -279,7 +279,7 @@
   "CmdExportEmptyPlan": "Se rechaza la creación de una exportación de cero paquetes. Instale los paquetes antes de exportarlos.",
   "CmdExportExample1": "vcpkg export <port names> [--nuget] [--output-dir=out_dir]",
   "CmdExportOpt7Zip": "Exporta a un archivo 7zip (.7z)",
-  "CmdExportOptDereferenceSymlinks": "Copies symlinks as regular files and directories in the exported results",
+  "CmdExportOptDereferenceSymlinks": "Copia los vínculos simbólicos como archivos y directorios normales en los resultados exportados",
   "CmdExportOptDryRun": "No exporta realmente",
   "CmdExportOptInstalled": "Exporta todos los paquetes instalados",
   "CmdExportOptNuget": "Exporta un paquete NuGet",

--- a/locales/messages.fr.json
+++ b/locales/messages.fr.json
@@ -279,7 +279,7 @@
   "CmdExportEmptyPlan": "Refus de la création d’une exportation sans aucun package. Installez des packages avant l’exportation.",
   "CmdExportExample1": "vcpkg export <port names> [--nuget] [--output-dir=out_dir]",
   "CmdExportOpt7Zip": "Exporte vers un fichier 7zip (.7z)",
-  "CmdExportOptDereferenceSymlinks": "Copies symlinks as regular files and directories in the exported results",
+  "CmdExportOptDereferenceSymlinks": "Copie les symlinks en tant que fichiers et répertoires normaux dans les résultats exportés",
   "CmdExportOptDryRun": "N’exporte pas réellement",
   "CmdExportOptInstalled": "Exporte tous les packages installés",
   "CmdExportOptNuget": "Exporte un package NuGet",

--- a/locales/messages.it.json
+++ b/locales/messages.it.json
@@ -279,7 +279,7 @@
   "CmdExportEmptyPlan": "Rifiuto di creare un'esportazione di zero pacchetti. Installare i pacchetti prima dell'esportazione.",
   "CmdExportExample1": "vcpkg export <port names> [--nuget] [--output-dir=out_dir]",
   "CmdExportOpt7Zip": "Esporta in un file 7zip (.7z)",
-  "CmdExportOptDereferenceSymlinks": "Copies symlinks as regular files and directories in the exported results",
+  "CmdExportOptDereferenceSymlinks": "Copia i collegamenti simbolici come file e directory regolari nei risultati esportati",
   "CmdExportOptDryRun": "Non esporta effettivamente",
   "CmdExportOptInstalled": "Esporta tutti i pacchetti installati",
   "CmdExportOptNuget": "Esporta un pacchetto NuGet",

--- a/locales/messages.ja.json
+++ b/locales/messages.ja.json
@@ -279,7 +279,7 @@
   "CmdExportEmptyPlan": "0 個のパッケージのエクスポートの作成を拒否しています。エクスポートする前にパッケージをインストールしてください。",
   "CmdExportExample1": "vcpkg export <port names> [--nuget] [--output-dir=out_dir]",
   "CmdExportOpt7Zip": "7zip (.7z) ファイルにエクスポートします",
-  "CmdExportOptDereferenceSymlinks": "Copies symlinks as regular files and directories in the exported results",
+  "CmdExportOptDereferenceSymlinks": "エクスポートされた結果の通常のファイルとディレクトリとしてシンボリック リンクをコピーします",
   "CmdExportOptDryRun": "実際にはエクスポートしません",
   "CmdExportOptInstalled": "インストールされているすべてのパッケージをエクスポートします",
   "CmdExportOptNuget": "NuGet パッケージをエクスポートします",

--- a/locales/messages.pl.json
+++ b/locales/messages.pl.json
@@ -279,7 +279,7 @@
   "CmdExportEmptyPlan": "Odmowa utworzenia eksportu pakietów o wartości zero. Zainstaluj pakiety przed wyeksportowaniem.",
   "CmdExportExample1": "vcpkg eksportuje <port names> [--nuget] [--output-dir=out_dir]",
   "CmdExportOpt7Zip": "Eksportuj do pliku 7zip (.7z)",
-  "CmdExportOptDereferenceSymlinks": "Copies symlinks as regular files and directories in the exported results",
+  "CmdExportOptDereferenceSymlinks": "Kopiuje linki symlink jako zwykłe pliki i katalogi w wyeksportowanych wynikach",
   "CmdExportOptDryRun": "W rzeczywistości nie eksportuje",
   "CmdExportOptInstalled": "Eksportuj wszystkie zainstalowane pakiety",
   "CmdExportOptNuget": "Eksportuje pakiet NuGet",

--- a/locales/messages.pt-BR.json
+++ b/locales/messages.pt-BR.json
@@ -279,7 +279,7 @@
   "CmdExportEmptyPlan": "Recusando-se a criar uma exportação de pacotes zero. Instale os pacotes antes de exportar.",
   "CmdExportExample1": "vcpkg export <port names> [--nuget] [--output-dir=out_dir]",
   "CmdExportOpt7Zip": "Exportar para um arquivo 7zip (.7z)",
-  "CmdExportOptDereferenceSymlinks": "Copies symlinks as regular files and directories in the exported results",
+  "CmdExportOptDereferenceSymlinks": "Copia symlinks como arquivos e diretórios regulares nos resultados exportados",
   "CmdExportOptDryRun": "Na verdade, não exporta",
   "CmdExportOptInstalled": "Exportar todos os pacotes instalados",
   "CmdExportOptNuget": "Exporta um pacote NuGet",

--- a/locales/messages.ru.json
+++ b/locales/messages.ru.json
@@ -279,7 +279,7 @@
   "CmdExportEmptyPlan": "Отказ от создания экспорта нулевых пакетов. Установите пакеты перед экспортом.",
   "CmdExportExample1": "vcpkg export <имена портов> [--nuget] [--output-dir=out_dir]",
   "CmdExportOpt7Zip": "Экспортирует в файл 7zip (.7z)",
-  "CmdExportOptDereferenceSymlinks": "Copies symlinks as regular files and directories in the exported results",
+  "CmdExportOptDereferenceSymlinks": "Копирует символические ссылки как обычные файлы и каталоги в экспортированные результаты",
   "CmdExportOptDryRun": "Фактически не выполняет экспорт",
   "CmdExportOptInstalled": "Экспортирует все установленные пакеты",
   "CmdExportOptNuget": "Экспортирует пакет NuGet",

--- a/locales/messages.tr.json
+++ b/locales/messages.tr.json
@@ -279,7 +279,7 @@
   "CmdExportEmptyPlan": "Sıfır paketlerin dışarı aktarılma işleminin oluşturulması reddediliyor. Dışarı aktarmadan önce paketleri yükleyin.",
   "CmdExportExample1": "vcpkg export <bağlantı noktası adları> [--nuget] [--output-dir=out_dir]",
   "CmdExportOpt7Zip": "7zip (.7z) dosyasına aktarır",
-  "CmdExportOptDereferenceSymlinks": "Copies symlinks as regular files and directories in the exported results",
+  "CmdExportOptDereferenceSymlinks": "Sembolik bağlantıları, dışa aktarılan sonuçlarda normal dosyalar ve dizinler olarak kopyalar",
   "CmdExportOptDryRun": "Gerçekten dışarı aktarmaz",
   "CmdExportOptInstalled": "Yüklü tüm paketleri dışarı aktarır",
   "CmdExportOptNuget": "NuGet paketini dışarı aktarır",

--- a/locales/messages.zh-Hans.json
+++ b/locales/messages.zh-Hans.json
@@ -279,7 +279,7 @@
   "CmdExportEmptyPlan": "拒绝创建零包导出。在导出之前安装包。",
   "CmdExportExample1": "vcpkg export <port names> [--nuget] [--output-dir=out_dir]",
   "CmdExportOpt7Zip": "导出为 7zip (.7z)文件",
-  "CmdExportOptDereferenceSymlinks": "Copies symlinks as regular files and directories in the exported results",
+  "CmdExportOptDereferenceSymlinks": "将符号链接复制为导出结果中的常规文件和目录",
   "CmdExportOptDryRun": "不实际导出",
   "CmdExportOptInstalled": "导出所有安装的包",
   "CmdExportOptNuget": "导出 NuGet 包",

--- a/locales/messages.zh-Hant.json
+++ b/locales/messages.zh-Hant.json
@@ -279,7 +279,7 @@
   "CmdExportEmptyPlan": "拒絕建立零套件的匯出。匯出之前請先安裝套件。",
   "CmdExportExample1": "vcpkg export <連接埠名稱> [--nuget] [--output-dir=out_dir]",
   "CmdExportOpt7Zip": "匯出至 7zip (.7z) 檔案",
-  "CmdExportOptDereferenceSymlinks": "Copies symlinks as regular files and directories in the exported results",
+  "CmdExportOptDereferenceSymlinks": "將符號連結複製為匯出結果中的常規檔案和目錄",
   "CmdExportOptDryRun": "實際上不匯出",
   "CmdExportOptInstalled": "匯出所有已安裝的套件",
   "CmdExportOptNuget": "匯出 NuGet 套件",


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.