### PR TITLE
Switch default Ninja minimal version to a reasonable value

### DIFF
--- a/src/vcpkg/tools.cpp
+++ b/src/vcpkg/tools.cpp
@@ -488,7 +488,7 @@ namespace vcpkg
         virtual bool is_abi_sensitive() const override { return false; }
         virtual StringView tool_data_name() const override { return Tools::NINJA; }
         virtual std::vector<StringView> system_exe_stems() const override { return {Tools::NINJA}; }
-        virtual std::array<int, 3> default_min_version() const override { return {3, 5, 1}; }
+        virtual std::array<int, 3> default_min_version() const override { return {1, 12, 1}; }
 #if !defined(_WIN32)
         virtual void add_system_paths(DiagnosticContext&,
                                       const ReadOnlyFilesystem&,


### PR DESCRIPTION
The previous value (3.5.1) doesn't make much sense and it being that broke systems like FreeBSD which didn't have a tool download link.

This also comes with a question, while this solves the problem for now, what would be a more reasonable solution to keep the minimum versions in sync for all those platforms (like RISC-V Linux, *BSD, Solaris and more) that will most probably never have all download links added, should there a be separate JSON file listing minimal versions, should all those platforms get spoofed to x64 Linux for version checks or maybe something entirely else.