### PR TITLE
2025-08-29 Regressions Fixes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,21 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "vcpkg linux debug",
+      "type": "cppdbg",
+      "request": "launch",
+      "environment": [
+        {
+          "name": "VCPKG_ROOT",
+          "value": "/vcpkg"
+        }
+      ],
+      "program": "${workspaceRoot}/out/build/linux-debug/vcpkg",
+      "cwd": "${workspaceRoot}/out/build/linux-debug",
+      "args": [
+      ]
+    },
+    {
       "name": "vcpkg-ce cli",
       "request": "launch",
       "type": "node",
@@ -20,7 +35,7 @@
     },
     {
       "name": "MochaTest",
-      "type": "pwa-node",
+      "type": "node",
       "request": "attach",
       "port": 9229,
       "continueOnAttach": true,

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -136,6 +136,17 @@
             ]
         },
         {
+            "name": "linux-debug",
+            "inherits": [
+                "base",
+                "debug",
+                "linux"
+            ],
+            "cacheVariables": {
+                "VCPKG_WARNINGS_AS_ERRORS": true
+            }
+        },
+        {
             "name": "linux-ci",
             "inherits": [
                 "base",
@@ -218,6 +229,10 @@
             "configurePreset": "windows-ci"
         },
         {
+            "name": "linux-debug",
+            "configurePreset": "linux-debug"
+        },
+        {
             "name": "linux-ci",
             "configurePreset": "linux-ci"
         },
@@ -238,6 +253,10 @@
         {
             "name": "windows-ci",
             "configurePreset": "windows-ci"
+        },
+        {
+            "name": "linux-debug",
+            "configurePreset": "linux-debug"
         },
         {
             "name": "linux-ci",

--- a/azure-pipelines/e2e-ports/broken-symlink/portfile.cmake
+++ b/azure-pipelines/e2e-ports/broken-symlink/portfile.cmake
@@ -16,3 +16,5 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/../../../LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
 file(CREATE_LINK "definitely-nonexistent-target-file.txt" "${CURRENT_PACKAGES_DIR}/share/${PORT}/broken-symlink" SYMBOLIC)
+file(CREATE_LINK "self-symlink-b" "${CURRENT_PACKAGES_DIR}/share/${PORT}/self-symlink-a" SYMBOLIC)
+file(CREATE_LINK "self-symlink-a" "${CURRENT_PACKAGES_DIR}/share/${PORT}/self-symlink-b" SYMBOLIC)

--- a/azure-pipelines/e2e-ports/broken-symlink/portfile.cmake
+++ b/azure-pipelines/e2e-ports/broken-symlink/portfile.cmake
@@ -1,0 +1,18 @@
+# This block is more or less identical to vcpkg-hello-world-1 because that ensures all the
+# post-build checks actually run
+
+set(SOURCE_PATH "${CURRENT_BUILDTREES_DIR}/src")
+file(REMOVE_RECURSE "${SOURCE_PATH}")
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/src" DESTINATION "${CURRENT_BUILDTREES_DIR}")
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(PACKAGE_NAME broken-symlink)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/../../../LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+file(CREATE_LINK "definitely-nonexistent-target-file.txt" "${CURRENT_PACKAGES_DIR}/share/${PORT}/broken-symlink" SYMBOLIC)

--- a/azure-pipelines/e2e-ports/broken-symlink/src/CMakeLists.txt
+++ b/azure-pipelines/e2e-ports/broken-symlink/src/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.7.2)
+
+project(broken-symlink CXX)
+
+include(GNUInstallDirs)
+
+add_library(broken-symlink hello.cpp hello.def hello-broken-symlink.h)
+
+install(FILES hello-broken-symlink.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+target_include_directories(broken-symlink INTERFACE "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
+
+install(TARGETS broken-symlink EXPORT broken-symlinkConfig)
+
+install(EXPORT broken-symlinkConfig NAMESPACE broken-symlink:: DESTINATION share/broken-symlink)

--- a/azure-pipelines/e2e-ports/broken-symlink/src/hello-broken-symlink.h
+++ b/azure-pipelines/e2e-ports/broken-symlink/src/hello-broken-symlink.h
@@ -1,0 +1,1 @@
+extern "C" void hello_symlink_earth();

--- a/azure-pipelines/e2e-ports/broken-symlink/src/hello.cpp
+++ b/azure-pipelines/e2e-ports/broken-symlink/src/hello.cpp
@@ -1,0 +1,6 @@
+#include <stdio.h>
+#include "hello-broken-symlink.h"
+
+extern "C" void hello_symlink_earth() {
+    puts("hello earth!");
+}

--- a/azure-pipelines/e2e-ports/broken-symlink/src/hello.def
+++ b/azure-pipelines/e2e-ports/broken-symlink/src/hello.def
@@ -1,0 +1,5 @@
+LIBRARY broken-symlink
+
+EXPORTS
+
+hello_symlink_earth

--- a/azure-pipelines/e2e-ports/broken-symlink/vcpkg.json
+++ b/azure-pipelines/e2e-ports/broken-symlink/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "broken-symlink",
+  "version": "1",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/azure-pipelines/end-to-end-tests-dir/regression-ports.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/regression-ports.ps1
@@ -1,5 +1,10 @@
 . $PSScriptRoot/../end-to-end-tests-prelude.ps1
 
+Run-Vcpkg install --overlay-ports="$PSScriptRoot/../e2e-ports" --binarysource clear broken-symlink
+Throw-IfFailed
+Run-Vcpkg remove broken-symlink
+Throw-IfFailed
+
 if ($IsWindows) {
     Run-Vcpkg install --overlay-ports="$PSScriptRoot/../e2e-ports/llvm-lto-lib" llvm-lto-lib:x64-windows-static
     Throw-IfFailed

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -2660,7 +2660,8 @@ namespace vcpkg
                         ret.push_back(from_stdfs_path(b->path()));
                     }
 
-                    if (ec)
+                    if (ec && ec != std::make_error_condition(std::errc::no_such_file_or_directory) &&
+                        ec != std::make_error_condition(std::errc::not_a_directory))
                     {
                         ret.clear();
                         break;
@@ -2736,7 +2737,8 @@ namespace vcpkg
                         ret.push_back(from_stdfs_path(b->path()));
                     }
 
-                    if (ec)
+                    if (ec && ec != std::make_error_condition(std::errc::no_such_file_or_directory) &&
+                        ec != std::make_error_condition(std::errc::not_a_directory))
                     {
                         ret.clear();
                         break;

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -318,9 +318,14 @@ namespace
 #endif // ^^^ !_WIN32
     }
 
+#if !defined(_WIN32)
+    bool is_not_found_errno_code(int err) { return err == ENOENT || err == ENOTDIR || err == ELOOP; }
+#endif // ^^^ !_WIN32
+
     void translate_not_found_to_success(std::error_code& ec)
     {
-        if (ec && (ec == std::errc::no_such_file_or_directory || ec == std::errc::not_a_directory))
+        if (ec && (ec == std::errc::no_such_file_or_directory || ec == std::errc::not_a_directory ||
+                   ec == std::errc::too_many_symbolic_link_levels))
         {
             ec.clear();
         }
@@ -2894,8 +2899,9 @@ namespace vcpkg
                         default:
                             if (::lstat(full.c_str(), &ls) != 0)
                             {
-                                if (errno == ENOENT || errno == ENOTDIR)
+                                if (is_not_found_errno_code(errno))
                                 {
+                                    // report broken symlink as just a symlink rather than the target
                                     ec.clear();
                                 }
                                 else
@@ -2918,8 +2924,9 @@ namespace vcpkg
                                 {
                                     if (::stat(full.c_str(), &s) != 0)
                                     {
-                                        if (errno == ENOENT || errno == ENOTDIR)
+                                        if (is_not_found_errno_code(errno))
                                         {
+                                            // report broken symlink as just a symlink rather than the target
                                             ec.clear();
                                         }
                                         else
@@ -3177,7 +3184,7 @@ namespace vcpkg
                 return posix_translate_stat_mode_to_file_type(s.st_mode);
             }
 
-            if (errno == ENOENT || errno == ENOTDIR)
+            if (is_not_found_errno_code(errno))
             {
                 ec.clear();
                 return FileType::not_found;
@@ -3202,7 +3209,7 @@ namespace vcpkg
                 return posix_translate_stat_mode_to_file_type(s.st_mode);
             }
 
-            if (errno == ENOENT || errno == ENOTDIR)
+            if (is_not_found_errno_code(errno))
             {
                 ec.clear();
                 return FileType::not_found;
@@ -3390,6 +3397,8 @@ namespace vcpkg
             }
 
             const auto remove_errno = errno;
+            // note that this does not treat ELOOP as 'nonexistent' because we still need to remove
+            // the symlink itself
             if (remove_errno == ENOENT || remove_errno == ENOTDIR)
             {
                 ec.clear();

--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -1068,19 +1068,30 @@ namespace vcpkg
         const auto json_path = package_dir / FileShare / action.spec.name() / FileVcpkgSpdxJson;
         // Gather all the files in the package directory
         // Note: For packages with many files, this sequential hashing may be slow
-        const auto relative_package_files =
-            fs.get_regular_files_recursive_lexically_proximate(package_dir, VCPKG_LINE_INFO);
+        std::vector<Path> package_files;
         std::vector<std::string> package_hashes;
-        for (const auto& file : relative_package_files)
         {
-            auto hash = Hash::get_file_hash(fs, package_dir / file, Hash::Algorithm::Sha256);
-            package_hashes.push_back(hash.value_or_exit(VCPKG_LINE_INFO));
-        }
+            auto maybe_relative_package_files = fs.try_get_regular_files_recursive_lexically_proximate(package_dir);
+            if (auto relative_package_files = maybe_relative_package_files.get())
+            {
+                package_files.reserve(relative_package_files->size());
+                package_hashes.reserve(relative_package_files->size());
+                for (auto& file : *relative_package_files)
+                {
+                    auto maybe_hash = Hash::get_file_hash(fs, package_dir / file, Hash::Algorithm::Sha256);
+                    if (auto hash = maybe_hash.get())
+                    {
+                        package_files.push_back(std::move(file));
+                        package_hashes.push_back(std::move(*hash));
+                    }
+                }
+            }
+        } // destroy maybe_relative_package_files
         fs.write_contents_and_dirs(json_path,
                                    create_spdx_sbom(action,
                                                     abi.relative_port_files,
                                                     abi.relative_port_hashes,
-                                                    relative_package_files,
+                                                    package_files,
                                                     package_hashes,
                                                     now,
                                                     doc_ns,


### PR DESCRIPTION
#1744 introduced a lot of regressions into how vcpkg installs ports, particularly around handling symlinks and files we can't read.

Previously, all calls to the filesystem looking at the packages tree explicitly ignored errors. However, in #1744 recursive directory enumeration and opening the files to write hashes was added with the "crash on error" VCPKG_LINE_INFO forms.

This exposed some latent bugs in how we handle symlinks in recursive enumeration (which is good!).