### PR TITLE
Fix wrong usage of stdfs::file_time_type

### DIFF
--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -3930,7 +3930,7 @@ namespace vcpkg
         {
 #if defined(_WIN32)
             stdfs::last_write_time(to_stdfs_path(target),
-                                   stdfs::file_time_type::time_point{stdfs::file_time_type::time_point::duration {
+                                   stdfs::file_time_type{stdfs::file_time_type::duration {
                                        new_time
                                    }},
                                    ec);


### PR DESCRIPTION
I got this error when I use clang + windows:
```
[build] FAILED: CMakeFiles/vcpkglib.dir/src/vcpkg/base/files.cpp.obj
[build] C:\PROGRA~1\MICROS~3\2022\COMMUN~1\VC\Tools\Llvm\x64\bin\CLANG_~1.EXE -DVCPKG_BASE_VERSION=2999-12-31 -DVCPKG_VERSION=unknownhash -D_FILE_OFFSET_BITS=64 -ID:/github/miyanyan/vcpkg-tool/include -ID:/github/miyanyan/vcpkg-tool/out/build/Win-x64-Debug/_deps/fmt-src/include -ID:/github/miyanyan/vcpkg-tool/out/build/Win-x64-Debug/_cmrc/include -Wall -Wextra -Wpedantic -Wno-unknown-pragmas -Wno-missing-field-initializers -Wno-redundant-move -Wmissing-prototypes -Wno-range-loop-analysis -O0 -g -Xclang -gcodeview -std=c++17 -D_DEBUG -Xclang -flto-visibility-public-std -D_MT -Xclang --dependent-lib=libcmtd -Xclang -include-pch -Xclang D:/github/miyanyan/vcpkg-tool/out/build/Win-x64-Debug/CMakeFiles/vcpkglib.dir/cmake_pch.hxx.pch -Xclang -include -Xclang D:/github/miyanyan/vcpkg-tool/out/build/Win-x64-Debug/CMakeFiles/vcpkglib.dir/cmake_pch.hxx -MD -MT CMakeFiles/vcpkglib.dir/src/vcpkg/base/files.cpp.obj -MF CMakeFiles\vcpkglib.dir\src\vcpkg\base\files.cpp.obj.d -o CMakeFiles/vcpkglib.dir/src/vcpkg/base/files.cpp.obj -c D:/github/miyanyan/vcpkg-tool/src/vcpkg/base/files.cpp
[build] D:/github/miyanyan/vcpkg-tool/src/vcpkg/base/files.cpp:3933:59: error: qualified reference to 'time_point' is a constructor name rather than a type in this context
[build]  3933 |                                    stdfs::file_time_type::time_point{stdfs::file_time_type::time_point::duration {
[build]       |                                                           ^
[build] 1 error generated.
```
file_time_type is time_point, and doesn't have time_point type, I'm wondering why MSVC support this...

https://en.cppreference.com/w/cpp/filesystem/file_time_type.html
 https://en.cppreference.com/w/cpp/chrono/time_point.html