### PR TITLE
Remove the 'upgrade' message.

### DIFF
--- a/include/vcpkg/base/checks.h
+++ b/include/vcpkg/base/checks.h
@@ -28,8 +28,6 @@ namespace vcpkg::Checks
     [[noreturn]] void exit_success(const LineInfo& line_info);
 
     // Display an error message to the user and exit the tool.
-    [[noreturn]] void exit_with_message(const LineInfo& line_info, StringView error_message);
-    [[noreturn]] void exit_with_message(const LineInfo& line_info, const LocalizedString&) = delete;
     [[noreturn]] void msg_exit_with_message(const LineInfo& line_info, const LocalizedString& error_message);
     template<VCPKG_DECL_MSG_TEMPLATE>
     [[noreturn]] void msg_exit_with_message(const LineInfo& line_info, VCPKG_DECL_MSG_ARGS)
@@ -55,33 +53,6 @@ namespace vcpkg::Checks
         }
     }
 
-    // Display a message indicating that vcpkg should be upgraded and exit.
-    [[noreturn]] void exit_maybe_upgrade(const LineInfo& line_info);
-    [[noreturn]] void exit_maybe_upgrade(const LineInfo& line_info, StringView error_message);
-    [[noreturn]] void exit_maybe_upgrade(const LineInfo&, const LocalizedString&) = delete;
-    [[noreturn]] void msg_exit_maybe_upgrade(const LineInfo& line_info, const LocalizedString& error_message);
-    template<VCPKG_DECL_MSG_TEMPLATE>
-    [[noreturn]] void msg_exit_maybe_upgrade(const LineInfo& line_info, VCPKG_DECL_MSG_ARGS)
-    {
-        msg_exit_maybe_upgrade(line_info, msg::format(VCPKG_EXPAND_MSG_ARGS));
-    }
-
-    // Check the indicated condition and call exit_maybe_upgrade if it is false.
-    void check_maybe_upgrade(const LineInfo& line_info, bool condition);
-    void check_maybe_upgrade(const LineInfo& line_info, bool condition, StringView error_message);
-    void check_maybe_upgrade(const LineInfo& line_info, bool condition, const LocalizedString&) = delete;
-    void msg_check_maybe_upgrade(const LineInfo& line_info, bool condition, const LocalizedString& error_message);
-    template<VCPKG_DECL_MSG_TEMPLATE>
-    VCPKG_SAL_ANNOTATION(_Post_satisfies_(_Old_(expression)))
-    void msg_check_maybe_upgrade(const LineInfo& line_info, bool expression, VCPKG_DECL_MSG_ARGS)
-    {
-        if (!expression)
-        {
-            // Only create the string if the expression is false
-            msg_exit_maybe_upgrade(line_info, msg::format(VCPKG_EXPAND_MSG_ARGS));
-        }
-    }
-
     [[noreturn]] inline void msg_exit_with_error(const LineInfo& line_info, const LocalizedString& message)
     {
         msg::write_unlocalized_text_to_stderr(Color::error, error_prefix().append_raw(message).append_raw('\n'));
@@ -94,5 +65,4 @@ namespace vcpkg::Checks
                                               error_prefix().append(VCPKG_EXPAND_MSG_ARGS).append_raw('\n'));
         Checks::exit_fail(line_info);
     }
-
 }

--- a/include/vcpkg/base/message-data.inc.h
+++ b/include/vcpkg/base/message-data.inc.h
@@ -464,8 +464,6 @@ DECLARE_MESSAGE(
     "different architecture. This usually means toolchain information is incorrectly conveyed to the binaries' "
     "build system. To suppress this message, add set(VCPKG_POLICY_SKIP_ARCHITECTURE_CHECK enabled)")
 DECLARE_MESSAGE(ChecksFailedCheck, (), "", "vcpkg has crashed; no additional details are available.")
-DECLARE_MESSAGE(ChecksUnreachableCode, (), "", "unreachable code was reached")
-DECLARE_MESSAGE(ChecksUpdateVcpkg, (), "", "updating vcpkg by rerunning bootstrap-vcpkg may resolve this failure.")
 DECLARE_MESSAGE(CiBaselineAllowUnexpectedPassingRequiresBaseline,
                 (),
                 "",

--- a/include/vcpkg/base/messages.h
+++ b/include/vcpkg/base/messages.h
@@ -149,9 +149,7 @@ namespace vcpkg
     inline constexpr StringLiteral MessagePrefix = "message: ";
     LocalizedString message_prefix();
     inline constexpr StringLiteral InfoPrefix = "info: ";
-    LocalizedString info_prefix();
     inline constexpr StringLiteral NotePrefix = "note: ";
-    LocalizedString note_prefix();
     inline constexpr StringLiteral WarningPrefix = "warning: ";
     LocalizedString warning_prefix();
 }

--- a/locales/messages.json
+++ b/locales/messages.json
@@ -296,8 +296,6 @@
   "CMakeUsingExportedLibs": "To use exported libraries in CMake projects, add {value} to your CMake command line.",
   "_CMakeUsingExportedLibs.comment": "{value} is a CMake command line switch of the form -DFOO=BAR",
   "ChecksFailedCheck": "vcpkg has crashed; no additional details are available.",
-  "ChecksUnreachableCode": "unreachable code was reached",
-  "ChecksUpdateVcpkg": "updating vcpkg by rerunning bootstrap-vcpkg may resolve this failure.",
   "CiBaselineAllowUnexpectedPassingRequiresBaseline": "--allow-unexpected-passing can only be used if a baseline is provided via --ci-baseline.",
   "CiBaselineDisallowedCascade": "REGRESSION: {spec} cascaded, but it is required to pass. ({path}).",
   "_CiBaselineDisallowedCascade.comment": "An example of {spec} is zlib:x64-windows. An example of {path} is /foo/bar.",

--- a/src/vcpkg/base/checks.cpp
+++ b/src/vcpkg/base/checks.cpp
@@ -60,7 +60,7 @@ namespace vcpkg
     [[noreturn]] void Checks::unreachable(const LineInfo& line_info)
     {
         msg::write_unlocalized_text_to_stderr(
-            Color::error, locale_invariant_lineinfo(line_info).append(msgChecksUnreachableCode).append_raw('\n'));
+            Color::error, locale_invariant_lineinfo(line_info).append_raw(" unreachable code was reached\n"));
 #ifndef NDEBUG
         std::abort();
 #else
@@ -89,12 +89,6 @@ namespace vcpkg
 
     [[noreturn]] void Checks::exit_success(const LineInfo& line_info) { exit_with_code(line_info, EXIT_SUCCESS); }
 
-    [[noreturn]] void Checks::exit_with_message(const LineInfo& line_info, StringView error_message)
-    {
-        msg::write_unlocalized_text(Color::error, error_message);
-        msg::write_unlocalized_text(Color::error, "\n");
-        exit_fail(line_info);
-    }
     [[noreturn]] void Checks::msg_exit_with_message(const LineInfo& line_info, const LocalizedString& error_message)
     {
         msg::println(Color::error, error_message);
@@ -136,59 +130,6 @@ namespace vcpkg
         if (!expression)
         {
             msg_exit_with_message(line_info, error_message);
-        }
-    }
-
-    static void display_upgrade_message()
-    {
-        msg::write_unlocalized_text_to_stderr(Color::error,
-                                              note_prefix().append(msgChecksUpdateVcpkg).append_raw('\n'));
-    }
-
-    [[noreturn]] void Checks::exit_maybe_upgrade(const LineInfo& line_info)
-    {
-        display_upgrade_message();
-        exit_fail(line_info);
-    }
-
-    [[noreturn]] void Checks::exit_maybe_upgrade(const LineInfo& line_info, StringView error_message)
-    {
-        msg::write_unlocalized_text_to_stderr(
-            Color::error,
-            LocalizedString::from_raw(error_message).append_raw('\n').append(msgChecksUpdateVcpkg).append_raw('\n'));
-        exit_fail(line_info);
-    }
-    [[noreturn]] void Checks::msg_exit_maybe_upgrade(const LineInfo& line_info, const LocalizedString& error_message)
-    {
-        msg::write_unlocalized_text_to_stderr(Color::error, error_message);
-        msg::write_unlocalized_text_to_stderr(Color::none, "\n");
-        display_upgrade_message();
-        exit_fail(line_info);
-    }
-
-    void Checks::check_maybe_upgrade(const LineInfo& line_info, bool expression)
-    {
-        if (!expression)
-        {
-            exit_maybe_upgrade(line_info);
-        }
-    }
-
-    void Checks::check_maybe_upgrade(const LineInfo& line_info, bool expression, StringView error_message)
-    {
-        if (!expression)
-        {
-            exit_maybe_upgrade(line_info, error_message);
-        }
-    }
-
-    void Checks::msg_check_maybe_upgrade(const LineInfo& line_info,
-                                         bool expression,
-                                         const LocalizedString& error_message)
-    {
-        if (!expression)
-        {
-            msg_exit_maybe_upgrade(line_info, error_message);
         }
     }
 }

--- a/src/vcpkg/base/messages.cpp
+++ b/src/vcpkg/base/messages.cpp
@@ -123,8 +123,6 @@ namespace vcpkg
     LocalizedString error_prefix() { return LocalizedString::from_raw(ErrorPrefix); }
     LocalizedString internal_error_prefix() { return LocalizedString::from_raw(InternalErrorPrefix); }
     LocalizedString message_prefix() { return LocalizedString::from_raw(MessagePrefix); }
-    LocalizedString info_prefix() { return LocalizedString::from_raw(InfoPrefix); }
-    LocalizedString note_prefix() { return LocalizedString::from_raw(NotePrefix); }
     LocalizedString warning_prefix() { return LocalizedString::from_raw(WarningPrefix); }
 }
 

--- a/src/vcpkg/base/strings.cpp
+++ b/src/vcpkg/base/strings.cpp
@@ -377,33 +377,34 @@ std::vector<StringView> Strings::find_all_enclosed(StringView input, StringView 
 StringView Strings::find_exactly_one_enclosed(StringView input, StringView left_tag, StringView right_tag)
 {
     std::vector<StringView> result = find_all_enclosed(input, left_tag, right_tag);
-    Checks::msg_check_maybe_upgrade(VCPKG_LINE_INFO,
-                                    result.size() == 1,
-                                    msgExpectedOneSetOfTags,
-                                    msg::count = result.size(),
-                                    msg::old_value = left_tag,
-                                    msg::new_value = right_tag,
-                                    msg::value = input);
-    return result.front();
+    if (result.size() == 1)
+    {
+        return result.front();
+    }
+
+    Checks::msg_exit_with_message(VCPKG_LINE_INFO,
+                                  msgExpectedOneSetOfTags,
+                                  msg::count = result.size(),
+                                  msg::old_value = left_tag,
+                                  msg::new_value = right_tag,
+                                  msg::value = input);
 }
 
 Optional<StringView> Strings::find_at_most_one_enclosed(StringView input, StringView left_tag, StringView right_tag)
 {
     std::vector<StringView> result = find_all_enclosed(input, left_tag, right_tag);
-    Checks::msg_check_maybe_upgrade(VCPKG_LINE_INFO,
-                                    result.size() <= 1,
-                                    msgExpectedAtMostOneSetOfTags,
-                                    msg::count = result.size(),
-                                    msg::old_value = left_tag,
-                                    msg::new_value = right_tag,
-                                    msg::value = input);
-
-    if (result.empty())
+    switch (result.size())
     {
-        return nullopt;
+        case 0: return nullopt;
+        case 1: return result.front();
+        default:
+            Checks::msg_exit_with_message(VCPKG_LINE_INFO,
+                                          msgExpectedAtMostOneSetOfTags,
+                                          msg::count = result.size(),
+                                          msg::old_value = left_tag,
+                                          msg::new_value = right_tag,
+                                          msg::value = input);
     }
-
-    return result.front();
 }
 
 bool vcpkg::Strings::contains_any_ignoring_c_comments(const std::string& source, View<vcpkg_searcher> to_find)

--- a/src/vcpkg/binaryparagraph.cpp
+++ b/src/vcpkg/binaryparagraph.cpp
@@ -248,7 +248,7 @@ namespace vcpkg
             Paragraphs::parse_single_paragraph(StringView{out_str}.substr(initial_end), sanity_parse_origin);
         if (!parsed_paragraph)
         {
-            Checks::msg_exit_maybe_upgrade(
+            Checks::msg_exit_with_message(
                 VCPKG_LINE_INFO,
                 msg::format(msgFailedToParseSerializedBinParagraph, msg::error_msg = parsed_paragraph.error())
                     .append_raw('\n')
@@ -258,12 +258,12 @@ namespace vcpkg
         auto binary_paragraph = BinaryParagraph(sanity_parse_origin, std::move(*parsed_paragraph.get()));
         if (binary_paragraph != pgh)
         {
-            Checks::msg_exit_maybe_upgrade(VCPKG_LINE_INFO,
-                                           msg::format(msgMismatchedBinParagraphs)
-                                               .append(msgOriginalBinParagraphHeader)
-                                               .append_raw(format_binary_paragraph(pgh))
-                                               .append(msgSerializedBinParagraphHeader)
-                                               .append_raw(format_binary_paragraph(binary_paragraph)));
+            Checks::msg_exit_with_message(VCPKG_LINE_INFO,
+                                          msg::format(msgMismatchedBinParagraphs)
+                                              .append(msgOriginalBinParagraphHeader)
+                                              .append_raw(format_binary_paragraph(pgh))
+                                              .append(msgSerializedBinParagraphHeader)
+                                              .append_raw(format_binary_paragraph(binary_paragraph)));
         }
     }
 

--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -435,7 +435,7 @@ namespace vcpkg
             msg::println_error(msgInvalidArchitectureValue,
                                msg::value = target_architecture,
                                msg::expected = all_comma_separated_cpu_architectures());
-            Checks::exit_maybe_upgrade(VCPKG_LINE_INFO);
+            Checks::exit_fail(VCPKG_LINE_INFO);
         }
 
         auto target_arch = maybe_target_arch.value_or_exit(VCPKG_LINE_INFO);
@@ -464,7 +464,7 @@ namespace vcpkg
                            msg::path = toolset.visual_studio_root_path,
                            msg::list = toolset_list);
         msg::println(msgSeeURL, msg::url = docs::vcpkg_visual_studio_path_url);
-        Checks::exit_maybe_upgrade(VCPKG_LINE_INFO);
+        Checks::exit_fail(VCPKG_LINE_INFO);
     }
 #endif
 
@@ -1042,10 +1042,10 @@ namespace vcpkg
         }
         else
         {
-            Checks::msg_exit_maybe_upgrade(VCPKG_LINE_INFO,
-                                           msgUndeterminedToolChainForTriplet,
-                                           msg::triplet = triplet,
-                                           msg::system_name = cmake_system_name);
+            Checks::msg_exit_with_message(VCPKG_LINE_INFO,
+                                          msgUndeterminedToolChainForTriplet,
+                                          msg::triplet = triplet,
+                                          msg::system_name = cmake_system_name);
         }
     }
 
@@ -2144,7 +2144,7 @@ namespace vcpkg
             return inner_create_buildinfo(filepath, std::move(*paragraph));
         }
 
-        Checks::msg_exit_maybe_upgrade(VCPKG_LINE_INFO, msgInvalidBuildInfo, msg::error_msg = maybe_paragraph.error());
+        Checks::msg_exit_with_message(VCPKG_LINE_INFO, msgInvalidBuildInfo, msg::error_msg = maybe_paragraph.error());
     }
 
     static ExpectedL<bool> from_cmake_bool(StringView value, StringView name)

--- a/src/vcpkg/commands.edit.cpp
+++ b/src/vcpkg/commands.edit.cpp
@@ -168,7 +168,7 @@ namespace vcpkg
             if (!fs.is_directory(portpath))
             {
                 msg::println_error(msgPortDoesNotExist, msg::package_name = port_name);
-                Checks::exit_maybe_upgrade(VCPKG_LINE_INFO);
+                Checks::exit_fail(VCPKG_LINE_INFO);
             }
         }
 

--- a/src/vcpkg/commands.format-manifest.cpp
+++ b/src/vcpkg/commands.format-manifest.cpp
@@ -56,7 +56,7 @@ namespace
 
         if (!reparse_matches)
         {
-            Checks::msg_exit_maybe_upgrade(
+            Checks::msg_exit_with_message(
                 VCPKG_LINE_INFO,
                 msg::format(msgMismatchedManifestAfterReserialize)
                     .append_raw(fmt::format("\n=== Original File ===\n{}\n=== Serialized File ===\n{}\n",

--- a/src/vcpkg/commands.integrate.cpp
+++ b/src/vcpkg/commands.integrate.cpp
@@ -655,7 +655,7 @@ namespace vcpkg
             return integrate_fish(paths);
         }
 
-        Checks::msg_exit_maybe_upgrade(
+        Checks::msg_exit_with_message(
             VCPKG_LINE_INFO, msgUnknownParameterForIntegrate, msg::value = parsed.command_arguments[0]);
     }
 }

--- a/src/vcpkg/commands.package-info.cpp
+++ b/src/vcpkg/commands.package-info.cpp
@@ -44,7 +44,7 @@ namespace vcpkg
         const ParsedArguments options = args.parse_arguments(CommandPackageInfoMetadata);
         if (!Util::Vectors::contains(options.switches, SwitchXJson))
         {
-            Checks::msg_exit_maybe_upgrade(VCPKG_LINE_INFO, msgMissingOption, msg::option = SwitchXJson);
+            Checks::msg_exit_with_message(VCPKG_LINE_INFO, msgMissingOption, msg::option = SwitchXJson);
         }
 
         const bool installed = Util::Sets::contains(options.switches, SwitchXInstalled);

--- a/src/vcpkg/commands.remove.cpp
+++ b/src/vcpkg/commands.remove.cpp
@@ -181,7 +181,7 @@ namespace vcpkg
         (void)host_triplet;
         if (paths.manifest_mode_enabled())
         {
-            Checks::msg_exit_maybe_upgrade(VCPKG_LINE_INFO, msgRemoveDependencies);
+            Checks::msg_exit_with_message(VCPKG_LINE_INFO, msgRemoveDependencies);
         }
         const ParsedArguments options = args.parse_arguments(CommandRemoveMetadata);
 

--- a/src/vcpkg/commands.update.cpp
+++ b/src/vcpkg/commands.update.cpp
@@ -59,7 +59,7 @@ namespace vcpkg
     {
         if (paths.manifest_mode_enabled())
         {
-            Checks::msg_exit_maybe_upgrade(VCPKG_LINE_INFO, msgUnsupportedUpdateCMD);
+            Checks::msg_exit_with_message(VCPKG_LINE_INFO, msgUnsupportedUpdateCMD);
         }
 
         (void)args.parse_arguments(CommandUpdateMetadata);

--- a/src/vcpkg/commands.z-applocal.cpp
+++ b/src/vcpkg/commands.z-applocal.cpp
@@ -394,7 +394,8 @@ namespace
                     }
                     else
                     {
-                        Checks::exit_with_message(VCPKG_LINE_INFO, "qml directory must exist with Qt5Qml.dll");
+                        msg::write_unlocalized_text(Color::error, "qml directory must exist with Qt5Qml.dll\n");
+                        Checks::exit_fail(VCPKG_LINE_INFO);
                     }
                 }
                 std::vector<std::string> libs = {"Qt5Quick.dll",

--- a/src/vcpkg/dependencies.cpp
+++ b/src/vcpkg/dependencies.cpp
@@ -296,13 +296,15 @@ namespace vcpkg
                 else if (spec.feature() != FeatureNameDefault)
                 {
                     auto maybe_paragraph = get_scfl_or_exit().source_control_file->find_feature(spec.feature());
-                    Checks::msg_check_maybe_upgrade(VCPKG_LINE_INFO,
-                                                    maybe_paragraph.has_value(),
-                                                    msgFailedToFindPortFeature,
-                                                    msg::feature = spec.feature(),
-                                                    msg::package_name = spec.port());
+                    if (auto paragraph = maybe_paragraph.get())
+                    {
+                        return paragraph->supports_expression;
+                    }
 
-                    return maybe_paragraph.get()->supports_expression;
+                    Checks::msg_exit_with_message(VCPKG_LINE_INFO,
+                                                  msgFailedToFindPortFeature,
+                                                  msg::feature = spec.feature(),
+                                                  msg::package_name = spec.port());
                 }
                 return nullopt;
             }
@@ -857,13 +859,18 @@ namespace vcpkg
                     {
                         auto maybe_paragraph =
                             clust.get_scfl_or_exit().source_control_file->find_feature(spec.feature());
-                        Checks::msg_check_maybe_upgrade(VCPKG_LINE_INFO,
-                                                        maybe_paragraph.has_value(),
-                                                        msgFailedToFindPortFeature,
-                                                        msg::feature = spec.feature(),
-                                                        msg::package_name = spec.port());
-                        paragraph_depends = &maybe_paragraph.value_or_exit(VCPKG_LINE_INFO).dependencies;
-                        has_supports = !maybe_paragraph.get()->supports_expression.is_empty();
+                        if (auto paragraph = maybe_paragraph.get())
+                        {
+                            paragraph_depends = &paragraph->dependencies;
+                            has_supports = !paragraph->supports_expression.is_empty();
+                        }
+                        else
+                        {
+                            Checks::msg_exit_with_message(VCPKG_LINE_INFO,
+                                                          msgFailedToFindPortFeature,
+                                                          msg::feature = spec.feature(),
+                                                          msg::package_name = spec.port());
+                        }
                     }
 
                     // And it has at least one qualified dependency

--- a/src/vcpkg/registries.cpp
+++ b/src/vcpkg/registries.cpp
@@ -862,10 +862,7 @@ namespace
                          [&](const GitVersionDbEntry& entry) noexcept { return entry.version.version == version; });
         if (it == port_version_entries.end())
         {
-            return format_version_git_entry_missing(port_name, version, port_version_entries)
-                .append_raw('\n')
-                .append_raw(NotePrefix)
-                .append(msgChecksUpdateVcpkg);
+            return format_version_git_entry_missing(port_name, version, port_version_entries);
         }
 
         return m_paths.versions_dot_git_dir()

--- a/src/vcpkg/statusparagraph.cpp
+++ b/src/vcpkg/statusparagraph.cpp
@@ -83,7 +83,7 @@ namespace vcpkg
     StatusParagraph::StatusParagraph(StringView origin, Paragraph&& fields)
     {
         auto status_it = fields.find(ParagraphIdStatus);
-        Checks::msg_check_maybe_upgrade(VCPKG_LINE_INFO, status_it != fields.end(), msgExpectedStatusField);
+        Checks::msg_check_exit(VCPKG_LINE_INFO, status_it != fields.end(), msgExpectedStatusField);
         auto status_field = std::move(status_it->second);
         fields.erase(status_it);
         this->package = BinaryParagraph(origin, std::move(fields));

--- a/src/vcpkg/tools.cpp
+++ b/src/vcpkg/tools.cpp
@@ -851,11 +851,11 @@ namespace vcpkg
 
             const std::array<int, 3>& version = tool_data.version;
             const std::string version_as_string = fmt::format("{}.{}.{}", version[0], version[1], version[2]);
-            Checks::msg_check_maybe_upgrade(VCPKG_LINE_INFO,
-                                            !tool_data.url.empty(),
-                                            msgToolOfVersionXNotFound,
-                                            msg::tool_name = tool_data.name,
-                                            msg::version = version_as_string);
+            Checks::msg_check_exit(VCPKG_LINE_INFO,
+                                   !tool_data.url.empty(),
+                                   msgToolOfVersionXNotFound,
+                                   msg::tool_name = tool_data.name,
+                                   msg::version = version_as_string);
             status_sink.println(Color::none,
                                 msgDownloadingPortableToolVersionX,
                                 msg::tool_name = tool_data.name,
@@ -1050,7 +1050,7 @@ namespace vcpkg
                     .append_raw('\n')
                     .append_raw(considered_versions);
             }
-            Checks::msg_exit_maybe_upgrade(VCPKG_LINE_INFO, s);
+            Checks::msg_exit_with_message(VCPKG_LINE_INFO, s);
         }
 
         const PathAndVersion& get_tool_pathversion(StringView tool, MessageSink& status_sink) const

--- a/src/vcpkg/vcpkglib.cpp
+++ b/src/vcpkg/vcpkglib.cpp
@@ -198,7 +198,7 @@ namespace vcpkg
 
         for (auto&& ipv : ipv_map)
         {
-            Checks::msg_check_maybe_upgrade(VCPKG_LINE_INFO, ipv.second.core != nullptr, msgCorruptedDatabase);
+            Checks::msg_check_exit(VCPKG_LINE_INFO, ipv.second.core != nullptr, msgCorruptedDatabase);
         }
 
         return Util::fmap(ipv_map, [](auto&& p) -> InstalledPackageView { return std::move(p.second); });

--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -83,10 +83,10 @@ namespace
             return ManifestAndPath{std::move(*manifest_object), std::move(manifest_path)};
         }
 
-        Checks::msg_exit_maybe_upgrade(VCPKG_LINE_INFO,
-                                       msg::format(msgFailedToLoadManifest, msg::path = manifest_dir)
-                                           .append_raw('\n')
-                                           .append(maybe_manifest_object.error()));
+        Checks::msg_exit_with_message(VCPKG_LINE_INFO,
+                                      msg::format(msgFailedToLoadManifest, msg::path = manifest_dir)
+                                          .append_raw('\n')
+                                          .append(maybe_manifest_object.error()));
     }
 
     static Optional<ManifestConfiguration> config_from_manifest(const Optional<ManifestAndPath>& manifest_doc)
@@ -192,9 +192,9 @@ namespace
                 if (!is_git_sha(*p_baseline))
                 {
                     get_global_metrics_collector().track_define(DefineMetric::VersioningErrorBaseline);
-                    Checks::msg_exit_maybe_upgrade(VCPKG_LINE_INFO,
-                                                   msg::format(msgInvalidBuiltInBaseline, msg::value = *p_baseline)
-                                                       .append_raw(paths.get_current_git_sha_baseline_message()));
+                    Checks::msg_exit_with_message(VCPKG_LINE_INFO,
+                                                  msg::format(msgInvalidBuiltInBaseline, msg::value = *p_baseline)
+                                                      .append_raw(paths.get_current_git_sha_baseline_message()));
                 }
 
                 if (ret.config.default_reg)


### PR DESCRIPTION
The 'upgrade' message asks users to rerun bootstrap-vcpkg. We used to do this all over the place but have been slowly doing it less often. Unfortunately, even the places that were reasonable, were mostly inconsistent about applying it.

In particular, emitting the upgrade message for things that require `git pull` is *incorrect*. Ever emitting the message in Visual Studio or one-liner deployments was always bogus.

(The reason for this is because I'm context-izing `vcpkg fetch` and there are a lot of problematic upgrade cases in there)

Audit results:

* strings.cpp:380: Wrong, parse failure is not a tool upgrade fix. (Note however the only callers where visualstudio.cpp which was questionably ok)
* strings.cpp:396: Ditto
* binaryparagraph.cpp:251: Both cases are about corrupted installation databases and both are wrong.
* binaryparagraph.cpp:261: Ditto
* commands.build.cpp:438: Probably correct, new vcpkg.exe may learn about new cpu architecture.
* commands.build.cpp:467: Probably correct, new vcpkg.exe may learn about new VS.
* commands.build.cpp:1045: Probably correct, new vcpkg may learn about new known architectures.
* commands.build.cpp:2147: Wrong, corrupted installation database.
* commands.edit.cpp:171: Wrong, nonexistent port won't be fixed by bootstrap.
* commands.format-manifest.cpp:59: This is just a bug in vcpkg and *probably* shouldn't be localized in the first place. It's a parse failure so it's wrong.
* commands.integrate.cpp:658: Plausible, new integrates may be learned by new vcpkg.exe.
* commands.package-info.cpp:47: Plausible, new vcpkg may have new package-info formats. But we don't emit the message for other unknown command line arguments so why is this one special?
* commands.remove.cpp:184: Wrong, upgrading vcpkg.exe won't make this not be manifest mode.
* commands.update.cpp:62: Ditto
* dependencies.cpp:299: Wrong, missing feature won't change by rebootstrap
* dependencies.cpp:860: Ditto
* registries.cpp:865: Wrong, missing git sha in the registry won't change by rebootstrap
* statusparagraph.cpp:86: Wrong, corrupted installation database.
* tools.cpp:854: Wrong, missing tool entry won't change by rebootstrap
* tools.cpp:1053: Plausible, new vcpkg.exe may learn new ways to find a tool from the system
* vcpkglib.cpp:201: Wrong, corrupted database.
* vcpkgpaths.cpp:86: Wrong, parse error.
* vcpkgpaths.cpp:195: Wrong, bogus git SHA.

Total: 6 correct/plausible, 16 wrong.