### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 15684: Build ID 13990285

### DIFF
--- a/locales/messages.cs.json
+++ b/locales/messages.cs.json
@@ -60,7 +60,6 @@
   "AddVersionAddedVersionToFile": "přidal(a) verzi {version} do cesty {path}.",
   "AddVersionArtifactsOnly": "--version je jenom artefakty a nedá se použít s portem vcpkg add.",
   "AddVersionCommitChangesReminder": "Nezapomněli jste potvrdit změny?",
-  "AddVersionFileNotFound": "Nepovedlo se najít požadovaný soubor {path}.",
   "AddVersionFormatPortSuggestion": "Spuštěním {command_line} naformátujte soubor.",
   "AddVersionIgnoringOptionAll": "Parametr --{option} se ignoruje, protože se zadal argument názvu portu.",
   "AddVersionInstructions": "spuštěním následujících příkazů můžete automaticky přidat aktuální verzi {package_name}:",

--- a/locales/messages.de.json
+++ b/locales/messages.de.json
@@ -60,7 +60,6 @@
   "AddVersionAddedVersionToFile": "Version {version} zu {path} hinzugefügt",
   "AddVersionArtifactsOnly": "--version ist nur Artefakte und kann nicht mit vcpkg-Hinzufügungport verwendet werden.",
   "AddVersionCommitChangesReminder": "Haben Sie daran gedacht, Ihre Änderungen zu übernehmen?",
-  "AddVersionFileNotFound": "Die erforderliche Datei \"{path}\" wurde nicht gefunden",
   "AddVersionFormatPortSuggestion": "Führen Sie \"{command_line}\" aus, um die Datei zu formatieren",
   "AddVersionIgnoringOptionAll": "--{option} wird ignoriert, da ein Portnamenargument angegeben wurde",
   "AddVersionInstructions": "Sie können die folgenden Befehle ausführen, um die aktuelle Version von „{package_name}“ automatisch hinzuzufügen:",

--- a/locales/messages.es.json
+++ b/locales/messages.es.json
@@ -60,7 +60,6 @@
   "AddVersionAddedVersionToFile": "se ha agregado la versión {version} a {path}",
   "AddVersionArtifactsOnly": "--La versión es solo artefactos y no se puede usar con vcpkg add port",
   "AddVersionCommitChangesReminder": "¿Se acordó de confirmar los cambios?",
-  "AddVersionFileNotFound": "no se pudo encontrar la ruta {path} de archivo que se necesita",
   "AddVersionFormatPortSuggestion": "Ejecute \"{command_line}\" para dar formato al archivo.",
   "AddVersionIgnoringOptionAll": "omitiendo --{option} desde que se proporcionó un argumento de nombre de puerto",
   "AddVersionInstructions": "puede ejecutar los siguientes comandos para agregar automáticamente la versión actual de {package_name}:",

--- a/locales/messages.fr.json
+++ b/locales/messages.fr.json
@@ -60,7 +60,6 @@
   "AddVersionAddedVersionToFile": "version ajoutée {version} à {path}",
   "AddVersionArtifactsOnly": "--cette version est composée uniquement d’artefacts et ne peut pas être utilisée avec le port d’ajout vcpkg",
   "AddVersionCommitChangesReminder": "Avez-vous pensé à valider vos modifications ?",
-  "AddVersionFileNotFound": "Impossible de trouver le fichier requis {path}",
   "AddVersionFormatPortSuggestion": "Exécutez `{command_line}` pour formater le fichier.",
   "AddVersionIgnoringOptionAll": "ignorer --{option} car un argument de nom de port a été fourni.",
   "AddVersionInstructions": "vous pouvez exécuter les commandes suivantes pour ajouter automatiquement la version actuelle de {package_name} :",

--- a/locales/messages.it.json
+++ b/locales/messages.it.json
@@ -60,7 +60,6 @@
   "AddVersionAddedVersionToFile": "ha aggiunto la versione {version} a {path}",
   "AddVersionArtifactsOnly": "--version è solo artefatto e non può essere utilizzato con la porta di aggiunta vcpkg",
   "AddVersionCommitChangesReminder": "È stato eseguito il commit delle modifiche?",
-  "AddVersionFileNotFound": "non è stato possibile trovare il file richiesto {path}",
   "AddVersionFormatPortSuggestion": "Eseguire '{command_line}' per formattare il file",
   "AddVersionIgnoringOptionAll": "--{option} verrà ignorato perché è stato specificato un argomento per il nome della porta",
   "AddVersionInstructions": "è possibile eseguire i comandi seguenti per aggiungere automaticamente la versione corrente di {package_name}:",

--- a/locales/messages.ja.json
+++ b/locales/messages.ja.json
@@ -60,7 +60,6 @@
   "AddVersionAddedVersionToFile": "バージョン {version} を {path} に追加しました",
   "AddVersionArtifactsOnly": "--version は成果物のみであり、vcpkg 追加ポートでは使用できません",
   "AddVersionCommitChangesReminder": "変更をコミットしたことを覚えていますか?",
-  "AddVersionFileNotFound": "必要なファイル {path} が見つかりませんでした",
   "AddVersionFormatPortSuggestion": "'{command_line}' を実行してファイルをフォーマットします",
   "AddVersionIgnoringOptionAll": "ポート名引数が指定されたため、--{option} を無視しています",
   "AddVersionInstructions": "次のコマンドを実行して、{package_name} の現在のバージョンを自動的に追加できます。",

--- a/locales/messages.ko.json
+++ b/locales/messages.ko.json
@@ -60,7 +60,6 @@
   "AddVersionAddedVersionToFile": "버전{version}을(를) {path}에 추가했습니다.",
   "AddVersionArtifactsOnly": "--version은 아티팩트 전용이며 vcpkg add port와 함께 사용할 수 없습니다.",
   "AddVersionCommitChangesReminder": "변경 내용을 커밋하기로 하셨나요?",
-  "AddVersionFileNotFound": "필요한 파일 {path}을(를) 찾을 수 없음",
   "AddVersionFormatPortSuggestion": "'{command_line}'을(를) 실행하여 파일 서식 지정",
   "AddVersionIgnoringOptionAll": "포트 이름 인수가 제공되었으므로 --{option}을(를) 무시합니다.",
   "AddVersionInstructions": "다음 명령을 실행하여 현재 버전의 {package_name}을(를) 자동으로 추가할 수 있습니다.",

--- a/locales/messages.pl.json
+++ b/locales/messages.pl.json
@@ -60,7 +60,6 @@
   "AddVersionAddedVersionToFile": "dodano wersję {version} do ścieżki {path}",
   "AddVersionArtifactsOnly": "Parametr --version jest tylko dla artefaktów i nie można go używać z portem dodawania vcpkg",
   "AddVersionCommitChangesReminder": "Czy pamiętasz o zatwierdzeniu zmian?",
-  "AddVersionFileNotFound": "nie można odnaleźć wymaganej ścieżki pliku {path}",
   "AddVersionFormatPortSuggestion": "Uruchom polecenie „{command_line}”, aby sformatować plik",
   "AddVersionIgnoringOptionAll": "ignorowanie parametru --{option}, ponieważ podano argument nazwy portu",
   "AddVersionInstructions": "możesz uruchomić następujące polecenia, aby automatycznie dodać bieżącą wersję pakietu {package_name}:",

--- a/locales/messages.pt-BR.json
+++ b/locales/messages.pt-BR.json
@@ -60,7 +60,6 @@
   "AddVersionAddedVersionToFile": "versão adicionada {version} para {path}",
   "AddVersionArtifactsOnly": "--version é somente artefatos e não pode ser usado com vcpkg add port",
   "AddVersionCommitChangesReminder": "Você se lembrou de confirmar suas alterações?",
-  "AddVersionFileNotFound": "não foi possível encontrar o arquivo necessário {path}",
   "AddVersionFormatPortSuggestion": "Execute `{command_line}` para formatar o arquivo",
   "AddVersionIgnoringOptionAll": "ignorando --{option} desde que um argumento de nome de porta foi fornecido",
   "AddVersionInstructions": "você pode executar os seguintes comandos para adicionar a versão atual do {package_name} automaticamente:",

--- a/locales/messages.ru.json
+++ b/locales/messages.ru.json
@@ -60,7 +60,6 @@
   "AddVersionAddedVersionToFile": "добавлена версия {version} в {path}",
   "AddVersionArtifactsOnly": "--version содержит только артефакты и не может использоваться с портом добавления vcpkg",
   "AddVersionCommitChangesReminder": "Вы не забыли зафиксировать изменения?",
-  "AddVersionFileNotFound": "не удалось найти необходимый файл {path}",
   "AddVersionFormatPortSuggestion": "Выполните \"{command_line}\", чтобы форматировать файл",
   "AddVersionIgnoringOptionAll": "пропуск --{option}, так как указан аргумент имени порта",
   "AddVersionInstructions": "для автоматического добавления текущей версии {package_name} можно выполнить следующие команды:",

--- a/locales/messages.tr.json
+++ b/locales/messages.tr.json
@@ -60,7 +60,6 @@
   "AddVersionAddedVersionToFile": "{version} sürümü {path} yoluna eklendi",
   "AddVersionArtifactsOnly": "--version yalnızca yapıtlar içindir ve vcpkg ekleme bağlantı noktasıyla kullanılamaz",
   "AddVersionCommitChangesReminder": "Değişikliklerinizi işlediniz mi?",
-  "AddVersionFileNotFound": "gerekli {path} dosyası bulunamadı",
   "AddVersionFormatPortSuggestion": "Dosyayı biçimlendirmek için '{command_line}' komutunu çalıştırın",
   "AddVersionIgnoringOptionAll": "bağlantı noktası adı bağımsız değişkeni sağlandığı için --{option} yok sayılıyor",
   "AddVersionInstructions": "{package_name}'in geçerli sürümünü otomatik olarak eklemek için aşağıdaki komutları çalıştırabilirsiniz:",

--- a/locales/messages.zh-Hans.json
+++ b/locales/messages.zh-Hans.json
@@ -60,7 +60,6 @@
   "AddVersionAddedVersionToFile": "已将版本 {version} 添加到 {path}",
   "AddVersionArtifactsOnly": "--version 仅适用于项目，不能与 vcpkg 添加端口一起使用",
   "AddVersionCommitChangesReminder": "是否记得提交更改?",
-  "AddVersionFileNotFound": "找不到所需的文件 {path}",
   "AddVersionFormatPortSuggestion": "运行 `{command_line}` 以设置文件格式",
   "AddVersionIgnoringOptionAll": "忽略 --{option}，因为已提供端口名称参数",
   "AddVersionInstructions": "你可以运行以下命令来自动添加 {package_name} 的当前版本:",

--- a/locales/messages.zh-Hant.json
+++ b/locales/messages.zh-Hant.json
@@ -60,7 +60,6 @@
   "AddVersionAddedVersionToFile": "已將版本 {version} 新增到 {path}",
   "AddVersionArtifactsOnly": "--version 只是成品，無法與 vcpkg add port 一起使用",
   "AddVersionCommitChangesReminder": "您是否記得要提交變更?",
-  "AddVersionFileNotFound": "找不到必要的檔案 {path}",
   "AddVersionFormatPortSuggestion": "執行 `{command_line}` 以格式化檔案",
   "AddVersionIgnoringOptionAll": "正在忽略 --{option}，因為已提供連接埠名稱引數",
   "AddVersionInstructions": "您可以執行下列命令以自動新增 {package_name} 的目前版本：",


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.