### PR TITLE
Add /msys64/ to msys detection for cmake tool on Windows

### DIFF
--- a/src/vcpkg/tools.cpp
+++ b/src/vcpkg/tools.cpp
@@ -400,7 +400,7 @@ namespace vcpkg
             // the cmake version from mysys and cygwin can not be used because that version can't handle 'C:' in paths
             auto path = exe_path.generic_u8string();
             return !Strings::ends_with(path, "/usr/bin") && !Strings::ends_with(path, "/cygwin64/bin") &&
-                   path.find("/msys2/") == std::string::npos;
+                   path.find("/msys64/") == std::string::npos;
         }
 
 #endif


### PR DESCRIPTION
I noticed that the path */msys64/* slips through when checking if the CMake binary is from msys.

Related issues: https://github.com/microsoft/vcpkg/issues?q=is%3Aissue%20state%3Aopen%20%22Command%20failed%3A%20C%3A%2Fmsys64%22

Closes https://github.com/microsoft/vcpkg/issues/47171 
Closes https://github.com/microsoft/vcpkg/issues/46391
Closes https://github.com/microsoft/vcpkg/issues/46188
Closes https://github.com/microsoft/vcpkg/issues/44155
Closes https://github.com/microsoft/vcpkg/issues/44154
Closes https://github.com/microsoft/vcpkg/issues/47135
