### PR TITLE
Fix GitHub API endpoint selection based on host parsing

### DIFF
--- a/include/vcpkg/base/downloads.h
+++ b/include/vcpkg/base/downloads.h
@@ -37,6 +37,10 @@ namespace vcpkg
                                                  const std::string& github_repository,
                                                  const Json::Object& snapshot);
 
+    // Builds the dependency graph snapshots endpoint used for GitHub submission.
+    std::string github_dependency_graph_snapshots_uri(const Optional<std::string>& maybe_github_server_url,
+                                                      StringView github_repository);
+
     std::vector<int> url_heads(DiagnosticContext& context, View<std::string> urls, View<std::string> headers);
 
     struct AssetCachingSettings

--- a/src/vcpkg-test/downloads.cpp
+++ b/src/vcpkg-test/downloads.cpp
@@ -61,12 +61,15 @@ TEST_CASE ("github_dependency_graph_snapshots_uri", "[downloads]")
     REQUIRE(github_dependency_graph_snapshots_uri(Optional<std::string>{"https://github.com"}, "owner/repo") ==
             "https://api.github.com/repos/owner/repo/dependency-graph/snapshots");
 
-    REQUIRE(github_dependency_graph_snapshots_uri(Optional<std::string>{"https://user:pass@github.com:443"},
-                                                  "owner/repo") ==
-            "https://api.github.com/repos/owner/repo/dependency-graph/snapshots");
+    REQUIRE(github_dependency_graph_snapshots_uri(Optional<std::string>{"https://github.com/"}, "owner/repo") ==
+            "https://github.com//api/v3/repos/owner/repo/dependency-graph/snapshots");
 
     REQUIRE(github_dependency_graph_snapshots_uri(Optional<std::string>{"https://github.example.com"}, "owner/repo") ==
             "https://github.example.com/api/v3/repos/owner/repo/dependency-graph/snapshots");
+
+    REQUIRE(github_dependency_graph_snapshots_uri(Optional<std::string>{"https://user:pass@github.example.com:443"},
+                                              "owner/repo") ==
+        "https://user:pass@github.example.com:443/api/v3/repos/owner/repo/dependency-graph/snapshots");
 
     REQUIRE(
         github_dependency_graph_snapshots_uri(Optional<std::string>{"https://github.com"}, "owner/repo with space") ==

--- a/src/vcpkg-test/downloads.cpp
+++ b/src/vcpkg-test/downloads.cpp
@@ -53,6 +53,26 @@ TEST_CASE ("url_encode_spaces", "[downloads]")
             "https://example.com/a%20%20space/b?query=value&query2=value2");
 }
 
+TEST_CASE ("github_dependency_graph_snapshots_uri", "[downloads]")
+{
+    REQUIRE(github_dependency_graph_snapshots_uri(nullopt, "owner/repo") ==
+            "https://api.github.com/repos/owner/repo/dependency-graph/snapshots");
+
+    REQUIRE(github_dependency_graph_snapshots_uri(Optional<std::string>{"https://github.com"}, "owner/repo") ==
+            "https://api.github.com/repos/owner/repo/dependency-graph/snapshots");
+
+    REQUIRE(github_dependency_graph_snapshots_uri(Optional<std::string>{"https://user:pass@github.com:443"},
+                                                  "owner/repo") ==
+            "https://api.github.com/repos/owner/repo/dependency-graph/snapshots");
+
+    REQUIRE(github_dependency_graph_snapshots_uri(Optional<std::string>{"https://github.example.com"}, "owner/repo") ==
+            "https://github.example.com/api/v3/repos/owner/repo/dependency-graph/snapshots");
+
+    REQUIRE(
+        github_dependency_graph_snapshots_uri(Optional<std::string>{"https://github.com"}, "owner/repo with space") ==
+        "https://api.github.com/repos/owner/repo%20with%20space/dependency-graph/snapshots");
+}
+
 /*
  * To run this test:
  * - Set environment variables VCPKG_TEST_AZBLOB_URL and VCPKG_TEST_AZBLOB_SAS.

--- a/src/vcpkg-test/downloads.cpp
+++ b/src/vcpkg-test/downloads.cpp
@@ -62,9 +62,12 @@ TEST_CASE ("github_dependency_graph_snapshots_uri", "[downloads]")
             "https://api.github.com/repos/owner/repo/dependency-graph/snapshots");
 
     REQUIRE(github_dependency_graph_snapshots_uri(Optional<std::string>{"https://github.com/"}, "owner/repo") ==
-            "https://github.com//api/v3/repos/owner/repo/dependency-graph/snapshots");
+            "https://api.github.com/repos/owner/repo/dependency-graph/snapshots");
 
     REQUIRE(github_dependency_graph_snapshots_uri(Optional<std::string>{"https://github.example.com"}, "owner/repo") ==
+            "https://github.example.com/api/v3/repos/owner/repo/dependency-graph/snapshots");
+
+    REQUIRE(github_dependency_graph_snapshots_uri(Optional<std::string>{"https://github.example.com/"}, "owner/repo") ==
             "https://github.example.com/api/v3/repos/owner/repo/dependency-graph/snapshots");
 
     REQUIRE(github_dependency_graph_snapshots_uri(Optional<std::string>{"https://user:pass@github.example.com:443"},

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -38,45 +38,6 @@ namespace
             curl, static_cast<CURLoption>(229) /* CURLOPT_HEADEROPT */, (1L << 0) /* CURLHEADER_SEPARATE */);
     }
 
-    // Extracts the host part from a URL string.
-    std::string extract_host(StringView url)
-    {
-        // Remove scheme if present
-        StringView http_scheme = "http://";
-        StringView https_scheme = "https://";
-        if (url.starts_with(http_scheme))
-        {
-            url = url.substr(http_scheme.size());
-        }
-        else if (url.starts_with(https_scheme))
-        {
-            url = url.substr(https_scheme.size());
-        }
-
-        // Remove userinfo if present (e.g., user:pass@host)
-        const char* at_sign = Strings::find_first_of(url, "@");
-        size_t at_pos = at_sign[0] == '\0' ? std::string::npos : static_cast<size_t>(at_sign - url.data());
-        if (at_pos != std::string::npos && at_pos + 1 < url.size())
-        {
-            // Move past the '@'
-            url = url.substr(at_pos + 1);
-        }
-
-        // Find the start of the path (first '/')
-        const char* first_slash = Strings::find_first_of(url, "/");
-        size_t slash_pos = first_slash[0] == '\0' ? std::string::npos : static_cast<size_t>(first_slash - url.data());
-        StringView host_part = slash_pos != std::string::npos ? url.substr(0, slash_pos) : url;
-
-        // Remove port if present (e.g., host:port)
-        const char* colon = Strings::find_first_of(host_part, ":");
-        size_t colon_pos = colon[0] == '\0' ? std::string::npos : static_cast<size_t>(colon - host_part.data());
-        if (colon_pos != std::string::npos)
-        {
-            host_part = host_part.substr(0, colon_pos);
-        }
-
-        return std::string(host_part);
-    }
 }
 
 namespace vcpkg
@@ -366,22 +327,23 @@ namespace vcpkg
                                                       StringView github_repository)
     {
         std::string uri;
+        constexpr StringLiteral github_com_url = "https://github.com";
+        constexpr StringLiteral api_github_com_url = "https://api.github.com";
         if (auto github_server_url = maybe_github_server_url.get())
         {
-            const auto host = extract_host(*github_server_url);
-            if (host != "github.com")
+            if (*github_server_url == github_com_url)
+            {
+                uri = api_github_com_url.data();
+            }
+            else
             {
                 uri = *github_server_url;
                 uri.append("/api/v3");
             }
-            else
-            {
-                uri = "https://api.github.com";
-            }
         }
         else
         {
-            uri = "https://api.github.com";
+            uri = api_github_com_url.data();
         }
 
         fmt::format_to(

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -327,27 +327,7 @@ namespace vcpkg
                                                  const std::string& github_repository,
                                                  const Json::Object& snapshot)
     {
-        std::string uri;
-        if (auto github_server_url = maybe_github_server_url.get())
-        {
-            const auto host = extract_host(*github_server_url);
-            if (host != "github.com")
-            {
-                uri = *github_server_url;
-                uri.append("/api/v3");
-            }
-            else
-            {
-                uri = "https://api.github.com";
-            }
-        }
-        else
-        {
-            uri = "https://api.github.com";
-        }
-
-        fmt::format_to(
-            std::back_inserter(uri), "/repos/{}/dependency-graph/snapshots", url_encode_spaces(github_repository));
+        const auto uri = github_dependency_graph_snapshots_uri(maybe_github_server_url, github_repository);
 
         CurlEasyHandle handle;
         CURL* curl = handle.get();
@@ -380,6 +360,33 @@ namespace vcpkg
         }
 
         return response_code >= 200 && response_code < 300;
+    }
+
+    std::string github_dependency_graph_snapshots_uri(const Optional<std::string>& maybe_github_server_url,
+                                                      StringView github_repository)
+    {
+        std::string uri;
+        if (auto github_server_url = maybe_github_server_url.get())
+        {
+            const auto host = extract_host(*github_server_url);
+            if (host != "github.com")
+            {
+                uri = *github_server_url;
+                uri.append("/api/v3");
+            }
+            else
+            {
+                uri = "https://api.github.com";
+            }
+        }
+        else
+        {
+            uri = "https://api.github.com";
+        }
+
+        fmt::format_to(
+            std::back_inserter(uri), "/repos/{}/dependency-graph/snapshots", url_encode_spaces(github_repository));
+        return uri;
     }
 
     static size_t read_file_callback(char* buffer, size_t size, size_t nitems, void* param)

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -37,7 +37,6 @@ namespace
         vcpkg_curl_easy_setopt(
             curl, static_cast<CURLoption>(229) /* CURLOPT_HEADEROPT */, (1L << 0) /* CURLHEADER_SEPARATE */);
     }
-
 }
 
 namespace vcpkg

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -330,19 +330,25 @@ namespace vcpkg
         constexpr StringLiteral api_github_com_url = "https://api.github.com";
         if (auto github_server_url = maybe_github_server_url.get())
         {
-            if (*github_server_url == github_com_url)
+            StringView normalized_server_url = *github_server_url;
+            if (!normalized_server_url.empty() && normalized_server_url[normalized_server_url.size() - 1] == '/')
             {
-                uri = api_github_com_url.data();
+                normalized_server_url = normalized_server_url.substr(0, normalized_server_url.size() - 1);
+            }
+
+            if (normalized_server_url == github_com_url)
+            {
+                uri.assign(api_github_com_url.data(), api_github_com_url.size());
             }
             else
             {
-                uri = *github_server_url;
+                uri.assign(normalized_server_url.data(), normalized_server_url.size());
                 uri.append("/api/v3");
             }
         }
         else
         {
-            uri = api_github_com_url.data();
+            uri.assign(api_github_com_url.data(), api_github_com_url.size());
         }
 
         fmt::format_to(


### PR DESCRIPTION
Previously, when `GITHUB_SERVER_URL` was set, vcpkg always treated it as a GitHub Enterprise Server(GHES) endpoint and appended `/api/v3` for `GITHUB_SERVER_URL=https://github.com`, this produced an incorrect endpoint (`https://github.com/api/v3/...`).

This change special-cases the exact value `https://github.com` and uses `https://api.github.com` for dependency graph submission. All other server URLs keep the existing behavior (`<server>/api/v3/...`).

Added tests for endpoint selection behavior in `src/vcpkg-test/downloads.cpp`.

Fixes https://github.com/microsoft/vcpkg/issues/48347