### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 15684: Build ID 14716597

### DIFF
--- a/locales/messages.cs.json
+++ b/locales/messages.cs.json
@@ -742,6 +742,7 @@
   "InvalidFilename": "Název souboru nemůže obsahovat neplatné znaky {value}, ale byl {path}.",
   "InvalidFloatingPointConst": "Neplatná konstanta čísla s plovoucí desetinnou čárkou: {count}",
   "InvalidFormatString": "neplatný formátovací řetězec: {actual}",
+  "InvalidGitObjectSha": "invalid git object SHA: {sha}. Expected a 40-character lowercase hexadecimal string.",
   "InvalidHexDigit": "Neplatná šestnáctková číslice v řídicím znaku Unicode",
   "InvalidIntegerConst": "Neplatná celočíselná konstanta: {count}",
   "InvalidLibraryMissingLinkerMembers": "Knihovna byla neplatná: Nelze najít člena linkeru.",

--- a/locales/messages.de.json
+++ b/locales/messages.de.json
@@ -742,6 +742,7 @@
   "InvalidFilename": "Der Dateiname darf keine ungültigen Zeichen {value} enthalten, lautete aber {path}",
   "InvalidFloatingPointConst": "Ungültige Gleitkommakonstante: {count}",
   "InvalidFormatString": "Ungültige Formatzeichenfolge. {actual}",
+  "InvalidGitObjectSha": "invalid git object SHA: {sha}. Expected a 40-character lowercase hexadecimal string.",
   "InvalidHexDigit": "Ungültige Hexadezimalziffer im Unicode-Escapezeichen",
   "InvalidIntegerConst": "Ungültige ganzzahlige Konstante: {count}",
   "InvalidLibraryMissingLinkerMembers": "Die Bibliothek war ungültig: Es wurde kein Linkerelement gefunden.",

--- a/locales/messages.es.json
+++ b/locales/messages.es.json
@@ -742,6 +742,7 @@
   "InvalidFilename": "El nombre de archivo no puede contener los caracteres que no son válidos {value}, pero tenía la ruta {path}",
   "InvalidFloatingPointConst": "Constante de punto flotante no válida: {count}",
   "InvalidFormatString": "cadena de formato no válida: {actual}",
+  "InvalidGitObjectSha": "invalid git object SHA: {sha}. Expected a 40-character lowercase hexadecimal string.",
   "InvalidHexDigit": "Dígito hexadecimal no válido en el escape unicode",
   "InvalidIntegerConst": "Constante entera no válida: {count}",
   "InvalidLibraryMissingLinkerMembers": "La biblioteca no era válida: no se pudo encontrar un miembro vinculador.",

--- a/locales/messages.fr.json
+++ b/locales/messages.fr.json
@@ -742,6 +742,7 @@
   "InvalidFilename": "Le nom de fichier ne peut pas contenir de caractères non valides {value}, mais était {path}",
   "InvalidFloatingPointConst": "Constante à virgule flottante non valide : {count}",
   "InvalidFormatString": "format de chaîne non valide : {actual}",
+  "InvalidGitObjectSha": "invalid git object SHA: {sha}. Expected a 40-character lowercase hexadecimal string.",
   "InvalidHexDigit": "Chiffre hexadécimal non valide dans l’échappement Unicode",
   "InvalidIntegerConst": "Constante entière non valide : {count}",
   "InvalidLibraryMissingLinkerMembers": "La bibliothèque n’était pas valide : aucun membre de l’éditeur de liens n’a été trouvé.",

--- a/locales/messages.it.json
+++ b/locales/messages.it.json
@@ -742,6 +742,7 @@
   "InvalidFilename": "Il nome file non può contenere caratteri non validi {value}, ma è stato {path}",
   "InvalidFloatingPointConst": "Costante a virgola mobile non valida: {count}",
   "InvalidFormatString": "stringa di formato non valida: {actual}",
+  "InvalidGitObjectSha": "invalid git object SHA: {sha}. Expected a 40-character lowercase hexadecimal string.",
   "InvalidHexDigit": "Cifra esadecimale non valida nella sequenza di escape Unicode",
   "InvalidIntegerConst": "Costante integer non valida: {count}",
   "InvalidLibraryMissingLinkerMembers": "Libreria non valida: impossibile trovare un membro del linker.",

--- a/locales/messages.ja.json
+++ b/locales/messages.ja.json
@@ -742,6 +742,7 @@
   "InvalidFilename": "ファイル名に無効な文字 {value} を含めることはできませんが、{path} を含みます",
   "InvalidFloatingPointConst": "無効な浮動小数点定数: {count}",
   "InvalidFormatString": "無効な形式の文字列: {actual}",
+  "InvalidGitObjectSha": "invalid git object SHA: {sha}. Expected a 40-character lowercase hexadecimal string.",
   "InvalidHexDigit": "Unicode エスケープの 16 進数が無効です",
   "InvalidIntegerConst": "整数定数が無効です: {count}",
   "InvalidLibraryMissingLinkerMembers": "ライブラリが無効です: リンカー メンバーが見つかりませんでした。",

--- a/locales/messages.ko.json
+++ b/locales/messages.ko.json
@@ -742,6 +742,7 @@
   "InvalidFilename": "파일 이름에 유효하지 않은 문자({value})를 포함할 수 없습니다. 입력값: {path}",
   "InvalidFloatingPointConst": "잘못된 부동 소수점 상수: {count}",
   "InvalidFormatString": "잘못된 서식 문자열: {actual}",
+  "InvalidGitObjectSha": "invalid git object SHA: {sha}. Expected a 40-character lowercase hexadecimal string.",
   "InvalidHexDigit": "유니코드 이스케이프의 16진수가 잘못되었습니다.",
   "InvalidIntegerConst": "잘못된 정수 상수: {count}",
   "InvalidLibraryMissingLinkerMembers": "라이브러리가 잘못되었습니다. 링커 멤버를 찾을 수 없습니다.",

--- a/locales/messages.pl.json
+++ b/locales/messages.pl.json
@@ -742,6 +742,7 @@
   "InvalidFilename": "Nazwa pliku nie może zawierać nieprawidłowych znaków {value}, ale była {path}",
   "InvalidFloatingPointConst": "Nieprawidłowa stała zmiennoprzecinkowa: {count}",
   "InvalidFormatString": "Nieprawidłowy ciąg formatu: {actual}",
+  "InvalidGitObjectSha": "invalid git object SHA: {sha}. Expected a 40-character lowercase hexadecimal string.",
   "InvalidHexDigit": "Nieprawidłowa cyfra szesnastkowa w sekwencji ucieczki Unicode",
   "InvalidIntegerConst": "Nieprawidłowa stała całkowita: {count}",
   "InvalidLibraryMissingLinkerMembers": "Biblioteka była nieprawidłowa: nie można odnaleźć elementu członkowskiego konsolidatora.",

--- a/locales/messages.pt-BR.json
+++ b/locales/messages.pt-BR.json
@@ -742,6 +742,7 @@
   "InvalidFilename": "O nome do arquivo não pode conter caracteres inválidos {value}, mas era {path}",
   "InvalidFloatingPointConst": "Constante de ponto flutuante inválida: {count}",
   "InvalidFormatString": "cadeia de caracteres de formato inválido: {actual}",
+  "InvalidGitObjectSha": "invalid git object SHA: {sha}. Expected a 40-character lowercase hexadecimal string.",
   "InvalidHexDigit": "Dígito hexadecimal inválido no escape unicode",
   "InvalidIntegerConst": "Constante inteira inválida: {count}",
   "InvalidLibraryMissingLinkerMembers": "A biblioteca era inválida: não foi possível localizar um membro do vinculador.",

--- a/locales/messages.ru.json
+++ b/locales/messages.ru.json
@@ -742,6 +742,7 @@
   "InvalidFilename": "Имя файла не может содержать недопустимые символы {value}, но использовалось имя {path}",
   "InvalidFloatingPointConst": "Недопустимые константы с плавающей точкой: {count}",
   "InvalidFormatString": "Недопустимая строка формата: {actual}",
+  "InvalidGitObjectSha": "invalid git object SHA: {sha}. Expected a 40-character lowercase hexadecimal string.",
   "InvalidHexDigit": "Недопустимая шестнадцатеричная цифра в escape-коде Юникода",
   "InvalidIntegerConst": "Недопустимая целая константа: {count}",
   "InvalidLibraryMissingLinkerMembers": "Недопустимая библиотека: не удалось найти элемент компоновщика.",

--- a/locales/messages.tr.json
+++ b/locales/messages.tr.json
@@ -742,6 +742,7 @@
   "InvalidFilename": "Dosya adı geçersiz karakterler {value} içeremez, ancak {path} geçersizdi",
   "InvalidFloatingPointConst": "Geçersiz kayan nokta sabiti: {count}",
   "InvalidFormatString": "geçersiz biçim dizesi: {actual}",
+  "InvalidGitObjectSha": "invalid git object SHA: {sha}. Expected a 40-character lowercase hexadecimal string.",
   "InvalidHexDigit": "Unicode kaçışında geçersiz onaltılık basamak",
   "InvalidIntegerConst": "Invalid integer constant: {count}",
   "InvalidLibraryMissingLinkerMembers": "Kitaplık geçersizdi: bağlayıcı üyesi bulunamadı.",

--- a/locales/messages.zh-Hans.json
+++ b/locales/messages.zh-Hans.json
@@ -742,6 +742,7 @@
   "InvalidFilename": "文件名不能包含无效字符 {value}，但为 {path}",
   "InvalidFloatingPointConst": "无效的浮点常量: {count}",
   "InvalidFormatString": "格式字符串无效: {actual}",
+  "InvalidGitObjectSha": "invalid git object SHA: {sha}. Expected a 40-character lowercase hexadecimal string.",
   "InvalidHexDigit": "unicode 转义中的十六进制数字无效",
   "InvalidIntegerConst": "无效的整数常量: {count}",
   "InvalidLibraryMissingLinkerMembers": "库无效: 找不到链接器成员。",

--- a/locales/messages.zh-Hant.json
+++ b/locales/messages.zh-Hant.json
@@ -742,6 +742,7 @@
   "InvalidFilename": "檔案名不能包含無效字元 {value}，但為 {path}",
   "InvalidFloatingPointConst": "無效的浮點常數: {count}",
   "InvalidFormatString": "格式字串無效: {actual}",
+  "InvalidGitObjectSha": "invalid git object SHA: {sha}. Expected a 40-character lowercase hexadecimal string.",
   "InvalidHexDigit": "Unicode 逸出中無效的十六進位數字",
   "InvalidIntegerConst": "無效的整數常數: {count}",
   "InvalidLibraryMissingLinkerMembers": "程式庫無效: 找不到連結器成員。",


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.