### PR TITLE
Allow MSVC on non Windows platforms for cross compilation

### DIFF
--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -1221,7 +1221,9 @@ namespace vcpkg
 
     const Toolset& VcpkgPaths::get_toolset(const PreBuildInfo& prebuildinfo) const
     {
+#if defined(_WIN32)
         if (!prebuildinfo.using_vcvars())
+#endif
         {
             static const Toolset external_toolset{
                 Path{},


### PR DESCRIPTION
This allows MSVC to be used on Linux. I tested this with a setup using the msvc-wine project that provided wrapper scripts around the Wine compatibility layer to run the MSVC compiler on other platforms. By forcing an external toolset this forces vcpkg to use the default compiler or the CC/CXX environment flags, which with use of I was able to cross compile some projects from Linux to Windows/MSVC.