### PR TITLE
Add a generic `bsd` platform for expressions

### DIFF
--- a/src/vcpkg/platform-expression.cpp
+++ b/src/vcpkg/platform-expression.cpp
@@ -27,6 +27,7 @@ namespace vcpkg::PlatformExpression
         linux,
         freebsd,
         openbsd,
+        bsd,
         solaris,
         osx,
         uwp,
@@ -62,6 +63,7 @@ namespace vcpkg::PlatformExpression
             {"linux", Identifier::linux},
             {"freebsd", Identifier::freebsd},
             {"openbsd", Identifier::openbsd},
+            {"bsd", Identifier::bsd},
             {"solaris", Identifier::solaris},
             {"osx", Identifier::osx},
             {"uwp", Identifier::uwp},
@@ -568,6 +570,9 @@ namespace vcpkg::PlatformExpression
                         case Identifier::linux: return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "Linux");
                         case Identifier::freebsd: return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "FreeBSD");
                         case Identifier::openbsd: return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "OpenBSD");
+                        case Identifier::bsd:
+                            return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "FreeBSD") ||
+                                   true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "OpenBSD");
                         case Identifier::solaris: return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "SunOS");
                         case Identifier::osx: return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "Darwin");
                         case Identifier::uwp:


### PR DESCRIPTION
In most places there's a check for either FreeBSD or OpenBSD it should actually check for BSD in general. This will make some expressions cleaner and make adding support for other BSD systems easier.

It has a similar counterpart on the vcpkg repo: microsoft/vcpkg#47309