### PR TITLE
fix double adding of additional_files_0...

### DIFF
--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -1419,20 +1419,8 @@ namespace vcpkg
                 port_dir_cache_entry.files = std::move(rel_port_files);
             }
             const auto& rel_port_files = port_dir_cache_entry.files;
-            // Technically the pre_build_info is not part of the port_dir cache key, but a given port_dir is only going
-            // to be associated with 1 port
-            for (size_t i = 0; i < abi_info.pre_build_info->hash_additional_files.size(); ++i)
-            {
-                const auto& file = abi_info.pre_build_info->hash_additional_files[i];
-                if (file.is_relative() || !fs.is_regular_file(file))
-                {
-                    Checks::msg_exit_with_message(
-                        VCPKG_LINE_INFO, msgInvalidValueHashAdditionalFiles, msg::path = file);
-                }
-                abi_tag_entries.emplace_back(
-                    fmt::format("additional_file_{}", i),
-                    Hash::get_file_hash(fs, file, Hash::Algorithm::Sha256).value_or_exit(VCPKG_LINE_INFO));
-            }
+            // Note: hash_additional_files are triplet-specific, not port-specific,
+            // so they are processed outside this cache lambda (see lines 1474-1488)
 
             for (const Path& rel_port_file : rel_port_files)
             {


### PR DESCRIPTION
Should fix https://github.com/microsoft/vcpkg-tool/issues/1900 but i'm not sure if i would break an additional feature (this is why i first draft the PR)


As already commented in the ticket:

There are two places where hash_additional_files are added to abi_tag_entries:

Lines 1425-1435 (INCORRECT): Inside the port_dir_cache.get_lazy() lambda, the code adds entries directly to abi_tag_entries:

```
for (size_t i = 0; i < abi_info.pre_build_info->hash_additional_files.size(); ++i)
{
    // ...
    abi_tag_entries.emplace_back(
        fmt::format("additional_file_{}", i),
        Hash::get_file_hash(fs, file, Hash::Algorithm::Sha256).value_or_exit(VCPKG_LINE_INFO));
}
```

Lines 1474-1488 (CORRECT): After retrieving the cache entry, the code adds the same entries again:

```
for (auto& filestr : abi_info.pre_build_info->hash_additional_files)
{
    // ...
    abi_tag_entries.emplace_back(fmt::format("additional_file_{}", i++), hash);
}
```

### Why This Causes Inconsistent Behavior

First package built (cache miss): The lambda at lines 1409-1468 executes, and line 1432 incorrectly adds additional_file_* to abi_tag_entries. Then line 1486 adds them again → double entries.

Second package with same port_dir (cache hit): The lambda doesn't execute (cache hit), so only line 1486 runs → single entry.
