### PR TITLE
[z-applocal] Only log dependency deployment details with --verbose

### DIFF
--- a/include/vcpkg/base/message-data.inc.h
+++ b/include/vcpkg/base/message-data.inc.h
@@ -910,6 +910,10 @@ DECLARE_MESSAGE(
     (),
     "",
     "Copies a binary's dependencies from the installed tree to where that binary's location for app-local deployment")
+DECLARE_MESSAGE(CmdZApplocalOptVerbose,
+                (),
+                "",
+                "Prints which dependencies are being processed and which are already up to date")
 DECLARE_MESSAGE(CmdZExtractExample1,
                 (),
                 "This is a command line, only the parts in <>s should be localized",

--- a/locales/messages.json
+++ b/locales/messages.json
@@ -522,6 +522,7 @@
   "CmdXDownloadOptSkipSha": "Skips check of SHA512 of the downloaded file",
   "CmdXDownloadOptStore": "Stores the the file should father than fetching it",
   "CmdXDownloadOptUrl": "URL to download and store if missing from cache",
+  "CmdZApplocalOptVerbose": "Prints which dependencies are being processed and which are already up to date",
   "CmdZApplocalSynopsis": "Copies a binary's dependencies from the installed tree to where that binary's location for app-local deployment",
   "CmdZExtractExample1": "vcpkg z-extract <archive path> <output directory>",
   "_CmdZExtractExample1.comment": "This is a command line, only the parts in <>s should be localized",

--- a/src/vcpkg/commands.z-applocal.cpp
+++ b/src/vcpkg/commands.z-applocal.cpp
@@ -92,6 +92,7 @@ namespace
                            const Path& installed_bin_dir,
                            const Path& installed,
                            bool is_debug,
+                           bool verbose,
 #if defined(_WIN32)
                            WriteFilePointer&& tlog_file,
 #endif // ^^^ _WIN32
@@ -101,6 +102,7 @@ namespace
             , m_installed_bin_dir(installed_bin_dir)
             , m_installed(installed)
             , m_is_debug(is_debug)
+            , m_verbose(verbose)
 #if defined(_WIN32)
             , m_tlog_file(std::move(tlog_file))
 #endif // ^^^ _WIN32
@@ -119,7 +121,7 @@ namespace
 
         void resolve(const Path& binary)
         {
-            if (Debug::g_debugging)
+            if (m_verbose)
             {
                 msg::print(LocalizedString::from_raw(binary)
                                .append_raw(": ")
@@ -517,7 +519,7 @@ namespace
             }
             else if (!ec)
             {
-                if (Debug::g_debugging)
+                if (m_verbose)
                 {
                     msg::println(
                         msgInstallSkippedUpToDateFile, msg::path_source = source, msg::path_destination = target);
@@ -563,6 +565,7 @@ namespace
         Path m_installed_bin_dir;
         Path m_installed;
         bool m_is_debug;
+        bool m_verbose;
 #if defined(_WIN32)
         WriteFilePointer m_tlog_file;
 #endif // ^^^ _WIN32
@@ -575,6 +578,10 @@ namespace
 #if !defined(_WIN32)
         Path m_temp_dir;
 #endif // ^^^ !_WIN32
+    };
+
+    constexpr CommandSwitch SWITCHES[] = {
+        {SwitchVerbose, msgCmdZApplocalOptVerbose},
     };
 
     constexpr CommandSetting SETTINGS[] = {
@@ -603,13 +610,14 @@ namespace vcpkg
         AutocompletePriority::Internal,
         0,
         0,
-        {{}, SETTINGS},
+        {SWITCHES, SETTINGS},
         nullptr,
     };
 
     void command_z_applocal_and_exit(const VcpkgCmdArguments& args, const Filesystem& fs)
     {
         auto parsed = args.parse_arguments(CommandZApplocalMetadata);
+        const bool verbose = Util::Sets::contains(parsed.switches, SwitchVerbose);
         const auto target_binary = parsed.settings.find(SwitchTargetBinary);
         if (target_binary == parsed.settings.end())
         {
@@ -628,7 +636,7 @@ namespace vcpkg
 
         // the first binary is special in that it might not be a DLL or might not exist
         const Path target_binary_path = target_binary->second;
-        if (Debug::g_debugging)
+        if (verbose)
         {
             msg::print(LocalizedString::from_raw(target_binary_path)
                            .append_raw(": ")
@@ -687,6 +695,7 @@ namespace vcpkg
                                       target_installed_bin_dir,
                                       decoded.installed_root,
                                       decoded.is_debug,
+                                      verbose,
 #if defined(_WIN32)
                                       maybe_create_log(parsed.settings, SwitchTLogFile, fs),
 #endif // ^^^ _WIN32

--- a/src/vcpkg/commands.z-applocal.cpp
+++ b/src/vcpkg/commands.z-applocal.cpp
@@ -119,11 +119,14 @@ namespace
 
         void resolve(const Path& binary)
         {
-            msg::print(LocalizedString::from_raw(binary)
-                           .append_raw(": ")
-                           .append_raw(MessagePrefix)
-                           .append(msgApplocalProcessing)
-                           .append_raw('\n'));
+            if (Debug::g_debugging)
+            {
+                msg::print(LocalizedString::from_raw(binary)
+                               .append_raw(": ")
+                               .append_raw(MessagePrefix)
+                               .append(msgApplocalProcessing)
+                               .append_raw('\n'));
+            }
 
             auto dll_file = m_fs.open_for_read(binary, VCPKG_LINE_INFO);
             const auto dll_metadata = vcpkg::try_read_dll_metadata_required(dll_file).value_or_exit(VCPKG_LINE_INFO);
@@ -514,7 +517,11 @@ namespace
             }
             else if (!ec)
             {
-                msg::println(msgInstallSkippedUpToDateFile, msg::path_source = source, msg::path_destination = target);
+                if (Debug::g_debugging)
+                {
+                    msg::println(
+                        msgInstallSkippedUpToDateFile, msg::path_source = source, msg::path_destination = target);
+                }
             }
             else if (is_not_found_errc(ec))
             {
@@ -621,11 +628,14 @@ namespace vcpkg
 
         // the first binary is special in that it might not be a DLL or might not exist
         const Path target_binary_path = target_binary->second;
-        msg::print(LocalizedString::from_raw(target_binary_path)
-                       .append_raw(": ")
-                       .append_raw(MessagePrefix)
-                       .append(msgApplocalProcessing)
-                       .append_raw('\n'));
+        if (Debug::g_debugging)
+        {
+            msg::print(LocalizedString::from_raw(target_binary_path)
+                           .append_raw(": ")
+                           .append_raw(MessagePrefix)
+                           .append(msgApplocalProcessing)
+                           .append_raw('\n'));
+        }
 
         std::error_code ec;
         auto dll_file = fs.open_for_read(target_binary_path, ec);


### PR DESCRIPTION
Addresses microsoft/vcpkg#52550.

Since `vcpkg z-applocal` became the default DLL deployment path (microsoft/vcpkg#52315), builds emit a lot of noise: a "deploying dependencies" header for every target and dependency, plus a "skipped, up to date" line for every DLL that is already present.

The legacy `applocal.ps1` logged all of this via `Write-Verbose`, which MSBuild hides by default, so the old behavior was quiet. This restores parity by demoting those informational messages to debug-only output (`Debug::g_debugging`), while keeping the "copied file" line  which reports an actual deployment at normal verbosity.

Result: the first build still shows DLLs that are actually deployed; subsequent builds are quiet.

The existing end-to-end test (`z-applocalcpp.ps1`) only asserts on the "copied file" message, which is unchanged, so it continues to pass.