### PR TITLE
Update vcpkg-tool-release-process.

### DIFF
--- a/docs/vcpkg_tool_release_process.md
+++ b/docs/vcpkg_tool_release_process.md
@@ -3,8 +3,9 @@
 This document describes the acceptance criteria / process we use when doing a vcpkg-tool update,
 such as https://github.com/microsoft/vcpkg/pull/23757
 
-1. Run `$/vcpkg-init/update-scripts-sha.ps1` to update `$/vcpkg-init/vcpkg-scripts-sha.txt` to the
-  current `master` branch SHA in the registry repo.
+1. Run `$/vcpkg-init/update-scripts-sha.ps1` to update `$/vcpkg-init/vcpkg-scripts-sha.txt` and the
+  default registry baseline in `$/src/vcpkg-configuration.json` to the current `master` branch SHA
+  in the registry repo.
 1. Verify that all tests etc. are passing in the vcpkg-tool repo's `main` branch, and that the
   contents therein are acceptable for release. (Steps after this will sign code there, so this
   review is responsible gating what has access to code signing.)
@@ -35,26 +36,26 @@ such as https://github.com/microsoft/vcpkg/pull/23757
         `. <(curl https://github.com/microsoft/vcpkg-tool/releases/download/2025-03-22/vcpkg-init -L)`
   (and test that `vcpkg use microsoft:cmake` works from each of these)
 1. In the vcpkg repo, run `$/scripts/update-vcpkg-tool-metadata.ps1 -Date 2025-03-22`
-  with the new release date, which updates SHAs as appropriate. Commit these changes and submit as a PR.
+  with the new release date, which updates SHAs as appropriate. Commit these changes and submit as a
+  PR.
 1. If changes in this release that might affect ports, submit a new full tree rebuild by
   microsoft.vcpkg.ci (https://dev.azure.com/vcpkg/public/_build?definitionId=29 as of this writing)
   targeting `refs/pull/NUMBER/head`
 1. (Probably the next day) Check over the failures and ensure any differences with the most recent
   full rebuild using the previous tool version are understood.
-1. Create a new task in the DevDiv VS instance for this release. (PRs into VS require an associated work
-   item in order to be merged.)
+1. Create a new task in the DevDiv VS instance for this release. (PRs into VS require an associated
+  work item in order to be merged.)
 1. Download the VS-insertion .nupkg from the "vcpkg Signed Binaries (from GitHub)" run.
-1. In the DevDiv VS repo ( https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/VS ),
-   update `src/ConfigData/Packages/Redist/Setup.props` with the version number from the name of the
-   nupkg:
-   `<PackageVersion Include="VS.Redist.Vcpkg.amd64" Version="1.0.0-2025-02-11-bec4296bf5289dc9ce83b4f5095943e44162f9c2" />`
-1. The first time you try to do a VS update on a machine, clone the VS repo, and open a text editor
-   go to `$/src/vc/projbld/Vcpkg/VcpkgInsertionUtility/Program.cs`, and look for the command line
-   in a comment to build it. Open a developer command prompt, go to
-   `$/src/vc/projbld/Vcpkg/VcpkgInsertionUtility` and run that command.
-1. Run `src/vc/projbld/Vcpkg/VcpkgInsertionUtility/Program.exe path-to-VS-insertion-nupkg`
+1. Clone the DevDiv VS repo ( https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/VS ), or
+  update your existing checkout.
+1. The first time you try to do a VS update on a machine, open
+  `$/src/vc/projbld/Vcpkg/VcpkgInsertionUtility/Program.cs` in a text editor and look for the
+  command line in a comment to build it. Open a developer command prompt, go to
+  `$/src/vc/projbld/Vcpkg/VcpkgInsertionUtility` and run that command.
+1. Return to `$/`, then run
+  `src/vc/projbld/Vcpkg/VcpkgInsertionUtility/Program.exe path-to-VS-insertion-nupkg`.
 1. Submit this as a change to the VS repo. Example: https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/VS/pullrequest/498110
-   Don't forget to attach the work item number from the previous step.
+   Don't forget to attach the work item created earlier.
 1. Smoke test the copy of vcpkg inserted into VS. See smoke test steps below. The prototype copy is
   at "CloudBuild - PR -> Extensions\VS Enterprise\Release Channel" as of 2023-10-19 but this UI
   changes frequently.
@@ -141,14 +142,16 @@ flowchart TD
 
 # Smoke Testing VS
 
-1. Install the prototype version of VS with the vcpkg inserted. Ensure the native desktop workload is selected, and that vcpkg and cmake bits are installed. Don't forget about preinstall. ( `https://aka.ms/VSPreinstall` ? )
-1. Open a developer command prompt and run `vcpkg integrate install` (this step hopefully removed soon)
+1. Install the prototype version of VS with the vcpkg inserted. Ensure the native desktop workload
+  is selected, and that vcpkg and cmake bits are installed. Don't forget about preinstall if
+  necessary. ( `https://aka.ms/VSPreinstall` ? )
+1. Open a developer command prompt and run `vcpkg integrate install`
     * This also verifies that vcpkg installed into the developer command prompt correctly.
 1. Create a new C++ console project.
 1. Turn on diagnostic logging.
     * Tools -> Options: Projects and Solutions\Build and Run\\MSBuild project output verbosity
 1. Build the console project, check that vcpkg isn't affecting that project:
-    * Lib AdditionalLibraryDirectories doesn't contain a hypothetical vcpkg installed directory
+    * Link AdditionalLibraryDirectories doesn't contain a hypothetical vcpkg installed directory
     * Target VcpkgInstallManifestDependencies doesn't run
     * Target AppLocalFromInstalled doesn't run
 1. In the developer command prompt cd to the directory with the vcxproj for the console app and run:
@@ -156,17 +159,14 @@ flowchart TD
     vcpkg new --application
     vcpkg add port zlib
     ```
-1. Rebuild the console app, and verify the manifest mode warning is printed:
+1. Rebuild the console app, and look for output like the following to verify the manifest mode
+  warning is printed (the paths and surrounding diagnostic output will vary):
     ```
-    1>Target "VcpkgCheckManifestRoot" in file "C:\Program Files\Microsoft Visual Studio\2022\Preview\VC\vcpkg\scripts\buildsystems\msbuild\vcpkg.targets":
-    1>  Task "Error" skipped, due to false condition; ('$(VcpkgEnableManifest)' == 'true' and '$(_ZVcpkgManifestRoot)' == '') was evaluated as ('false' == 'true' and 'C:\Users\bion\source\repos\ConsoleApplication3\ConsoleApplication3\' == '').
-    1>  Task "Message"
-    1>    Task Parameter:Importance=High
-    1>    Task Parameter:Text=The vcpkg manifest was disabled, but we found a manifest file in C:\Users\bion\source\repos\ConsoleApplication3\ConsoleApplication3\. You may want to enable vcpkg manifests in your properties page or pass /p:VcpkgEnableManifest=true to the msbuild invocation.
-    1>    The vcpkg manifest was disabled, but we found a manifest file in C:\Users\bion\source\repos\ConsoleApplication3\ConsoleApplication3\. You may want to enable vcpkg manifests in your properties page or pass /p:VcpkgEnableManifest=true to the msbuild invocation.
-    1>  Done executing task "Message".
+    Target "VcpkgCheckManifestRoot" in file "<Visual Studio installation>\VC\vcpkg\scripts\buildsystems\msbuild\vcpkg.targets":
+      The vcpkg manifest was disabled, but we found a manifest file in <project directory>. You may want to enable vcpkg manifests in your properties page or pass /p:VcpkgEnableManifest=true to the msbuild invocation.
     ```
-1. Right click the console application, properties, and in the property pages change vcpkg\\Use vcpkg Manifest to "Yes"
+1. Right click the console application, properties, and in the property pages change
+  vcpkg\\Use vcpkg Manifest to "Yes"
 1. Rebuild the project, observe vcpkg builds zlib.
 1. Change the .cpp to:
     ```
@@ -204,10 +204,5 @@ flowchart TD
     ninja -C build_artifact
     build_artifact\program.exe
     ```
-    and check that the cmake version acquired by artifacts is printed during the cmake configure, and that a reasonable zlib version is printed.
-1. Close Visual Studio.
-1. Back in the developer command prompt, run:
-    ```
-    vcpkg add artifact microsoft:cmake
-    ```
-1. Open Visual Studio and use "Open Folder" on the directory containing the vcxproj. Verify that vcpkg activation happens in the terminal.
+    and check that the cmake version acquired by artifacts is printed during the cmake configure,
+    and that a reasonable zlib version is printed.


### PR DESCRIPTION
This doc drifted a bit.

* `src/ConfigData/Packages/Redist/Setup.props` is now automatically updated by `VcpkgInsertionUtility`
* `2022` is out of date in several places.
* Artifacts activation in VS was removed in VS 2026 so remove that from the smoke test. (See also https://github.com/microsoft/vcpkg-tool/pull/2032 )