### PR TITLE
Accept tags in portsdiff and z-changelog.

### DIFF
--- a/include/vcpkg/base/git.h
+++ b/include/vcpkg/base/git.h
@@ -93,11 +93,6 @@ namespace vcpkg
                           const Path& destination,
                           StringView treeish);
 
-    Optional<bool> git_check_is_commit(DiagnosticContext& context,
-                                       const Path& git_exe,
-                                       GitRepoLocator locator,
-                                       StringView git_commit_id);
-
     Optional<std::string> git_merge_base(DiagnosticContext& context,
                                          const Path& git_exe,
                                          GitRepoLocator locator,
@@ -112,4 +107,9 @@ namespace vcpkg
 
     Optional<std::vector<GitDiffTreeLine>> git_diff_tree(
         DiagnosticContext& context, const Path& git_exe, GitRepoLocator locator, StringView tree1, StringView tree2);
+
+    bool check_commit_exists(DiagnosticContext& context,
+                             const Path& git_exe,
+                             const Path& builtin_ports_dir,
+                             StringView git_commit_id);
 }

--- a/include/vcpkg/base/system.process.h
+++ b/include/vcpkg/base/system.process.h
@@ -254,11 +254,30 @@ namespace vcpkg
     void replace_secrets(std::string& target, View<std::string> secrets);
 
     void report_nonzero_exit_code(DiagnosticContext& context, const Command& command, ExitCodeIntegral exit);
+
+    void report_nonzero_exit_code_and_output(DiagnosticContext& context,
+                                             const Command& command,
+                                             const ExitCodeAndOutput& exit);
+    void report_nonzero_exit_code_and_output(DiagnosticContext& context,
+                                             DiagKind kind,
+                                             const Command& command,
+                                             const ExitCodeAndOutput& exit);
     void report_nonzero_exit_code_and_output(DiagnosticContext& context,
                                              const Command& command,
                                              const ExitCodeAndOutput& exit,
                                              EchoInDebug echo_in_debug);
     void report_nonzero_exit_code_and_output(DiagnosticContext& context,
+                                             DiagKind kind,
+                                             const Command& command,
+                                             const ExitCodeAndOutput& exit,
+                                             EchoInDebug echo_in_debug);
+    void report_nonzero_exit_code_and_output(DiagnosticContext& context,
+                                             const Command& command,
+                                             const ExitCodeAndOutput& exit,
+                                             EchoInDebug echo_in_debug,
+                                             View<std::string> secrets);
+    void report_nonzero_exit_code_and_output(DiagnosticContext& context,
+                                             DiagKind kind,
                                              const Command& command,
                                              const ExitCodeAndOutput& exit,
                                              EchoInDebug echo_in_debug,

--- a/src/vcpkg/base/git.cpp
+++ b/src/vcpkg/base/git.cpp
@@ -308,17 +308,6 @@ namespace vcpkg
         return false;
     }
 
-    Optional<bool> git_check_is_commit(DiagnosticContext& context,
-                                       const Path& git_exe,
-                                       GitRepoLocator locator,
-                                       StringView git_commit_id)
-    {
-        StringView args[] = {StringLiteral{"cat-file"}, StringLiteral{"-t"}, git_commit_id};
-        return run_cmd_trim(context, make_git_command(git_exe, locator, args)).map([](std::string&& output) {
-            return output == "commit";
-        });
-    }
-
     Optional<std::string> git_merge_base(
         DiagnosticContext& context, const Path& git_exe, GitRepoLocator locator, StringView commit1, StringView commit2)
     {
@@ -554,5 +543,30 @@ namespace vcpkg
             return parse_git_diff_tree_lines(context, cmd.command_line(), *git_diff_tree_output);
         }
         return nullopt;
+    }
+
+    bool check_commit_exists(DiagnosticContext& context,
+                             const Path& git_exe,
+                             const Path& builtin_ports_dir,
+                             StringView git_commit_id)
+    {
+        // Resolve any commit-ish (for example, annotated tags) to a commit object.
+        const auto commitish = fmt::format("{}^{{commit}}", git_commit_id);
+        StringView args[] = {StringLiteral{"cat-file"}, StringLiteral{"-e"}, commitish};
+        auto cmd =
+            make_git_command(git_exe, GitRepoLocator{GitRepoLocatorKind::CurrentDirectory, builtin_ports_dir}, args);
+        auto maybe_output = cmd_execute_and_capture_output(context, cmd);
+        if (auto output = maybe_output.get())
+        {
+            if (output->exit_code == 0)
+            {
+                return true;
+            }
+
+            context.report_error(msgInvalidCommitId, msg::commit_sha = git_commit_id);
+            report_nonzero_exit_code_and_output(context, DiagKind::Note, cmd, *output);
+        }
+
+        return false;
     }
 }

--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -2137,13 +2137,50 @@ namespace vcpkg
 
     void report_nonzero_exit_code_and_output(DiagnosticContext& context,
                                              const Command& command,
-                                             const ExitCodeAndOutput& exit,
-                                             EchoInDebug echo_in_debug)
+                                             const ExitCodeAndOutput& exit)
     {
-        report_nonzero_exit_code_and_output(context, command, exit, echo_in_debug, View<std::string>{});
+        report_nonzero_exit_code_and_output(
+            context, DiagKind::Error, command, exit, RedirectedProcessLaunchSettings{}.echo_in_debug);
     }
 
     void report_nonzero_exit_code_and_output(DiagnosticContext& context,
+                                             DiagKind kind,
+                                             const Command& command,
+                                             const ExitCodeAndOutput& exit)
+    {
+        report_nonzero_exit_code_and_output(
+            context, kind, command, exit, RedirectedProcessLaunchSettings{}.echo_in_debug);
+    }
+
+    void report_nonzero_exit_code_and_output(DiagnosticContext& context,
+                                             const Command& command,
+                                             const ExitCodeAndOutput& exit,
+                                             EchoInDebug echo_in_debug)
+    {
+        report_nonzero_exit_code_and_output(
+            context, DiagKind::Error, command, exit, echo_in_debug, View<std::string>{});
+    }
+
+    void report_nonzero_exit_code_and_output(DiagnosticContext& context,
+                                             DiagKind kind,
+                                             const Command& command,
+                                             const ExitCodeAndOutput& exit,
+                                             EchoInDebug echo_in_debug)
+    {
+        report_nonzero_exit_code_and_output(context, kind, command, exit, echo_in_debug, View<std::string>{});
+    }
+
+    void report_nonzero_exit_code_and_output(DiagnosticContext& context,
+                                             const Command& command,
+                                             const ExitCodeAndOutput& exit,
+                                             EchoInDebug echo_in_debug,
+                                             View<std::string> secrets)
+    {
+        report_nonzero_exit_code_and_output(context, DiagKind::Error, command, exit, echo_in_debug, secrets);
+    }
+
+    void report_nonzero_exit_code_and_output(DiagnosticContext& context,
+                                             DiagKind kind,
                                              const Command& command,
                                              const ExitCodeAndOutput& exit,
                                              EchoInDebug echo_in_debug,
@@ -2161,7 +2198,7 @@ namespace vcpkg
             error_line.append_raw('\n').append_raw(exit.output);
         }
 
-        context.report(DiagnosticLine{DiagKind::Error, std::move(error_line)});
+        context.report(DiagnosticLine{kind, std::move(error_line)});
     }
 
     bool check_zero_exit_code(DiagnosticContext& context,

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -1391,8 +1391,7 @@ namespace
                     return CacheAvailability::available;
                 }
 
-                report_nonzero_exit_code_and_output(
-                    context, cmd, *code_and_output, RedirectedProcessLaunchSettings{}.echo_in_debug);
+                report_nonzero_exit_code_and_output(context, cmd, *code_and_output);
             }
 
             return nullopt;
@@ -1555,8 +1554,7 @@ namespace
                     return true;
                 }
 
-                report_nonzero_exit_code_and_output(
-                    context, cmd, *code_and_output, RedirectedProcessLaunchSettings{}.echo_in_debug);
+                report_nonzero_exit_code_and_output(context, cmd, *code_and_output);
                 // az command line error message: Before you can run Azure DevOps commands, you need to
                 // run the login command(az login if using AAD/MSA identity else az devops login if using PAT
                 // token) to setup credentials.

--- a/src/vcpkg/commands.portsdiff.cpp
+++ b/src/vcpkg/commands.portsdiff.cpp
@@ -77,24 +77,6 @@ namespace
                               return cache_entry.second->source_control_file->to_version_spec();
                           });
     }
-
-    bool check_commit_exists(DiagnosticContext& context,
-                             const Path& git_exe,
-                             const Path& builtin_ports_dir,
-                             StringView git_commit_id)
-    {
-        if (!git_check_is_commit(context,
-                                 git_exe,
-                                 GitRepoLocator{GitRepoLocatorKind::CurrentDirectory, builtin_ports_dir},
-                                 git_commit_id)
-                 .value_or(false))
-        {
-            context.report_error(msgInvalidCommitId, msg::commit_sha = git_commit_id);
-            return false;
-        }
-
-        return true;
-    }
 } // unnamed namespace
 
 namespace vcpkg


### PR DESCRIPTION
In https://github.com/microsoft/vcpkg-tool/pull/1842/ I broke portsdiff and z-changelog because the previous behavior checked only if git cat-file -t succeeded, not whether the target was actually a commit. By "fixing" that to actually check for commit that breaks tag inputs.

Using -e and ^{commit} was suggested by gpt-5.3-codex but it was unable to make the other changes.

Demonstration:

```console
PS C:\Dev\vcpkg> .\vcpkg.exe z-changelog 2026.01.16
error: Invalid commit id: 2026.01.16
PS C:\Dev\vcpkg> C:\Dev\vcpkg-tool\out\build\Win-x64-Debug-WithArtifacts\vcpkg.exe z-changelog bogus
error: Invalid commit id: bogus
note: "C:\Program Files\Git\cmd\git.exe" -C "C:\Dev\vcpkg" -c core.autocrlf=false cat-file -e "bogus^{commit}" failed with exit code 128
fatal: Not a valid object name bogus^{commit}

PS C:\Dev\vcpkg> C:\Dev\vcpkg-tool\out\build\Win-x64-Debug-WithArtifacts\vcpkg.exe z-changelog 2026.01.16
#### Total port count: 2765
#### Total port count per triplet (tested): LINK
.
.
.
```

(Also with color:

<img width="1402" height="330" alt="the same console output above color screenshot" src="https://github.com/user-attachments/assets/548bcdb1-df5f-4727-b6c9-237eff4e2d73" />

)