### PR TITLE
Fix dependency snapshot relationships and correlators

### DIFF
--- a/include/vcpkg/base/contractual-constants.h
+++ b/include/vcpkg/base/contractual-constants.h
@@ -59,6 +59,7 @@ namespace vcpkg
     inline constexpr StringLiteral JsonIdHost = "host";
     inline constexpr StringLiteral JsonIdHostTriplet = "host-triplet";
     inline constexpr StringLiteral JsonIdId = "id";
+    inline constexpr StringLiteral JsonIdIndirect = "indirect";
     inline constexpr StringLiteral JsonIdInstalled = "installed";
     inline constexpr StringLiteral JsonIdJob = "job";
     inline constexpr StringLiteral JsonIdKey = "key";

--- a/include/vcpkg/commands.set-installed.h
+++ b/include/vcpkg/commands.set-installed.h
@@ -36,6 +36,7 @@ namespace vcpkg
 
     void command_set_installed_and_exit_ex(const VcpkgCmdArguments& args,
                                            const VcpkgPaths& paths,
+                                           Triplet default_triplet,
                                            Triplet host_triplet,
                                            const BuildPackageOptions& build_options,
                                            const CMakeVars::CMakeVarProvider& cmake_vars,
@@ -52,5 +53,7 @@ namespace vcpkg
                                         Triplet host_triplet);
 
     Optional<Json::Object> create_dependency_graph_snapshot(const VcpkgCmdArguments& args,
-                                                            const ActionPlan& action_plan);
+                                                            const ActionPlan& action_plan,
+                                                            Triplet default_triplet,
+                                                            Triplet host_triplet);
 }

--- a/src/vcpkg-test/dependencies.cpp
+++ b/src/vcpkg-test/dependencies.cpp
@@ -1,6 +1,8 @@
 #include <vcpkg-test/util.h>
 
 #include <vcpkg/base/contractual-constants.h>
+#include <vcpkg/base/json.h>
+#include <vcpkg/base/messages.h>
 
 #include <vcpkg/commands.set-installed.h>
 #include <vcpkg/dependencies.h>
@@ -2613,7 +2615,7 @@ TEST_CASE ("dependency graph API snapshot uses canonical purls", "[dependencies]
     };
     auto v = VcpkgCmdArguments::create_from_arg_sequence(nullptr, nullptr);
     v.imbue_from_fake_environment(envmap);
-    auto s = create_dependency_graph_snapshot(v, plan);
+    auto s = create_dependency_graph_snapshot(v, plan, Test::X86_WINDOWS, Test::X64_WINDOWS);
 
     CHECK(s.has_value());
     auto obj = *s.get();
@@ -2650,7 +2652,7 @@ TEST_CASE ("dependency graph API snapshot uses canonical purls", "[dependencies]
 
     CHECK(static_cast<int>(version) == 0);
     CHECK(id == "123");
-    CHECK(correlator == "test-build-x64-windows-x86-windows");
+    CHECK(correlator == "test-build-target-x86-windows-host-x64-windows");
     CHECK(sha == "abc123");
     CHECK(ref == "refs/heads/main");
     CHECK(name == "vcpkg");
@@ -2668,9 +2670,81 @@ TEST_CASE ("dependency graph API snapshot uses canonical purls", "[dependencies]
     envmap[EnvironmentVariableGitHubRunId] = "456";
     auto v2 = VcpkgCmdArguments::create_from_arg_sequence(nullptr, nullptr);
     v2.imbue_from_fake_environment(envmap);
-    auto s2 = create_dependency_graph_snapshot(v2, plan);
+    auto s2 = create_dependency_graph_snapshot(v2, plan, Test::X86_WINDOWS, Test::X64_WINDOWS);
     REQUIRE(s2.has_value());
     auto job2 = s2.get()->get("job")->object(VCPKG_LINE_INFO);
     CHECK(job2.get("id")->string(VCPKG_LINE_INFO) == "456");
     CHECK(job2.get("correlator")->string(VCPKG_LINE_INFO) == correlator);
+
+    auto s3 = create_dependency_graph_snapshot(v2, plan, Test::X64_WINDOWS, Test::X86_WINDOWS);
+    REQUIRE(s3.has_value());
+    auto job3 = s3.get()->get("job")->object(VCPKG_LINE_INFO);
+    CHECK(job3.get("correlator")->string(VCPKG_LINE_INFO) != correlator);
+}
+
+TEST_CASE ("dependency graph API snapshot uses manifest relationships", "[dependencies]")
+{
+    auto parsed_manifest = Json::parse(R"json(
+{
+    "name": "toplevel-spec",
+    "version-string": "1.0",
+    "dependencies": ["a"]
+}
+)json",
+                                       "test manifest")
+                               .value(VCPKG_LINE_INFO);
+    auto manifest = SourceControlFile::parse_project_manifest_object(
+                        "test manifest", parsed_manifest.value.object(VCPKG_LINE_INFO), null_sink)
+                        .value(VCPKG_LINE_INFO);
+
+    MockBaselineProvider bp;
+    bp.v["a"] = {"1", 0};
+    bp.v["b"] = {"1", 0};
+
+    MockVersionedPortfileProvider vp;
+    vp.emplace("a", {"1", 0}).source_control_file->core_paragraph->dependencies = {Dependency{"b"}};
+    vp.emplace("b", {"1", 0});
+
+    MockCMakeVarProvider var_provider;
+    auto plan =
+        create_versioned_install_plan(vp, bp, var_provider, manifest->core_paragraph->dependencies, {}, toplevel_spec())
+            .value_or_exit(VCPKG_LINE_INFO);
+
+    const auto direct = std::find_if(plan.install_actions.begin(), plan.install_actions.end(), [](const auto& action) {
+        return action.spec.name() == "a";
+    });
+    const auto indirect = std::find_if(plan.install_actions.begin(),
+                                       plan.install_actions.end(),
+                                       [](const auto& action) { return action.spec.name() == "b"; });
+    REQUIRE(direct != plan.install_actions.end());
+    REQUIRE(indirect != plan.install_actions.end());
+    const auto direct_purl = make_vcpkg_purl(*direct);
+    const auto indirect_purl = make_vcpkg_purl(*indirect);
+
+    std::map<StringLiteral, std::string, std::less<>> envmap = {
+        {EnvironmentVariableGitHubJob, "build"},
+        {EnvironmentVariableGitHubRunId, "123"},
+        {EnvironmentVariableGitHubRef, "refs/heads/main"},
+        {EnvironmentVariableGitHubSha, "abc123"},
+        {EnvironmentVariableGitHubWorkflow, "test"},
+    };
+    auto args = VcpkgCmdArguments::create_from_arg_sequence(nullptr, nullptr);
+    args.imbue_from_fake_environment(envmap);
+    auto snapshot = create_dependency_graph_snapshot(args, plan, Test::X86_WINDOWS, Test::X64_WINDOWS);
+    REQUIRE(snapshot.has_value());
+
+    const auto resolved = snapshot.get()
+                              ->get("manifests")
+                              ->object(VCPKG_LINE_INFO)
+                              .get("vcpkg.json")
+                              ->object(VCPKG_LINE_INFO)
+                              .get("resolved")
+                              ->object(VCPKG_LINE_INFO);
+    const auto direct_item = resolved.get(direct_purl)->object(VCPKG_LINE_INFO);
+    const auto indirect_item = resolved.get(indirect_purl)->object(VCPKG_LINE_INFO);
+    CHECK(direct_item.get("relationship")->string(VCPKG_LINE_INFO) == "direct");
+    CHECK(indirect_item.get("relationship")->string(VCPKG_LINE_INFO) == "indirect");
+    const auto dependencies = direct_item.get("dependencies")->array(VCPKG_LINE_INFO);
+    REQUIRE(dependencies.size() == 1);
+    CHECK(dependencies[0].string(VCPKG_LINE_INFO) == indirect_purl);
 }

--- a/src/vcpkg-test/dependencies.cpp
+++ b/src/vcpkg-test/dependencies.cpp
@@ -2583,7 +2583,7 @@ TEST_CASE ("dependency graph API snapshot uses canonical purls", "[dependencies]
     InstallPlanAction install_a({"a", Test::X86_WINDOWS},
                                 scfl_a,
                                 packages_dir_assigner,
-                                RequestType::AUTO_SELECTED,
+                                RequestType::USER_REQUESTED,
                                 UseHeadVersion::No,
                                 Editable::No,
                                 {},
@@ -2603,7 +2603,7 @@ TEST_CASE ("dependency graph API snapshot uses canonical purls", "[dependencies]
     plan.install_actions.push_back(std::move(install_a));
     plan.install_actions.push_back(std::move(install_a_host));
     std::map<StringLiteral, std::string, std::less<>> envmap = {
-        {EnvironmentVariableGitHubJob, "123"},
+        {EnvironmentVariableGitHubJob, "build"},
         {EnvironmentVariableGitHubRunId, "123"},
         {EnvironmentVariableGitHubRef, "refs/heads/main"},
         {EnvironmentVariableGitHubRepository, "owner/repo"},
@@ -2650,7 +2650,7 @@ TEST_CASE ("dependency graph API snapshot uses canonical purls", "[dependencies]
 
     CHECK(static_cast<int>(version) == 0);
     CHECK(id == "123");
-    CHECK(correlator == "test-123");
+    CHECK(correlator == "test-build-x64-windows-x86-windows");
     CHECK(sha == "abc123");
     CHECK(ref == "refs/heads/main");
     CHECK(name == "vcpkg");
@@ -2658,10 +2658,19 @@ TEST_CASE ("dependency graph API snapshot uses canonical purls", "[dependencies]
     CHECK(url == "https://github.com/microsoft/vcpkg");
     CHECK(name1 == "vcpkg.json");
     CHECK(package_url_a_host == purl_a_host);
-    CHECK(relationship_a_host == "direct");
+    CHECK(relationship_a_host == "indirect");
     CHECK(dependencies_a_host.size() == 0);
     CHECK(package_url_a == purl_a_target);
     CHECK(relationship_a == "direct");
     REQUIRE(dependencies_a.size() == 1);
     CHECK(dependencies_a[0].string(VCPKG_LINE_INFO) == purl_a_host);
+
+    envmap[EnvironmentVariableGitHubRunId] = "456";
+    auto v2 = VcpkgCmdArguments::create_from_arg_sequence(nullptr, nullptr);
+    v2.imbue_from_fake_environment(envmap);
+    auto s2 = create_dependency_graph_snapshot(v2, plan);
+    REQUIRE(s2.has_value());
+    auto job2 = s2.get()->get("job")->object(VCPKG_LINE_INFO);
+    CHECK(job2.get("id")->string(VCPKG_LINE_INFO) == "456");
+    CHECK(job2.get("correlator")->string(VCPKG_LINE_INFO) == correlator);
 }

--- a/src/vcpkg-test/dependencies.cpp
+++ b/src/vcpkg-test/dependencies.cpp
@@ -2602,8 +2602,8 @@ TEST_CASE ("dependency graph API snapshot uses canonical purls", "[dependencies]
                                      {});
     install_a.package_dependencies.push_back(install_a_host.spec);
     ActionPlan plan;
-    plan.install_actions.push_back(std::move(install_a));
     plan.install_actions.push_back(std::move(install_a_host));
+    plan.install_actions.push_back(std::move(install_a));
     std::map<StringLiteral, std::string, std::less<>> envmap = {
         {EnvironmentVariableGitHubJob, "build"},
         {EnvironmentVariableGitHubRunId, "123"},

--- a/src/vcpkg/commands.install.cpp
+++ b/src/vcpkg/commands.install.cpp
@@ -1469,6 +1469,7 @@ namespace vcpkg
             track_manifest_metrics(dependencies, manifest_core);
             command_set_installed_and_exit_ex(args,
                                               paths,
+                                              default_triplet,
                                               host_triplet,
                                               build_package_options,
                                               var_provider,

--- a/src/vcpkg/commands.set-installed.cpp
+++ b/src/vcpkg/commands.set-installed.cpp
@@ -52,7 +52,9 @@ namespace vcpkg
     };
 
     Optional<Json::Object> create_dependency_graph_snapshot(const VcpkgCmdArguments& args,
-                                                            const ActionPlan& action_plan)
+                                                            const ActionPlan& action_plan,
+                                                            Triplet default_triplet,
+                                                            Triplet host_triplet)
     {
         const auto github_ref = args.github_ref.get();
         const auto github_sha = args.github_sha.get();
@@ -61,20 +63,10 @@ namespace vcpkg
         const auto github_run_id = args.github_run_id.get();
         if (github_ref && github_sha && github_job && github_workflow && github_run_id)
         {
-            std::vector<std::string> triplets;
-            for (const auto& action : action_plan.install_actions)
-            {
-                triplets.push_back(action.spec.triplet().canonical_name());
-            }
-            Util::sort_unique_erase(triplets);
-
             Json::Object snapshot;
             {
-                std::string correlator = fmt::format("{}-{}", *github_workflow, *github_job);
-                for (const auto& triplet : triplets)
-                {
-                    fmt::format_to(std::back_inserter(correlator), "-{}", triplet);
-                }
+                std::string correlator = fmt::format(
+                    "{}-{}-target-{}-host-{}", *github_workflow, *github_job, default_triplet, host_triplet);
 
                 Json::Object job;
                 job.insert(JsonIdId, Json::Value::string(*github_run_id));
@@ -200,6 +192,7 @@ namespace vcpkg
 
     void command_set_installed_and_exit_ex(const VcpkgCmdArguments& args,
                                            const VcpkgPaths& paths,
+                                           Triplet default_triplet,
                                            Triplet host_triplet,
                                            const BuildPackageOptions& build_options,
                                            const CMakeVars::CMakeVarProvider& cmake_vars,
@@ -229,7 +222,7 @@ namespace vcpkg
         if (paths.manifest_mode_enabled() && paths.get_feature_flags().dependency_graph)
         {
             msg::println(msgDependencyGraphCalculation);
-            auto maybe_snapshot = create_dependency_graph_snapshot(args, action_plan);
+            auto maybe_snapshot = create_dependency_graph_snapshot(args, action_plan, default_triplet, host_triplet);
             auto snapshot = maybe_snapshot.get();
             auto github_token = args.github_token.get();
             auto github_repository = args.github_repository.get();
@@ -423,6 +416,7 @@ namespace vcpkg
         command_set_installed_and_exit_ex(
             args,
             paths,
+            default_triplet,
             host_triplet,
             build_options,
             *cmake_vars,

--- a/src/vcpkg/commands.set-installed.cpp
+++ b/src/vcpkg/commands.set-installed.cpp
@@ -2,6 +2,7 @@
 #include <vcpkg/base/downloads.h>
 #include <vcpkg/base/json.h>
 #include <vcpkg/base/system.debug.h>
+#include <vcpkg/base/util.h>
 
 #include <vcpkg/binarycaching.h>
 #include <vcpkg/cmakevars.h>
@@ -60,12 +61,24 @@ namespace vcpkg
         const auto github_run_id = args.github_run_id.get();
         if (github_ref && github_sha && github_job && github_workflow && github_run_id)
         {
+            std::vector<std::string> triplets;
+            for (const auto& action : action_plan.install_actions)
+            {
+                triplets.push_back(action.spec.triplet().canonical_name());
+            }
+            Util::sort_unique_erase(triplets);
+
             Json::Object snapshot;
             {
+                std::string correlator = fmt::format("{}-{}", *github_workflow, *github_job);
+                for (const auto& triplet : triplets)
+                {
+                    fmt::format_to(std::back_inserter(correlator), "-{}", triplet);
+                }
+
                 Json::Object job;
                 job.insert(JsonIdId, Json::Value::string(*github_run_id));
-                job.insert(JsonIdCorrelator,
-                           Json::Value::string(fmt::format("{}-{}", *github_workflow, *github_run_id)));
+                job.insert(JsonIdCorrelator, Json::Value::string(std::move(correlator)));
                 snapshot.insert(JsonIdJob, std::move(job));
             } // destroy job
 
@@ -104,7 +117,10 @@ namespace vcpkg
                 const auto& pkg_url = found->second;
                 Json::Object resolved_item;
                 resolved_item.insert(JsonIdPackageUnderscoreUrl, pkg_url);
-                resolved_item.insert(JsonIdRelationship, Json::Value::string(JsonIdDirect));
+                resolved_item.insert(JsonIdRelationship,
+                                     Json::Value::string(action.request_type == RequestType::USER_REQUESTED
+                                                             ? JsonIdDirect
+                                                             : JsonIdIndirect));
 
                 Json::Array deps_list;
                 for (auto&& dep : action.package_dependencies)


### PR DESCRIPTION
Marks only user-requested packages as direct.

The old correlator included `GITHUB_RUN_ID`, so it changed on every workflow run. GitHub merged those submissions instead of replacing the previous one, which could leave stale dependencies in the graph. The new correlator uses the workflow, job, and triplets, giving each build configuration a stable identity across reruns.