### PR TITLE
[RFC] make it possible to _not_ have a baseline for git registries

### DIFF
--- a/include/vcpkg/portfileprovider.h
+++ b/include/vcpkg/portfileprovider.h
@@ -97,7 +97,7 @@ namespace vcpkg
 
     struct IBaselineProvider
     {
-        virtual ExpectedL<Version> get_baseline_version(StringView port_name) const = 0;
+        virtual ExpectedL<Optional<Version>> get_baseline_version(StringView port_name) const = 0;
         virtual ~IBaselineProvider() = default;
     };
 

--- a/include/vcpkg/registries.h
+++ b/include/vcpkg/registries.h
@@ -153,7 +153,7 @@ namespace vcpkg
     std::unique_ptr<RegistryImplementation> make_git_registry(const VcpkgPaths& paths,
                                                               std::string repo,
                                                               std::string reference,
-                                                              std::string baseline);
+                                                              Optional<std::string> baseline);
     std::unique_ptr<RegistryImplementation> make_filesystem_registry(const ReadOnlyFilesystem& fs,
                                                                      Path path,
                                                                      std::string baseline);

--- a/src/vcpkg-test/dependencies.cpp
+++ b/src/vcpkg-test/dependencies.cpp
@@ -26,7 +26,7 @@ struct MockBaselineProvider : IBaselineProvider
 {
     mutable std::map<std::string, Version, std::less<>> v;
 
-    ExpectedL<Version> get_baseline_version(StringView name) const override
+    ExpectedL<Optional<Version>> get_baseline_version(StringView name) const override
     {
         auto it = v.find(name);
         if (it == v.end())

--- a/src/vcpkg/configuration.cpp
+++ b/src/vcpkg/configuration.cpp
@@ -234,11 +234,7 @@ namespace
             r.required_object_field(
                 msg::format(msgAGitRegistry), obj, JsonIdRepository, res.repo.emplace(), GitUrlDeserializer::instance);
             r.optional_object_field_emplace(obj, JsonIdReference, res.reference, GitReferenceDeserializer::instance);
-            r.required_object_field(msg::format(msgAGitRegistry),
-                                    obj,
-                                    JsonIdBaseline,
-                                    res.baseline.emplace(),
-                                    BaselineShaDeserializer::instance);
+            r.optional_object_field_emplace(obj, JsonIdBaseline, res.baseline, BaselineShaDeserializer::instance);
             r.check_for_unexpected_fields(obj, valid_git_fields, msg::format(msgAGitRegistry));
         }
         else if (kind == JsonIdArtifact)
@@ -897,7 +893,7 @@ namespace vcpkg
                 return make_git_registry(paths,
                                          config.repo.value_or_exit(VCPKG_LINE_INFO),
                                          config.reference.value_or("HEAD"),
-                                         config.baseline.value_or_exit(VCPKG_LINE_INFO));
+                                         config.baseline);
             }
             else if (*k == JsonIdFilesystem)
             {

--- a/src/vcpkg/dependencies.cpp
+++ b/src/vcpkg/dependencies.cpp
@@ -3,6 +3,7 @@
 #include <vcpkg/base/optional.h>
 #include <vcpkg/base/strings.h>
 #include <vcpkg/base/util.h>
+#include <vcpkg/base/system.debug.h>
 
 #include <vcpkg/cmakevars.h>
 #include <vcpkg/dependencies.h>
@@ -1456,7 +1457,7 @@ namespace vcpkg
 
             // Add an initial requirement for a package.
             // Returns a reference to the node to place additional constraints
-            Optional<PackageNode&> require_package(const PackageSpec& spec, const std::string& origin);
+            Optional<PackageNode&> require_package(const PackageSpec& spec, const std::string& origin, Optional<Version> maybe_declared_ver);
 
             void require_scfl(PackageNode& ref, const SourceControlFileAndLocation* scfl, const std::string& origin);
 
@@ -1512,14 +1513,15 @@ namespace vcpkg
                 if (!dep.platform.is_empty() && !dep.platform.evaluate(batch_load_vars(frame.spec))) continue;
 
                 PackageSpec dep_spec(dep.name, dep.host ? m_host_triplet : frame.spec.triplet());
-                auto maybe_node = require_package(dep_spec, frame.spec.name());
+
+                auto maybe_dep_ver = dep.constraint.try_get_minimum_version();
+                auto maybe_node = require_package(dep_spec, frame.spec.name(), maybe_dep_ver);
                 if (auto node = maybe_node.get())
                 {
                     // If the node is overlayed or overridden, don't apply version constraints
                     // If the baseline is a version_string, it occludes other constraints
                     if (!node->second.overlay_or_override)
                     {
-                        const auto maybe_dep_ver = dep.constraint.try_get_minimum_version();
                         if (auto dep_ver = maybe_dep_ver.get())
                         {
                             auto maybe_scfl = m_ver_provider.get_control_file({dep.name, *dep_ver});
@@ -1640,7 +1642,8 @@ namespace vcpkg
         }
 
         Optional<VersionedPackageGraph::PackageNode&> VersionedPackageGraph::require_package(const PackageSpec& spec,
-                                                                                             const std::string& origin)
+                                                                                             const std::string& origin,
+                                                                                             Optional<Version> maybe_declared_ver)
         {
             // Implicit defaults are disabled if spec is requested from top-level spec.
             const bool default_features_mask = origin != m_toplevel.name();
@@ -1686,9 +1689,24 @@ namespace vcpkg
                 }
                 else
                 {
-                    auto maybe_scfl = m_base_provider.get_baseline_version(spec.name()).then([&](const Version& ver) {
-                        return m_ver_provider.get_control_file({spec.name(), ver});
-                    });
+                    auto maybe_scfl =
+                        m_base_provider.get_baseline_version(spec.name())
+                            .then([&](const Optional<Version>& ver) -> ExpectedL<const SourceControlFileAndLocation&> {
+                                if (auto baseline_ver = ver.get())
+                                {
+                                    return m_ver_provider.get_control_file({spec.name(), *baseline_ver});
+                                }
+                                else if (auto declared_ver = maybe_declared_ver.get())
+                                {
+                                    return m_ver_provider.get_control_file({spec.name(), *declared_ver});
+                                }
+                                else
+                                {
+                                    // TODO: this should be a PortNotInBaselineAndNoVersion
+                                    Debug::println("port {} not in baseline, no declared version", spec.name());
+                                    return msg::format_error(msgPortNotInBaseline, msg::package_name = spec.name());
+                                }
+                            });
                     if (auto p_scfl = maybe_scfl.get())
                     {
                         it = m_graph.emplace(spec, PackageNodeData{}).first;

--- a/src/vcpkg/portfileprovider.cpp
+++ b/src/vcpkg/portfileprovider.cpp
@@ -372,15 +372,15 @@ namespace vcpkg
         {
             return *scfl;
         }
-        auto maybe_baseline = m_baseline->get_baseline_version(spec);
-        if (auto baseline = maybe_baseline.get())
-        {
-            return m_versioned->get_control_file({spec, *baseline});
-        }
-        else
-        {
-            return std::move(maybe_baseline).error();
-        }
+        return m_baseline->get_baseline_version(spec).then([&](const Optional<Version>& ver) -> ExpectedL<const SourceControlFileAndLocation&> {
+            if (auto v = ver.get())
+            {
+                return m_versioned->get_control_file({spec, *v});
+            } else
+            {
+                return msg::format_error(msgPortNotInBaseline, msg::package_name = spec);
+            }
+        });
     }
 
     std::vector<const SourceControlFileAndLocation*> PathsPortFileProvider::load_all_control_files() const
@@ -399,25 +399,16 @@ namespace vcpkg
             BaselineProviderImpl(const BaselineProviderImpl&) = delete;
             BaselineProviderImpl& operator=(const BaselineProviderImpl&) = delete;
 
-            virtual ExpectedL<Version> get_baseline_version(StringView port_name) const override
+            virtual ExpectedL<Optional<Version>> get_baseline_version(StringView port_name) const override
             {
-                return m_baseline_cache.get_lazy(port_name, [this, port_name]() -> ExpectedL<Version> {
-                    return registry_set.baseline_for_port(port_name).then(
-                        [&](Optional<Version>&& maybe_version) -> ExpectedL<Version> {
-                            auto version = maybe_version.get();
-                            if (!version)
-                            {
-                                return msg::format_error(msgPortNotInBaseline, msg::package_name = port_name);
-                            }
-
-                            return std::move(*version);
-                        });
+                return m_baseline_cache.get_lazy(port_name, [this, port_name]() -> ExpectedL<Optional<Version>> {
+                    return registry_set.baseline_for_port(port_name);
                 });
             }
 
         private:
             const RegistrySet& registry_set;
-            Cache<std::string, ExpectedL<Version>> m_baseline_cache;
+            Cache<std::string, ExpectedL<Optional<Version>>> m_baseline_cache;
         };
 
         struct VersionedPortfileProviderImpl : IFullVersionedPortfileProvider


### PR DESCRIPTION
Internally to reMarkable, we want to not have a baseline for our internal dependencies, and only use `"version>="` constraints; this current set of changes does work for our current workflow, but of course we can make the code better; I just want to put it out there to see if there's interest (and so we can maybe avoid a fork).

Also, hi! It's been fun to do work on vcpkg again!