### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 15684: Build ID 12520663

### DIFF
--- a/locales/messages.cs.json
+++ b/locales/messages.cs.json
@@ -1054,6 +1054,7 @@
   "UnexpectedPortversion": "Neočekávaná verze portu bez pole správy verzí",
   "UnexpectedStateCascade": "U {feature_spec} došlo neočekávaně ke kaskádovému selhání, protože nejsou k dispozici následující závislosti:",
   "UnexpectedStateCascadePortNote": "Zvažte změnu této možnosti na =cascade.",
+  "UnexpectedStateCascadeSuggestLine": "consider adding the following line:",
   "UnexpectedStateFailedCascade": "Sestavení {feature_spec} selhalo, ale očekávalo se, že se bude jednat o kaskádové selhání.",
   "UnexpectedStateFailedNoteConsiderSkippingPort": "Zvažte přidání {package_name}=fail, {spec}=fail nebo ekvivalentních přeskočení.",
   "UnexpectedStateFailedNoteConsiderSkippingPortOrCombination": "Zvažte přidání {package_name}=fail, {spec}=fail, {feature_spec}=combination-fails nebo ekvivalentních přeskočení nebo označení vzájemně se vylučujících funkcí jako možností.",

--- a/locales/messages.de.json
+++ b/locales/messages.de.json
@@ -1054,6 +1054,7 @@
   "UnexpectedPortversion": "Unerwartete \"port-version\" ohne Versionsverwaltungsfeld",
   "UnexpectedStateCascade": "Bei {feature_spec} ist unerwartet ein Kaskadierungsfehler aufgetreten, da die folgenden Abhängigkeiten nicht verfügbar sind:",
   "UnexpectedStateCascadePortNote": "Erwägen Sie stattdessen, dies in „=cascade“ zu ändern.",
+  "UnexpectedStateCascadeSuggestLine": "consider adding the following line:",
   "UnexpectedStateFailedCascade": "Der Build von {feature_spec} ist fehlgeschlagen, obwohl ein kaskadierter Fehler erwartet wurde.",
   "UnexpectedStateFailedNoteConsiderSkippingPort": "Erwägen Sie, „{package_name}=fail“ oder „{spec}=fail“ oder entsprechende Überspringungen hinzuzufügen.",
   "UnexpectedStateFailedNoteConsiderSkippingPortOrCombination": "Erwägen Sie, „{package_name}=fail“, „{spec}=fail“, „{feature_spec}=kombinationsfehler“ oder äquivalente Überspringungen hinzuzufügen, oder markieren Sie sich gegenseitig ausschließende Features als Optionen.",

--- a/locales/messages.es.json
+++ b/locales/messages.es.json
@@ -1054,6 +1054,7 @@
   "UnexpectedPortversion": "\"port-version\" inesperado sin un campo de control de versión",
   "UnexpectedStateCascade": "{feature_spec} fue inesperadamente un error en cascada porque las siguientes dependencias no están disponibles:",
   "UnexpectedStateCascadePortNote": "considere cambiar esto a =cascade en su lugar",
+  "UnexpectedStateCascadeSuggestLine": "consider adding the following line:",
   "UnexpectedStateFailedCascade": "la compilación de {feature_spec} falló, pero se esperaba que fuera un error en cascada",
   "UnexpectedStateFailedNoteConsiderSkippingPort": "considere agregar '{package_name}=fail' o '{spec}=fail', u omisiones equivalentes",
   "UnexpectedStateFailedNoteConsiderSkippingPortOrCombination": "considere agregar '{package_name}=fail', '{spec}=fail', '{feature_spec}=combination-fails' u omisiones equivalentes, o marcando características mutuamente exclusivas como opciones",

--- a/locales/messages.fr.json
+++ b/locales/messages.fr.json
@@ -1054,6 +1054,7 @@
   "UnexpectedPortversion": "« port-version » inattendu sans champ de contrôle de version",
   "UnexpectedStateCascade": "{feature_spec} est un échec en cascade inattendu, car les dépendances suivantes ne sont pas disponibles :",
   "UnexpectedStateCascadePortNote": "envisagez de remplacer ceci par =cascade à la place",
+  "UnexpectedStateCascadeSuggestLine": "consider adding the following line:",
   "UnexpectedStateFailedCascade": "la build de {feature_spec} a échoué, alors qu’elle était censée être un échec en cascade",
   "UnexpectedStateFailedNoteConsiderSkippingPort": "envisagez d’ajouter `{package_name}=fail`, ou `{spec}=fail`, ou des sauts équivalents",
   "UnexpectedStateFailedNoteConsiderSkippingPortOrCombination": "envisagez d’ajouter `{package_name}=fail`, `{spec}=fail`, `{feature_spec}=combination-fails`, ou des sauts équivalents, ou en marquant les fonctionnalités qui s’excluent mutuellement comme options",

--- a/locales/messages.it.json
+++ b/locales/messages.it.json
@@ -1054,6 +1054,7 @@
   "UnexpectedPortversion": "\"port-version\" imprevisto senza un campo di controllo delle versioni",
   "UnexpectedStateCascade": "{feature_spec} ha subito un errore imprevisto a cascata perché le dipendenze seguenti non sono disponibili:",
   "UnexpectedStateCascadePortNote": "prova a cambiare con =cascade",
+  "UnexpectedStateCascadeSuggestLine": "consider adding the following line:",
   "UnexpectedStateFailedCascade": "la compilazione di {feature_spec} non è riuscita ma era previsto un errore a cascata",
   "UnexpectedStateFailedNoteConsiderSkippingPort": "prova ad aggiungere '{package_name}=fail' o '{spec}=fail' o skip equivalenti",
   "UnexpectedStateFailedNoteConsiderSkippingPortOrCombination": "prova ad aggiungere '{package_name}=fail`, `{spec}=fail`, `{feature_spec}=combination-fails' o skip equivalenti oppure a contrassegnare le funzionalità che si escludono a vicenda come opzioni",

--- a/locales/messages.ja.json
+++ b/locales/messages.ja.json
@@ -1054,6 +1054,7 @@
   "UnexpectedPortversion": "バージョン管理フィールドのない予期しない \"port-version\" です",
   "UnexpectedStateCascade": "{feature_spec} は、次の依存関係が使用できないため、予期せずカスケード エラーになりました:",
   "UnexpectedStateCascadePortNote": "代わりにこれを =cascade に変更することを検討してください",
+  "UnexpectedStateCascadeSuggestLine": "consider adding the following line:",
   "UnexpectedStateFailedCascade": "{feature_spec} のビルドは失敗しましたが、カスケード エラーである必要がありました",
   "UnexpectedStateFailedNoteConsiderSkippingPort": "`{package_name}=fail` または `{spec}=fail` または同等のスキップを追加することを検討してください",
   "UnexpectedStateFailedNoteConsiderSkippingPortOrCombination": "`{package_name}=fail`、`{spec}=fail`、`{feature_spec}=combination-fail`、または同等のスキップを追加するか、相互に排他的な機能をオプションとしてマークすることを検討してください",

--- a/locales/messages.ko.json
+++ b/locales/messages.ko.json
@@ -1054,6 +1054,7 @@
   "UnexpectedPortversion": "버전 관리 필드가 없는 예기치 않은 \"port-version\"",
   "UnexpectedStateCascade": "{feature_spec}가 다음 종속성을 사용할 수 없으므로 예기치 않게 연속 오류가 발생했습니다.",
   "UnexpectedStateCascadePortNote": "이것을 =cascade로 변경하는 것을 고려해 보세요.",
+  "UnexpectedStateCascadeSuggestLine": "consider adding the following line:",
   "UnexpectedStateFailedCascade": "{feature_spec} 빌드에 실패했지만 연속 오류여야 합니다.",
   "UnexpectedStateFailedNoteConsiderSkippingPort": "{package_name}=fail`, {spec}=fail` 또는 동등한 건너뛰기를 추가하는 것을 고려해 보세요.",
   "UnexpectedStateFailedNoteConsiderSkippingPortOrCombination": "{package_name}=fail`, {spec}=fail`, {feature_spec}=combination-fails` 또는 동등한 건너뛰기를 추가하거나 상호 배타적인 기능을 옵션으로 표시해 보세요.",

--- a/locales/messages.pl.json
+++ b/locales/messages.pl.json
@@ -1054,6 +1054,7 @@
   "UnexpectedPortversion": "nieoczekiwany element „port-version” bez pola przechowywania wersji",
   "UnexpectedStateCascade": "Funkcja {feature_spec} nieoczekiwanie zakończyła się niepowodzeniem kaskadowym, ponieważ następujące zależności są niedostępne:",
   "UnexpectedStateCascadePortNote": "zamiast tego rozważ zmianę tego na =cascade",
+  "UnexpectedStateCascadeSuggestLine": "consider adding the following line:",
   "UnexpectedStateFailedCascade": "Kompilacja elementu {feature_spec} nie powiodła się, ale oczekiwano awarii kaskadowej",
   "UnexpectedStateFailedNoteConsiderSkippingPort": "rozważ dodanie elementu „{package_name}=fail”, „{spec}=fail” lub równoważnych pominięć",
   "UnexpectedStateFailedNoteConsiderSkippingPortOrCombination": "rozważ dodanie „{package_name}=fail”, „{spec}=fail”, „{feature_spec}=combination-fails” lub równoważnych pominięć albo poprzez oznaczenie wzajemnie wykluczających się funkcji jako opcji",

--- a/locales/messages.pt-BR.json
+++ b/locales/messages.pt-BR.json
@@ -1054,6 +1054,7 @@
   "UnexpectedPortversion": "\"port-version\" inesperado sem um campo de controle de versão",
   "UnexpectedStateCascade": "{feature\\_spec} foi inesperadamente uma falha em cascata porque as seguintes dependências estão indisponíveis:",
   "UnexpectedStateCascadePortNote": "considere alterar isso para =propagar",
+  "UnexpectedStateCascadeSuggestLine": "consider adding the following line:",
   "UnexpectedStateFailedCascade": "a criação de {feature_spec} falhou, mas deveria ser uma falha propagada",
   "UnexpectedStateFailedNoteConsiderSkippingPort": "considere adicionar `{package_name}=falha` ou `{spec}=falha` ou ignorar equivalentes",
   "UnexpectedStateFailedNoteConsiderSkippingPortOrCombination": "considere adicionar `{package_name}=falha`, `{spec}=falha`, `{feature_spec}=combinação-falhas` ou ignorar equivalentes, ou marcar recursos mutuamente exclusivos como opções",

--- a/locales/messages.ru.json
+++ b/locales/messages.ru.json
@@ -1054,6 +1054,7 @@
   "UnexpectedPortversion": "неожиданный параметр \"port-version\" без поля управления версиями",
   "UnexpectedStateCascade": "В {feature_spec} произошла непредвиденная каскадная ошибка из-за недоступности следующих зависимостей:",
   "UnexpectedStateCascadePortNote": "рассмотрите возможность замены этого на =cascade",
+  "UnexpectedStateCascadeSuggestLine": "consider adding the following line:",
   "UnexpectedStateFailedCascade": "сборка {feature_spec} завершилась сбоем, хотя ожидался каскадный сбой",
   "UnexpectedStateFailedNoteConsiderSkippingPort": "рассмотрите возможность добавления \"{package_name}=fail\", \"{spec}=fail\" или эквивалентных пропусков",
   "UnexpectedStateFailedNoteConsiderSkippingPortOrCombination": "рассмотрите возможность добавления \"{package_name}=fail\", \"{spec}=fail\", \"{feature_spec}=combination-fails\" или эквивалентных пропусков или пометки взаимоисключающих функций в качестве параметров",

--- a/locales/messages.tr.json
+++ b/locales/messages.tr.json
@@ -1054,6 +1054,7 @@
   "UnexpectedPortversion": "sürüm oluşturma alanı olmadan \"port-version\" beklenmiyordu",
   "UnexpectedStateCascade": "Aşağıdaki bağımlılıklar mevcut olmadığından {feature_spec} beklenmedik bir şekilde art arda hatalar verdi:",
   "UnexpectedStateCascadePortNote": "bunun yerine bunu =cascade olarak değiştirmeyi düşünün",
+  "UnexpectedStateCascadeSuggestLine": "consider adding the following line:",
   "UnexpectedStateFailedCascade": "{feature_spec} derleme başarısız oldu, ancak art arda hata vermesi bekleniyordu",
   "UnexpectedStateFailedNoteConsiderSkippingPort": "'{package_name}=fail' veya '{spec}=fail' veya eşdeğer atlamalar eklemeyi düşünün",
   "UnexpectedStateFailedNoteConsiderSkippingPortOrCombination": "'{package_name}=fail', '{spec}=fail', '{feature_spec}=combination-fails' veya eşdeğer atlamalar eklemeyi ya da birbirini dışlayan özellikleri seçenekler olarak işaretlemeyi düşünün",

--- a/locales/messages.zh-Hans.json
+++ b/locales/messages.zh-Hans.json
@@ -1054,6 +1054,7 @@
   "UnexpectedPortversion": "没有版本控制字段的意外 \"port-version\"",
   "UnexpectedStateCascade": "{feature_spec} 意外发生级联故障，因为以下依赖项不可用:",
   "UnexpectedStateCascadePortNote": "请考虑将此项更改为 =cascade",
+  "UnexpectedStateCascadeSuggestLine": "consider adding the following line:",
   "UnexpectedStateFailedCascade": "{feature_spec} 生成失败，但应该是级联失效",
   "UnexpectedStateFailedNoteConsiderSkippingPort": "请考虑添加 `{package_name}=fail`、`{spec}=fail` 或等效的跳过选项",
   "UnexpectedStateFailedNoteConsiderSkippingPortOrCombination": "请考虑添加 `{package_name}=fail`、`{spec}=fail`、`{feature_spec}=combination-fails` 或等效的跳过选项，或者通过将互斥功能标记为选项来处理",

--- a/locales/messages.zh-Hant.json
+++ b/locales/messages.zh-Hant.json
@@ -1054,6 +1054,7 @@
   "UnexpectedPortversion": "未預期的 \"port-version\" 沒有版本設定欄位",
   "UnexpectedStateCascade": "{feature_spec} 意外地發生串聯失敗，因為下列相依性無法使用:",
   "UnexpectedStateCascadePortNote": "考慮改為將此變更為 =cascade",
+  "UnexpectedStateCascadeSuggestLine": "consider adding the following line:",
   "UnexpectedStateFailedCascade": "{feature_spec} 建置失敗，但預期為串聯失敗",
   "UnexpectedStateFailedNoteConsiderSkippingPort": "考慮新增 `{package_name}=fail` 或 `{spec}=fail` 或對等的略過",
   "UnexpectedStateFailedNoteConsiderSkippingPortOrCombination": "請考慮新增 `{package_name}=fail`, `{spec}=fail`、`{feature_spec}=combination-fails` 或同等的略過，或將互斥功能標示為選項",


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.