### PR TITLE
Fix arm64 macOS GitHub Actions.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,7 +78,7 @@ jobs:
       - name: Install Mono (macOS) (for NuGet export)
         if: matrix.preset == 'macos-ci'
         run: |
-          brew install mono
+          arch -arm64 brew install mono
       - name: Run vcpkg end-to-end tests
         shell: pwsh
         run: |


### PR DESCRIPTION
https://github.com/microsoft/vcpkg-tool/actions/runs/19948355928/job/57202915561

```
Error: Cannot install under Rosetta 2 in ARM default prefix (/opt/homebrew)! To rerun under ARM use:
    arch -arm64 brew install ...
To install under x86_64, install Homebrew into /usr/local.
```