### PR TITLE
[telemetry] Add --use-test-data to z-upload-metrics

### DIFF
--- a/include/vcpkg/base/contractual-constants.h
+++ b/include/vcpkg/base/contractual-constants.h
@@ -294,6 +294,7 @@ namespace vcpkg
     inline constexpr StringLiteral SwitchToolDataFile = "tool-data-file";
     inline constexpr StringLiteral SwitchTriplet = "triplet";
     inline constexpr StringLiteral SwitchUrl = "url";
+    inline constexpr StringLiteral SwitchUseTestData = "use-test-data";
     inline constexpr StringLiteral SwitchVcpkgRoot = "vcpkg-root";
     inline constexpr StringLiteral SwitchVerbose = "verbose";
     inline constexpr StringLiteral SwitchVerifyGitTrees = "verify-git-trees";

--- a/src/vcpkg/commands.z-upload-metrics.cpp
+++ b/src/vcpkg/commands.z-upload-metrics.cpp
@@ -1,11 +1,22 @@
 #include <vcpkg/base/checks.h>
+#include <vcpkg/base/chrono.h>
 #include <vcpkg/base/contractual-constants.h>
 #include <vcpkg/base/files.h>
 #include <vcpkg/base/system.debug.h>
+#include <vcpkg/base/util.h>
 
 #include <vcpkg/commands.z-upload-metrics.h>
 #include <vcpkg/metrics.h>
 #include <vcpkg/vcpkgcmdarguments.h>
+
+using namespace vcpkg;
+
+namespace
+{
+    constexpr CommandSwitch command_switches[] = {
+        {SwitchUseTestData, {}},
+    };
+}
 
 namespace vcpkg
 {
@@ -15,9 +26,9 @@ namespace vcpkg
         {},
         Undocumented,
         AutocompletePriority::Never,
+        0,
         1,
-        1,
-        {},
+        {command_switches},
         nullptr,
     };
 
@@ -28,19 +39,42 @@ namespace vcpkg
         // note that z-upload-metrics is usually going to have metrics disabled as it is usually
         // invoked inside vcpkg, and we don't collect vcpkg-in-vcpkg metrics.
         const auto parsed = args.parse_arguments(CommandZUploadMetricsMetadata);
-        const auto& payload_path = parsed.command_arguments[0];
-        auto payload = fs.read_contents(payload_path, VCPKG_LINE_INFO);
+
+        std::string payload;
+        if (Util::Sets::contains(parsed.switches, SwitchUseTestData))
+        {
+            MetricsUserConfig user{
+                "00000000-0000-0000-0000-000000000000", // user_id
+                CTime::now_string(),                    // user_time
+                "0",                                    // user_mac
+            };
+            auto session = MetricsSessionData::from_system();
+            MetricsSubmission submission;
+            submission.track_string(StringMetric::CommandName, "z-upload-metrics-test-data");
+            submission.track_string(StringMetric::DevDeviceId, "00000000-0000-0000-0000-000000000000");
+            payload = format_metrics_payload(user, session, submission);
+        }
+        else
+        {
+            Checks::check_exit(
+                VCPKG_LINE_INFO, !parsed.command_arguments.empty(), "Expected a payload file path argument");
+            payload = fs.read_contents(parsed.command_arguments[0], VCPKG_LINE_INFO);
+        }
+
         if (!curl_upload_metrics(payload))
         {
             Debug::println("Failed to upload metrics");
             Checks::exit_fail(VCPKG_LINE_INFO);
         }
 
-        std::error_code ec;
-        fs.remove(payload_path, ec);
-        if (ec)
+        if (!parsed.command_arguments.empty())
         {
-            Debug::println("Failed to remove file after upload: {}", ec.message());
+            std::error_code ec;
+            fs.remove(parsed.command_arguments[0], ec);
+            if (ec)
+            {
+                Debug::println("Failed to remove file after upload: {}", ec.message());
+            }
         }
 
         Checks::exit_success(VCPKG_LINE_INFO);


### PR DESCRIPTION
This let us send dummy data for testing purposes that is easily identifiable.

An alternative would be to check in a dummy payload file and use that as the payload-file parameter instead.