### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 15684: Build ID 12263503

### DIFF
--- a/locales/messages.ko.json
+++ b/locales/messages.ko.json
@@ -279,7 +279,7 @@
   "CmdExportEmptyPlan": "제로 패키지 내보내기 생성을 거부합니다. 내보내기 전에 패키지를 설치하세요.",
   "CmdExportExample1": "vcpkg export <port names> [--nuget] [--output-dir=out_dir]",
   "CmdExportOpt7Zip": "7zip(.7z) 파일로 내보냅니다.",
-  "CmdExportOptDereferenceSymlinks": "Copies symlinks as regular files and directories in the exported results",
+  "CmdExportOptDereferenceSymlinks": "내보낸 결과에서 symlink를 일반 파일 및 디렉터리로 복사합니다.",
   "CmdExportOptDryRun": "실제로 내보내지 않습니다.",
   "CmdExportOptInstalled": "설치된 모든 패키지를 내보냅니다.",
   "CmdExportOptNuget": "NuGet 패키지를 내보냅니다.",


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.