### PR TITLE
Qualify C math functions

### DIFF
--- a/src/vcpkg-test/json.cpp
+++ b/src/vcpkg-test/json.cpp
@@ -3,6 +3,7 @@
 #include <vcpkg/base/json.h>
 #include <vcpkg/base/messages.h>
 
+#include <cmath>
 #include <iostream>
 
 // TODO: remove this once we switch to C++20 completely
@@ -150,12 +151,12 @@ TEST_CASE ("JSON parse floats", "[json]")
     REQUIRE(res.get()->value.is_number());
     REQUIRE(!res.get()->value.is_integer());
     REQUIRE(res.get()->value.number(VCPKG_LINE_INFO) == 0.0);
-    REQUIRE(!signbit(res.get()->value.number(VCPKG_LINE_INFO)));
+    REQUIRE(!std::signbit(res.get()->value.number(VCPKG_LINE_INFO)));
     res = Json::parse("-0.0", "test");
     REQUIRE(res);
     REQUIRE(res.get()->value.is_number());
     REQUIRE(res.get()->value.number(VCPKG_LINE_INFO) == 0.0);
-    REQUIRE(signbit(res.get()->value.number(VCPKG_LINE_INFO)));
+    REQUIRE(std::signbit(res.get()->value.number(VCPKG_LINE_INFO)));
     res = Json::parse("12345.6789", "test");
     REQUIRE(res);
     REQUIRE(res.get()->value.is_number());

--- a/src/vcpkg/base/json.cpp
+++ b/src/vcpkg/base/json.cpp
@@ -10,9 +10,8 @@
 
 #include <vcpkg/documentation.h>
 
-#include <math.h>
-
 #include <atomic>
+#include <cmath>
 #include <type_traits>
 
 namespace vcpkg::Json
@@ -320,7 +319,7 @@ namespace vcpkg::Json
     }
     Value Value::number(double d) noexcept
     {
-        vcpkg::Checks::check_exit(VCPKG_LINE_INFO, isfinite(d));
+        vcpkg::Checks::check_exit(VCPKG_LINE_INFO, std::isfinite(d));
         Value val;
         val.underlying_ = std::make_unique<ValueImpl>(ValueKindConstant<VK::Number>(), d);
         return val;

--- a/src/vcpkg/metrics.cpp
+++ b/src/vcpkg/metrics.cpp
@@ -18,8 +18,7 @@
 #include <vcpkg/metrics.h>
 #include <vcpkg/paragraphs.h>
 
-#include <math.h>
-
+#include <cmath>
 #include <iterator>
 #include <limits>
 #include <mutex>
@@ -190,7 +189,7 @@ namespace vcpkg
 
     void MetricsSubmission::track_elapsed_us(double value)
     {
-        if (!isfinite(value) || value < 0.0)
+        if (!std::isfinite(value) || value < 0.0)
         {
             value = 0.0;
         }


### PR DESCRIPTION
Use <cmath> and std::isfinite/std::signbit for floating point checks in JSON and metrics code.  Some C++ standard libraries do not expose these functions unqualified through the global namespace.

This fixes some build errors on BSD