### PR TITLE
Change `GITHUB_SERVER_URL` to `GITHUB_API_URL` to allow submission of dependency graph data again

### DIFF
--- a/include/vcpkg/base/contractual-constants.h
+++ b/include/vcpkg/base/contractual-constants.h
@@ -501,6 +501,7 @@ namespace vcpkg
     inline constexpr StringLiteral EnvironmentVariableGitHubRepositoryID = "GITHUB_REPOSITORY_ID";
     inline constexpr StringLiteral EnvironmentVariableGitHubRepositoryOwnerId = "GITHUB_REPOSITORY_OWNER_ID";
     inline constexpr StringLiteral EnvironmentVariableGitHubRunId = "GITHUB_RUN_ID";
+    inline constexpr StringLiteral EnvironmentVariableGitHubServerUrl = "GITHUB_SERVER_URL";
     inline constexpr StringLiteral EnvironmentVariableGitHubApiUrl = "GITHUB_API_URL";
     inline constexpr StringLiteral EnvironmentVariableGitHubSha = "GITHUB_SHA";
     inline constexpr StringLiteral EnvironmentVariableGitHubToken = "GITHUB_TOKEN";

--- a/include/vcpkg/base/contractual-constants.h
+++ b/include/vcpkg/base/contractual-constants.h
@@ -501,7 +501,7 @@ namespace vcpkg
     inline constexpr StringLiteral EnvironmentVariableGitHubRepositoryID = "GITHUB_REPOSITORY_ID";
     inline constexpr StringLiteral EnvironmentVariableGitHubRepositoryOwnerId = "GITHUB_REPOSITORY_OWNER_ID";
     inline constexpr StringLiteral EnvironmentVariableGitHubRunId = "GITHUB_RUN_ID";
-    inline constexpr StringLiteral EnvironmentVariableGitHubServerUrl = "GITHUB_SERVER_URL";
+    inline constexpr StringLiteral EnvironmentVariableGitHubApiUrl = "GITHUB_API_URL";
     inline constexpr StringLiteral EnvironmentVariableGitHubSha = "GITHUB_SHA";
     inline constexpr StringLiteral EnvironmentVariableGitHubToken = "GITHUB_TOKEN";
     inline constexpr StringLiteral EnvironmentVariableGitHubWorkflow = "GITHUB_WORKFLOW";

--- a/include/vcpkg/base/downloads.h
+++ b/include/vcpkg/base/downloads.h
@@ -32,7 +32,7 @@ namespace vcpkg
                                              View<std::string> headers);
 
     bool submit_github_dependency_graph_snapshot(DiagnosticContext& context,
-                                                 const Optional<std::string>& maybe_github_server_url,
+                                                 const Optional<std::string>& maybe_github_api_url,
                                                  const std::string& github_token,
                                                  const std::string& github_repository,
                                                  const Json::Object& snapshot);

--- a/include/vcpkg/vcpkgcmdarguments.h
+++ b/include/vcpkg/vcpkgcmdarguments.h
@@ -240,7 +240,7 @@ namespace vcpkg
         Optional<bool> use_nuget_cache;
         Optional<std::string> vcpkg_nuget_repository;
         Optional<std::string> github_repository;
-        Optional<std::string> github_server_url;
+        Optional<std::string> github_api_url;
         Optional<std::string> github_ref;
         Optional<std::string> github_sha;
         Optional<std::string> ci_repository_id;

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -326,7 +326,8 @@ namespace vcpkg
         {
             uri = *github_server_url;
         }
-        else
+
+        if (uri.empty())
         {
             uri = "https://api.github.com";
         }

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -325,7 +325,6 @@ namespace vcpkg
         if (auto github_server_url = maybe_github_server_url.get())
         {
             uri = *github_server_url;
-            uri.append("/api/v3");
         }
         else
         {

--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -316,15 +316,15 @@ namespace vcpkg
     }
 
     bool submit_github_dependency_graph_snapshot(DiagnosticContext& context,
-                                                 const Optional<std::string>& maybe_github_server_url,
+                                                 const Optional<std::string>& maybe_github_api_url,
                                                  const std::string& github_token,
                                                  const std::string& github_repository,
                                                  const Json::Object& snapshot)
     {
         std::string uri;
-        if (auto github_server_url = maybe_github_server_url.get())
+        if (auto github_api_url = maybe_github_api_url.get())
         {
-            uri = *github_server_url;
+            uri = *github_api_url;
         }
 
         if (uri.empty())

--- a/src/vcpkg/commands.set-installed.cpp
+++ b/src/vcpkg/commands.set-installed.cpp
@@ -221,7 +221,7 @@ namespace vcpkg
             {
                 WarningDiagnosticContext wdc{console_diagnostic_context};
                 dependency_graph_success = submit_github_dependency_graph_snapshot(
-                    wdc, args.github_server_url, *github_token, *github_repository, *snapshot);
+                    wdc, args.github_api_url, *github_token, *github_repository, *snapshot);
                 if (dependency_graph_success)
                 {
                     msg::println(msgDependencyGraphSuccess);

--- a/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/src/vcpkg/vcpkgcmdarguments.cpp
@@ -574,7 +574,7 @@ namespace vcpkg
         });
         from_env(get_env, EnvironmentVariableVcpkgNuGetRepository, vcpkg_nuget_repository);
         from_env(get_env, EnvironmentVariableGitHubRepository, github_repository);
-        from_env(get_env, EnvironmentVariableGitHubServerUrl, github_server_url);
+        from_env(get_env, EnvironmentVariableGitHubApiUrl, github_api_url);
         from_env(get_env, EnvironmentVariableGitHubRef, github_ref);
         from_env(get_env, EnvironmentVariableGitHubSha, github_sha);
         from_env(get_env, EnvironmentVariableGitHubJob, github_job);


### PR DESCRIPTION
This PR fixes #2055 and allows to upload dependency graph again on the public GitHub instance.

The `VcpkgCmdArguments` for `GITHUB_SERVER_URL` was removed as it was only used in the context where the submission of the dependency graph is happening. Instead the `GITHUB_API_URL` environment variable is used. The usage is adjusted as for GHES and github.com the `GITHUB_API_URL` contains the right URL for API requests so there is no need to append `/api/v3` anymore.