### PR TITLE
[curl] Add VCPKG_SSL_REVOKE_BEST_EFFORT to fix Schannel proxy revocation errors

### DIFF
--- a/include/vcpkg/base/contractual-constants.h
+++ b/include/vcpkg/base/contractual-constants.h
@@ -545,6 +545,7 @@ namespace vcpkg
     inline constexpr StringLiteral EnvironmentVariableVcpkgNuGetRepository = "VCPKG_NUGET_REPOSITORY";
     inline constexpr StringLiteral EnvironmentVariableVcpkgOverlayPorts = "VCPKG_OVERLAY_PORTS";
     inline constexpr StringLiteral EnvironmentVariableVcpkgRoot = "VCPKG_ROOT";
+    inline constexpr StringLiteral EnvironmentVariableVcpkgSSLRevokeBestEffort = "VCPKG_SSL_REVOKE_BEST_EFFORT";
     inline constexpr StringLiteral EnvironmentVariableVcpkgUseNuGetCache = "VCPKG_USE_NUGET_CACHE";
     inline constexpr StringLiteral EnvironmentVariableVcpkgVisualStudioPath = "VCPKG_VISUAL_STUDIO_PATH";
     inline constexpr StringLiteral EnvironmentVariableVsLang = "VSLANG";

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -59,7 +59,7 @@ namespace
         // Apply accumulated SSL options if any were set
         if (ssl_options != 0L)
         {
-#if defined(CURLOPT_SSL_OPTIONS)
+#if LIBCURL_VERSION_NUM >= 0x071900 // 7.25.0
             vcpkg_curl_easy_setopt(curl, CURLOPT_SSL_OPTIONS, ssl_options);
 #endif
         }

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -43,6 +43,7 @@ namespace
         // Track SSL options as a bitmask to avoid clobbering flags if more are added in the future
         long ssl_options = 0L;
 
+#if defined(CURLSSLOPT_REVOKE_BEST_EFFORT)
         // Fix for schannel missing certificate revocation list errors with proxy server.
         const auto maybe_revoke_best_effort = get_environment_variable_nonempty(EnvironmentVariableVcpkgSSLRevokeBestEffort);
         if (const auto revoke_best_effort = maybe_revoke_best_effort.get())
@@ -50,19 +51,18 @@ namespace
             // Only applied if VCPKG_SSL_REVOKE_BEST_EFFORT is explicitly set to "1"
             if (*revoke_best_effort == "1")
             {
-#if defined(CURLSSLOPT_REVOKE_BEST_EFFORT)
                 ssl_options |= CURLSSLOPT_REVOKE_BEST_EFFORT;
-#endif
             }
         }
+#endif
 
+#if LIBCURL_VERSION_NUM >= 0x071900 // 7.25.0
         // Apply accumulated SSL options if any were set
         if (ssl_options != 0L)
         {
-#if LIBCURL_VERSION_NUM >= 0x071900 // 7.25.0
             vcpkg_curl_easy_setopt(curl, CURLOPT_SSL_OPTIONS, ssl_options);
-#endif
         }
+#endif
     }
 }
 

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -45,7 +45,8 @@ namespace
 
 #if defined(CURLSSLOPT_REVOKE_BEST_EFFORT)
         // Fix for schannel missing certificate revocation list errors with proxy server.
-        const auto maybe_revoke_best_effort = get_environment_variable_nonempty(EnvironmentVariableVcpkgSSLRevokeBestEffort);
+        const auto maybe_revoke_best_effort =
+            get_environment_variable_nonempty(EnvironmentVariableVcpkgSSLRevokeBestEffort);
         if (const auto revoke_best_effort = maybe_revoke_best_effort.get())
         {
             // Only applied if VCPKG_SSL_REVOKE_BEST_EFFORT is explicitly set to "1"

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -39,7 +39,10 @@ namespace
         // don't send headers to proxy CONNECT ; this intentionally fails on older versions of libcurl
         vcpkg_curl_easy_setopt(
             curl, static_cast<CURLoption>(229) /* CURLOPT_HEADEROPT */, (1L << 0) /* CURLHEADER_SEPARATE */);
-        
+
+        // Track SSL options as a bitmask to avoid clobbering flags if more are added in the future
+        long ssl_options = 0L;
+
         // Fix for schannel missing certificate revocation list errors with proxy server.
         const auto maybe_revoke_best_effort = get_environment_variable_nonempty(EnvironmentVariableVcpkgSSLRevokeBestEffort);
         if (const auto revoke_best_effort = maybe_revoke_best_effort.get())
@@ -47,8 +50,18 @@ namespace
             // Only applied if VCPKG_SSL_REVOKE_BEST_EFFORT is explicitly set to "1"
             if (*revoke_best_effort == "1")
             {
-                vcpkg_curl_easy_setopt(curl, CURLOPT_SSL_OPTIONS, CURLSSLOPT_REVOKE_BEST_EFFORT);
+#if defined(CURLSSLOPT_REVOKE_BEST_EFFORT)
+                ssl_options |= CURLSSLOPT_REVOKE_BEST_EFFORT;
+#endif
             }
+        }
+
+        // Apply accumulated SSL options if any were set
+        if (ssl_options != 0L)
+        {
+#if defined(CURLOPT_SSL_OPTIONS)
+            vcpkg_curl_easy_setopt(curl, CURLOPT_SSL_OPTIONS, ssl_options);
+#endif
         }
     }
 }

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -39,6 +39,17 @@ namespace
         // don't send headers to proxy CONNECT ; this intentionally fails on older versions of libcurl
         vcpkg_curl_easy_setopt(
             curl, static_cast<CURLoption>(229) /* CURLOPT_HEADEROPT */, (1L << 0) /* CURLHEADER_SEPARATE */);
+        
+        // Fix for schannel missing certificate revocation list errors with proxy server.
+        const auto maybe_revoke_best_effort = get_environment_variable_nonempty(EnvironmentVariableVcpkgSSLRevokeBestEffort);
+        if (const auto revoke_best_effort = maybe_revoke_best_effort.get())
+        {
+            // Only applied if VCPKG_SSL_REVOKE_BEST_EFFORT is explicitly set to "1"
+            if (*revoke_best_effort == "1")
+            {
+                vcpkg_curl_easy_setopt(curl, CURLOPT_SSL_OPTIONS, CURLSSLOPT_REVOKE_BEST_EFFORT);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
#1939 
Fix for schannel missing certificate revocation list errors with proxy server.
Only applied if VCPKG_SSL_REVOKE_BEST_EFFORT environment variable is explicitly set to "1"