### PR TITLE
Allow Terrapin Retrieval Tool env vars.

### DIFF
--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -654,7 +654,7 @@ namespace vcpkg
             "CUDA_PATH",
             // Enables Terrapin Retrieval Tool
             "TRT_",
-            "X_TRT_"
+            "X_TRT_",
         };
 
         const Optional<std::string> keep_vars = get_environment_variable(EnvironmentVariableVcpkgKeepEnvVars);


### PR DESCRIPTION
Terrpain is an internal Microsoft network isolation tool frequently used with `x-script` asset caching settings. Allow environment variables used to pass authentication data like which tentant to use to it.