### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 15684: Build ID 13296385

### DIFF
--- a/locales/messages.cs.json
+++ b/locales/messages.cs.json
@@ -397,7 +397,6 @@
   "ConflictingEmbeddedConfiguration": "lze použít pouze jednu z {{\"configuration\", \"vcpkg-configuration\"}}",
   "ConflictingFiles": "Následující soubory jsou už nainstalované v {path} a jsou v konfliktu s {spec}.",
   "ConsideredVersions": "Následující spustitelné soubory byly zvažovány, ale byly vyřazeny, protože je vyžadována verze {version}:",
-  "ConstraintViolation": "Bylo nalezeno porušení omezení:",
   "ContinueCodeUnitInStart": "našla se jednotka kódu pro pokračování na počáteční pozici",
   "ControlCharacterInString": "Řídicí znak v řetězci",
   "ControlSupportsMustBeAPlatformExpression": "„Supports“ musí být výraz platformy.",

--- a/locales/messages.de.json
+++ b/locales/messages.de.json
@@ -397,7 +397,6 @@
   "ConflictingEmbeddedConfiguration": "es darf nur eines von {{\"configuration\", \"vcpkg-configuration\"}} verwendet werden",
   "ConflictingFiles": "Die folgenden Dateien sind bereits in {path} installiert und stehen in Konflikt mit {spec}",
   "ConsideredVersions": "Die folgenden ausführbaren Dateien wurden berücksichtigt, aber aufgrund der Versionsanforderung von {version} verworfen:",
-  "ConstraintViolation": "Es wurde eine Einschränkungsverletzung gefunden:",
   "ContinueCodeUnitInStart": "Fortsetzungscodeeinheit wurde an der Startposition gefunden.",
   "ControlCharacterInString": "Steuerzeichen in Zeichenfolge",
   "ControlSupportsMustBeAPlatformExpression": "\"Unterstützt\" muss ein Plattformausdruck sein",

--- a/locales/messages.es.json
+++ b/locales/messages.es.json
@@ -397,7 +397,6 @@
   "ConflictingEmbeddedConfiguration": "solo se puede usar un {{\"configuration\", \"vcpkg-configuration\"}}",
   "ConflictingFiles": "Los siguientes archivos ya están instalados en {path} y están en conflicto con {spec}",
   "ConsideredVersions": "Se tuvieron en cuenta los siguientes ejecutables, pero se descartaron debido al requisito de versión de {version}:",
-  "ConstraintViolation": "Se ha encontrado una infracción de restricción:",
   "ContinueCodeUnitInStart": "se encontró la unidad de código de continuación en la posición inicial",
   "ControlCharacterInString": "Carácter de control en la cadena",
   "ControlSupportsMustBeAPlatformExpression": "\"Supports\" debe ser una expresión de plataforma",

--- a/locales/messages.fr.json
+++ b/locales/messages.fr.json
@@ -397,7 +397,6 @@
   "ConflictingEmbeddedConfiguration": "une seule de {{\"configuration\", \"vcpkg-configuration\"}} peut être utilisée",
   "ConflictingFiles": "Les fichiers suivants sont déjà installés dans {path} et sont en conflit avec {spec}",
   "ConsideredVersions": "Les exécutables suivants ont été pris en compte mais ignorés en raison de l’exigence de version de {version} :",
-  "ConstraintViolation": "Une violation de contrainte a été trouvée :",
   "ContinueCodeUnitInStart": "unité de code continue trouvée en position de départ",
   "ControlCharacterInString": "Caractère de contrôle dans la chaîne",
   "ControlSupportsMustBeAPlatformExpression": "« Supports » doit être une expression de plateforme",

--- a/locales/messages.it.json
+++ b/locales/messages.it.json
@@ -397,7 +397,6 @@
   "ConflictingEmbeddedConfiguration": "è possibile utilizzare solo uno di {{\"configuration\", \"vcpkg-configuration\"}}",
   "ConflictingFiles": "I file seguenti sono già installati in {path} e sono in conflitto con {spec}",
   "ConsideredVersions": "I seguenti eseguibili sono stati considerati ma rimossi a causa del requisito di versione di {version}:",
-  "ConstraintViolation": "È stata trovata una violazione di vincolo:",
   "ContinueCodeUnitInStart": "è stata trovata un'unità di codice continua nella posizione iniziale",
   "ControlCharacterInString": "Carattere di controllo nella stringa",
   "ControlSupportsMustBeAPlatformExpression": "\"Supporti\" deve essere un'espressione di piattaforma",

--- a/locales/messages.ja.json
+++ b/locales/messages.ja.json
@@ -397,7 +397,6 @@
   "ConflictingEmbeddedConfiguration": "{{\"configuration\", \"vcpkg-configuration\"}} のうち 1 つだけを使用できます",
   "ConflictingFiles": "次のファイルはすでに {path} にインストールされており、{spec} と競合しています",
   "ConsideredVersions": "次の実行可能ファイルが検討されましたが、{version} のバージョン要件により破棄されました。",
-  "ConstraintViolation": "以下の制約違反が見つかりました。",
   "ContinueCodeUnitInStart": "開始位置で continue コード単位が見つかりました",
   "ControlCharacterInString": "文字列内の制御文字",
   "ControlSupportsMustBeAPlatformExpression": "\"Supports\" はプラットフォーム式である必要があります",

--- a/locales/messages.ko.json
+++ b/locales/messages.ko.json
@@ -397,7 +397,6 @@
   "ConflictingEmbeddedConfiguration": "{{\"configuration\", \"vcpkg-configuration\"}} 중 하나만 사용할 수 있습니다.",
   "ConflictingFiles": "다음 파일은 {path}에 이미 설치되어 있으며 {spec}과(와) 충돌합니다.",
   "ConsideredVersions": "{version}의 버전 요구 사항으로 인해 다음 실행 파일이 고려되었지만 삭제되었습니다.",
-  "ConstraintViolation": "제약 조건 위반 발견:",
   "ContinueCodeUnitInStart": "시작 위치에서 계속 코드 단위를 찾음",
   "ControlCharacterInString": "문자열의 제어 문자",
   "ControlSupportsMustBeAPlatformExpression": "\"Supports\"는 반드시 플랫폼 식이어야 합니다.",

--- a/locales/messages.pl.json
+++ b/locales/messages.pl.json
@@ -397,7 +397,6 @@
   "ConflictingEmbeddedConfiguration": "można użyć tylko jednego z {{\"configuration\", \"vcpkg-configuration\"}}",
   "ConflictingFiles": "Następujące pliki są już zainstalowane w ścieżce {path} i są w konflikcie z {spec}",
   "ConsideredVersions": "Następujące pliki wykonywalne zostały uwzględnione, ale odrzucone ze względu na wymaganie wersji {version}:",
-  "ConstraintViolation": "Znaleziono naruszenie ograniczenia:",
   "ContinueCodeUnitInStart": "znaleziono jednostkę kodu kontynuacji w pozycji początkowej",
   "ControlCharacterInString": "Znak kontrolny w ciągu",
   "ControlSupportsMustBeAPlatformExpression": "Element „Supports” musi być wyrażeniem platformy",

--- a/locales/messages.pt-BR.json
+++ b/locales/messages.pt-BR.json
@@ -397,7 +397,6 @@
   "ConflictingEmbeddedConfiguration": "apenas um de {{\"configuration\", \"vcpkg-configuration\"}} pode ser usado",
   "ConflictingFiles": "Os seguintes arquivos já estão instalados em {path} e estão em conflito com {spec}",
   "ConsideredVersions": "Os executáveis a seguir foram considerados, mas descartados devido ao requisito de versão de {version}:",
-  "ConstraintViolation": "Encontrou uma violação de restrição:",
   "ContinueCodeUnitInStart": "encontrou unidade de código de continuação na posição inicial",
   "ControlCharacterInString": "Caractere de controle na cadeia de caracteres",
   "ControlSupportsMustBeAPlatformExpression": "\"Supports\" deve ser uma expressão de plataforma",

--- a/locales/messages.ru.json
+++ b/locales/messages.ru.json
@@ -397,7 +397,6 @@
   "ConflictingEmbeddedConfiguration": "можно использовать только один из {{\"configuration\", \"vcpkg-configuration\"}}",
   "ConflictingFiles": "Следующие файлы уже установлены в {path} и конфликтуют с {spec}",
   "ConsideredVersions": "Следующие исполняемые файлы были рассмотрены, но отклонены из-за требования версии {version}:",
-  "ConstraintViolation": "Обнаружено нарушение ограничения:",
   "ContinueCodeUnitInStart": "найдена единица кода продолжения в начальной позиции",
   "ControlCharacterInString": "Управляющий символ в строке",
   "ControlSupportsMustBeAPlatformExpression": "\"Supports\" должно быть выражением платформы",

--- a/locales/messages.tr.json
+++ b/locales/messages.tr.json
@@ -397,7 +397,6 @@
   "ConflictingEmbeddedConfiguration": "sadece bir {{\"configuration\", \"vcpkg-configuration\"}} kullanılabilir",
   "ConflictingFiles": "Aşağıdaki dosyalar zaten {path} yolunda yüklü ve {spec} ile çakışıyor",
   "ConsideredVersions": "Aşağıdaki yürütülebilir dosyalar dikkate alındı ancak {version} gereksinimi nedeniyle atıldı:",
-  "ConstraintViolation": "Bir kısıtlama ihlali bulundu:",
   "ContinueCodeUnitInStart": "başlangıç konumunda devam kodu birimi bulundu",
   "ControlCharacterInString": "Control character in string",
   "ControlSupportsMustBeAPlatformExpression": "“Destekler”, bir platform ifadesi olmalıdır",

--- a/locales/messages.zh-Hans.json
+++ b/locales/messages.zh-Hans.json
@@ -397,7 +397,6 @@
   "ConflictingEmbeddedConfiguration": "只能使用 {{\"configuration\", \"vcpkg-configuration\"}} 之一",
   "ConflictingFiles": "以下文件已安装在 {path} 中，并与 {spec} 发生冲突",
   "ConsideredVersions": "考虑了以下可执行文件，但由于 {version} 的版本要求而被放弃:",
-  "ConstraintViolation": "发现约束冲突:",
   "ContinueCodeUnitInStart": "在“开始”位置找到了继续码位",
   "ControlCharacterInString": "字符串中的控件字符",
   "ControlSupportsMustBeAPlatformExpression": "“Supports”必须是平台表达式",

--- a/locales/messages.zh-Hant.json
+++ b/locales/messages.zh-Hant.json
@@ -397,7 +397,6 @@
   "ConflictingEmbeddedConfiguration": "只能使用 {{\"configuration\", \"vcpkg-configuration\"}} 其中之一",
   "ConflictingFiles": "下列檔案已安裝在 {path} 中，且與 {spec} 衝突",
   "ConsideredVersions": "由於 {version} 的版本需求，已考慮下列可執行檔，但已捨棄:",
-  "ConstraintViolation": "發現強制違規:",
   "ContinueCodeUnitInStart": "在開始位置找到繼續字碼單位",
   "ControlCharacterInString": "字串中的控制字元",
   "ControlSupportsMustBeAPlatformExpression": "\"Supports\" 必須是平台運算式",


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.