### PR TITLE
Fix self-cascade bug in feature test baseline checking

### DIFF
--- a/azure-pipelines/e2e-assets/ci-feature-baseline/vcpkg-self-fail.txt
+++ b/azure-pipelines/e2e-assets/ci-feature-baseline/vcpkg-self-fail.txt
@@ -1,0 +1,1 @@
+vcpkg-self-fail = fail

--- a/azure-pipelines/e2e-ports/vcpkg-self-fail/portfile.cmake
+++ b/azure-pipelines/e2e-ports/vcpkg-self-fail/portfile.cmake
@@ -1,0 +1,1 @@
+message(FATAL_ERROR "this port always fails")

--- a/azure-pipelines/e2e-ports/vcpkg-self-fail/vcpkg.json
+++ b/azure-pipelines/e2e-ports/vcpkg-self-fail/vcpkg.json
@@ -1,0 +1,21 @@
+{
+  "name": "vcpkg-self-fail",
+  "version": "0",
+  "features": {
+    "depends-on-self": {
+      "description": "Depends on the other feature, mirroring cpprestsdk[brotli] depending on cpprestsdk[compression]",
+      "dependencies": [
+        {
+          "name": "vcpkg-self-fail",
+          "default-features": false,
+          "features": [
+            "other"
+          ]
+        }
+      ]
+    },
+    "other": {
+      "description": "Some other feature"
+    }
+  }
+}

--- a/azure-pipelines/end-to-end-tests-dir/test-features.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/test-features.ps1
@@ -148,6 +148,21 @@ $ciFeatureBaseline = "$PSScriptRoot/../e2e-assets/ci-feature-baseline/vcpkg-self
 Run-VcpkgAndCaptureOutput x-test-features @commonArgs $vcpkgSelfCascadePortsArg --all --ci-feature-baseline $ciFeatureBaseline
 Throw-IfFailed
 
+# Regression test: a self-dependent port marked `=fail` must not be misclassified as cascading on
+# itself. cpprestsdk hit this because cpprestsdk[brotli] depends on cpprestsdk[compression]: the
+# install plan for the [brotli] separate test and the all-features combined test share an ABI with
+# an earlier failed feature test of the same port, which caused the second test to be treated as a
+# cascade rather than a build failure.
+$vcpkgSelfFailPortsArg = New-TestPortsRootArg vcpkg-self-fail
+$ciFeatureBaseline = "$PSScriptRoot/../e2e-assets/ci-feature-baseline/vcpkg-self-fail.txt"
+$output = Run-VcpkgAndCaptureOutput x-test-features @commonArgs $vcpkgSelfFailPortsArg --all --ci-feature-baseline $ciFeatureBaseline
+Throw-IfFailed
+Throw-IfNonContains -Expected "Feature Test [1/4] vcpkg-self-fail[core]:$Triplet" -Actual $output
+Throw-IfNonContains -Expected "Feature Test [2/4] vcpkg-self-fail[core,depends-on-self]:$Triplet" -Actual $output
+Throw-IfNonContains -Expected "Feature Test [3/4] vcpkg-self-fail[core,other]:$Triplet" -Actual $output
+Throw-IfNonContains -Expected "Feature Test [4/4] vcpkg-self-fail[core,depends-on-self,other]:$Triplet" -Actual $output
+Throw-IfNonContains -Expected "All feature tests passed." -Actual $output
+
 $ciFeatureBaseline = "$PSScriptRoot/../e2e-assets/ci-feature-baseline/empty-baseline.txt"
 $output = Run-VcpkgAndCaptureOutput x-test-features @commonArgs $vcpkgSelfCascadePortsArg --all --ci-feature-baseline $ciFeatureBaseline
 Throw-IfNotFailed

--- a/src/vcpkg/commands.test-features.cpp
+++ b/src/vcpkg/commands.test-features.cpp
@@ -828,11 +828,13 @@ namespace vcpkg
                 continue;
             }
 
-            if (auto iter = Util::find_if(install_plan.install_actions,
-                                          [&known_failures](const auto& install_action) {
-                                              return Util::Sets::contains(
-                                                  known_failures, install_action.package_abi_or_exit(VCPKG_LINE_INFO));
-                                          });
+            if (auto iter =
+                    Util::find_if(install_plan.install_actions,
+                                  [&known_failures, &spec](const auto& install_action) {
+                                      return install_action.spec != spec.package_spec &&
+                                             Util::Sets::contains(known_failures,
+                                                                  install_action.package_abi_or_exit(VCPKG_LINE_INFO));
+                                  });
                 iter != install_plan.install_actions.end())
             {
                 msg::println(msgDependencyWillFail, msg::feature_spec = iter->display_name());


### PR DESCRIPTION
When a port is marked =fail in the feature baseline and has a self-dependency via a feature (e.g., `cpprestsdk[brotli]` depends on `cpprestsdk[compression]`), the install plan for a later feature test of the same port may resolve to the same ABI as an earlier failed test. Without this fix, the code would match that ABI in `known_failures` and incorrectly report the test as an unexpectedly cascading failure rather than recognizing it as a build failure.

The fix filters out install actions whose `package_spec` matches the spec being tested, since those are part of testing the port itself, not external dependencies.

Adds regression test vcpkg-self-fail port and assertions in test-features.ps1.

Most of this was written by Claude Opus 4.7.