### PR TITLE
Add support for AIX/ppc64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -413,6 +413,11 @@ if(MINGW)
     target_link_libraries(vcpkglib PUBLIC winhttp bcrypt version ole32 uuid)
 endif()
 
+if(CMAKE_SYSTEM_NAME STREQUAL "AIX")
+    target_link_libraries(vcpkglib PUBLIC bsd)
+    target_link_options(vcpkglib PUBLIC -Wl,-bbigtoc)
+endif()
+
 # === Target: vcpkg-ps1 ===
 add_custom_command(
     OUTPUT

--- a/docs/vcpkg-tools.schema.json
+++ b/docs/vcpkg-tools.schema.json
@@ -22,7 +22,7 @@
           "os": {
             "type": "string",
             "description": "The platform where the record is valid.",
-            "enum": [ "windows", "osx", "linux", "freebsd", "openbsd", "netbsd", "solaris" ]
+            "enum": [ "windows", "osx", "linux", "freebsd", "openbsd", "netbsd", "solaris", "aix" ]
           },
           "version": {
             "type": "string",
@@ -32,7 +32,7 @@
           "arch": {
             "type": "string",
             "description": "The architecture where the record is valid.",
-            "enum": [ "x86", "x64", "amd64", "arm", "arm64", "arm64ec", "s390x", "ppc64le", "riscv32", "riscv64", "loongarch32", "loongarch64", "mips64" ]
+            "enum": [ "x86", "x64", "amd64", "arm", "arm64", "arm64ec", "s390x", "ppc64", "ppc64le", "riscv32", "riscv64", "loongarch32", "loongarch64", "mips64" ]
           },
           "executable": {
             "type": "string",

--- a/include/vcpkg/base/cofffilereader.h
+++ b/include/vcpkg/base/cofffilereader.h
@@ -12,6 +12,10 @@
 #include <string>
 #include <vector>
 
+#ifdef _AIX
+#undef IA64
+#endif
+
 namespace vcpkg
 {
     // See https://docs.microsoft.com/en-us/windows/win32/debug/pe-format

--- a/include/vcpkg/base/fwd/system.h
+++ b/include/vcpkg/base/fwd/system.h
@@ -10,6 +10,7 @@ namespace vcpkg
         ARM64,
         ARM64EC,
         S390X,
+        PPC64,
         PPC64LE,
         RISCV32,
         RISCV64,

--- a/include/vcpkg/base/system.process.h
+++ b/include/vcpkg/base/system.process.h
@@ -73,6 +73,7 @@ namespace vcpkg
                                  const Path& cmake_script,
                                  const std::vector<CMakeVariable>& pass_variables);
 
+    void init_exe_path_of_current_process(int argc, const char* const* argv);
     Path get_exe_path_of_current_process();
 
     struct ExitCodeAndOutput

--- a/include/vcpkg/tools.test.h
+++ b/include/vcpkg/tools.test.h
@@ -49,6 +49,7 @@ namespace vcpkg
         OpenBsd,
         NetBsd,
         Solaris,
+        Aix,
     };
 
     Optional<ToolOs> to_tool_os(StringView os) noexcept;

--- a/src/vcpkg-test/catch.cpp
+++ b/src/vcpkg-test/catch.cpp
@@ -2,6 +2,7 @@
 #include <vcpkg-test/util.h>
 
 #include <vcpkg/base/system.debug.h>
+#include <vcpkg/base/system.process.h>
 #include <vcpkg/base/system.h>
 
 namespace vcpkg::Checks
@@ -14,6 +15,6 @@ int main(int argc, char** argv)
     if (vcpkg::get_environment_variable("VCPKG_DEBUG").value_or("") == "1") vcpkg::Debug::g_debugging = true;
     // We set VCPKG_ROOT to an invalid value to ensure unit tests do not attempt to instantiate VcpkgRoot
     vcpkg::set_environment_variable("VCPKG_ROOT", "VCPKG_TESTS_SHOULD_NOT_USE_VCPKG_ROOT");
-
+    vcpkg::init_exe_path_of_current_process(argc, argv);
     return Catch::Session().run(argc, argv);
 }

--- a/src/vcpkg-test/tools.cpp
+++ b/src/vcpkg-test/tools.cpp
@@ -255,7 +255,7 @@ TEST_CASE ("parse_tool_data errors", "[tools]")
     REQUIRE(!invalid_os.has_value());
     CHECK(
         "invalid_os.json: error: $.tools[0].os (a tool data operating system): Invalid tool operating system: notanos. "
-        "Expected one of: windows, osx, linux, freebsd, openbsd, netbsd, solaris" == invalid_os.error());
+        "Expected one of: windows, osx, linux, freebsd, openbsd, netbsd, solaris, aix" == invalid_os.error());
 
     auto invalid_version = parse_tool_data(R"(
 {
@@ -284,7 +284,7 @@ TEST_CASE ("parse_tool_data errors", "[tools]")
                                         "invalid_arch.json");
     REQUIRE(!invalid_arch.has_value());
     CHECK("invalid_arch.json: error: $.tools[0].arch (a CPU architecture): Invalid architecture: notanarchitecture. "
-          "Expected one of: x86, x64, amd64, arm, arm64, arm64ec, s390x, ppc64le, riscv32, riscv64, loongarch32, "
+          "Expected one of: x86, x64, amd64, arm, arm64, arm64ec, s390x, ppc64, ppc64le, riscv32, riscv64, loongarch32, "
           "loongarch64, mips64" == invalid_arch.error());
 
     auto invalid_sha512 = parse_tool_data(R"(

--- a/src/vcpkg.cpp
+++ b/src/vcpkg.cpp
@@ -31,7 +31,7 @@
 #pragma comment(lib, "shell32")
 #endif
 
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(_AIX)
 #define TEST_LIBCURL_AVAILABLE
 #include <dlfcn.h>
 #endif
@@ -283,6 +283,7 @@ int main(const int argc, const char* const* const argv)
         }
     }
 #endif
+    init_exe_path_of_current_process(argc, argv);
     set_environment_variable(EnvironmentVariableVcpkgCommand, get_exe_path_of_current_process().generic_u8string());
 
     // Prevent child processes (ex. cmake) from producing "colorized"

--- a/src/vcpkg/base/system.cpp
+++ b/src/vcpkg/base/system.cpp
@@ -150,6 +150,7 @@ namespace
         {"arm64", CPUArchitecture::ARM64},
         {"arm64ec", CPUArchitecture::ARM64EC},
         {"s390x", CPUArchitecture::S390X},
+        {"ppc64", CPUArchitecture::PPC64},
         {"ppc64le", CPUArchitecture::PPC64LE},
         {"riscv32", CPUArchitecture::RISCV32},
         {"riscv64", CPUArchitecture::RISCV64},
@@ -292,7 +293,8 @@ namespace vcpkg
         return CPUArchitecture::S390X;
 #elif (defined(__ppc64__) || defined(__PPC64__) || defined(__ppc64le__) || defined(__PPC64LE__)) &&                    \
     defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
-        return CPUArchitecture::PPC64LE;
+#elif (defined(__ppc64__) || defined(__PPC64__)) && defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+        return CPUArchitecture::PPC64;
 #elif defined(__riscv) && defined(__riscv_xlen) && (__riscv_xlen == 32)
         return CPUArchitecture::RISCV32;
 #elif defined(__riscv) && defined(__riscv_xlen) && (__riscv_xlen == 64)
@@ -787,6 +789,8 @@ namespace vcpkg
         return "android";
 #elif defined(__linux__)
         return "linux";
+#elif defined(_AIX)
+        return "aix";
 #else
         return "unknown";
 #endif

--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -984,6 +984,10 @@ namespace vcpkg
         {
             return m_paths.scripts / "toolchains/linux.cmake";
         }
+        else if (cmake_system_name == "AIX")
+        {
+            return m_paths.scripts / "toolchains/aix.cmake";
+        }
         else if (cmake_system_name == "Darwin")
         {
             return m_paths.scripts / "toolchains/osx.cmake";

--- a/src/vcpkg/platform-expression.cpp
+++ b/src/vcpkg/platform-expression.cpp
@@ -33,6 +33,7 @@ namespace vcpkg::PlatformExpression
         bsd,
         solaris,
         osx,
+        aix,
         uwp,
         xbox,
         android,
@@ -70,6 +71,7 @@ namespace vcpkg::PlatformExpression
             {"bsd", Identifier::bsd},
             {"solaris", Identifier::solaris},
             {"osx", Identifier::osx},
+            {"aix", Identifier::aix},
             {"uwp", Identifier::uwp},
             {"xbox", Identifier::xbox},
             {"android", Identifier::android},
@@ -692,6 +694,7 @@ namespace vcpkg::PlatformExpression
                                    true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "NetBSD");
                         case Identifier::solaris: return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "SunOS");
                         case Identifier::osx: return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "Darwin");
+                        case Identifier::aix: return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "AIX");
                         case Identifier::uwp:
                             return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "WindowsStore");
                         case Identifier::xbox: return true_if_exists_and_nonempty("VCPKG_XBOX_CONSOLE_TARGET");

--- a/src/vcpkg/tools.cpp
+++ b/src/vcpkg/tools.cpp
@@ -40,6 +40,7 @@ namespace
         {"openbsd", ToolOs::OpenBsd},
         {"netbsd", ToolOs::NetBsd},
         {"solaris", ToolOs::Solaris},
+        {"aix", ToolOs::Aix},
     };
 }
 
@@ -182,6 +183,8 @@ namespace vcpkg
         auto data = get_raw_tool_data(tool_data_table, tool, hp, ToolOs::NetBsd);
 #elif defined(__SVR4) && defined(__sun)
         auto data = get_raw_tool_data(tool_data_table, tool, hp, ToolOs::Solaris);
+#elif defined(_AIX)
+        auto data = get_raw_tool_data(tool_data_table, tool, hp, ToolOs::Aix);
 #else
         ToolDataEntry* data = nullptr;
 #endif


### PR DESCRIPTION
Add support for IBM AIX. Tested on AIX 7.3 TL2 SP2 with IBM Open XL C/C++ 17.1.1.4.

Some highlights:

* AIX is a PPC64 big endian system only, requiring a new CPU type.
* AIX defines a macro `IA64` in one of its system headers, so we have to undef it in `include/vcpkg/base/cofffilereader.h`
* We need the `-bbigtoc` linker option as the TOC for the `vcpkg` and `vcpkg-test` executables are bigger than 64K.
* AIX has no way of easily determining the name of the current executable. We can ask `/proc/<pid>/object/a.out` but that's not a link to the actual file like it is on Solaris. We could use it to get the file's inode and device number but we'd still need to search the filesystem to find it. Alternatively we can just trust `argv[0]` and introduce a mandatory init call.
* AIX doesn't provide a `timegm` function, so we have to hand roll one.
* We need to use the `getkerninfo` info syscall to get network device information, but no system header defines it in a C++ safe manner so we manually define its prototype.
* During testing the process tests failed with EAGAIN. I updated `ChildStdinTracker` to not treat `EAGAIN` or `EWOULDBLOCK` as errors and that fixed the test.

`vcpkg-test` passes cleanly on this branch on the system I have access to.