### PR TITLE
Group feature test results by port.

### DIFF
--- a/src/vcpkg/commands.test-features.cpp
+++ b/src/vcpkg/commands.test-features.cpp
@@ -41,11 +41,6 @@ namespace
     };
 
     using DiagnosticVec = std::vector<SpecDiagnostic>;
-    void add_diagnostic(DiagnosticVec& diagnostics, const PackageSpec& spec, DiagnosticLine&& line)
-    {
-        diagnostics.push_back(SpecDiagnostic{&spec, std::move(line)});
-    }
-
     void add_diagnostic(DiagnosticVec& diagnostics, const FullPackageSpec& spec, DiagnosticLine&& line)
     {
         diagnostics.push_back(SpecDiagnostic{&spec.package_spec, std::move(line)});


### PR DESCRIPTION
I'm going through ~1200 failures in https://github.com/microsoft/vcpkg/pull/45331 and the diagnostics are ordered by the size of the `ActionPlan` even though generally baseline settings for a given port must be considered together which is inconvenient.

/cc @autoantwort 