### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 15684: Build ID 14114773

### DIFF
--- a/locales/messages.cs.json
+++ b/locales/messages.cs.json
@@ -695,7 +695,7 @@
   "IntegrateBashHelp": "Povolit dokončování karet bash. Pouze jiný systém než Windows",
   "IntegrateFishHelp": "Povolit dokončování karet fish. Pouze jiný systém než Windows",
   "IntegrateInstallHelpLinux": "Zpřístupní nainstalované balíčky pro všechny uživatele",
-  "IntegrateInstallHelpWindows": "Makes installed packages available to MSBuild C++ projects for the current user",
+  "IntegrateInstallHelpWindows": "Zpřístupní nainstalované balíčky pro projekty MSBuild C++ pro aktuálního uživatele.",
   "IntegrateNonWindowsOnly": "{command_line} je pouze pro jiné systémy než Windows a není na tomto systému podporován.",
   "IntegratePowerShellHelp": "Povolte dokončování karet PowerShellu. Pouze pro Windows",
   "IntegrateProjectHelp": "Vygeneruje odkazující balíček NuGet pro jednotlivé Visual Studio použití projektu. Pouze pro Windows",

--- a/locales/messages.de.json
+++ b/locales/messages.de.json
@@ -695,7 +695,7 @@
   "IntegrateBashHelp": "Aktivieren Sie die Tab-Vervollständigung in bash. Nur Nicht-Windows",
   "IntegrateFishHelp": "Aktivieren Sie die Tab-Vervollständigung in Fish. Nur Nicht-Windows",
   "IntegrateInstallHelpLinux": "Macht installierte Pakete benutzerweit verfügbar",
-  "IntegrateInstallHelpWindows": "Makes installed packages available to MSBuild C++ projects for the current user",
+  "IntegrateInstallHelpWindows": "Macht installierte Pakete für MSBuild-C++-Projekte für den aktuellen Benutzer verfügbar.",
   "IntegrateNonWindowsOnly": "{command_line} ist nur für Nicht-Windows verfügbar und wird auf diesem System nicht unterstützt.",
   "IntegratePowerShellHelp": "Aktivieren Sie die Tab-Vervollständigung in PowerShell. Nur Windows",
   "IntegrateProjectHelp": "Generiert ein verweisendes NuGet-Paket für einzelne Visual Studio-Projektverwendung. Nur Windows",

--- a/locales/messages.es.json
+++ b/locales/messages.es.json
@@ -695,7 +695,7 @@
   "IntegrateBashHelp": "Habilitar la finalización con tabulación de Bash. Solo para usuarios que no son de Windows",
   "IntegrateFishHelp": "Habilitar la finalización de tabulación de pez. Solo para usuarios que no son de Windows",
   "IntegrateInstallHelpLinux": "Hace que los paquetes instalados estén disponibles para todo el usuario",
-  "IntegrateInstallHelpWindows": "Makes installed packages available to MSBuild C++ projects for the current user",
+  "IntegrateInstallHelpWindows": "Hace que los paquetes instalados estén disponibles para los proyectos de C++ de MSBuild para el usuario actual",
   "IntegrateNonWindowsOnly": "{command_line} no es de solo Windows y no se admite en este sistema.",
   "IntegratePowerShellHelp": "Habilite la finalización con tabulación de PowerShell. Solo Windows",
   "IntegrateProjectHelp": "Genera un paquete NuGet de referencia para el uso de proyectos de Visual Studio individuales. Solo Windows",

--- a/locales/messages.fr.json
+++ b/locales/messages.fr.json
@@ -695,7 +695,7 @@
   "IntegrateBashHelp": "Activez la saisie semi-automatique de tabulation Bash. Non-Windows uniquement",
   "IntegrateFishHelp": "Activez la saisie semi-automatique des onglets. Non Windows uniquement",
   "IntegrateInstallHelpLinux": "Rend les packages installés disponibles à l’échelle de l’utilisateur",
-  "IntegrateInstallHelpWindows": "Makes installed packages available to MSBuild C++ projects for the current user",
+  "IntegrateInstallHelpWindows": "Rend les packages installés disponibles pour les projets C++ MSBuild pour l’utilisateur(-trice) actuel(le)",
   "IntegrateNonWindowsOnly": "{command_line} n’est pas Windows uniquement et n’est pas pris en charge sur ce système.",
   "IntegratePowerShellHelp": "Activez la saisie semi-automatique des onglets PowerShell. Windows uniquement",
   "IntegrateProjectHelp": "Génère un package NuGet référençant pour une utilisation de projet Visual Studio individuelle. Windows uniquement",

--- a/locales/messages.it.json
+++ b/locales/messages.it.json
@@ -695,7 +695,7 @@
   "IntegrateBashHelp": "Abilitare il completamento tramite tabulazione bash. Solo non Windows",
   "IntegrateFishHelp": "Abilitare il completamento tramite tabulazione fish. Solo non Windows",
   "IntegrateInstallHelpLinux": "Rende disponibili i pacchetti installati a livello di utente",
-  "IntegrateInstallHelpWindows": "Makes installed packages available to MSBuild C++ projects for the current user",
+  "IntegrateInstallHelpWindows": "Rende i pacchetti installati disponibili ai progetti C++ di MSBuild per l'utente corrente",
   "IntegrateNonWindowsOnly": "{command_line} non è solo Windows e non è supportato in questo sistema.",
   "IntegratePowerShellHelp": "Abilitare il completamento tramite tabulazione di PowerShell. Solo Windows",
   "IntegrateProjectHelp": "Genera un pacchetto NuGet di riferimento per l'uso di singoli progetti Visual Studio. Solo Windows",

--- a/locales/messages.ja.json
+++ b/locales/messages.ja.json
@@ -695,7 +695,7 @@
   "IntegrateBashHelp": "bash タブ補完を有効にします。Windows 以外のみ",
   "IntegrateFishHelp": "fish タブ補完を有効にします。Windows 以外のみ",
   "IntegrateInstallHelpLinux": "インストールされているパッケージをユーザー全体で利用できるようにします",
-  "IntegrateInstallHelpWindows": "Makes installed packages available to MSBuild C++ projects for the current user",
+  "IntegrateInstallHelpWindows": "現在のユーザーの MSBuild C++ プロジェクトで、インストールされたパッケージを使用できるようにします",
   "IntegrateNonWindowsOnly": "{command_line} は Windows 以外のみではなく、このシステムではサポートされていません。",
   "IntegratePowerShellHelp": "PowerShell タブ補完を有効にします。Windows のみ",
   "IntegrateProjectHelp": "個々の Visual Studio プロジェクトで使用する参照元の NuGet パッケージを生成します。Windows のみ",

--- a/locales/messages.ko.json
+++ b/locales/messages.ko.json
@@ -695,7 +695,7 @@
   "IntegrateBashHelp": "bash 탭 완성을 사용합니다. 비 Windows 전용입니다.",
   "IntegrateFishHelp": "fish 탭 완성을 사용합니다. 비 Windows 전용입니다.",
   "IntegrateInstallHelpLinux": "설치된 패키지를 사용자 전체가 사용할 수 있도록 함",
-  "IntegrateInstallHelpWindows": "Makes installed packages available to MSBuild C++ projects for the current user",
+  "IntegrateInstallHelpWindows": "현재 사용자에 대해 설치된 패키지를 MSBuild C++ 프로젝트에서 사용할 수 있도록 합니다.",
   "IntegrateNonWindowsOnly": "{command_line}은(는) Windows 전용이 아니므로 이 시스템에서 지원되지 않습니다.",
   "IntegratePowerShellHelp": "PowerShell 탭 완성을 사용합니다. Windows 전용입니다.",
   "IntegrateProjectHelp": "개별 Visual Studio 프로젝트 사용에 대한 참조 NuGet 패키지를 생성합니다. Windows 전용입니다.",

--- a/locales/messages.pl.json
+++ b/locales/messages.pl.json
@@ -695,7 +695,7 @@
   "IntegrateBashHelp": "Włącz bash tab-completion. Dotyczy systemu innego niż Windows",
   "IntegrateFishHelp": "Włącz uzupełnianie karty ryby. Dotyczy systemu innego niż Windows",
   "IntegrateInstallHelpLinux": "Udostępnia zainstalowane pakiety dla wszystkich użytkowników",
-  "IntegrateInstallHelpWindows": "Makes installed packages available to MSBuild C++ projects for the current user",
+  "IntegrateInstallHelpWindows": "Udostępnia zainstalowane pakiety dla projektów MSBuild C++ w przypadku bieżącego użytkownika",
   "IntegrateNonWindowsOnly": "{command_line} nie jest przeznaczony tylko dla systemu Windows i nie jest obsługiwany w tym systemie.",
   "IntegratePowerShellHelp": "Włącz uzupełnianie karty programu PowerShell. Dotyczy tylko systemu Windows",
   "IntegrateProjectHelp": "Wygeneruj odwołujący się pakiet NuGet dla pojedynczego użycia projektu programu Visual Studio. Dotyczy tylko systemu Windows",

--- a/locales/messages.pt-BR.json
+++ b/locales/messages.pt-BR.json
@@ -695,7 +695,7 @@
   "IntegrateBashHelp": "Habilite a conclusão de guias bash. Apenas fora do Windows",
   "IntegrateFishHelp": "Habilite a conclusão da guia peixe. Apenas fora do Windows",
   "IntegrateInstallHelpLinux": "Disponibiliza pacotes instalados em todo o usuário",
-  "IntegrateInstallHelpWindows": "Makes installed packages available to MSBuild C++ projects for the current user",
+  "IntegrateInstallHelpWindows": "Disponibiliza os pacotes instalados para projetos C++ do MSBuild para o usuário atual",
   "IntegrateNonWindowsOnly": "{command_line} não é apenas para Windows e não é compatível com este sistema.",
   "IntegratePowerShellHelp": "Habilite a conclusão de guias do PowerShell. Somente Windows",
   "IntegrateProjectHelp": "Gera um pacote NuGet de referência para uso individual do projeto do Visual Studio. Somente Windows",

--- a/locales/messages.ru.json
+++ b/locales/messages.ru.json
@@ -695,7 +695,7 @@
   "IntegrateBashHelp": "Включить завершение табуляции bash. Только для систем, отличных от Windows",
   "IntegrateFishHelp": "Включить завершение табуляции fish. Только для систем, отличных от Windows.",
   "IntegrateInstallHelpLinux": "Делает установленные пакеты доступными на уровне пользователя.",
-  "IntegrateInstallHelpWindows": "Makes installed packages available to MSBuild C++ projects for the current user",
+  "IntegrateInstallHelpWindows": "Делает установленные пакеты доступными для проектов C++ в MSBuild текущего пользователя",
   "IntegrateNonWindowsOnly": "{command_line} используется только для систем, отличных от Windows, и не поддерживается в этой системе.",
   "IntegratePowerShellHelp": "Включите заполнение табуляции Windows PowerShell. Только для Windows",
   "IntegrateProjectHelp": "Создает ссылочный пакет NuGet для использования в отдельном проекте Visual Studio. Только для Windows.",

--- a/locales/messages.tr.json
+++ b/locales/messages.tr.json
@@ -695,7 +695,7 @@
   "IntegrateBashHelp": "bash sekme tamamlamayı etkinleştirir. Yalnızca Windows olmayanlarda yapılabilir.",
   "IntegrateFishHelp": "fish sekme tamamlamayı etkinleştirir. Yalnızca Windows olmayanlarda yapılabilir.",
   "IntegrateInstallHelpLinux": "Yüklü paketleri kullanıcı genelinde kullanılabilir hale getirir",
-  "IntegrateInstallHelpWindows": "Makes installed packages available to MSBuild C++ projects for the current user",
+  "IntegrateInstallHelpWindows": "Yüklü paketlerin geçerli kullanıcı için MSBuild C++ projelerinde kullanılabilir olmasını sağlar",
   "IntegrateNonWindowsOnly": "{command_line} yalnızca Windows'a özgü değildir ve bu sistemde desteklenmez.",
   "IntegratePowerShellHelp": "PowerShell sekme tamamlamayı etkinleştirir. Yalnızca Windows olanlarda yapılabilir.",
   "IntegrateProjectHelp": "Bireysel Visual Studio projesi kullanımı için referans veren bir NuGet paketi oluşturur. Yalnızca Windows olanlarda yapılabilir.",

--- a/locales/messages.zh-Hans.json
+++ b/locales/messages.zh-Hans.json
@@ -695,7 +695,7 @@
   "IntegrateBashHelp": "启用 bash Tab-completion。仅限非 Windows",
   "IntegrateFishHelp": "启用 fish 选项卡补全。仅限非 Windows",
   "IntegrateInstallHelpLinux": "使已安装的包在用户范围内可用",
-  "IntegrateInstallHelpWindows": "Makes installed packages available to MSBuild C++ projects for the current user",
+  "IntegrateInstallHelpWindows": "将已安装的包设为可用于当前用户的 MSBuild C++ 项目",
   "IntegrateNonWindowsOnly": "{command_line} 仅限非 Windows，在此系统上不受支持。",
   "IntegratePowerShellHelp": "启用 PowerShell 选项卡补全。仅限 Windows",
   "IntegrateProjectHelp": "为单个 Visual Studio 项目使用生成引用 NuGet 包。仅限 Windows",

--- a/locales/messages.zh-Hant.json
+++ b/locales/messages.zh-Hant.json
@@ -695,7 +695,7 @@
   "IntegrateBashHelp": "啟用 bash Tab 鍵自動完成。僅限非 Windows",
   "IntegrateFishHelp": "啟用 fish Tab 鍵自動完成。僅限非 Windows",
   "IntegrateInstallHelpLinux": "讓安裝的套件可供全使用者使用",
-  "IntegrateInstallHelpWindows": "Makes installed packages available to MSBuild C++ projects for the current user",
+  "IntegrateInstallHelpWindows": "讓目前使用者的 MSBuild C++ 專案可以使用已安裝的套件",
   "IntegrateNonWindowsOnly": "{command_line} 非僅限 Windows，而且不支援此系統。",
   "IntegratePowerShellHelp": "啟用 PowerShell Tab 鍵自動完成。僅限 Windows",
   "IntegrateProjectHelp": "產生個別 Visual Studio 專案使用的參考 NuGet 套件。僅限 Windows",


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.