### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 15684: Build ID 12640684

### DIFF
--- a/locales/messages.cs.json
+++ b/locales/messages.cs.json
@@ -213,8 +213,6 @@
   "CMakeToolChainFile": "Projekty CMake by měly používat: -DCMAKE_TOOLCHAIN_FILE={path}",
   "CMakeUsingExportedLibs": "Pokud chcete v projektech CMake používat exportované knihovny, přidejte do příkazového řádku CMake {value}.",
   "ChecksFailedCheck": "vcpkg se zhroutilo. blížší podrobnosti nejsou k dispozici.",
-  "ChecksUnreachableCode": "nedosažitelný kód byl dosažen",
-  "ChecksUpdateVcpkg": "aktualizace vcpkg opětovným spuštěním bootstrap-vcpkg může tuto chybu vyřešit.",
   "CiBaselineAllowUnexpectedPassingRequiresBaseline": "Parametr --allow-unexpected-passing lze použít pouze v případě, že je směrný plán poskytnut prostřednictvím parametru --ci-baseline.",
   "CiBaselineDisallowedCascade": "REGRESE: {spec} kaskádovité, ale je nutný úspěch. ({path}).",
   "CiBaselineIndependentRegression": "REGRESE: Nezávislá specifikace {spec} selhala s {build_result}.",

--- a/locales/messages.de.json
+++ b/locales/messages.de.json
@@ -213,8 +213,6 @@
   "CMakeToolChainFile": "CMake-Projekte sollten Folgendes verwenden: „-DCMAKE_TOOLCHAIN_FILE={path}“",
   "CMakeUsingExportedLibs": "Um exportierte Bibliotheken in CMake-Projekten zu verwenden, fügen Sie Ihrer CMake-Befehlszeile {value} hinzu.",
   "ChecksFailedCheck": "„vcpkg“ ist abgestürzt; es sind keine weiteren Details verfügbar.",
-  "ChecksUnreachableCode": "Nicht erreichbarer Code wurde erreicht.",
-  "ChecksUpdateVcpkg": "Das Aktualisieren von vcpkg durch erneutes Ausführen von „bootstrap-vcpkg“ kann diesen Fehler möglicherweise beheben.",
   "CiBaselineAllowUnexpectedPassingRequiresBaseline": "--allow-unexpected-passing kann nur verwendet werden, wenn eine Baseline über --ci-baseline bereitgestellt wird.",
   "CiBaselineDisallowedCascade": "REGRESSION: {spec} überlappend, muss aber übergeben werden. ({path}.)",
   "CiBaselineIndependentRegression": "REGRESSION: Fehler bei unabhängigem {spec} mit {build_result}.",

--- a/locales/messages.es.json
+++ b/locales/messages.es.json
@@ -213,8 +213,6 @@
   "CMakeToolChainFile": "Los proyectos de CMake deben usar\" \"-DCMAKE_TOOLCHAIN_FILE={path}\"",
   "CMakeUsingExportedLibs": "Para usar bibliotecas exportadas en proyectos de CMake, agregue {value} a la línea de comandos de CMake.",
   "ChecksFailedCheck": "vcpkg se bloqueó; no hay detalles adicionales disponibles.",
-  "ChecksUnreachableCode": "se ha alcanzado un código inaccesible",
-  "ChecksUpdateVcpkg": "actualizar vcpkg volviendo a ejecutar bootstrap-vcpkg puede resolver este error.",
   "CiBaselineAllowUnexpectedPassingRequiresBaseline": "--allow-unexpected-passing solo se puede usar si se proporciona una base de referencia mediante --ci-baseline.",
   "CiBaselineDisallowedCascade": "REGRESIÓN: {spec} en cascada, pero es necesario pasar. ({path}).",
   "CiBaselineIndependentRegression": "REGRESIÓN: error de {spec} independiente con {build_result}.",

--- a/locales/messages.fr.json
+++ b/locales/messages.fr.json
@@ -213,8 +213,6 @@
   "CMakeToolChainFile": "Les projets CMake doivent utiliser : « -DCMAKE_TOOLCHAIN_FILE={path} »",
   "CMakeUsingExportedLibs": "Pour utiliser des bibliothèques exportées dans des projets CMake, ajoutez {value} à votre ligne de commande CMake.",
   "ChecksFailedCheck": "vcpkg s’est bloqué; aucun détail supplémentaire n’est disponible.",
-  "ChecksUnreachableCode": "code inaccessible atteint",
-  "ChecksUpdateVcpkg": "la mise à jour de vcpkg en réexécutant bootstrap-vcpkg peut résoudre cet échec.",
   "CiBaselineAllowUnexpectedPassingRequiresBaseline": "--allow-unexpected-passing ne peut être utilisé que si une ligne de base est fournie via --ci-baseline.",
   "CiBaselineDisallowedCascade": "RÉGRESSION : {spec} en cascade, mais il est nécessaire de passer. ({path}).",
   "CiBaselineIndependentRegression": "RÉGRESSION : échec de la {spec} indépendante avec {build_result}.",

--- a/locales/messages.it.json
+++ b/locales/messages.it.json
@@ -213,8 +213,6 @@
   "CMakeToolChainFile": "I progetti CMake devono usare: \"-DCMAKE_TOOLCHAIN_FILE={path}>",
   "CMakeUsingExportedLibs": "Per usare le librerie esportate nei progetti CMake, aggiungere {value} alla riga di comando di CMake.",
   "ChecksFailedCheck": "vcpkg si è arrestato in modo anomalo; non sono disponibili altri dettagli.",
-  "ChecksUnreachableCode": "è stato raggiunto il codice non raggiungibile",
-  "ChecksUpdateVcpkg": "l'aggiornamento di vcpkg eseguendo di nuovo bootstrap-vcpkg può risolvere questo errore.",
   "CiBaselineAllowUnexpectedPassingRequiresBaseline": "--allow-unexpected-passing può essere usato solo se viene fornita una baseline tramite --ci-baseline.",
   "CiBaselineDisallowedCascade": "REGRESSIONE: {spec} a catena, ma è necessario passarla. ({path}).",
   "CiBaselineIndependentRegression": "REGRESSIONE: {spec} indipendente non riuscito con {build_result}.",

--- a/locales/messages.ja.json
+++ b/locales/messages.ja.json
@@ -213,8 +213,6 @@
   "CMakeToolChainFile": "CMake プロジェクトでは次を使用する必要があります: \"-DCMAKE_TOOLCHAIN_FILE={path}\"",
   "CMakeUsingExportedLibs": "CMake プロジェクトでエクスポートされたライブラリを使用するには、CMake コマンド ラインに {value} を追加します。",
   "ChecksFailedCheck": "vcpkg がクラッシュしました。その他の詳細はありません。",
-  "ChecksUnreachableCode": "到達できないコードに達しました",
-  "ChecksUpdateVcpkg": "bootstrap-vcpkg を再実行して vcpkg を更新すると、このエラーが解決される可能性があります。",
   "CiBaselineAllowUnexpectedPassingRequiresBaseline": "--allow-unexpected-passing は、--ci-baseline を介してベースラインが指定されている場合にのみ使用できます。",
   "CiBaselineDisallowedCascade": "回帰: {spec} がカスケードされましたが、渡す必要があります。({path})。",
   "CiBaselineIndependentRegression": "回帰: 独立した {spec} が {build_result} で失敗しました。",

--- a/locales/messages.ko.json
+++ b/locales/messages.ko.json
@@ -213,8 +213,6 @@
   "CMakeToolChainFile": "CMake 프로젝트는 \"-DCMAKE_TOOLCHAIN_FILE={path}\"를 사용해야 합니다.",
   "CMakeUsingExportedLibs": "CMake 프로젝트에서 내보낸 라이브러리를 사용하려면 CMake 명령줄에 {value}을(를) 추가하세요.",
   "ChecksFailedCheck": "vcpkg가 충돌했습니다. 추가 정보가 없습니다.",
-  "ChecksUnreachableCode": "연결할 수 없는 코드에 도달했습니다",
-  "ChecksUpdateVcpkg": "bootstrap-vcpkg를 다시 실행하여 vcpkg를 업데이트하면 이 오류가 해결될 수 있습니다.",
   "CiBaselineAllowUnexpectedPassingRequiresBaseline": "--allow-unexpected-passing은 --ci-baseline을 통해 기준선을 제공하는 경우에만 사용할 수 있습니다.",
   "CiBaselineDisallowedCascade": "회귀: {spec} 단계식이지만 통과해야 합니다. ({path}).",
   "CiBaselineIndependentRegression": "회귀: {build_result}(으)로 독립 {spec}이(가) 실패했습니다.",

--- a/locales/messages.pl.json
+++ b/locales/messages.pl.json
@@ -213,8 +213,6 @@
   "CMakeToolChainFile": "Projekty w narzędziu CMake powinny używać ścieżki: \"-DCMAKE_TOOLCHAIN_FILE={path}\"",
   "CMakeUsingExportedLibs": "Aby używać wyeksportowanych bibliotek w projektach narzędzia CMake, dodaj {value} do wiersza polecenia narzędzia CMake.",
   "ChecksFailedCheck": "Pakiet vcpkg uległ awarii; nie są dostępne żadne dodatkowe szczegóły",
-  "ChecksUnreachableCode": "osiągnięto nieosiągalny kod",
-  "ChecksUpdateVcpkg": "zaktualizowanie pakietu vcpkg przez ponowne uruchomienie pakietu bootstrap-vcpkg może rozwiązać ten problem.",
   "CiBaselineAllowUnexpectedPassingRequiresBaseline": "Parametru --allow-unexpected-passing można użyć tylko wtedy, gdy punkt odniesienia jest dostarczany za pośrednictwem --ci-baseline.",
   "CiBaselineDisallowedCascade": "REGRESJA: {spec} kaskadowo, ale jest wymagana do przekazania. ({path}).",
   "CiBaselineIndependentRegression": "REGRESJA: niezależne {spec} nie powiodło się z {build_result}.",

--- a/locales/messages.pt-BR.json
+++ b/locales/messages.pt-BR.json
@@ -213,8 +213,6 @@
   "CMakeToolChainFile": "Os projetos do CMake devem usar: \"-DCMAKE_TOOLCHAIN_FILE={path}\"",
   "CMakeUsingExportedLibs": "Para usar bibliotecas exportadas em projetos do CMake, adicione {value} à linha de comando do CMake.",
   "ChecksFailedCheck": "vcpkg falhou; nenhum detalhe adicional está disponível.",
-  "ChecksUnreachableCode": "código inacessível atingido",
-  "ChecksUpdateVcpkg": "atualizar vcpkg executando novamente bootstrap-vcpkg pode resolver essa falha.",
   "CiBaselineAllowUnexpectedPassingRequiresBaseline": "--allow-unexpected-passing só poderá ser usado se uma linha de base for fornecida por --ci-baseline.",
   "CiBaselineDisallowedCascade": "REGRESSÃO: {spec} em cascata, mas é necessário passar. ({path}).",
   "CiBaselineIndependentRegression": "REGRESSÃO: {spec} independente falhou com {build_result}.",

--- a/locales/messages.ru.json
+++ b/locales/messages.ru.json
@@ -213,8 +213,6 @@
   "CMakeToolChainFile": "В проектах CMake следует использовать: \"-DCMAKE_TOOLCHAIN_FILE={path}\"",
   "CMakeUsingExportedLibs": "Чтобы использовать экспортированные библиотеки в проектах CMake, добавьте {value} в командную строку CMake.",
   "ChecksFailedCheck": "сбой vcpkg; дополнительные сведения недоступны.",
-  "ChecksUnreachableCode": "достигнут недостижимый код",
-  "ChecksUpdateVcpkg": "обновление vcpkg путем повторного запуска bootstrap-vcpkg может устранить этот сбой.",
   "CiBaselineAllowUnexpectedPassingRequiresBaseline": "--allow-unexpected-passing-passing можно использовать, только если указан базовый план с помощью --ci-baseline.",
   "CiBaselineDisallowedCascade": "Регрессия: значение {spec} является каскадным, но необходима его передача ({path}).",
   "CiBaselineIndependentRegression": "РЕГРЕССИЯ: сбой независимого объекта {spec} с {build_result}.",

--- a/locales/messages.tr.json
+++ b/locales/messages.tr.json
@@ -213,8 +213,6 @@
   "CMakeToolChainFile": "CMake projeleri \"-DCMAKE_TOOLCHAIN_FILE={path}\" kullanmalıdır",
   "CMakeUsingExportedLibs": "Dışa aktarılan kitaplıkları CMake projelerinde kullanmak için CMake komut satırınıza {value} ekleyin.",
   "ChecksFailedCheck": "vcpkg kilitlendi; ek ayrıntı yok.",
-  "ChecksUnreachableCode": "ulaşılamayan koda ulaşıldı",
-  "ChecksUpdateVcpkg": "vcpkg’nin bootstrap-vcpkg’nin yeniden çalıştırılarak güncelleştirilmesi bu hatayı çözebilir.",
   "CiBaselineAllowUnexpectedPassingRequiresBaseline": "--allow-unexpected-passing yalnızca --ci-baseline aracılığıyla bir taban çizgisi sağlandıysa kullanılabilir.",
   "CiBaselineDisallowedCascade": "GERİLEME: {spec} basamaklandı ancak başarılı olması için gerileme gerekiyor. ({path}).",
   "CiBaselineIndependentRegression": "REGRESSION: Bağımsız {spec}, {build_result} ile başarısız oldu.",

--- a/locales/messages.zh-Hans.json
+++ b/locales/messages.zh-Hans.json
@@ -213,8 +213,6 @@
   "CMakeToolChainFile": "CMake 项目应使用:“-DCMAKE_TOOLCHAIN_FILE={path}”",
   "CMakeUsingExportedLibs": "要在 CMake 项目中使用导出的库，请将 {value} 添加到 CMake 命令行。",
   "ChecksFailedCheck": "vcpkg 已崩溃；没有其他详细信息可用。",
-  "ChecksUnreachableCode": "已访问无法访问的代码",
-  "ChecksUpdateVcpkg": "通过重新运行 bootstrap-vcpkg 更新 vcpkg 可能会解决此故障。",
   "CiBaselineAllowUnexpectedPassingRequiresBaseline": "只有当通过 --ci-baseline 提供基线时才能使用 --allow-unexpected-passing。",
   "CiBaselineDisallowedCascade": "回归: {spec} 已级联，但需要它才能通过。({path})。",
   "CiBaselineIndependentRegression": "REGRESSION: 独立 {spec} 失败，出现 {build_result}。",

--- a/locales/messages.zh-Hant.json
+++ b/locales/messages.zh-Hant.json
@@ -213,8 +213,6 @@
   "CMakeToolChainFile": "CMake 專案應使用: \"-DCMAKE_TOOLCHAIN_FILE={path}\"",
   "CMakeUsingExportedLibs": "若要在 CMake 專案中使用匯出的程式庫，請將 {value} 新增至 CMake 命令列。",
   "ChecksFailedCheck": "vcpkg 已損毀; 沒有其他詳細資料。",
-  "ChecksUnreachableCode": "已連線到無法連線的代碼",
-  "ChecksUpdateVcpkg": "重新執行 bootstrap-vcpkg 來更新 vcpkg 或許可以解決此失敗問題。",
   "CiBaselineAllowUnexpectedPassingRequiresBaseline": "--allow-unexpected-passing 只有在透過 --ci-baseline 提供基準時才能使用。",
   "CiBaselineDisallowedCascade": "迴歸: {spec} 串聯，但需要通過。({path})。",
   "CiBaselineIndependentRegression": "迴歸: 獨立 {spec} 失敗，發生 {build_result}。",


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.