### PR TITLE
Upgrade CodeQL and disable on macos-ci.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,8 +32,8 @@ jobs:
       - name: Enable Problem Matchers
         run: echo "::add-matcher::.github/workflows/matchers.json"
       - name: '[CI Only] Initialize CodeQL'
-        if: inputs.codeql && matrix.preset != 'linux-arm64-ci'
-        uses: github/codeql-action/init@v3
+        if: inputs.codeql && matrix.preset != 'linux-arm64-ci' && matrix.preset != 'macos-ci'
+        uses: github/codeql-action/init@v4
         with:
           languages: javascript-typescript, c-cpp
       - name: Configure and Build
@@ -54,8 +54,8 @@ jobs:
           IF %ERRORLEVEL% NEQ 0 exit /B %ERRORLEVEL%
           cmake --build --preset ${{ matrix.preset }} -- -k0
       - name: '[CI Only] Perform CodeQL Analysis'
-        if: inputs.codeql && matrix.preset != 'linux-arm64-ci'
-        uses: github/codeql-action/analyze@v3
+        if: inputs.codeql && matrix.preset != 'linux-arm64-ci' && matrix.preset != 'macos-ci'
+        uses: github/codeql-action/analyze@v4
       - name: Run vcpkg and vcpkg-artifacts unit tests
         run: ctest --preset ${{ matrix.preset }} --output-on-failure 2>&1
       - name: Get microsoft/vcpkg pinned sha into VCPKG_SHA


### PR DESCRIPTION
This tries to fix failures reported in https://github.com/microsoft/vcpkg-tool/actions/runs/20175286709

1. macOS-26 takes 15 times as long when CodeQL is turned on which causes the overall run to exceed GitHub's 2 hour time limit. I'm guessing this is because the macOS machines have very little RAM and CodeQL is RAM hungry.
2. [CI Only] Initialize CodeQL CodeQL Action v3 will be deprecated in December 2026. Please update all occurrences of the CodeQL Action in your workflow files to v4. For more information, see https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/