### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 15684: Build ID 12714412

### DIFF
--- a/locales/messages.cs.json
+++ b/locales/messages.cs.json
@@ -222,6 +222,8 @@
   "CiBaselineUnexpectedFail": "REGRESSION: {spec} je označen jako neúspěšný, ale pro {triplet} se nepodporuje.",
   "CiBaselineUnexpectedFailCascade": "REGRESE: {spec} je označena jako neúspěšná, ale jedna závislost se pro {triplet} nepodporuje.",
   "CiBaselineUnexpectedPass": "PŘEDÁVÁNÍ, ODEBRAT ZE SEZNAMU SELHÁNÍ: {spec} ({path}).",
+  "CiBaselineUnexpectedPassCascade": "REGRESSION: {spec} is marked as pass but one dependency is not supported for {triplet}.",
+  "CiBaselineUnexpectedPassUnsupported": "REGRESSION: {spec} is marked as pass but not supported for {triplet}.",
   "ClearingContents": "Mazání obsahu cesty {path}.",
   "CmakeTargetsExcluded": "Nezobrazuje se tento počet dalších cílů: {count}.",
   "CmdAcquireExample1": "vcpkg acquire <artifact>",

--- a/locales/messages.de.json
+++ b/locales/messages.de.json
@@ -222,6 +222,8 @@
   "CiBaselineUnexpectedFail": "REGRESSION: {spec} ist als Fehler markiert, wird aber für {triplet} nicht unterstützt.",
   "CiBaselineUnexpectedFailCascade": "REGRESSION: {spec} ist als Fehler markiert, aber eine Abhängigkeit wird für {triplet} nicht unterstützt.",
   "CiBaselineUnexpectedPass": "BESTANDEN, VON DER FEHLERLISTE ENTFERNEN: {spec} ({Pfad}).",
+  "CiBaselineUnexpectedPassCascade": "REGRESSION: {spec} is marked as pass but one dependency is not supported for {triplet}.",
+  "CiBaselineUnexpectedPassUnsupported": "REGRESSION: {spec} is marked as pass but not supported for {triplet}.",
   "ClearingContents": "Inhalt von {path} wird gelöscht",
   "CmakeTargetsExcluded": "{count} zusätzliche Ziele werden nicht angezeigt.",
   "CmdAcquireExample1": "vcpkg abrufen <artifact>",

--- a/locales/messages.es.json
+++ b/locales/messages.es.json
@@ -222,6 +222,8 @@
   "CiBaselineUnexpectedFail": "REGRESIÓN: {spec} está marcado como error, pero no se admite para {triplet}.",
   "CiBaselineUnexpectedFailCascade": "REGRESIÓN: {spec} está marcado como error, pero no se admite una dependencia para {triplet}.",
   "CiBaselineUnexpectedPass": "PASANDO, QUITAR DE LA LISTA DE ERRORES: {spec} ({path}).",
+  "CiBaselineUnexpectedPassCascade": "REGRESSION: {spec} is marked as pass but one dependency is not supported for {triplet}.",
+  "CiBaselineUnexpectedPassUnsupported": "REGRESSION: {spec} is marked as pass but not supported for {triplet}.",
   "ClearingContents": "Borrando el contenido de {path}",
   "CmakeTargetsExcluded": "{count} destinos adicionales no se muestran.",
   "CmdAcquireExample1": "vcpkg acquire <artefacto>",

--- a/locales/messages.fr.json
+++ b/locales/messages.fr.json
@@ -222,6 +222,8 @@
   "CiBaselineUnexpectedFail": "RÉGRESSION : {spec} est marqué comme échec mais n’est pas pris en charge pour {triplet}.",
   "CiBaselineUnexpectedFailCascade": "REGRESSION : {spec} est marqué comme échec, mais une dépendance n’est pas prise en charge pour {triplet}.",
   "CiBaselineUnexpectedPass": "RÉUSSITE, SUPPRESSION DE LA LISTE D’ÉCHEC : {spec} ({path}).",
+  "CiBaselineUnexpectedPassCascade": "REGRESSION: {spec} is marked as pass but one dependency is not supported for {triplet}.",
+  "CiBaselineUnexpectedPassUnsupported": "REGRESSION: {spec} is marked as pass but not supported for {triplet}.",
   "ClearingContents": "Effacement du contenu de {path}",
   "CmakeTargetsExcluded": "{count} cibles supplémentaires ne sont pas affichées.",
   "CmdAcquireExample1": "vcpkg acquire <artifact>",

--- a/locales/messages.it.json
+++ b/locales/messages.it.json
@@ -222,6 +222,8 @@
   "CiBaselineUnexpectedFail": "REGRESSIONE: {spec} è contrassegnato come non riuscito ma non supportato per {triplet}.",
   "CiBaselineUnexpectedFailCascade": "REGRESSIONE: {spec} è contrassegnato come non riuscito ma una dipendenza non è supportata per {triplet}.",
   "CiBaselineUnexpectedPass": "PASSAGGIO, RIMOZIONE DALL'ELENCO ERRORI: {spec} ({path}).",
+  "CiBaselineUnexpectedPassCascade": "REGRESSION: {spec} is marked as pass but one dependency is not supported for {triplet}.",
+  "CiBaselineUnexpectedPassUnsupported": "REGRESSION: {spec} is marked as pass but not supported for {triplet}.",
   "ClearingContents": "Cancellazione del contenuto di {path}",
   "CmakeTargetsExcluded": "{count} destinazioni aggiuntive non vengono visualizzate.",
   "CmdAcquireExample1": "acquisizione vcpkg <artefatto>",

--- a/locales/messages.ja.json
+++ b/locales/messages.ja.json
@@ -222,6 +222,8 @@
   "CiBaselineUnexpectedFail": "回帰: {spec} は失敗とマークされていますが、{triplet} ではサポートされていません。",
   "CiBaselineUnexpectedFailCascade": "回帰: {spec} は失敗とマークされていますが、1 つの依存関係が {triplet} ではサポートされていません。",
   "CiBaselineUnexpectedPass": "成功、失敗リストから削除: {spec} ({path})。",
+  "CiBaselineUnexpectedPassCascade": "REGRESSION: {spec} is marked as pass but one dependency is not supported for {triplet}.",
+  "CiBaselineUnexpectedPassUnsupported": "REGRESSION: {spec} is marked as pass but not supported for {triplet}.",
   "ClearingContents": "{path} の内容をクリアしています",
   "CmakeTargetsExcluded": "追加の {count} 件のターゲットは表示されません。",
   "CmdAcquireExample1": "vcpkg acquire <artifact>",

--- a/locales/messages.ko.json
+++ b/locales/messages.ko.json
@@ -222,6 +222,8 @@
   "CiBaselineUnexpectedFail": "회귀: {spec}이(가) 실패로 표시되었지만 {triplet}에는 지원되지 않습니다.",
   "CiBaselineUnexpectedFailCascade": "회귀: {spec}이(가) 실패로 표시되었지만 {triplet}에 대해 하나의 종속성이 지원되지 않습니다.",
   "CiBaselineUnexpectedPass": "통과, FAIL LIST에서 제거: {spec}({path}).",
+  "CiBaselineUnexpectedPassCascade": "REGRESSION: {spec} is marked as pass but one dependency is not supported for {triplet}.",
+  "CiBaselineUnexpectedPassUnsupported": "REGRESSION: {spec} is marked as pass but not supported for {triplet}.",
   "ClearingContents": "{path} 내용을 지우는 중",
   "CmakeTargetsExcluded": "{count}개의 추가 대상이 표시되지 않습니다.",
   "CmdAcquireExample1": "vcpkg acquire <아티팩트>",

--- a/locales/messages.pl.json
+++ b/locales/messages.pl.json
@@ -222,6 +222,8 @@
   "CiBaselineUnexpectedFail": "REGRESJA: parametr {spec} jest oznaczony jako niepowodzenie, ale nie jest obsługiwany dla parametru {triplet}.",
   "CiBaselineUnexpectedFailCascade": "REGRESJA: parametr {spec} jest oznaczony jako niepowodzenie, ale jedna zależność nie jest obsługiwana dla parametru {triplet}.",
   "CiBaselineUnexpectedPass": "PRZEKAZYWANIE, USUWANIE Z LISTY BŁĘDÓW: {spec} ({path}).",
+  "CiBaselineUnexpectedPassCascade": "REGRESSION: {spec} is marked as pass but one dependency is not supported for {triplet}.",
+  "CiBaselineUnexpectedPassUnsupported": "REGRESSION: {spec} is marked as pass but not supported for {triplet}.",
   "ClearingContents": "Czyszczenie zawartości ścieżki {path}",
   "CmakeTargetsExcluded": "Dodatkowe elementy docelowe ({count}) nie są wyświetlane.",
   "CmdAcquireExample1": "uzyskanie vcpkg <artifact>",

--- a/locales/messages.pt-BR.json
+++ b/locales/messages.pt-BR.json
@@ -222,6 +222,8 @@
   "CiBaselineUnexpectedFail": "REGRESSÃO: {spec} está marcada como falha, mas não tem suporte para {triplet}.",
   "CiBaselineUnexpectedFailCascade": "REGRESSÃO: {spec} está marcada como falha, mas uma dependência não possui suporte para {triplet}.",
   "CiBaselineUnexpectedPass": "PASSANDO, REMOVER DA LISTA DE FALHA: {spec} ({path}).",
+  "CiBaselineUnexpectedPassCascade": "REGRESSION: {spec} is marked as pass but one dependency is not supported for {triplet}.",
+  "CiBaselineUnexpectedPassUnsupported": "REGRESSION: {spec} is marked as pass but not supported for {triplet}.",
   "ClearingContents": "Limpando os conteúdos de {path}",
   "CmakeTargetsExcluded": "observação: {count} destinos adicionais não estão exibidos.",
   "CmdAcquireExample1": "vcpkg acquire <artefato>",

--- a/locales/messages.ru.json
+++ b/locales/messages.ru.json
@@ -222,6 +222,8 @@
   "CiBaselineUnexpectedFail": "РЕГРЕССИЯ: {spec} помечен как сбой, но не поддерживается для {triplet}.",
   "CiBaselineUnexpectedFailCascade": "РЕГРЕССИЯ: {spec} помечен как сбой, но одна зависимость не поддерживается для {triplet}.",
   "CiBaselineUnexpectedPass": "ПЕРЕДАЧА, УДАЛЕНИЕ ИЗ СПИСКА СБОЕВ: {spec} ({path}).",
+  "CiBaselineUnexpectedPassCascade": "REGRESSION: {spec} is marked as pass but one dependency is not supported for {triplet}.",
+  "CiBaselineUnexpectedPassUnsupported": "REGRESSION: {spec} is marked as pass but not supported for {triplet}.",
   "ClearingContents": "Очистка содержимого {path}",
   "CmakeTargetsExcluded": "Дополнительные целевые объекты ({count}) не отображаются.",
   "CmdAcquireExample1": "vcpkg acquire <artifact>",

--- a/locales/messages.tr.json
+++ b/locales/messages.tr.json
@@ -222,6 +222,8 @@
   "CiBaselineUnexpectedFail": "REGRESYON: {spec} başarısız olarak işaretlenmiş ancak {triplet} için desteklenmiyor.",
   "CiBaselineUnexpectedFailCascade": "REGRESYON: {spec} başarısız olarak işaretlenmiş ancak bir bağımlılık {triplet} için desteklenmiyor.",
   "CiBaselineUnexpectedPass": "GEÇİRİLİYOR, HATA LİSTESİNDEN KALDIR: {spec} ({path}).",
+  "CiBaselineUnexpectedPassCascade": "REGRESSION: {spec} is marked as pass but one dependency is not supported for {triplet}.",
+  "CiBaselineUnexpectedPassUnsupported": "REGRESSION: {spec} is marked as pass but not supported for {triplet}.",
   "ClearingContents": "{path} yolunun içeriği temizleniyor",
   "CmakeTargetsExcluded": "{count} ek hedef görüntülenmez.",
   "CmdAcquireExample1": "vcpkg acquire <yapıt>",

--- a/locales/messages.zh-Hans.json
+++ b/locales/messages.zh-Hans.json
@@ -222,6 +222,8 @@
   "CiBaselineUnexpectedFail": "REGRESSION: {spec} 被标记为失败，但 {triplet} 不支持。",
   "CiBaselineUnexpectedFailCascade": "REGRESSION: {spec} 被标记为失败，但 {triplet} 不支持一个依赖项。",
   "CiBaselineUnexpectedPass": "正在通过，从失败列表中删除: {spec} ({path})。",
+  "CiBaselineUnexpectedPassCascade": "REGRESSION: {spec} is marked as pass but one dependency is not supported for {triplet}.",
+  "CiBaselineUnexpectedPassUnsupported": "REGRESSION: {spec} is marked as pass but not supported for {triplet}.",
   "ClearingContents": "正在清除 {path} 的内容",
   "CmakeTargetsExcluded": "未显示其他 {count} 个目标。",
   "CmdAcquireExample1": "vcpkg 获取 <artifact>",

--- a/locales/messages.zh-Hant.json
+++ b/locales/messages.zh-Hant.json
@@ -222,6 +222,8 @@
   "CiBaselineUnexpectedFail": "迴歸: {spec} 標示為失敗，但 {triplet} 不支援。",
   "CiBaselineUnexpectedFailCascade": "迴歸: {spec} 標示為失敗，但 {triplet} 不支援一個相依性。",
   "CiBaselineUnexpectedPass": "通過，從失敗清單移除: {spec} ({path})。",
+  "CiBaselineUnexpectedPassCascade": "REGRESSION: {spec} is marked as pass but one dependency is not supported for {triplet}.",
+  "CiBaselineUnexpectedPassUnsupported": "REGRESSION: {spec} is marked as pass but not supported for {triplet}.",
   "ClearingContents": "正在清除 {path} 的內容",
   "CmakeTargetsExcluded": "不會顯示 {count} 個其他目標。",
   "CmdAcquireExample1": "vcpkg acquire <成品>",


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.