### PR TITLE
x-add-version: Regenerate baseline on --all.

### DIFF
--- a/azure-pipelines/end-to-end-tests-dir/versions.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/versions.ps1
@@ -38,6 +38,114 @@ Write-Host $CurrentTest
 Run-Vcpkg @portsRedirectArgsOK x-ci-verify-versions --verbose
 Throw-IfFailed
 
+$CurrentTest = "x-add-version --all rewrites baseline"
+Set-Content -LiteralPath "$versionFilesPath/versions/baseline.json" -Value @"
+{
+  "default": {
+    "cat": {
+      "baseline": "1.0",
+      "port-version": 0
+    },
+    "dog": {
+      "baseline": "2001-01-01",
+      "port-version": 0
+    },
+    "duck": {
+      "baseline": "mallard",
+      "port-version": 0
+    },
+    "mouse": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
+    "stale-entry": {
+      "baseline": "9.9.9",
+      "port-version": 0
+    }
+  }
+}
+"@ -Encoding Ascii -NoNewline
+Run-Vcpkg @portsRedirectArgsOK x-add-version --all
+Throw-IfFailed
+Require-JsonFileEquals "$versionFilesPath/versions/baseline.json" @"
+{
+  "default": {
+    "cat": {
+      "baseline": "1.0",
+      "port-version": 0
+    },
+    "dog": {
+      "baseline": "2001-01-01",
+      "port-version": 0
+    },
+    "duck": {
+      "baseline": "mallard",
+      "port-version": 0
+    },
+    "mouse": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    }
+  }
+}
+"@
+
+$CurrentTest = "x-add-version --all creates baseline"
+Remove-Item -LiteralPath "$versionFilesPath/versions/baseline.json"
+Run-Vcpkg @portsRedirectArgsOK x-add-version --all
+Throw-IfFailed
+Require-JsonFileEquals "$versionFilesPath/versions/baseline.json" @"
+{
+  "default": {
+    "cat": {
+      "baseline": "1.0",
+      "port-version": 0
+    },
+    "dog": {
+      "baseline": "2001-01-01",
+      "port-version": 0
+    },
+    "duck": {
+      "baseline": "mallard",
+      "port-version": 0
+    },
+    "mouse": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    }
+  }
+}
+"@
+
+$CurrentTest = "x-add-version --all recreates versions directory"
+Remove-Item -Recurse -Force -LiteralPath "$versionFilesPath/versions"
+Run-Vcpkg @portsRedirectArgsOK x-add-version --all
+Throw-IfFailed
+Require-JsonFileEquals "$versionFilesPath/versions/baseline.json" @"
+{
+  "default": {
+    "cat": {
+      "baseline": "1.0",
+      "port-version": 0
+    },
+    "dog": {
+      "baseline": "2001-01-01",
+      "port-version": 0
+    },
+    "duck": {
+      "baseline": "mallard",
+      "port-version": 0
+    },
+    "mouse": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    }
+  }
+}
+"@
+Remove-Item -Recurse -Force -LiteralPath "$versionFilesPath/versions"
+Copy-Item -Recurse "$versionFilesPathSources/versions" "$versionFilesPath/versions"
+
 $CurrentTest = "x-verify-ci-versions (Incomplete)"
 Run-Vcpkg @portsRedirectArgsIncomplete x-ci-verify-versions --verbose
 Throw-IfNotFailed

--- a/include/vcpkg/base/files.h
+++ b/include/vcpkg/base/files.h
@@ -27,6 +27,8 @@
 
 namespace vcpkg
 {
+    bool is_not_found_errc(const std::error_code& ec) noexcept;
+
     LocalizedString format_filesystem_call_error(const std::error_code& ec,
                                                  StringView call_name,
                                                  std::initializer_list<StringView> args);

--- a/include/vcpkg/base/message-data.inc.h
+++ b/include/vcpkg/base/message-data.inc.h
@@ -43,7 +43,6 @@ DECLARE_MESSAGE(AddVersionArtifactsOnly,
                 "--version is artifacts only and can't be used with vcpkg add port")
 DECLARE_MESSAGE(AddVersionAddedVersionToFile, (msg::version, msg::path), "", "added version {version} to {path}")
 DECLARE_MESSAGE(AddVersionCommitChangesReminder, (), "", "Did you remember to commit your changes?")
-DECLARE_MESSAGE(AddVersionFileNotFound, (msg::path), "", "couldn't find required file {path}")
 DECLARE_MESSAGE(AddVersionFormatPortSuggestion, (msg::command_line), "", "Run `{command_line}` to format the file")
 DECLARE_MESSAGE(AddVersionIgnoringOptionAll,
                 (msg::option),

--- a/locales/messages.json
+++ b/locales/messages.json
@@ -66,8 +66,6 @@
   "AddVersionArtifactsOnly": "--version is artifacts only and can't be used with vcpkg add port",
   "_AddVersionArtifactsOnly.comment": "'--version', and 'vcpkg add port' are command lines that must not be localized",
   "AddVersionCommitChangesReminder": "Did you remember to commit your changes?",
-  "AddVersionFileNotFound": "couldn't find required file {path}",
-  "_AddVersionFileNotFound.comment": "An example of {path} is /foo/bar.",
   "AddVersionFormatPortSuggestion": "Run `{command_line}` to format the file",
   "_AddVersionFormatPortSuggestion.comment": "An example of {command_line} is vcpkg install zlib.",
   "AddVersionIgnoringOptionAll": "ignoring --{option} since a port name argument was provided",

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -325,8 +325,7 @@ namespace
 
     void translate_not_found_to_success(std::error_code& ec)
     {
-        if (ec && (ec == std::errc::no_such_file_or_directory || ec == std::errc::not_a_directory ||
-                   ec == std::errc::too_many_symbolic_link_levels))
+        if (ec && is_not_found_errc(ec))
         {
             ec.clear();
         }
@@ -935,6 +934,12 @@ namespace
 
 namespace vcpkg
 {
+    bool is_not_found_errc(const std::error_code& ec) noexcept
+    {
+        return ec == std::errc::no_such_file_or_directory || ec == std::errc::not_a_directory ||
+               ec == std::errc::too_many_symbolic_link_levels;
+    }
+
     LocalizedString format_filesystem_call_error(const std::error_code& ec,
                                                  StringView call_name,
                                                  std::initializer_list<StringView> args)
@@ -2794,8 +2799,7 @@ namespace vcpkg
                         ret.push_back(from_stdfs_path(b->path()));
                     }
 
-                    if (ec && ec != std::make_error_condition(std::errc::no_such_file_or_directory) &&
-                        ec != std::make_error_condition(std::errc::not_a_directory))
+                    if (ec && !is_not_found_errc(ec))
                     {
                         ret.clear();
                         break;
@@ -2871,8 +2875,7 @@ namespace vcpkg
                         ret.push_back(from_stdfs_path(b->path()));
                     }
 
-                    if (ec && ec != std::make_error_condition(std::errc::no_such_file_or_directory) &&
-                        ec != std::make_error_condition(std::errc::not_a_directory))
+                    if (ec && !is_not_found_errc(ec))
                     {
                         ret.clear();
                         break;

--- a/src/vcpkg/base/hash.cpp
+++ b/src/vcpkg/base/hash.cpp
@@ -563,7 +563,7 @@ namespace vcpkg::Hash
         auto file = fs.open_for_read(path, ec);
         if (ec)
         {
-            if (ec == std::errc::no_such_file_or_directory || ec == std::errc::not_a_directory)
+            if (is_not_found_errc(ec))
             {
                 result.prognosis = HashPrognosis::FileNotFound;
                 return result;

--- a/src/vcpkg/commands.add-version.cpp
+++ b/src/vcpkg/commands.add-version.cpp
@@ -419,11 +419,6 @@ namespace vcpkg
         auto& fs = paths.get_filesystem();
         const auto& builtin_ports_directory = paths.builtin_ports_directory();
         auto baseline_path = paths.builtin_registry_versions / "baseline.json";
-        if (!fs.exists(baseline_path, IgnoreErrors{}))
-        {
-            Checks::msg_exit_with_error(VCPKG_LINE_INFO, msgAddVersionFileNotFound, msg::path = baseline_path);
-        }
-
         if (parsed_args.command_arguments.empty())
         {
             Checks::msg_check_exit(
@@ -472,7 +467,11 @@ namespace vcpkg
             swap(selected_git_trees, port_git_trees);
         }
 
-        auto baseline_map = vcpkg::get_builtin_baseline(paths).value_or_exit(VCPKG_LINE_INFO);
+        std::map<std::string, Version, std::less<>> baseline_map;
+        if (!add_all)
+        {
+            baseline_map = vcpkg::get_builtin_baseline(paths).value_or_exit(VCPKG_LINE_INFO);
+        }
 
         // Find ports with uncommitted changes
         for (auto&& port_git_tree_entry : port_git_trees)

--- a/src/vcpkg/commands.z-applocal.cpp
+++ b/src/vcpkg/commands.z-applocal.cpp
@@ -516,7 +516,7 @@ namespace
             {
                 msg::println(msgInstallSkippedUpToDateFile, msg::path_source = source, msg::path_destination = target);
             }
-            else if (ec == std::errc::no_such_file_or_directory)
+            else if (is_not_found_errc(ec))
             {
                 Debug::println("Attempted to deploy ", source, ", but it didn't exist");
                 return false;
@@ -632,7 +632,7 @@ namespace vcpkg
         if (ec)
         {
             auto io_error = ec.message();
-            if (ec == std::errc::no_such_file_or_directory)
+            if (is_not_found_errc(ec))
             {
                 msg::print(Color::warning,
                            LocalizedString::from_raw(target_binary_path)

--- a/src/vcpkg/paragraphs.cpp
+++ b/src/vcpkg/paragraphs.cpp
@@ -426,8 +426,7 @@ namespace vcpkg::Paragraphs
                                   manifest_contents};
         }
 
-        auto manifest_exists = ec != std::errc::no_such_file_or_directory;
-        if (manifest_exists)
+        if (!is_not_found_errc(ec))
         {
             return PortLoadResult{LocalizedString::from_raw(port_location.port_directory)
                                       .append_raw(": ")
@@ -448,7 +447,7 @@ namespace vcpkg::Paragraphs
                                   control_contents};
         }
 
-        if (ec != std::errc::no_such_file_or_directory)
+        if (!is_not_found_errc(ec))
         {
             return PortLoadResult{LocalizedString::from_raw(port_location.port_directory)
                                       .append_raw(": ")

--- a/src/vcpkg/registries.cpp
+++ b/src/vcpkg/registries.cpp
@@ -1051,9 +1051,19 @@ namespace
                                                const Path& baseline_path,
                                                StringView baseline)
     {
-        return fs.try_read_contents(baseline_path).then([&](FileContents&& fc) {
-            return parse_baseline_versions(fc.content, baseline, fc.origin);
-        });
+        std::error_code ec;
+        auto contents = fs.read_contents(baseline_path, ec);
+        if (ec)
+        {
+            if (is_not_found_errc(ec))
+            {
+                return Baseline{};
+            }
+
+            return format_filesystem_call_error(ec, "read_contents", {baseline_path});
+        }
+
+        return parse_baseline_versions(contents, baseline, baseline_path);
     }
 }
 
@@ -1299,7 +1309,7 @@ namespace
         auto contents = fs.read_contents(versions_file_path, ec);
         if (ec)
         {
-            if (ec == std::errc::no_such_file_or_directory)
+            if (is_not_found_errc(ec))
             {
                 return nullopt;
             }
@@ -1335,7 +1345,7 @@ namespace
         auto contents = fs.read_contents(versions_file_path, ec);
         if (ec)
         {
-            if (ec == std::errc::no_such_file_or_directory)
+            if (is_not_found_errc(ec))
             {
                 return nullopt;
             }


### PR DESCRIPTION
In https://github.com/microsoft/vcpkg/pull/51431 I observed that `x-add-version --all` does not remove removed entries which seems incorrect. This changes `--all` to completely regenerate the baseline file. It also changes `x-add-version` to create the file if it doesn't exist.

Drive by refactor: deduplicate all the "file not found" std::errc comparisons.