### PR TITLE
Emit a PURL in generated SPDX SBOMs

### DIFF
--- a/include/vcpkg/base/contractual-constants.h
+++ b/include/vcpkg/base/contractual-constants.h
@@ -133,6 +133,12 @@ namespace vcpkg
     inline constexpr StringLiteral SpdxDocumentNamespace = "documentNamespace";
     inline constexpr StringLiteral SpdxDownloadLocation = "downloadLocation";
     inline constexpr StringLiteral SpdxElementId = "spdxElementId";
+    inline constexpr StringLiteral SpdxExternalReferenceCategory = "referenceCategory";
+    inline constexpr StringLiteral SpdxExternalReferenceCategoryPackageManager = "PACKAGE_MANAGER";
+    inline constexpr StringLiteral SpdxExternalReferenceLocator = "referenceLocator";
+    inline constexpr StringLiteral SpdxExternalReferenceType = "referenceType";
+    inline constexpr StringLiteral SpdxExternalReferenceTypePurl = "purl";
+    inline constexpr StringLiteral SpdxExternalRefs = "externalRefs";
     inline constexpr StringLiteral SpdxFileName = "fileName";
     inline constexpr StringLiteral SpdxGenerates = "GENERATES";
     inline constexpr StringLiteral SpdxLicenseConcluded = "licenseConcluded";

--- a/include/vcpkg/registries.h
+++ b/include/vcpkg/registries.h
@@ -25,6 +25,8 @@ namespace vcpkg
 {
     inline constexpr StringLiteral builtin_registry_git_url = "https://github.com/microsoft/vcpkg";
 
+    bool is_builtin_git_registry_url(StringView url);
+
     struct LockFile
     {
         struct EntryData

--- a/include/vcpkg/sourceparagraph.h
+++ b/include/vcpkg/sourceparagraph.h
@@ -211,16 +211,8 @@ namespace vcpkg
         Filesystem,
     };
 
-    struct NoAssertionTag
-    {
-    };
-
-    inline constexpr NoAssertionTag no_assertion;
-
     struct PortLocation
     {
-        explicit PortLocation(const Path& port_directory, NoAssertionTag, PortSourceKind kind);
-        explicit PortLocation(Path&& port_directory, NoAssertionTag, PortSourceKind kind);
         explicit PortLocation(const Path& port_directory,
                               std::string&& spdx_location,
                               std::string&& spdx_repository_url,

--- a/include/vcpkg/sourceparagraph.h
+++ b/include/vcpkg/sourceparagraph.h
@@ -221,8 +221,14 @@ namespace vcpkg
     {
         explicit PortLocation(const Path& port_directory, NoAssertionTag, PortSourceKind kind);
         explicit PortLocation(Path&& port_directory, NoAssertionTag, PortSourceKind kind);
-        explicit PortLocation(const Path& port_directory, std::string&& spdx_location, PortSourceKind kind);
-        explicit PortLocation(Path&& port_directory, std::string&& spdx_location, PortSourceKind kind);
+        explicit PortLocation(const Path& port_directory,
+                              std::string&& spdx_location,
+                              std::string&& spdx_repository_url,
+                              PortSourceKind kind);
+        explicit PortLocation(Path&& port_directory,
+                              std::string&& spdx_location,
+                              std::string&& spdx_repository_url,
+                              PortSourceKind kind);
         PortLocation(const PortLocation&) = default;
         PortLocation(PortLocation&&) = default;
         PortLocation& operator=(const PortLocation&) = default;
@@ -233,6 +239,9 @@ namespace vcpkg
         /// Should model SPDX PackageDownloadLocation. Empty implies NOASSERTION.
         /// See https://spdx.github.io/spdx-spec/package-information/#77-package-download-location-field
         std::string spdx_location;
+
+        /// The repository URL portion of spdx_location for git registries. Empty otherwise.
+        std::string spdx_repository_url;
 
         PortSourceKind kind;
     };
@@ -306,7 +315,7 @@ namespace vcpkg
                 scf = std::make_unique<SourceControlFile>(source_control_file->clone());
             }
 
-            return SourceControlFileAndLocation{std::move(scf), control_path, spdx_location, kind};
+            return SourceControlFileAndLocation{std::move(scf), control_path, spdx_location, spdx_repository_url, kind};
         }
 
         std::unique_ptr<SourceControlFile> source_control_file;
@@ -315,6 +324,9 @@ namespace vcpkg
         /// Should model SPDX PackageDownloadLocation. Empty implies NOASSERTION.
         /// See https://spdx.github.io/spdx-spec/package-information/#77-package-download-location-field
         std::string spdx_location;
+
+        /// The repository URL portion of spdx_location for git registries. Empty otherwise.
+        std::string spdx_repository_url;
 
         PortSourceKind kind = PortSourceKind::Unknown;
     };

--- a/src/vcpkg-test/dependencies.cpp
+++ b/src/vcpkg-test/dependencies.cpp
@@ -68,12 +68,14 @@ struct MockVersionedPortfileProvider : IVersionedPortfileProvider
             core->version_scheme = scheme;
             core->version = version;
             scf->core_paragraph = std::move(core);
-            it2 =
-                version_map
-                    .emplace(std::move(version),
-                             SourceControlFileAndLocation{
-                                 std::move(scf), Path(std::move(name)) / "vcpkg.json", spdx_location.to_string(), kind})
-                    .first;
+            it2 = version_map
+                      .emplace(std::move(version),
+                               SourceControlFileAndLocation{std::move(scf),
+                                                            Path(std::move(name)) / "vcpkg.json",
+                                                            spdx_location.to_string(),
+                                                            std::string{},
+                                                            kind})
+                      .first;
         }
 
         return it2->second;

--- a/src/vcpkg-test/registries.cpp
+++ b/src/vcpkg-test/registries.cpp
@@ -583,6 +583,27 @@ TEST_CASE ("git_version_db_parsing", "[registries]")
     CHECK(!r.messages().any_errors());
 }
 
+TEST_CASE ("builtin git registry url detection", "[registries]")
+{
+    CHECK(is_builtin_git_registry_url("https://github.com/microsoft/vcpkg"));
+    CHECK(is_builtin_git_registry_url("https://github.com/microsoft/vcpkg/"));
+    CHECK(is_builtin_git_registry_url("https://github.com/microsoft/vcpkg\\"));
+    CHECK(is_builtin_git_registry_url("https://github.com/microsoft/vcpkg.git"));
+    CHECK(is_builtin_git_registry_url("https://github.com/microsoft/vcpkg.git/"));
+    CHECK(is_builtin_git_registry_url("https://github.com/microsoft/vcpkg.git\\"));
+    CHECK(is_builtin_git_registry_url("https://github.com/Microsoft/vcpkg"));
+    CHECK(is_builtin_git_registry_url("git@github.com:microsoft/vcpkg"));
+    CHECK(is_builtin_git_registry_url("git@github.com:microsoft/vcpkg/"));
+    CHECK(is_builtin_git_registry_url("git@github.com:microsoft/vcpkg\\"));
+    CHECK(is_builtin_git_registry_url("git@github.com:microsoft/vcpkg.git"));
+    CHECK(is_builtin_git_registry_url("git@github.com:microsoft/vcpkg.git/"));
+    CHECK(is_builtin_git_registry_url("git@github.com:microsoft/vcpkg.git\\"));
+    CHECK(is_builtin_git_registry_url("git@github.com:Microsoft/vcpkg.git"));
+
+    CHECK_FALSE(is_builtin_git_registry_url("https://github.com/example/vcpkg"));
+    CHECK_FALSE(is_builtin_git_registry_url("git@github.com:example/vcpkg"));
+}
+
 TEST_CASE ("filesystem_version_db_parsing", "[registries]")
 {
     FilesystemVersionDbEntryArrayDeserializer filesystem_version_db("a/b");

--- a/src/vcpkg-test/spdx.cpp
+++ b/src/vcpkg-test/spdx.cpp
@@ -450,7 +450,14 @@ TEST_CASE ("spdx maximum serialization", "[spdx]")
       "copyrightText": "NOASSERTION",
       "summary": "summary",
       "description": "description",
-      "comment": "This is the port (recipe) consumed by vcpkg."
+      "comment": "This is the port (recipe) consumed by vcpkg.",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:vcpkg/zlib@1.0?port_version=5&triplet=arm-uwp&vcs_url=git%3A%2F%2Fsome-vcs-url"
+        }
+      ]
     },
     {
       "name": "zlib:arm-uwp",
@@ -604,7 +611,14 @@ TEST_CASE ("spdx minimum serialization", "[spdx]")
       "licenseConcluded": "NOASSERTION",
       "licenseDeclared": "NOASSERTION",
       "copyrightText": "NOASSERTION",
-      "comment": "This is the port (recipe) consumed by vcpkg."
+      "comment": "This is the port (recipe) consumed by vcpkg.",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:vcpkg/zlib@1.0?triplet=arm-uwp"
+        }
+      ]
     },
     {
       "name": "zlib:arm-uwp",
@@ -719,7 +733,14 @@ TEST_CASE ("spdx concat resources", "[spdx]")
       "licenseConcluded": "NOASSERTION",
       "licenseDeclared": "NOASSERTION",
       "copyrightText": "NOASSERTION",
-      "comment": "This is the port (recipe) consumed by vcpkg."
+      "comment": "This is the port (recipe) consumed by vcpkg.",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:vcpkg/zlib@1.0?triplet=arm-uwp"
+        }
+      ]
     },
     {
       "name": "zlib:arm-uwp",
@@ -748,6 +769,125 @@ TEST_CASE ("spdx concat resources", "[spdx]")
 
     auto doc = Json::parse(sbom, "test").value(VCPKG_LINE_INFO);
     Test::check_json_eq(expected.value, doc.value);
+}
+
+static std::string port_purl(StringView sbom)
+{
+    auto parsed = Json::parse(sbom, "test").value(VCPKG_LINE_INFO);
+    return parsed.value.object(VCPKG_LINE_INFO)["packages"]
+        .array(VCPKG_LINE_INFO)[0]
+        .object(VCPKG_LINE_INFO)["externalRefs"]
+        .array(VCPKG_LINE_INFO)[0]
+        .object(VCPKG_LINE_INFO)["referenceLocator"]
+        .string(VCPKG_LINE_INFO)
+        .to_string();
+}
+
+TEST_CASE ("spdx purl omits empty version", "[spdx]")
+{
+    PackagesDirAssigner packages_dir_assigner{"test_packages_root"};
+    PackageSpec spec{"zlib", Test::ARM_UWP};
+    SourceControlFileAndLocation scfl;
+    auto& scf = *(scfl.source_control_file = std::make_unique<SourceControlFile>());
+    auto& cpgh = *(scf.core_paragraph = std::make_unique<SourceParagraph>());
+    cpgh.name = "zlib";
+    cpgh.version = Version{"", 1};
+
+    InstallPlanAction ipa(
+        spec, scfl, packages_dir_assigner, RequestType::USER_REQUESTED, UseHeadVersion::No, Editable::No, {}, {}, {});
+    auto& abi = *(ipa.abi_info = AbiInfo{}).get();
+    abi.package_abi = "ABIHASH";
+
+    const auto sbom = create_spdx_sbom(ipa, {}, {}, {}, {}, "now", "https://test-document-namespace", {});
+    CHECK(port_purl(sbom) == "pkg:vcpkg/zlib?port_version=1&triplet=arm-uwp");
+}
+
+TEST_CASE ("spdx purl percent-encodes the version", "[spdx]")
+{
+    PackagesDirAssigner packages_dir_assigner{"test_packages_root"};
+    PackageSpec spec{"zlib", Test::ARM_UWP};
+    SourceControlFileAndLocation scfl;
+    auto& scf = *(scfl.source_control_file = std::make_unique<SourceControlFile>());
+    auto& cpgh = *(scf.core_paragraph = std::make_unique<SourceParagraph>());
+    cpgh.name = "zlib";
+    cpgh.version = Version{"1.0+r2", 0};
+
+    InstallPlanAction ipa(
+        spec, scfl, packages_dir_assigner, RequestType::USER_REQUESTED, UseHeadVersion::No, Editable::No, {}, {}, {});
+    auto& abi = *(ipa.abi_info = AbiInfo{}).get();
+    abi.package_abi = "ABIHASH";
+
+    const auto sbom = create_spdx_sbom(ipa, {}, {}, {}, {}, "now", "https://test-document-namespace", {});
+    CHECK(port_purl(sbom) == "pkg:vcpkg/zlib@1.0%2Br2?triplet=arm-uwp");
+}
+
+TEST_CASE ("spdx purl includes vcs_url for a builtin git-tree", "[spdx]")
+{
+    PackagesDirAssigner packages_dir_assigner{"test_packages_root"};
+    PackageSpec spec{"zlib", Test::ARM_UWP};
+    SourceControlFileAndLocation scfl;
+    scfl.kind = PortSourceKind::Builtin;
+    scfl.spdx_location = "git+https://github.com/Microsoft/vcpkg@84a143e4caf6b70db57f28d04c41df4a85c480fa";
+    auto& scf = *(scfl.source_control_file = std::make_unique<SourceControlFile>());
+    auto& cpgh = *(scf.core_paragraph = std::make_unique<SourceParagraph>());
+    cpgh.name = "zlib";
+    cpgh.version = Version{"1.0", 0};
+
+    InstallPlanAction ipa(
+        spec, scfl, packages_dir_assigner, RequestType::USER_REQUESTED, UseHeadVersion::No, Editable::No, {}, {}, {});
+    auto& abi = *(ipa.abi_info = AbiInfo{}).get();
+    abi.package_abi = "ABIHASH";
+
+    const auto sbom = create_spdx_sbom(ipa, {}, {}, {}, {}, "now", "https://test-document-namespace", {});
+    // The default microsoft/vcpkg registry is Builtin, so the locator has no repository_url.
+    CHECK(port_purl(sbom) == "pkg:vcpkg/zlib@1.0?triplet=arm-uwp"
+                             "&vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Fvcpkg%40"
+                             "84a143e4caf6b70db57f28d04c41df4a85c480fa");
+}
+
+TEST_CASE ("spdx purl includes repository_url and vcs_url for a non-default git registry", "[spdx]")
+{
+    PackagesDirAssigner packages_dir_assigner{"test_packages_root"};
+    PackageSpec spec{"zlib", Test::ARM_UWP};
+    SourceControlFileAndLocation scfl;
+    scfl.kind = PortSourceKind::Git;
+    scfl.spdx_location = "git+https://github.com/azure-sdk/vcpkg@84a143e4caf6b70db57f28d04c41df4a85c480fa";
+    auto& scf = *(scfl.source_control_file = std::make_unique<SourceControlFile>());
+    auto& cpgh = *(scf.core_paragraph = std::make_unique<SourceParagraph>());
+    cpgh.name = "zlib";
+    cpgh.version = Version{"1.0", 0};
+
+    InstallPlanAction ipa(
+        spec, scfl, packages_dir_assigner, RequestType::USER_REQUESTED, UseHeadVersion::No, Editable::No, {}, {}, {});
+    auto& abi = *(ipa.abi_info = AbiInfo{}).get();
+    abi.package_abi = "ABIHASH";
+
+    const auto sbom = create_spdx_sbom(ipa, {}, {}, {}, {}, "now", "https://test-document-namespace", {});
+    // repository_url is the registry URL with the git+ prefix and @git-tree stripped; vcs_url keeps both.
+    CHECK(port_purl(sbom) == "pkg:vcpkg/zlib@1.0?repository_url=https%3A%2F%2Fgithub.com%2Fazure-sdk%2Fvcpkg"
+                             "&triplet=arm-uwp"
+                             "&vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fazure-sdk%2Fvcpkg%40"
+                             "84a143e4caf6b70db57f28d04c41df4a85c480fa");
+}
+
+TEST_CASE ("spdx purl omits vcs_url and repository_url for overlay ports", "[spdx]")
+{
+    PackagesDirAssigner packages_dir_assigner{"test_packages_root"};
+    PackageSpec spec{"zlib", Test::ARM_UWP};
+    SourceControlFileAndLocation scfl;
+    scfl.kind = PortSourceKind::Overlay;
+    auto& scf = *(scfl.source_control_file = std::make_unique<SourceControlFile>());
+    auto& cpgh = *(scf.core_paragraph = std::make_unique<SourceParagraph>());
+    cpgh.name = "zlib";
+    cpgh.version = Version{"1.0", 0};
+
+    InstallPlanAction ipa(
+        spec, scfl, packages_dir_assigner, RequestType::USER_REQUESTED, UseHeadVersion::No, Editable::No, {}, {}, {});
+    auto& abi = *(ipa.abi_info = AbiInfo{}).get();
+    abi.package_abi = "ABIHASH";
+
+    const auto sbom = create_spdx_sbom(ipa, {}, {}, {}, {}, "now", "https://test-document-namespace", {});
+    CHECK(port_purl(sbom) == "pkg:vcpkg/zlib@1.0?triplet=arm-uwp");
 }
 
 TEST_CASE ("spdx license parse edge cases", "[spdx]")

--- a/src/vcpkg-test/spdx.cpp
+++ b/src/vcpkg-test/spdx.cpp
@@ -799,7 +799,7 @@ TEST_CASE ("spdx purl omits empty version", "[spdx]")
     abi.package_abi = "ABIHASH";
 
     const auto sbom = create_spdx_sbom(ipa, {}, {}, {}, {}, "now", "https://test-document-namespace", {});
-    CHECK(port_purl(sbom) == "pkg:vcpkg/zlib?port_version=1&triplet=arm-uwp");
+    CHECK(port_purl(sbom) == "pkg:vcpkg/zlib?triplet=arm-uwp");
 }
 
 TEST_CASE ("spdx purl percent-encodes the version", "[spdx]")
@@ -852,6 +852,7 @@ TEST_CASE ("spdx purl includes repository_url and vcs_url for a non-default git 
     SourceControlFileAndLocation scfl;
     scfl.kind = PortSourceKind::Git;
     scfl.spdx_location = "git+https://github.com/azure-sdk/vcpkg@84a143e4caf6b70db57f28d04c41df4a85c480fa";
+    scfl.spdx_repository_url = "https://github.com/azure-sdk/vcpkg";
     auto& scf = *(scfl.source_control_file = std::make_unique<SourceControlFile>());
     auto& cpgh = *(scf.core_paragraph = std::make_unique<SourceParagraph>());
     cpgh.name = "zlib";
@@ -868,6 +869,30 @@ TEST_CASE ("spdx purl includes repository_url and vcs_url for a non-default git 
                              "&triplet=arm-uwp"
                              "&vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fazure-sdk%2Fvcpkg%40"
                              "84a143e4caf6b70db57f28d04c41df4a85c480fa");
+}
+
+TEST_CASE ("spdx purl uses the dedicated repository_url field for git registries", "[spdx]")
+{
+    PackagesDirAssigner packages_dir_assigner{"test_packages_root"};
+    PackageSpec spec{"zlib", Test::ARM_UWP};
+    SourceControlFileAndLocation scfl;
+    scfl.kind = PortSourceKind::Git;
+    scfl.spdx_location = "git+https://github.com/azure-sdk/vcpkg";
+    scfl.spdx_repository_url = "https://example.com/registry";
+    auto& scf = *(scfl.source_control_file = std::make_unique<SourceControlFile>());
+    auto& cpgh = *(scf.core_paragraph = std::make_unique<SourceParagraph>());
+    cpgh.name = "zlib";
+    cpgh.version = Version{"1.0", 0};
+
+    InstallPlanAction ipa(
+        spec, scfl, packages_dir_assigner, RequestType::USER_REQUESTED, UseHeadVersion::No, Editable::No, {}, {}, {});
+    auto& abi = *(ipa.abi_info = AbiInfo{}).get();
+    abi.package_abi = "ABIHASH";
+
+    const auto sbom = create_spdx_sbom(ipa, {}, {}, {}, {}, "now", "https://test-document-namespace", {});
+    CHECK(port_purl(sbom) == "pkg:vcpkg/zlib@1.0?repository_url=https%3A%2F%2Fexample.com%2Fregistry"
+                             "&triplet=arm-uwp"
+                             "&vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fazure-sdk%2Fvcpkg");
 }
 
 TEST_CASE ("spdx purl omits vcs_url and repository_url for overlay ports", "[spdx]")

--- a/src/vcpkg/commands.ci-verify-versions.cpp
+++ b/src/vcpkg/commands.ci-verify-versions.cpp
@@ -59,6 +59,7 @@ namespace
             port_name,
             PortLocation(*extracted_tree,
                          Paragraphs::builtin_git_tree_spdx_location(version_entry.git_tree),
+                         std::string(),
                          PortSourceKind::Git));
         auto scfl = load_result.maybe_scfl.get();
         if (!scfl)

--- a/src/vcpkg/paragraphs.cpp
+++ b/src/vcpkg/paragraphs.cpp
@@ -421,6 +421,7 @@ namespace vcpkg::Paragraphs
                                           return SourceControlFileAndLocation{std::move(scf),
                                                                               std::move(manifest_path),
                                                                               port_location.spdx_location,
+                                                                              port_location.spdx_repository_url,
                                                                               port_location.kind};
                                       }),
                                   manifest_contents};
@@ -442,6 +443,7 @@ namespace vcpkg::Paragraphs
                                           return SourceControlFileAndLocation{std::move(scf),
                                                                               std::move(control_path),
                                                                               port_location.spdx_location,
+                                                                              port_location.spdx_repository_url,
                                                                               port_location.kind};
                                       }),
                                   control_contents};
@@ -507,10 +509,13 @@ namespace vcpkg::Paragraphs
                                                   StringView port_name,
                                                   const Path& builtin_ports_directory)
     {
+        // note that spdx_repository_url is intentionally left empty here because PURL suggests only supplying that for
+        // non "default" registries
         return Paragraphs::try_load_port_required(fs,
                                                   port_name,
                                                   PortLocation{builtin_ports_directory / port_name,
                                                                builtin_port_spdx_location(port_name),
+                                                               std::string(),
                                                                PortSourceKind::Builtin});
     }
 

--- a/src/vcpkg/portfileprovider.cpp
+++ b/src/vcpkg/portfileprovider.cpp
@@ -25,10 +25,12 @@ namespace
         switch (kind)
         {
             case OverlayPortKind::Directory:
-                return PortLocation{directory / port_name, no_assertion, PortSourceKind::Overlay};
+                return PortLocation{directory / port_name, std::string{}, std::string{}, PortSourceKind::Overlay};
             case OverlayPortKind::Builtin:
-                return PortLocation{
-                    directory / port_name, Paragraphs::builtin_port_spdx_location(port_name), PortSourceKind::Builtin};
+                return PortLocation{directory / port_name,
+                                    Paragraphs::builtin_port_spdx_location(port_name),
+                                    std::string(),
+                                    PortSourceKind::Builtin};
             case OverlayPortKind::Unknown:
             case OverlayPortKind::Port:
             default: Checks::unreachable(VCPKG_LINE_INFO);
@@ -58,9 +60,9 @@ namespace vcpkg
                 Checks::unreachable(VCPKG_LINE_INFO, "OverlayPortKind::Unknown empty cache constraint violated");
             }
 
-            auto maybe_scfl =
-                Paragraphs::try_load_port(fs, PortLocation{m_directory, no_assertion, PortSourceKind::Overlay})
-                    .maybe_scfl;
+            auto maybe_scfl = Paragraphs::try_load_port(
+                                  fs, PortLocation{m_directory, std::string{}, std::string{}, PortSourceKind::Overlay})
+                                  .maybe_scfl;
             if (auto scfl = maybe_scfl.get())
             {
                 if (scfl->source_control_file)

--- a/src/vcpkg/registries.cpp
+++ b/src/vcpkg/registries.cpp
@@ -28,6 +28,10 @@ namespace
 {
     using namespace vcpkg;
 
+    constexpr StringLiteral builtin_registry_git_url_with_dot_git = "https://github.com/microsoft/vcpkg.git";
+    constexpr StringLiteral builtin_registry_git_url_git_form = "git@github.com:microsoft/vcpkg";
+    constexpr StringLiteral builtin_registry_git_url_git_form_with_dot_git = "git@github.com:microsoft/vcpkg.git";
+
     struct GitTreeStringDeserializer : Json::StringDeserializer
     {
         LocalizedString type_name() const override { return msg::format(msgAGitObjectSha); }
@@ -880,6 +884,7 @@ namespace
                            port_name,
                            PortLocation{std::move(p),
                                         Paragraphs::builtin_git_tree_spdx_location(it->git_tree),
+                                        std::string(),
                                         PortSourceKind::Builtin})
                     .maybe_scfl;
             });
@@ -900,7 +905,7 @@ namespace
         }
 
         return Paragraphs::try_load_port_required(
-                   fs, port_name, PortLocation{it->p, no_assertion, PortSourceKind::Filesystem})
+                   fs, port_name, PortLocation{it->p, std::string{}, std::string{}, PortSourceKind::Filesystem})
             .maybe_scfl;
     }
     // } FilesystemRegistryEntry::RegistryEntry
@@ -967,7 +972,11 @@ namespace
                 return Paragraphs::try_load_port_required(
                            parent.m_paths.get_filesystem(),
                            port_name,
-                           PortLocation{p, fmt::format("git+{}@{}", parent.m_repo, it->git_tree), PortSourceKind::Git})
+                           PortLocation{std::move(p),
+                                        fmt::format("git+{}@{}", parent.m_repo, it->git_tree),
+                                        is_builtin_git_registry_url(parent.m_repo) ? std::string()
+                                                                                   : std::string(parent.m_repo),
+                                        PortSourceKind::Git})
                     .maybe_scfl;
             });
     }
@@ -1069,6 +1078,19 @@ namespace
 
 namespace vcpkg
 {
+    bool is_builtin_git_registry_url(StringView url)
+    {
+        if (!url.empty() && (url.back() == '/' || url.back() == '\\'))
+        {
+            url = url.substr(0, url.size() - 1);
+        }
+
+        return Strings::case_insensitive_ascii_equals(url, builtin_registry_git_url) ||
+               Strings::case_insensitive_ascii_equals(url, builtin_registry_git_url_with_dot_git) ||
+               Strings::case_insensitive_ascii_equals(url, builtin_registry_git_url_git_form) ||
+               Strings::case_insensitive_ascii_equals(url, builtin_registry_git_url_git_form_with_dot_git);
+    }
+
     ExpectedL<LockFile::Entry> LockFile::get_or_fetch(const VcpkgPaths& paths, StringView repo, StringView reference)
     {
         auto range = lockdata.equal_range(repo);

--- a/src/vcpkg/sourceparagraph.cpp
+++ b/src/vcpkg/sourceparagraph.cpp
@@ -133,16 +133,6 @@ namespace vcpkg
         return true;
     }
 
-    PortLocation::PortLocation(const Path& port_directory, NoAssertionTag, PortSourceKind kind)
-        : port_directory(port_directory), spdx_location(), spdx_repository_url(), kind(kind)
-    {
-    }
-
-    PortLocation::PortLocation(Path&& port_directory, NoAssertionTag, PortSourceKind kind)
-        : port_directory(std::move(port_directory)), spdx_location(), spdx_repository_url(), kind(kind)
-    {
-    }
-
     PortLocation::PortLocation(const Path& port_directory,
                                std::string&& spdx_location,
                                std::string&& spdx_repository_url,

--- a/src/vcpkg/sourceparagraph.cpp
+++ b/src/vcpkg/sourceparagraph.cpp
@@ -134,22 +134,34 @@ namespace vcpkg
     }
 
     PortLocation::PortLocation(const Path& port_directory, NoAssertionTag, PortSourceKind kind)
-        : port_directory(port_directory), spdx_location(), kind(kind)
+        : port_directory(port_directory), spdx_location(), spdx_repository_url(), kind(kind)
     {
     }
 
     PortLocation::PortLocation(Path&& port_directory, NoAssertionTag, PortSourceKind kind)
-        : port_directory(std::move(port_directory)), spdx_location(), kind(kind)
+        : port_directory(std::move(port_directory)), spdx_location(), spdx_repository_url(), kind(kind)
     {
     }
 
-    PortLocation::PortLocation(const Path& port_directory, std::string&& spdx_location, PortSourceKind kind)
-        : port_directory(port_directory), spdx_location(std::move(spdx_location)), kind(kind)
+    PortLocation::PortLocation(const Path& port_directory,
+                               std::string&& spdx_location,
+                               std::string&& spdx_repository_url,
+                               PortSourceKind kind)
+        : port_directory(port_directory)
+        , spdx_location(std::move(spdx_location))
+        , spdx_repository_url(std::move(spdx_repository_url))
+        , kind(kind)
     {
     }
 
-    PortLocation::PortLocation(Path&& port_directory, std::string&& spdx_location, PortSourceKind kind)
-        : port_directory(std::move(port_directory)), spdx_location(std::move(spdx_location)), kind(kind)
+    PortLocation::PortLocation(Path&& port_directory,
+                               std::string&& spdx_location,
+                               std::string&& spdx_repository_url,
+                               PortSourceKind kind)
+        : port_directory(std::move(port_directory))
+        , spdx_location(std::move(spdx_location))
+        , spdx_repository_url(std::move(spdx_repository_url))
+        , kind(kind)
     {
     }
 

--- a/src/vcpkg/spdx.cpp
+++ b/src/vcpkg/spdx.cpp
@@ -338,45 +338,33 @@ std::string vcpkg::create_spdx_sbom(const InstallPlanAction& action,
             std::string purl = fmt::format("pkg:vcpkg/{}", Strings::percent_encode(action.spec.name()));
             if (!cpgh.version.text.empty())
             {
-                purl += fmt::format("@{}", Strings::percent_encode(cpgh.version.text));
+                purl.push_back('@');
+                purl += Strings::percent_encode(cpgh.version.text);
             }
 
             // PURL qualifiers, emitted in canonical (alphabetical) key order.
             std::vector<std::string> qualifiers;
-            if (cpgh.version.port_version != 0)
+            if (!cpgh.version.text.empty() && cpgh.version.port_version != 0)
             {
                 qualifiers.push_back(fmt::format("port_version={}", cpgh.version.port_version));
             }
 
-            StringView spdx_location = scfl.spdx_location;
-            if (scfl.kind == PortSourceKind::Git && spdx_location.starts_with("git+"))
+            if (!scfl.spdx_repository_url.empty())
             {
-                // spdx_location has the form "git+<repository_url>@<git-tree>". The default microsoft/vcpkg
-                // registry is Builtin, so only non-default registries reach this branch.
-                auto revision_sep = scfl.spdx_location.rfind('@');
-                if (revision_sep == std::string::npos)
-                {
-                    revision_sep = spdx_location.size();
-                }
-
-                StringView repository_url = spdx_location.substr(4, revision_sep - 4);
-                qualifiers.push_back(fmt::format("repository_url={}", Strings::percent_encode(repository_url)));
+                qualifiers.push_back("repository_url=" + Strings::percent_encode(scfl.spdx_repository_url));
             }
 
-            qualifiers.push_back(
-                fmt::format("triplet={}", Strings::percent_encode(action.spec.triplet().canonical_name())));
+            qualifiers.push_back("triplet=" + Strings::percent_encode(action.spec.triplet().canonical_name()));
 
             // spdx_location is the SPDX PackageDownloadLocation: a VCS URL that pins the port's
             // git-tree, which identifies the exact port recipe.
-            if (!spdx_location.empty())
+            if (!scfl.spdx_location.empty())
             {
-                qualifiers.push_back(fmt::format("vcs_url={}", Strings::percent_encode(spdx_location)));
+                qualifiers.push_back("vcs_url=" + Strings::percent_encode(scfl.spdx_location));
             }
 
-            if (!qualifiers.empty())
-            {
-                purl += fmt::format("?{}", Strings::join("&", qualifiers));
-            }
+            purl.push_back('?');
+            purl += Strings::join("&", qualifiers);
 
             auto& external_refs = obj.insert(SpdxExternalRefs, Json::Array());
             auto& purl_ref = external_refs.push_back(Json::Object());

--- a/src/vcpkg/spdx.cpp
+++ b/src/vcpkg/spdx.cpp
@@ -335,6 +335,56 @@ std::string vcpkg::create_spdx_sbom(const InstallPlanAction& action,
         if (!cpgh.description.empty()) obj.insert(JsonIdDescription, Strings::join("\n", cpgh.description));
         obj.insert(JsonIdComment, "This is the port (recipe) consumed by vcpkg.");
         {
+            std::string purl = fmt::format("pkg:vcpkg/{}", Strings::percent_encode(action.spec.name()));
+            if (!cpgh.version.text.empty())
+            {
+                purl += fmt::format("@{}", Strings::percent_encode(cpgh.version.text));
+            }
+
+            // PURL qualifiers, emitted in canonical (alphabetical) key order.
+            std::vector<std::string> qualifiers;
+            if (cpgh.version.port_version != 0)
+            {
+                qualifiers.push_back(fmt::format("port_version={}", cpgh.version.port_version));
+            }
+
+            StringView spdx_location = scfl.spdx_location;
+            if (scfl.kind == PortSourceKind::Git && spdx_location.starts_with("git+"))
+            {
+                // spdx_location has the form "git+<repository_url>@<git-tree>". The default microsoft/vcpkg
+                // registry is Builtin, so only non-default registries reach this branch.
+                auto revision_sep = scfl.spdx_location.rfind('@');
+                if (revision_sep == std::string::npos)
+                {
+                    revision_sep = spdx_location.size();
+                }
+
+                StringView repository_url = spdx_location.substr(4, revision_sep - 4);
+                qualifiers.push_back(fmt::format("repository_url={}", Strings::percent_encode(repository_url)));
+            }
+
+            qualifiers.push_back(
+                fmt::format("triplet={}", Strings::percent_encode(action.spec.triplet().canonical_name())));
+
+            // spdx_location is the SPDX PackageDownloadLocation: a VCS URL that pins the port's
+            // git-tree, which identifies the exact port recipe.
+            if (!spdx_location.empty())
+            {
+                qualifiers.push_back(fmt::format("vcs_url={}", Strings::percent_encode(spdx_location)));
+            }
+
+            if (!qualifiers.empty())
+            {
+                purl += fmt::format("?{}", Strings::join("&", qualifiers));
+            }
+
+            auto& external_refs = obj.insert(SpdxExternalRefs, Json::Array());
+            auto& purl_ref = external_refs.push_back(Json::Object());
+            purl_ref.insert(SpdxExternalReferenceCategory, SpdxExternalReferenceCategoryPackageManager);
+            purl_ref.insert(SpdxExternalReferenceType, SpdxExternalReferenceTypePurl);
+            purl_ref.insert(SpdxExternalReferenceLocator, std::move(purl));
+        }
+        {
             auto& rel = rels.push_back(Json::Object());
             rel.insert(SpdxElementId, SpdxRefPort);
             rel.insert(SpdxRelationshipType, SpdxGenerates);


### PR DESCRIPTION
Adds a `purl` externalRef to `SPDXRef-port` so scanners can link installed packages to their CVEs, e.g. `pkg:vcpkg/zlib@1.0?port_version=5&triplet=x64-linux` (plus `vcs_url` for the port git-tree and `repository_url` for non-default registries). Follows package-url/purl-spec#885.

Closes #2046.