### PR TITLE
Add CMAKE_DL_LIBS for dlopen/dlsym.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -428,7 +428,7 @@ add_custom_target(vcpkg-ps1 ALL DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/vcpkg-shell
 # === Target: vcpkg ===
 
 add_executable(vcpkg ${VCPKG_SOURCES} "${CMAKE_CURRENT_SOURCE_DIR}/src/vcpkg.manifest")
-target_link_libraries(vcpkg PRIVATE vcpkglib)
+target_link_libraries(vcpkg PRIVATE vcpkglib ${CMAKE_DL_LIBS})
 
 if(VCPKG_ADD_SOURCELINK)
     if(VCPKG_VERSION STREQUAL "unknownhash")


### PR DESCRIPTION
Hopefully resolves build failures like: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=12288570

```console
: && /usr/bin/g++ --sysroot=/crossrootfs/arm64 -isystem /crossrootfs/arm64/usr/include/aarch64-linux-gnu/c++/9 -isystem /crossrootfs/arm64/usr/include/c++/9 -B/crossrootfs/arm64/usr/lib/aarch64-linux-gnu/ -isystem /crossrootfs/arm64/usr/lib/gcc/aarch64-linux-gnu/9/include-fixed -isystem /crossrootfs/arm64/usr/lib/gcc/aarch64-linux-gnu/9/include -isystem /crossrootfs/arm64/usr/include/aarch64-linux-gnu -isystem /crossrootfs/arm64/usr/include -static-libgcc -nostdinc -static-libstdc++ -L/crossrootfs/arm64/usr/lib/gcc/aarch64-linux-gnu/9/ -Wall -Wextra -Wpedantic -Wno-unknown-pragmas -Wno-missing-field-initializers -Wno-redundant-move -Wmissing-declarations -Wno-dangling-reference -Werror -O3 -DNDEBUG -Wl,--rpath-link=/crossrootfs/arm64/lib/aarch64-linux-gnu -Wl,--rpath-link=/crossrootfs/arm64/usr/lib/aarch64-linux-gnu -L/crossrootfs/arm64/usr/lib/aarch64-linux-gnu -Wl,--rpath-link=/crossrootfs/arm64/lib/aarch64-linux-gnu -Wl,--rpath-link=/crossrootfs/arm64/usr/lib/aarch64-linux-gnu -L/crossrootfs/arm64/usr/lib/aarch64-linux-gnu CMakeFiles/vcpkglib.dir/src/vcpkg/base/checks.cpp.o CMakeFiles/vcpkglib.dir/src/vcpkg/base/chrono.cpp.o CMakeFiles/vcpkglib.dir/src/vcpkg/base/cmd-parser.cpp.o CMakeFiles/vcpkglib.dir/src/vcpkg/base/cofffilereader.cpp.o 
[ many more .o files omitted ]
CMakeFiles/vcpkglib.dir/src/vcpkg/visualstudio.cpp.o CMakeFiles/vcpkglib.dir/src/vcpkg/xunitwriter.cpp.o CMakeFiles/vcpkg.dir/src/vcpkg.cpp.o -o vcpkg  _deps/fmt-build/libfmt.a  liblocale-resources.a  -pthread && :
/usr/bin/ld: CMakeFiles/vcpkg.dir/src/vcpkg.cpp.o: in function `(anonymous namespace)::inner(vcpkg::Filesystem const&, vcpkg::VcpkgCmdArguments const&, vcpkg::BundleSettings const&)':
vcpkg.cpp:(.text+0x47c): undefined reference to `dlopen'
/usr/bin/ld: vcpkg.cpp:(.text+0x48c): undefined reference to `dlsym'
/usr/bin/ld: vcpkg.cpp:(.text+0x494): undefined reference to `dlerror'
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
mv: cannot stat '/mnt/vss/_work/_temp/build/vcpkg': No such file or directory
```