### PR TITLE
Nuget warning when using binary cache 

### DIFF
--- a/src/vcpkg/archives.cpp
+++ b/src/vcpkg/archives.cpp
@@ -80,7 +80,7 @@ namespace
                        .string_arg(to_path)
                        .string_arg("-Source")
                        .string_arg(archive.parent_path())
-                       .string_arg("-nocache")
+                       .string_arg("-NoHttpCache")
                        .string_arg("-DirectDownload")
                        .string_arg("-NonInteractive")
                        .string_arg("-ForceEnglishOutput")

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -724,7 +724,7 @@ namespace
                 .string_arg("-PreRelease")
                 .string_arg("-PackageSaveMode")
                 .string_arg("nupkg");
-            if (!m_use_nuget_cache) cmd.string_arg("-DirectDownload").string_arg("-NoCache");
+            if (!m_use_nuget_cache) cmd.string_arg("-DirectDownload").string_arg("-NoHttpCache");
             cmd.string_arg(src.option).string_arg(src.value);
             return cmd;
         }


### PR DESCRIPTION
Hey as vcpkg now uses nuget 7.3.0

i get this warning when using the binary cache

warning : "D:\vcpkg\downloads\tools\nuget-7.3.0-windows\nuget.exe" install -ForceEnglishOutput -Verbosity detailed -NonInteractive "D:\vcpkg\buildtrees\packages.config" -OutputDirectory "D:\vcpkg\packages" -ExcludeVersion -PreRelease -PackageSaveMode nupkg -DirectDownload -NoCache -Source ****
NoCache is deprecated and has been renamed to NoHttpCache. Please use NoHttpCache instead.

as we have always nuget-7.3.0 i think we can change to -NoHttpCache

This pull requests changes from -NoCache to -NoHttpCache

This should fix issue:
https://github.com/microsoft/vcpkg-tool/issues/1989