### PR TITLE
Correctly detect case insensitive conflicts

### DIFF
--- a/azure-pipelines/e2e-ports/a-conflict/portfile.cmake
+++ b/azure-pipelines/e2e-ports/a-conflict/portfile.cmake
@@ -1,0 +1,7 @@
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" "license text")
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/include")
+file(WRITE "${CURRENT_PACKAGES_DIR}/include/conflict-a-header-only-lowercase.h" "// header only port")
+file(WRITE "${CURRENT_PACKAGES_DIR}/include/CONFLICT-A-HEADER-ONLY-CAPS.h" "// header only port")
+file(WRITE "${CURRENT_PACKAGES_DIR}/include/CONFLICT-a-header-ONLY-mixed.h" "// header only port")
+file(WRITE "${CURRENT_PACKAGES_DIR}/include/CONFLICT-a-header-ONLY-mixed2.h" "// header only port")

--- a/azure-pipelines/e2e-ports/a-conflict/vcpkg.json
+++ b/azure-pipelines/e2e-ports/a-conflict/vcpkg.json
@@ -1,0 +1,4 @@
+{
+  "name": "a-conflict",
+  "version": "0"
+}

--- a/azure-pipelines/e2e-ports/b-conflict/portfile.cmake
+++ b/azure-pipelines/e2e-ports/b-conflict/portfile.cmake
@@ -1,0 +1,7 @@
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" "license text")
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/include")
+file(WRITE "${CURRENT_PACKAGES_DIR}/include/conflict-b-header-only-lowercase.h" "// header only port")
+file(WRITE "${CURRENT_PACKAGES_DIR}/include/CONFLICT-B-HEADER-ONLY-CAPS.h" "// header only port")
+file(WRITE "${CURRENT_PACKAGES_DIR}/include/conflict-a-HEADER-only-MIXED.h" "// header only port")
+file(WRITE "${CURRENT_PACKAGES_DIR}/include/CONFLICT-a-header-ONLY-mixed2.h" "// header only port")

--- a/azure-pipelines/e2e-ports/b-conflict/vcpkg.json
+++ b/azure-pipelines/e2e-ports/b-conflict/vcpkg.json
@@ -1,0 +1,4 @@
+{
+  "name": "b-conflict",
+  "version": "0"
+}

--- a/include/vcpkg/base/messages.h
+++ b/include/vcpkg/base/messages.h
@@ -214,9 +214,9 @@ namespace vcpkg::msg
     template<VCPKG_DECL_MSG_TEMPLATE>
     void println_error(VCPKG_DECL_MSG_ARGS)
     {
-        auto s = error_prefix();
-        msg::format_to(s, VCPKG_EXPAND_MSG_ARGS);
-        println(Color::error, s);
+        msg::write_unlocalized_text(Color::error, "error");
+        msg::write_unlocalized_text(Color::none, ": ");
+        msg::write_unlocalized_text(Color::none, msg::format(VCPKG_EXPAND_MSG_ARGS).append_raw('\n'));
     }
 
     [[nodiscard]] LocalizedString format_warning(const LocalizedString& s);
@@ -231,9 +231,9 @@ namespace vcpkg::msg
     template<VCPKG_DECL_MSG_TEMPLATE>
     void println_warning(VCPKG_DECL_MSG_ARGS)
     {
-        auto s = LocalizedString::from_raw(WarningPrefix);
-        msg::format_to(s, VCPKG_EXPAND_MSG_ARGS);
-        println(Color::warning, s);
+        msg::write_unlocalized_text(Color::warning, "warning");
+        msg::write_unlocalized_text(Color::none, ": ");
+        msg::write_unlocalized_text(Color::none, msg::format(VCPKG_EXPAND_MSG_ARGS).append_raw('\n'));
     }
 
     template<VCPKG_DECL_MSG_TEMPLATE>

--- a/include/vcpkg/base/strings.h
+++ b/include/vcpkg/base/strings.h
@@ -108,10 +108,10 @@ namespace vcpkg::Strings
     std::string to_utf8(const std::wstring& ws);
 #endif
 
-    const char* case_insensitive_ascii_search(StringView s, StringView pattern);
-    bool case_insensitive_ascii_contains(StringView s, StringView pattern);
+    const char* case_insensitive_ascii_search(StringView s, StringView pattern) noexcept;
+    bool case_insensitive_ascii_contains(StringView s, StringView pattern) noexcept;
     bool case_insensitive_ascii_equals(StringView left, StringView right) noexcept;
-    bool case_insensitive_ascii_less(StringView left, StringView right);
+    bool case_insensitive_ascii_less(StringView left, StringView right) noexcept;
 
     void inplace_ascii_to_lowercase(char* first, char* last);
     void inplace_ascii_to_lowercase(std::string& s);

--- a/include/vcpkg/vcpkglib.h
+++ b/include/vcpkg/vcpkglib.h
@@ -5,8 +5,6 @@
 #include <vcpkg/fwd/installedpaths.h>
 #include <vcpkg/fwd/statusparagraphs.h>
 
-#include <vcpkg/base/sortedvector.h>
-
 #include <vcpkg/statusparagraph.h>
 
 #include <string>
@@ -24,7 +22,7 @@ namespace vcpkg
     struct StatusParagraphAndAssociatedFiles
     {
         StatusParagraph pgh;
-        SortedVector<std::string> files;
+        std::vector<std::string> files;
     };
 
     std::vector<InstalledPackageView> get_installed_ports(const StatusParagraphs& status_db);

--- a/src/vcpkg-test/update.cpp
+++ b/src/vcpkg-test/update.cpp
@@ -1,6 +1,6 @@
 #include <vcpkg-test/util.h>
 
-#include <vcpkg/base/sortedvector.h>
+#include <vcpkg/base/util.h>
 
 #include <vcpkg/commands.update.h>
 #include <vcpkg/portfileprovider.h>
@@ -24,8 +24,8 @@ TEST_CASE ("find outdated packages basic", "[update]")
     map.emplace("a", SourceControlFileAndLocation{std::move(scf), ""});
     MapPortFileProvider provider(map);
 
-    auto pkgs = SortedVector<OutdatedPackage, decltype(&OutdatedPackage::compare_by_name)>(
-        find_outdated_packages(provider, status_db), &OutdatedPackage::compare_by_name);
+    auto pkgs = find_outdated_packages(provider, status_db);
+    Util::sort(pkgs, &OutdatedPackage::compare_by_name);
 
     REQUIRE(pkgs.size() == 1);
     REQUIRE(pkgs[0].version_diff.left.to_string() == "2");
@@ -48,8 +48,8 @@ TEST_CASE ("find outdated packages features", "[update]")
     map.emplace("a", SourceControlFileAndLocation{std::move(scf), ""});
     MapPortFileProvider provider(map);
 
-    auto pkgs = SortedVector<OutdatedPackage, decltype(&OutdatedPackage::compare_by_name)>(
-        find_outdated_packages(provider, status_db), &OutdatedPackage::compare_by_name);
+    auto pkgs = find_outdated_packages(provider, status_db);
+    Util::sort(pkgs, &OutdatedPackage::compare_by_name);
 
     REQUIRE(pkgs.size() == 1);
     REQUIRE(pkgs[0].version_diff.left.to_string() == "2");
@@ -73,8 +73,8 @@ TEST_CASE ("find outdated packages features 2", "[update]")
     map.emplace("a", SourceControlFileAndLocation{std::move(scf), ""});
     MapPortFileProvider provider(map);
 
-    auto pkgs = SortedVector<OutdatedPackage, decltype(&OutdatedPackage::compare_by_name)>(
-        find_outdated_packages(provider, status_db), &OutdatedPackage::compare_by_name);
+    auto pkgs = find_outdated_packages(provider, status_db);
+    Util::sort(pkgs, &OutdatedPackage::compare_by_name);
 
     REQUIRE(pkgs.size() == 1);
     REQUIRE(pkgs[0].version_diff.left.to_string() == "2");
@@ -94,8 +94,6 @@ TEST_CASE ("find outdated packages none", "[update]")
     map.emplace("a", SourceControlFileAndLocation{std::move(scf), ""});
     MapPortFileProvider provider(map);
 
-    auto pkgs = SortedVector<OutdatedPackage, decltype(&OutdatedPackage::compare_by_name)>(
-        find_outdated_packages(provider, status_db), &OutdatedPackage::compare_by_name);
-
+    auto pkgs = find_outdated_packages(provider, status_db);
     REQUIRE(pkgs.size() == 0);
 }

--- a/src/vcpkg/base/strings.cpp
+++ b/src/vcpkg/base/strings.cpp
@@ -172,12 +172,12 @@ void Strings::to_utf8(std::string& output, const wchar_t* w, size_t size_in_char
 std::string Strings::to_utf8(const std::wstring& ws) { return to_utf8(ws.data(), ws.size()); }
 #endif
 
-const char* Strings::case_insensitive_ascii_search(StringView s, StringView pattern)
+const char* Strings::case_insensitive_ascii_search(StringView s, StringView pattern) noexcept
 {
     return std::search(s.begin(), s.end(), pattern.begin(), pattern.end(), icase_eq);
 }
 
-bool Strings::case_insensitive_ascii_contains(StringView s, StringView pattern)
+bool Strings::case_insensitive_ascii_contains(StringView s, StringView pattern) noexcept
 {
     return case_insensitive_ascii_search(s, pattern) != s.end();
 }
@@ -187,7 +187,7 @@ bool Strings::case_insensitive_ascii_equals(StringView left, StringView right) n
     return std::equal(left.begin(), left.end(), right.begin(), right.end(), icase_eq);
 }
 
-bool Strings::case_insensitive_ascii_less(StringView left, StringView right)
+bool Strings::case_insensitive_ascii_less(StringView left, StringView right) noexcept
 {
     return std::lexicographical_compare(left.begin(), left.end(), right.begin(), right.end(), icase_less);
 }

--- a/src/vcpkg/commands.install.cpp
+++ b/src/vcpkg/commands.install.cpp
@@ -4,6 +4,7 @@
 #include <vcpkg/base/files.h>
 #include <vcpkg/base/hash.h>
 #include <vcpkg/base/messages.h>
+#include <vcpkg/base/sortedvector.h>
 #include <vcpkg/base/system.debug.h>
 #include <vcpkg/base/system.h>
 #include <vcpkg/base/util.h>
@@ -30,9 +31,45 @@
 
 #include <iterator>
 
+namespace
+{
+    using namespace vcpkg;
+
+    struct InstalledFile
+    {
+        std::string file_path;
+        std::string package_display_name;
+
+        InstalledFile(std::string&& file_path_, const std::string& package_display_name_)
+            : file_path(std::move(file_path_)), package_display_name(package_display_name_)
+        {
+        }
+
+        InstalledFile(const InstalledFile&) = default;
+        InstalledFile(InstalledFile&&) = default;
+        InstalledFile& operator=(const InstalledFile&) = default;
+        InstalledFile& operator=(InstalledFile&&) = default;
+    };
+
+    struct InstalledFilePathCompare
+    {
+        bool operator()(const std::string& lhs, const InstalledFile& rhs) const noexcept
+        {
+            return Strings::case_insensitive_ascii_less(lhs, rhs.file_path);
+        }
+        bool operator()(const InstalledFile& lhs, const std::string& rhs) const noexcept
+        {
+            return Strings::case_insensitive_ascii_less(lhs.file_path, rhs);
+        }
+        bool operator()(const InstalledFile& lhs, const InstalledFile& rhs) const noexcept
+        {
+            return Strings::case_insensitive_ascii_less(lhs.file_path, rhs.file_path);
+        }
+    };
+}
+
 namespace vcpkg
 {
-    using file_pack = std::pair<std::string, std::string>;
 
     InstallDir InstallDir::from_destination_root(const InstalledPaths& ip, Triplet t, const BinaryParagraph& pgh)
     {
@@ -176,34 +213,7 @@ namespace vcpkg
         fs.write_lines(listfile, output, VCPKG_LINE_INFO);
     }
 
-    static std::vector<file_pack> extract_files_in_triplet(
-        const std::vector<StatusParagraphAndAssociatedFiles>& pgh_and_files,
-        Triplet triplet,
-        const size_t remove_chars = 0)
-    {
-        std::vector<file_pack> output;
-        for (const StatusParagraphAndAssociatedFiles& t : pgh_and_files)
-        {
-            if (t.pgh.package.spec.triplet() != triplet)
-            {
-                continue;
-            }
-
-            const std::string name = t.pgh.package.display_name();
-
-            for (const std::string& file : t.files)
-            {
-                output.emplace_back(file_pack{std::string(file, remove_chars), name});
-            }
-        }
-
-        std::sort(output.begin(), output.end(), [](const file_pack& lhs, const file_pack& rhs) {
-            return lhs.first < rhs.first;
-        });
-        return output;
-    }
-
-    static SortedVector<std::string> build_list_of_package_files(const ReadOnlyFilesystem& fs, const Path& package_dir)
+    static std::vector<std::string> build_list_of_package_files(const ReadOnlyFilesystem& fs, const Path& package_dir)
     {
         std::vector<Path> package_file_paths = fs.get_files_recursive(package_dir, IgnoreErrors{});
         Util::erase_remove_if(package_file_paths, [](Path& path) { return path.filename() == FileDotDsStore; });
@@ -212,88 +222,109 @@ namespace vcpkg
             return std::string(target.generic_u8string(), package_remove_char_count);
         });
 
-        return SortedVector<std::string>(std::move(package_files));
+        return package_files;
     }
 
-    static SortedVector<file_pack> build_list_of_installed_files(
-        const std::vector<StatusParagraphAndAssociatedFiles>& pgh_and_files, Triplet triplet)
+    static std::vector<InstalledFile> build_list_of_installed_files(
+        std::vector<StatusParagraphAndAssociatedFiles>&& pgh_and_files, Triplet triplet)
     {
         const size_t installed_remove_char_count = triplet.canonical_name().size() + 1; // +1 for the slash
-        std::vector<file_pack> installed_files =
-            extract_files_in_triplet(pgh_and_files, triplet, installed_remove_char_count);
+        std::vector<InstalledFile> output;
+        for (StatusParagraphAndAssociatedFiles& t : pgh_and_files)
+        {
+            if (t.pgh.package.spec.triplet() != triplet)
+            {
+                continue;
+            }
 
-        return SortedVector<file_pack>(std::move(installed_files));
+            const std::string package_display_name = t.pgh.package.display_name();
+            for (std::string& file : t.files)
+            {
+                file.erase(0, installed_remove_char_count);
+                output.emplace_back(std::move(file), package_display_name);
+            }
+        }
+
+        return output;
     }
 
-    static InstallResult install_package(const VcpkgPaths& paths,
-                                         const Path& package_dir,
-                                         const BinaryControlFile& bcf,
-                                         StatusParagraphs* status_db)
+    static bool check_for_install_conflicts(const Filesystem& fs,
+                                            const Path& package_dir,
+                                            const InstalledPaths& installed,
+                                            const StatusParagraphs& status_db,
+                                            const PackageSpec& spec)
     {
-        auto& fs = paths.get_filesystem();
-        const auto& installed = paths.installed();
-        Triplet triplet = bcf.core_paragraph.spec.triplet();
-        const std::vector<StatusParagraphAndAssociatedFiles> pgh_and_files =
-            get_installed_files_and_upgrade(fs, installed, *status_db);
+        std::vector<InstalledFile> installed_files =
+            build_list_of_installed_files(get_installed_files_and_upgrade(fs, installed, status_db), spec.triplet());
+        std::vector<std::string> package_files = build_list_of_package_files(fs, package_dir);
+        std::vector<InstalledFile> intersection;
 
-        const SortedVector<std::string> package_files = build_list_of_package_files(fs, package_dir);
-        const SortedVector<file_pack> installed_files = build_list_of_installed_files(pgh_and_files, triplet);
-
-        struct intersection_compare
-        {
-            bool operator()(const std::string& lhs, const file_pack& rhs) const
-            {
-                return Strings::case_insensitive_ascii_less(lhs, rhs.first);
-            }
-            bool operator()(const file_pack& lhs, const std::string& rhs) const
-            {
-                return Strings::case_insensitive_ascii_less(lhs.first, rhs);
-            }
-        };
-
-        std::vector<file_pack> intersection;
-
+        Util::sort(installed_files, InstalledFilePathCompare{});
+        Util::sort(package_files, Strings::case_insensitive_ascii_less);
         std::set_intersection(installed_files.begin(),
                               installed_files.end(),
                               package_files.begin(),
                               package_files.end(),
                               std::back_inserter(intersection),
-                              intersection_compare());
+                              InstalledFilePathCompare{});
 
-        std::sort(intersection.begin(), intersection.end(), [](const file_pack& lhs, const file_pack& rhs) {
-            return lhs.second < rhs.second;
-        });
-
-        if (!intersection.empty())
+        if (intersection.empty())
         {
-            const auto triplet_install_path = installed.triplet_dir(triplet);
-            msg::println_error(msgConflictingFiles,
-                               msg::path = triplet_install_path.generic_u8string(),
-                               msg::spec = bcf.core_paragraph.spec);
+            return false;
+        }
 
-            auto i = intersection.begin();
-            while (i != intersection.end())
+        // Re-sort by package display name to group conflicts by package
+        std::stable_sort(
+            intersection.begin(), intersection.end(), [](const InstalledFile& lhs, const InstalledFile& rhs) {
+                return lhs.package_display_name < rhs.package_display_name;
+            });
+
+        const auto triplet_install_path = installed.triplet_dir(spec.triplet());
+        msg::println_error(msgConflictingFiles, msg::path = triplet_install_path.generic_u8string(), msg::spec = spec);
+
+        auto i = intersection.begin();
+        while (i != intersection.end())
+        {
+            const auto& conflicting_display_name = i->package_display_name;
+            auto next = std::find_if(i, intersection.end(), [i](const auto& val) {
+                return i->package_display_name != val.package_display_name;
+            });
+            std::vector<LocalizedString> this_conflict_list;
+            this_conflict_list.reserve(next - i);
+            for (; i != next; ++i)
             {
-                msg::println(msg::format(msgInstalledBy, msg::path = i->second).append_indent());
-                auto next =
-                    std::find_if(i, intersection.end(), [i](const auto& val) { return i->second != val.second; });
-
-                msg::write_unlocalized_text(
-                    Color::none, Strings::join("\n    ", i, next, [](const file_pack& file) { return file.first; }));
-                msg::write_unlocalized_text(Color::none, "\n\n");
-
-                i = next;
+                this_conflict_list.emplace_back(LocalizedString::from_raw(std::move(i->file_path)));
             }
 
+            msg::print(msg::format(msgInstalledBy, msg::path = conflicting_display_name)
+                           .append_raw(':')
+                           .append_floating_list(1, this_conflict_list)
+                           .append_raw('\n'));
+        }
+
+        return true;
+    }
+
+    static InstallResult install_package(const VcpkgPaths& paths,
+                                         const Path& package_dir,
+                                         const BinaryControlFile& bcf,
+                                         StatusParagraphs& status_db)
+    {
+        auto& fs = paths.get_filesystem();
+        const auto& installed = paths.installed();
+        const auto& bcf_core_paragraph = bcf.core_paragraph;
+        const auto& bcf_spec = bcf_core_paragraph.spec;
+        if (check_for_install_conflicts(fs, package_dir, installed, status_db, bcf_spec))
+        {
             return InstallResult::FILE_CONFLICTS;
         }
 
         StatusParagraph source_paragraph;
-        source_paragraph.package = bcf.core_paragraph;
+        source_paragraph.package = bcf_core_paragraph;
         source_paragraph.status = StatusLine{Want::INSTALL, InstallState::HALF_INSTALLED};
 
         write_update(fs, installed, source_paragraph);
-        status_db->insert(std::make_unique<StatusParagraph>(source_paragraph));
+        status_db.insert(std::make_unique<StatusParagraph>(source_paragraph));
 
         std::vector<StatusParagraph> features_spghs;
         for (auto&& feature : bcf.features)
@@ -303,23 +334,23 @@ namespace vcpkg
             feature_paragraph.status = StatusLine{Want::INSTALL, InstallState::HALF_INSTALLED};
 
             write_update(fs, installed, feature_paragraph);
-            status_db->insert(std::make_unique<StatusParagraph>(feature_paragraph));
+            status_db.insert(std::make_unique<StatusParagraph>(feature_paragraph));
         }
 
         const InstallDir install_dir =
-            InstallDir::from_destination_root(paths.installed(), triplet, bcf.core_paragraph);
+            InstallDir::from_destination_root(paths.installed(), bcf_spec.triplet(), bcf_core_paragraph);
 
         install_package_and_write_listfile(fs, package_dir, install_dir);
 
         source_paragraph.status.state = InstallState::INSTALLED;
         write_update(fs, installed, source_paragraph);
-        status_db->insert(std::make_unique<StatusParagraph>(source_paragraph));
+        status_db.insert(std::make_unique<StatusParagraph>(source_paragraph));
 
         for (auto&& feature_paragraph : features_spghs)
         {
             feature_paragraph.status.state = InstallState::INSTALLED;
             write_update(fs, installed, feature_paragraph);
-            status_db->insert(std::make_unique<StatusParagraph>(feature_paragraph));
+            status_db.insert(std::make_unique<StatusParagraph>(feature_paragraph));
         }
 
         return InstallResult::SUCCESS;
@@ -417,7 +448,7 @@ namespace vcpkg
             if (all_dependencies_satisfied)
             {
                 const auto install_result =
-                    install_package(paths, action.package_dir.value_or_exit(VCPKG_LINE_INFO), *bcf, &status_db);
+                    install_package(paths, action.package_dir.value_or_exit(VCPKG_LINE_INFO), *bcf, status_db);
                 switch (install_result)
                 {
                     case InstallResult::SUCCESS: code = BuildResult::Succeeded; break;

--- a/src/vcpkg/commands.update.cpp
+++ b/src/vcpkg/commands.update.cpp
@@ -1,4 +1,5 @@
 #include <vcpkg/base/files.h>
+#include <vcpkg/base/util.h>
 
 #include <vcpkg/commands.update.h>
 #include <vcpkg/portfileprovider.h>
@@ -70,9 +71,8 @@ namespace vcpkg
         auto registry_set = paths.make_registry_set();
         PathsPortFileProvider provider(*registry_set, make_overlay_provider(fs, paths.overlay_ports));
 
-        const auto outdated_packages = SortedVector<OutdatedPackage, decltype(&OutdatedPackage::compare_by_name)>(
-            find_outdated_packages(provider, status_db), &OutdatedPackage::compare_by_name);
-
+        auto outdated_packages = find_outdated_packages(provider, status_db);
+        Util::sort(outdated_packages, &OutdatedPackage::compare_by_name);
         if (outdated_packages.empty())
         {
             msg::println(msgPackagesUpToDate);

--- a/src/vcpkg/vcpkglib.cpp
+++ b/src/vcpkg/vcpkglib.cpp
@@ -237,8 +237,7 @@ namespace vcpkg
             Util::erase_remove_if(installed_files_of_current_pgh,
                                   [](const std::string& file) { return file.back() == '/'; });
 
-            StatusParagraphAndAssociatedFiles pgh_and_files = {
-                *pgh, SortedVector<std::string>(std::move(installed_files_of_current_pgh))};
+            StatusParagraphAndAssociatedFiles pgh_and_files{*pgh, std::move(installed_files_of_current_pgh)};
             installed_files.push_back(std::move(pgh_and_files));
         }
 


### PR DESCRIPTION
This was first pointed out by @dg0yt in https://github.com/microsoft/vcpkg-tool/pull/1483#issuecomment-2378376039 but somehow we missed that. It was discovered again by @ras0219-msft trying to write a post-build lint using the CI file lists of recent builds for new ports.

`vcpkglib.h`: Remove SortedVector as the sort order we get here is not actually useful `commands.install.cpp`:
* Change file_pack to InstalledFile with named values instead of first and second. (file_pack sounded like more than one file was involved)
* Apply `std::move` a few places it was OK to do that. This also caused `extract_files_in_triplet` to get inlined into `build_list_of_installed_files`, its only caller. Note the call to `string::erase` and a move rather than making a copy of the suffix the `(const string&, size_t)` constructor.
* Extract `check_for_install_conflicts` from `install_package` to make it clearer that `installed_files`, `package_files`, and `intersection` are dead after this check is complete (and thus those can be moved-from)
* `stable_sort` to regroup by package name so that the sorted order within each group is preserved. Also added a comment for this. (I deleted that sort call entirely in a previous attempt because I initially read it as an attempt to sort the results of `set_intersection`, which are always already sorted. Missing that distinction is the whole reason I introduced `InstalledFile`)

I want to fix that we are doing redundant `get_files_recursive` here but we don't actually have a `get_files_recursive_lexically_proximate`, only `_directories_` and `_regular_files_` versions, so will do that as a subsequent PR.

Example with the unit test repro before and after:

```console
PS C:\Dev\vcpkg> .\vcpkg.exe install --overlay-ports "C:\Dev\vcpkg-tool\azure-pipelines\e2e-ports" a-conflict b-conflict --binarysource clear
Computing installation plan...
The following packages will be built and installed:
    a-conflict:x64-windows@0 -- C:\Dev\vcpkg-tool\azure-pipelines\e2e-ports\a-conflict
    b-conflict:x64-windows@0 -- C:\Dev\vcpkg-tool\azure-pipelines\e2e-ports\b-conflict
Detecting compiler hash for triplet x64-windows...
Compiler found: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.44.35207/bin/Hostx64/x64/cl.exe
Installing 1/2 a-conflict:x64-windows@0...
Building a-conflict:x64-windows@0...
C:\Dev\vcpkg-tool\azure-pipelines\e2e-ports\a-conflict: info: installing overlay port from here
-- Performing post-build validation
Elapsed time to handle a-conflict:x64-windows: 111 ms
a-conflict:x64-windows package ABI: 7d4b5f05d8fc195e77b84d5fb7722b9e23385392dd9f115632193da544222b9b
Installing 2/2 b-conflict:x64-windows@0...
Building b-conflict:x64-windows@0...
C:\Dev\vcpkg-tool\azure-pipelines\e2e-ports\b-conflict: info: installing overlay port from here
-- Performing post-build validation
warning: File C:\Dev\vcpkg\installed\x64-windows\include/conflict-a-HEADER-only-MIXED.h was already present and will be overwritten
warning: File C:\Dev\vcpkg\installed\x64-windows\include/CONFLICT-a-header-ONLY-mixed2.h was already present and will be overwritten
Elapsed time to handle b-conflict:x64-windows: 112 ms
b-conflict:x64-windows package ABI: 8010665bf1025c1dabed383a54f504013f467efc9ebbf1513380670586dbfd49
Total install time: 227 ms
Installed contents are licensed to you by owners. Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
Some packages did not declare an SPDX license. Check the `copyright` file for each package for more information about their licensing.
a-conflict is header-only and can be used from CMake via:

  find_path(A_CONFLICT_INCLUDE_DIRS "CONFLICT-A-HEADER-ONLY-CAPS.h")
  target_include_directories(main PRIVATE ${A_CONFLICT_INCLUDE_DIRS})

b-conflict is header-only and can be used from CMake via:

  find_path(B_CONFLICT_INCLUDE_DIRS "CONFLICT-B-HEADER-ONLY-CAPS.h")
  target_include_directories(main PRIVATE ${B_CONFLICT_INCLUDE_DIRS})

All requested installations completed successfully in: 227 ms
````

Broken.

```
PS C:\Dev\vcpkg> .\vcpkg.exe x-ci-clean
Clearing contents of C:\Dev\vcpkg\buildtrees
Clearing contents of C:\Dev\vcpkg\installed
Clearing contents of C:\Dev\vcpkg\packages
PS C:\Dev\vcpkg> C:\Dev\vcpkg-tool\out\build\Win-x64-Debug-WithArtifacts\vcpkg.exe  install --overlay-ports "C:\Dev\vcpkg-tool\azure-pipelines\e2e-ports" a-conflict b-conflict --binarysource clear
Computing installation plan...
The following packages will be built and installed:
    a-conflict:x64-windows@0 -- C:\Dev\vcpkg-tool\azure-pipelines\e2e-ports\a-conflict
    b-conflict:x64-windows@0 -- C:\Dev\vcpkg-tool\azure-pipelines\e2e-ports\b-conflict
Detecting compiler hash for triplet x64-windows...
Compiler found: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.44.35207/bin/Hostx64/x64/cl.exe
Installing 1/2 a-conflict:x64-windows@0...
Building a-conflict:x64-windows@0...
C:\Dev\vcpkg-tool\azure-pipelines\e2e-ports\a-conflict: info: installing overlay port from here
-- Performing post-build validation
Elapsed time to handle a-conflict:x64-windows: 114 ms
a-conflict:x64-windows package ABI: 96c3b79bd6770ff5944d733c4d3272d5d4d1042a1a7cba65d2677aae5847226f
Installing 2/2 b-conflict:x64-windows@0...
Building b-conflict:x64-windows@0...
C:\Dev\vcpkg-tool\azure-pipelines\e2e-ports\b-conflict: info: installing overlay port from here
-- Performing post-build validation
error: The following files are already installed in C:/Dev/vcpkg/installed/x64-windows and are in conflict with b-conflict:x64-windows
Installed by a-conflict:x64-windows:
  include/CONFLICT-a-header-ONLY-mixed.h
  include/CONFLICT-a-header-ONLY-mixed2.h
Elapsed time to handle b-conflict:x64-windows: 102 ms
Please ensure you're using the latest port files with `git pull` and `vcpkg update`.
Then check for known issues at:
  https://github.com/microsoft/vcpkg/issues?q=is%3Aissue+is%3Aopen+in%3Atitle+b-conflict
You can submit a new issue at:
  https://github.com/microsoft/vcpkg/issues/new?template=report-package-build-failure.md&title=%5Bb-conflict%5D+Build+error+on+x64-windows
Include '[b-conflict] Build error' in your bug report title, the following version information in your bug description, and attach any relevant failure logs from above.
    vcpkg-tool version: 2999-12-31-unknownhash-debug
    vcpkg-scripts version: 6ecbbbdf31 2025-08-20 (5 days ago)
```

Also drive-by fixes the floating list being generated improperly and that more than "error" was colored red, and removes a few SortedVector uses that were immediately thrown away in test code.