### PR TITLE
Exit when json::parse_string failed, avoid double valid string check

### DIFF
--- a/include/vcpkg/base/json.h
+++ b/include/vcpkg/base/json.h
@@ -130,6 +130,7 @@ namespace vcpkg::Json
         static Value integer(int64_t i) noexcept;
         static Value number(double d) noexcept;
         static Value string(std::string&& s) noexcept;
+        static Value string_valid(std::string&& s) noexcept;
         template<class StringLike, std::enable_if_t<std::is_constructible_v<StringView, const StringLike&>, int> = 0>
         static Value string(const StringLike& s) noexcept
         {

--- a/src/vcpkg/base/json.cpp
+++ b/src/vcpkg/base/json.cpp
@@ -336,6 +336,12 @@ namespace vcpkg::Json
         val.underlying_ = std::make_unique<ValueImpl>(ValueKindConstant<VK::String>(), std::move(s));
         return val;
     }
+    Value Value::string_valid(std::string&& s) noexcept
+    {
+        Value val;
+        val.underlying_ = std::make_unique<ValueImpl>(ValueKindConstant<VK::String>(), std::move(s));
+        return val;
+    }
     Value Value::array(Array&& arr) noexcept
     {
         Value val;
@@ -699,6 +705,7 @@ namespace vcpkg::Json
                 }
 
                 add_error(msg::format(msgUnexpectedEOFMidString));
+                vcpkg::Checks::msg_exit_with_message(VCPKG_LINE_INFO, msgInvalidString);
                 return res;
             }
 
@@ -1036,7 +1043,7 @@ namespace vcpkg::Json
                 {
                     case '{': return parse_object();
                     case '[': return parse_array();
-                    case '"': return Value::string(parse_string());
+                    case '"': return Value::string_valid(parse_string());
                     case 'n':
                     case 't':
                     case 'f': return parse_keyword();


### PR DESCRIPTION
There are two points to call `json::parse_string`
https://github.com/microsoft/vcpkg-tool/blob/46b8cce32be200765c7137203a6f9bcd81a80406/src/vcpkg/base/json.cpp#L910-L928
https://github.com/microsoft/vcpkg-tool/blob/46b8cce32be200765c7137203a6f9bcd81a80406/src/vcpkg/base/json.cpp#L1025-L1039

The current implementation of `json::parse_string` doesn't exit on invalid strings. So when the string is invalid: 
* `json::parse_value` exits but performs redundant string validation
* `json::parse_kv_pair` continues processing even with an invalid string, which is unnecessary.
