### PR TITLE
Fix `CopyOptions::update_existing` creating a 0 byte file when the destination is nonexistent.

### DIFF
--- a/src/vcpkg-test/files.cpp
+++ b/src/vcpkg-test/files.cpp
@@ -905,12 +905,14 @@ TEST_CASE ("copy_file", "[files]")
     // [update_existing] and exists(to) is true and to is newer than from
     fs.write_contents(existing_to, existing_to_contents, VCPKG_LINE_INFO);
     REQUIRE(fs.last_write_time(diagnostics, existing_to, source_write_time + timestamp_difference));
+    REQUIRE(diagnostics.empty());
     REQUIRE(!fs.copy_file(existing_from, existing_to, CopyOptions::update_existing, ec));
     REQUIRE(!ec);
     REQUIRE(fs.read_contents(existing_to, VCPKG_LINE_INFO) == existing_to_contents);
 
     // [update_existing] and exists(to) is true and to is older than from
     REQUIRE(fs.last_write_time(diagnostics, existing_to, source_write_time - timestamp_difference));
+    REQUIRE(diagnostics.empty());
     REQUIRE(fs.copy_file(existing_from, existing_to, CopyOptions::update_existing, ec));
     REQUIRE(!ec);
     REQUIRE(fs.read_contents(existing_to, VCPKG_LINE_INFO) == existing_from_contents);

--- a/src/vcpkg-test/files.cpp
+++ b/src/vcpkg-test/files.cpp
@@ -2,6 +2,7 @@
 
 #include <vcpkg-test/util.h>
 
+#include <vcpkg/base/diagnostics.h>
 #include <vcpkg/base/files.h>
 #include <vcpkg/base/strings.h>
 
@@ -896,6 +897,29 @@ TEST_CASE ("copy_file", "[files]")
     REQUIRE(fs.copy_file(existing_from, existing_to, CopyOptions::overwrite_existing, ec));
     REQUIRE(!ec);
     REQUIRE(fs.read_contents(existing_to, VCPKG_LINE_INFO) == existing_from_contents);
+
+    constexpr int64_t timestamp_difference = 10'000'000'000;
+    const auto source_write_time = fs.last_write_time(existing_from, VCPKG_LINE_INFO);
+    FullyBufferedDiagnosticContext diagnostics;
+
+    // [update_existing] and exists(to) is true and to is newer than from
+    fs.write_contents(existing_to, existing_to_contents, VCPKG_LINE_INFO);
+    REQUIRE(fs.last_write_time(diagnostics, existing_to, source_write_time + timestamp_difference));
+    REQUIRE(!fs.copy_file(existing_from, existing_to, CopyOptions::update_existing, ec));
+    REQUIRE(!ec);
+    REQUIRE(fs.read_contents(existing_to, VCPKG_LINE_INFO) == existing_to_contents);
+
+    // [update_existing] and exists(to) is true and to is older than from
+    REQUIRE(fs.last_write_time(diagnostics, existing_to, source_write_time - timestamp_difference));
+    REQUIRE(fs.copy_file(existing_from, existing_to, CopyOptions::update_existing, ec));
+    REQUIRE(!ec);
+    REQUIRE(fs.read_contents(existing_to, VCPKG_LINE_INFO) == existing_from_contents);
+
+    // [update_existing] and exists(to) is false
+    const auto update_nonexistent = temp_dir / "update_nonexistent";
+    REQUIRE(fs.copy_file(existing_from, update_nonexistent, CopyOptions::update_existing, ec));
+    REQUIRE(!ec);
+    REQUIRE(fs.read_contents(update_nonexistent, VCPKG_LINE_INFO) == existing_from_contents);
 
 #if !defined(_WIN32)
     // Also check that mode bits are copied

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -3872,8 +3872,12 @@ namespace vcpkg
             if (ec == std::errc::no_such_file_or_directory &&
                 (options == CopyOptions::overwrite_existing || options == CopyOptions::update_existing))
             {
-                destination_fd = PosixFd{destination.c_str(), O_WRONLY | O_CREAT, open_mode, ec};
+                destination_fd = PosixFd{destination.c_str(), O_WRONLY | O_CREAT | O_EXCL, open_mode, ec};
                 destination_was_created = !ec;
+                if (ec == std::errc::file_exists)
+                {
+                    destination_fd = PosixFd{destination.c_str(), O_WRONLY, ec};
+                }
             }
 
             if (ec)
@@ -4114,6 +4118,7 @@ namespace vcpkg
                                                msg::system_api = "futimens",
                                                msg::exit_code = local_errno,
                                                msg::error_msg = std::system_category().message(local_errno))});
+                return false;
             }
 
             return true;

--- a/src/vcpkg/base/files.cpp
+++ b/src/vcpkg/base/files.cpp
@@ -3857,17 +3857,25 @@ namespace vcpkg
                 return false;
             }
 
-            int open_options = O_WRONLY | O_CREAT;
+            const mode_t open_mode = source_stat.st_mode | 0222; // ensure the file is created writable
+            int open_options = O_WRONLY;
             if (options != CopyOptions::overwrite_existing && options != CopyOptions::update_existing)
             {
                 // the standard wording suggests that we should create a file through a broken symlink which would
                 // forbid use of O_EXCL. However, implementations like boost::copy_file don't do this and doing it
                 // would introduce more potential for TOCTOU bugs
-                open_options |= O_EXCL;
+                open_options |= O_CREAT | O_EXCL;
             }
 
-            const mode_t open_mode = source_stat.st_mode | 0222; // ensure the file is created writable
             PosixFd destination_fd{destination.c_str(), open_options, open_mode, ec};
+            bool destination_was_created = false;
+            if (ec == std::errc::no_such_file_or_directory &&
+                (options == CopyOptions::overwrite_existing || options == CopyOptions::update_existing))
+            {
+                destination_fd = PosixFd{destination.c_str(), O_WRONLY | O_CREAT, open_mode, ec};
+                destination_was_created = !ec;
+            }
+
             if (ec)
             {
                 if (options == CopyOptions::skip_existing && ec == std::errc::file_exists)
@@ -3897,7 +3905,8 @@ namespace vcpkg
                 return false;
             }
 
-            if (options == CopyOptions::update_existing && destination_stat.st_mtime >= source_stat.st_mtime)
+            if (options == CopyOptions::update_existing && !destination_was_created &&
+                destination_stat.st_mtime >= source_stat.st_mtime)
             {
                 ec.clear();
                 return false;


### PR DESCRIPTION
Track whether the POSIX destination file was opened or created so CopyOptions::update_existing only applies the timestamp check to preexisting files.

Add `copy_file` coverage for newer, older, and nonexistent update_existing destinations.

Hopefully resolves https://github.com/microsoft/vcpkg-tool/issues/2053

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Copilot-Session: 5cb7e534-b324-4976-b8f8-15816fe514f9