### PR TITLE
Update Component Governance manifest.

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -19,7 +19,7 @@
           "name": "fmt",
           "version": "11.2.0",
           "downloadUrl": "https://github.com/fmtlib/fmt/archive/refs/tags/11.2.0.tar.gz",
-          "hash": "sha256:bc23066d87ab3168f27cef3e97d545fa63314f5c79df5ea444d41d56f962c6af"
+          "hash": "sha1:bfa4fa35bb24f4ef239067173c373b211f2d8e84"
         }
       },
       "DevelopmentDependency": false,
@@ -32,7 +32,7 @@
           "name": "CMakeRC",
           "version": "2.0.1",
           "downloadUrl": "https://github.com/vector-of-bool/cmrc/archive/refs/tags/2.0.1.tar.gz",
-          "hash": "sha256:edad5faaa0bea1df124b5e8cb00bf0adbd2faeccecd3b5c146796cbcb8b5b71b"
+          "hash": "sha1:0684b3ab79f4b0c5546c287103c48824bf296980"
         }
       },
       "DevelopmentDependency": false,
@@ -45,7 +45,7 @@
           "name": "zstd",
           "version": "1.5.7",
           "downloadUrl": "https://github.com/facebook/zstd/archive/v1.5.7.tar.gz",
-          "hash": "sha256:37d7284556b20954e56e1ca85b80226768902e2edabd3b649e9e72c0c9012ee3"
+          "hash": "sha1:06b861746bfd5f4351c26bbe59e7a35841fe8471"
         }
       },
       "DevelopmentDependency": false,
@@ -58,7 +58,7 @@
           "name": "nghttp2",
           "version": "1.68.0",
           "downloadUrl": "https://github.com/nghttp2/nghttp2/archive/v1.68.0.tar.gz",
-          "hash": "sha256:07dfdadf670193baa7d6c23a007afa6ff2d3e4301b2a701c41dfd053e3468f09"
+          "hash": "sha1:ef55774c8811b7eb35aa2a45389eba9a05f5bef1"
         }
       },
       "DevelopmentDependency": false,
@@ -71,7 +71,7 @@
           "name": "zlib",
           "version": "1.3.1",
           "downloadUrl": "https://github.com/madler/zlib/archive/v1.3.1.tar.gz",
-          "hash": "sha256:17e88863f3600672ab49182f217281b6fc4d3c762bde361935e436a95214d05c"
+          "hash": "sha1:a7991aa4cf4911817f50b7d0ad4e50dcc9867041"
         }
       },
       "DevelopmentDependency": false,
@@ -84,7 +84,7 @@
           "name": "brotli",
           "version": "1.2.0",
           "downloadUrl": "https://github.com/google/brotli/archive/v1.2.0.tar.gz",
-          "hash": "sha256:816c96e8e8f193b40151dad7e8ff37b1221d019dbcb9c35cd3fadbfe6477dfec"
+          "hash": "sha1:fb74102a641ecce8ebcb13d2a992975a9f165de5"
         }
       },
       "DevelopmentDependency": false,
@@ -97,7 +97,7 @@
           "name": "curl",
           "version": "8.18.0",
           "downloadUrl": "https://github.com/curl/curl/archive/curl-8_18_0.tar.gz",
-          "hash": "sha256:be4b1e146ddd84bbb57f081e5c7238eee794e40563976ba2c89a44c433da219c"
+          "hash": "sha1:2db03c0bd94deed3338b746e656e105b159a49bb"
         }
       },
       "DevelopmentDependency": false,


### PR DESCRIPTION
Adds the new components that should have been added when I turned on curl.

Hopefully also fixes these errors we've been seeing recently:

```console
##[warning]The server rejected registration request for component CMakeRC 2.0.1 https://github.com/vector-of-bool/cmrc/archive/refs/tags/2.0.1.tar.gz - Other with message: The provided user input is not valid. Parameter name: 'Hash'.
##[warning]This component will be pruned from the submission and we will retry.
##[warning]The server rejected registration request for component fmt 11.2.0 https://github.com/fmtlib/fmt/archive/refs/tags/11.2.0.tar.gz - Other with message: The provided user input is not valid. Parameter name: 'Hash'.
##[warning]This component will be pruned from the submission and we will retry.
```