### PR TITLE
Do not abort when stdout is a broken pipe

### DIFF
--- a/azure-pipelines/end-to-end-tests-dir/cli.ps1
+++ b/azure-pipelines/end-to-end-tests-dir/cli.ps1
@@ -25,6 +25,29 @@ if (-Not ($out.StartsWith('Synopsis: Displays specific help topic')))
     throw 'Bad help help output'
 }
 
+# A closed stdout pipe should terminate vcpkg without aborting.
+$ports = Get-ChildItem -LiteralPath (Join-Path $VcpkgRoot 'ports') -Directory |
+    Select-Object -First 500 -ExpandProperty Name
+$responseFile = Join-Path $WorkingRoot 'closed-stdout-pipe.rsp'
+@("--vcpkg-root=$VcpkgRoot", 'x-package-info', '--x-json') + $ports |
+    Set-Content -LiteralPath $responseFile -Encoding utf8
+$closesStdinExe = Join-Path (Split-Path -Parent $VcpkgExe) "closes-stdin$executableExtension"
+if ($IsWindows)
+{
+    $command = "`"$VcpkgExe`" `"@$responseFile`" 2>`"$stderrFile`" | `"$closesStdinExe`""
+    & $env:COMSPEC /d /c $command
+}
+else
+{
+    & /bin/sh -c '"$0" "@$1" 2>"$2" | "$3"' $VcpkgExe $responseFile $stderrFile $closesStdinExe
+}
+
+$stderr = Get-Content -LiteralPath $stderrFile -Raw
+if (-Not [string]::IsNullOrEmpty($stderr))
+{
+    throw "Writing to a closed stdout pipe produced stderr: $stderr"
+}
+
 $out = Run-VcpkgAndCaptureStdErr -TestArgs @('help', 'not-a-topic')
 Throw-IfNotFailed
 if (-Not ($out.StartsWith('error: unknown topic not-a-topic')))

--- a/src/vcpkg/base/messages.cpp
+++ b/src/vcpkg/base/messages.cpp
@@ -292,6 +292,7 @@ namespace vcpkg
 namespace vcpkg::msg
 {
     // basic implementation - the write_unlocalized_text_to_stdout
+    // Write failures cannot be localized because localized output uses these functions and could recurse.
 #if defined(_WIN32)
     static bool is_console(HANDLE h)
     {
@@ -301,29 +302,26 @@ namespace vcpkg::msg
         return GetConsoleMode(h, &mode);
     }
 
-    static void check_write(BOOL success, bool is_stdout)
+    static void check_write(BOOL success)
     {
         if (!success)
         {
             const DWORD last_error = ::GetLastError();
-            if (is_stdout && (last_error == ERROR_BROKEN_PIPE || last_error == ERROR_NO_DATA))
+            if (last_error == ERROR_BROKEN_PIPE || last_error == ERROR_NO_DATA)
             {
-                // stdout's reader (e.g. a pager) closed the pipe; exit with a failure code rather than
+                // the stream's reader (e.g. a pager) closed the pipe; exit with a failure code rather than
                 // crashing via abort(). clear debugging first so cleanup doesn't re-write to the broken pipe.
                 Debug::g_debugging = false;
                 Checks::final_cleanup_and_exit(EXIT_FAILURE);
             }
 
-            ::fwprintf(stderr,
-                       L"[DEBUG] Failed to write to %s: %lu\n",
-                       is_stdout ? L"stdout" : L"stderr",
-                       last_error);
+            ::fwprintf(stderr, L"vcpkg standard stream write failed: %lu\n", last_error);
             std::abort();
         }
     }
     static DWORD size_to_write(::size_t size) { return size > MAXDWORD ? MAXDWORD : static_cast<DWORD>(size); }
 
-    static void write_unlocalized_text_impl(Color c, StringView sv, HANDLE the_handle, bool is_console, bool is_stdout)
+    static void write_unlocalized_text_impl(Color c, StringView sv, HANDLE the_handle, bool is_console)
     {
         if (sv.empty()) return;
 
@@ -346,7 +344,7 @@ namespace vcpkg::msg
             while (size != 0)
             {
                 DWORD written = 0;
-                check_write(::WriteConsoleW(the_handle, pointer, size_to_write(size), &written, nullptr), is_stdout);
+                check_write(::WriteConsoleW(the_handle, pointer, size_to_write(size), &written, nullptr));
                 pointer += written;
                 size -= written;
             }
@@ -364,7 +362,7 @@ namespace vcpkg::msg
             while (size != 0)
             {
                 DWORD written = 0;
-                check_write(::WriteFile(the_handle, pointer, size_to_write(size), &written, nullptr), is_stdout);
+                check_write(::WriteFile(the_handle, pointer, size_to_write(size), &written, nullptr));
                 pointer += written;
                 size -= written;
             }
@@ -375,14 +373,14 @@ namespace vcpkg::msg
     {
         static const HANDLE stdout_handle = ::GetStdHandle(STD_OUTPUT_HANDLE);
         static const bool stdout_is_console = is_console(stdout_handle);
-        return write_unlocalized_text_impl(c, sv, stdout_handle, stdout_is_console, true);
+        return write_unlocalized_text_impl(c, sv, stdout_handle, stdout_is_console);
     }
 
     void write_unlocalized_text_to_stderr(Color c, StringView sv)
     {
         static const HANDLE stderr_handle = ::GetStdHandle(STD_ERROR_HANDLE);
         static const bool stderr_is_console = is_console(stderr_handle);
-        return write_unlocalized_text_impl(c, sv, stderr_handle, stderr_is_console, false);
+        return write_unlocalized_text_impl(c, sv, stderr_handle, stderr_is_console);
     }
 #else
     static void write_all(const char* ptr, size_t to_write, int fd)
@@ -398,18 +396,15 @@ namespace vcpkg::msg
                     continue;
                 }
 
-                if (errno == EPIPE && fd == STDOUT_FILENO)
+                if (errno == EPIPE)
                 {
-                    // stdout's reader (e.g. a pager) closed the pipe; exit with a failure code rather than
+                    // the stream's reader (e.g. a pager) closed the pipe; exit with a failure code rather than
                     // crashing via abort(). clear debugging first so cleanup doesn't re-write to the broken pipe.
                     Debug::g_debugging = false;
                     Checks::final_cleanup_and_exit(EXIT_FAILURE);
                 }
 
-                ::fprintf(stderr,
-                          "[DEBUG] Failed to write to %s: %d\n",
-                          fd == STDOUT_FILENO ? "stdout" : "stderr",
-                          errno);
+                ::fprintf(stderr, "vcpkg standard stream write failed: %d\n", errno);
                 std::abort();
             }
             ptr += written;

--- a/src/vcpkg/base/messages.cpp
+++ b/src/vcpkg/base/messages.cpp
@@ -410,7 +410,10 @@ namespace vcpkg::msg
                     Checks::final_cleanup_and_exit(EXIT_SUCCESS);
                 }
 
-                ::fprintf(stderr, "[DEBUG] Failed to write to the output stream: %d\n", errno);
+                ::fprintf(stderr,
+                          "[DEBUG] Failed to write to %s: %d\n",
+                          fd == STDOUT_FILENO ? "stdout" : "stderr",
+                          errno);
                 std::abort();
             }
             ptr += written;

--- a/src/vcpkg/base/messages.cpp
+++ b/src/vcpkg/base/messages.cpp
@@ -308,12 +308,10 @@ namespace vcpkg::msg
             const DWORD last_error = ::GetLastError();
             if (is_stdout && (last_error == ERROR_BROKEN_PIPE || last_error == ERROR_NO_DATA))
             {
-                // stdout's reader (for example a pager like `more`/`less`) closed the pipe early;
-                // there is nothing more to write, so shut down cleanly rather than aborting. use
-                // final_cleanup_and_exit directly instead of exit_success so we do not re-enter this
-                // msg path via Debug::println when stdout is the broken stream. only stdout is treated
-                // this way; a broken pipe on stderr should not mask a real failure.
-                Checks::final_cleanup_and_exit(EXIT_SUCCESS);
+                // stdout's reader (e.g. a pager) closed the pipe; exit with a failure code rather than
+                // crashing via abort(). clear debugging first so cleanup doesn't re-write to the broken pipe.
+                Debug::g_debugging = false;
+                Checks::final_cleanup_and_exit(EXIT_FAILURE);
             }
 
             ::fwprintf(stderr,
@@ -402,12 +400,10 @@ namespace vcpkg::msg
 
                 if (errno == EPIPE && fd == STDOUT_FILENO)
                 {
-                    // stdout's reader (for example a pager like `more`/`less`) closed the pipe early;
-                    // there is nothing more to write, so shut down cleanly rather than aborting. use
-                    // final_cleanup_and_exit directly instead of exit_success so we do not re-enter this
-                    // msg path via Debug::println when stdout is the broken stream. only stdout is treated
-                    // this way; a broken pipe on stderr should not mask a real failure.
-                    Checks::final_cleanup_and_exit(EXIT_SUCCESS);
+                    // stdout's reader (e.g. a pager) closed the pipe; exit with a failure code rather than
+                    // crashing via abort(). clear debugging first so cleanup doesn't re-write to the broken pipe.
+                    Debug::g_debugging = false;
+                    Checks::final_cleanup_and_exit(EXIT_FAILURE);
                 }
 
                 ::fprintf(stderr,

--- a/src/vcpkg/base/messages.cpp
+++ b/src/vcpkg/base/messages.cpp
@@ -1,5 +1,6 @@
 #include <vcpkg/base/system-headers.h>
 
+#include <vcpkg/base/checks.h>
 #include <vcpkg/base/json.h>
 #include <vcpkg/base/messages.h>
 #include <vcpkg/base/setup-messages.h>
@@ -300,17 +301,28 @@ namespace vcpkg::msg
         return GetConsoleMode(h, &mode);
     }
 
-    static void check_write(BOOL success)
+    static void check_write(BOOL success, bool is_stdout)
     {
         if (!success)
         {
-            ::fwprintf(stderr, L"[DEBUG] Failed to write to stdout: %lu\n", GetLastError());
+            const DWORD last_error = ::GetLastError();
+            if (is_stdout && (last_error == ERROR_BROKEN_PIPE || last_error == ERROR_NO_DATA))
+            {
+                // stdout's reader (for example a pager like `more`/`less`) closed the pipe early;
+                // there is nothing more to write, so shut down cleanly rather than aborting. use
+                // final_cleanup_and_exit directly instead of exit_success so we do not re-enter this
+                // msg path via Debug::println when stdout is the broken stream. only stdout is treated
+                // this way; a broken pipe on stderr should not mask a real failure.
+                Checks::final_cleanup_and_exit(EXIT_SUCCESS);
+            }
+
+            ::fwprintf(stderr, L"[DEBUG] Failed to write to the output stream: %lu\n", last_error);
             std::abort();
         }
     }
     static DWORD size_to_write(::size_t size) { return size > MAXDWORD ? MAXDWORD : static_cast<DWORD>(size); }
 
-    static void write_unlocalized_text_impl(Color c, StringView sv, HANDLE the_handle, bool is_console)
+    static void write_unlocalized_text_impl(Color c, StringView sv, HANDLE the_handle, bool is_console, bool is_stdout)
     {
         if (sv.empty()) return;
 
@@ -333,7 +345,7 @@ namespace vcpkg::msg
             while (size != 0)
             {
                 DWORD written = 0;
-                check_write(::WriteConsoleW(the_handle, pointer, size_to_write(size), &written, nullptr));
+                check_write(::WriteConsoleW(the_handle, pointer, size_to_write(size), &written, nullptr), is_stdout);
                 pointer += written;
                 size -= written;
             }
@@ -351,7 +363,7 @@ namespace vcpkg::msg
             while (size != 0)
             {
                 DWORD written = 0;
-                check_write(::WriteFile(the_handle, pointer, size_to_write(size), &written, nullptr));
+                check_write(::WriteFile(the_handle, pointer, size_to_write(size), &written, nullptr), is_stdout);
                 pointer += written;
                 size -= written;
             }
@@ -362,14 +374,14 @@ namespace vcpkg::msg
     {
         static const HANDLE stdout_handle = ::GetStdHandle(STD_OUTPUT_HANDLE);
         static const bool stdout_is_console = is_console(stdout_handle);
-        return write_unlocalized_text_impl(c, sv, stdout_handle, stdout_is_console);
+        return write_unlocalized_text_impl(c, sv, stdout_handle, stdout_is_console, true);
     }
 
     void write_unlocalized_text_to_stderr(Color c, StringView sv)
     {
         static const HANDLE stderr_handle = ::GetStdHandle(STD_ERROR_HANDLE);
         static const bool stderr_is_console = is_console(stderr_handle);
-        return write_unlocalized_text_impl(c, sv, stderr_handle, stderr_is_console);
+        return write_unlocalized_text_impl(c, sv, stderr_handle, stderr_is_console, false);
     }
 #else
     static void write_all(const char* ptr, size_t to_write, int fd)
@@ -379,7 +391,23 @@ namespace vcpkg::msg
             auto written = ::write(fd, ptr, to_write);
             if (written == -1)
             {
-                ::fprintf(stderr, "[DEBUG] Failed to print to stdout: %d\n", errno);
+                if (errno == EINTR)
+                {
+                    // interrupted by a signal before writing anything; retry
+                    continue;
+                }
+
+                if (errno == EPIPE && fd == STDOUT_FILENO)
+                {
+                    // stdout's reader (for example a pager like `more`/`less`) closed the pipe early;
+                    // there is nothing more to write, so shut down cleanly rather than aborting. use
+                    // final_cleanup_and_exit directly instead of exit_success so we do not re-enter this
+                    // msg path via Debug::println when stdout is the broken stream. only stdout is treated
+                    // this way; a broken pipe on stderr should not mask a real failure.
+                    Checks::final_cleanup_and_exit(EXIT_SUCCESS);
+                }
+
+                ::fprintf(stderr, "[DEBUG] Failed to write to the output stream: %d\n", errno);
                 std::abort();
             }
             ptr += written;

--- a/src/vcpkg/base/messages.cpp
+++ b/src/vcpkg/base/messages.cpp
@@ -316,7 +316,10 @@ namespace vcpkg::msg
                 Checks::final_cleanup_and_exit(EXIT_SUCCESS);
             }
 
-            ::fwprintf(stderr, L"[DEBUG] Failed to write to the output stream: %lu\n", last_error);
+            ::fwprintf(stderr,
+                       L"[DEBUG] Failed to write to %s: %lu\n",
+                       is_stdout ? L"stdout" : L"stderr",
+                       last_error);
             std::abort();
         }
     }


### PR DESCRIPTION
fixes microsoft/vcpkg-tool#2058.

on windows, `check_write` ([`src/vcpkg/base/messages.cpp#L303-L318`](https://github.com/ricardoofnl/vcpkg-tool/blob/bc071168f2fdcfbc56743c4d41015d53695aadf5/src/vcpkg/base/messages.cpp#L303-L318)) aborted on any `WriteFile`/`WriteConsoleW` failure. when the output of a command such as `vcpkg list --x-json` is piped to a pager like `more`, `less` or `most` and the pager is closed before all output is written, the write fails with `ERROR_BROKEN_PIPE` (109) and the tool crashes with `[DEBUG] Failed to write to stdout: 109`.

this treats a broken pipe (`ERROR_BROKEN_PIPE` / `ERROR_NO_DATA` on windows, `EPIPE` on posix) as a benign end-of-output condition and exits quietly, while still aborting on other, genuinely unexpected write failures.

note: this is primarily a windows issue. on posix the default `SIGPIPE` disposition already terminates the process before `write` returns, so the `EPIPE` guard in `write_all` is defensive parity and does not change signal handling.

i developed this on linux and could not reproduce the windows path locally; both branches compile.
