### PR TITLE
Parallelize ObjectStorageProvider downloads

### DIFF
--- a/include/vcpkg/base/parallel-algorithms.h
+++ b/include/vcpkg/base/parallel-algorithms.h
@@ -68,7 +68,7 @@ namespace vcpkg
     };
 
     template<class F>
-    inline void execute_in_parallel(size_t work_count, F work) noexcept
+    inline void execute_in_parallel(size_t work_count, size_t max_concurrency, F work) noexcept
     {
         if (work_count == 0)
         {
@@ -89,7 +89,7 @@ namespace vcpkg
                          nullptr);
         if (ptp_work)
         {
-            auto max_threads = (std::min)(work_count, static_cast<size_t>(get_concurrency()));
+            auto max_threads = (std::min)({work_count, max_concurrency, static_cast<size_t>(get_concurrency())});
             max_threads = (std::min)(max_threads, (SIZE_MAX - work_count) + 1u); // to avoid overflow in fetch_add
             // start at 1 to account for the running thread
             for (size_t i = 1; i < max_threads; ++i)
@@ -99,6 +99,12 @@ namespace vcpkg
         }
 
         context.run();
+    }
+
+    template<class F>
+    inline void execute_in_parallel(size_t work_count, F work) noexcept
+    {
+        execute_in_parallel(work_count, SIZE_MAX, work);
     }
 #else  // ^^^ _WIN32 / !_WIN32 vvv
     struct JThread
@@ -120,7 +126,7 @@ namespace vcpkg
     };
 
     template<class F>
-    inline void execute_in_parallel(size_t work_count, F work) noexcept
+    inline void execute_in_parallel(size_t work_count, size_t max_concurrency, F work) noexcept
     {
         if (work_count == 0)
         {
@@ -132,9 +138,9 @@ namespace vcpkg
             work(size_t{});
             return;
         }
-
         WorkCallbackContext<F> context{work, work_count};
-        auto max_threads = std::min(work_count, static_cast<size_t>(get_concurrency()));
+        auto max_threads = std::min({work_count, max_concurrency, static_cast<size_t>(get_concurrency())});
+        auto max_threads = std::min({work_count, max_concurrency, static_cast<size_t>(get_concurrency())});
         max_threads = std::min(max_threads, (SIZE_MAX - work_count) + 1u); // to avoid overflow in fetch_add
         auto bg_thread_count = max_threads - 1;
         std::vector<JThread> bg_threads;
@@ -154,6 +160,12 @@ namespace vcpkg
 
         context.run();
         // destroying workers joins
+    }
+
+    template<class F>
+    inline void execute_in_parallel(size_t work_count, F work) noexcept
+    {
+        execute_in_parallel(work_count, SIZE_MAX, work);
     }
 #endif // ^^^ !_WIN32
 

--- a/include/vcpkg/base/parallel-algorithms.h
+++ b/include/vcpkg/base/parallel-algorithms.h
@@ -140,7 +140,6 @@ namespace vcpkg
         }
         WorkCallbackContext<F> context{work, work_count};
         auto max_threads = std::min({work_count, max_concurrency, static_cast<size_t>(get_concurrency())});
-        auto max_threads = std::min({work_count, max_concurrency, static_cast<size_t>(get_concurrency())});
         max_threads = std::min(max_threads, (SIZE_MAX - work_count) + 1u); // to avoid overflow in fetch_add
         auto bg_thread_count = max_threads - 1;
         std::vector<JThread> bg_threads;

--- a/src/vcpkg-test/parallel-algorithms.cpp
+++ b/src/vcpkg-test/parallel-algorithms.cpp
@@ -1,0 +1,33 @@
+#include <vcpkg-test/util.h>
+
+#include <vcpkg/base/parallel-algorithms.h>
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+using namespace vcpkg;
+
+TEST_CASE ("execute_in_parallel respects max concurrency", "[parallel-algorithms]")
+{
+    std::atomic<size_t> active_work{0};
+    std::atomic<size_t> maximum_active_work{0};
+    std::atomic<size_t> completed_work{0};
+
+    execute_in_parallel(100, 2, [&](size_t) {
+        const auto active = active_work.fetch_add(1, std::memory_order_relaxed) + 1;
+        auto observed_maximum = maximum_active_work.load(std::memory_order_relaxed);
+        while (observed_maximum < active &&
+               !maximum_active_work.compare_exchange_weak(observed_maximum, active, std::memory_order_relaxed))
+        {
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        active_work.fetch_sub(1, std::memory_order_relaxed);
+        completed_work.fetch_add(1, std::memory_order_relaxed);
+    });
+
+    CHECK(completed_work == 100);
+    CHECK(maximum_active_work >= 1);
+    CHECK(maximum_active_work <= 2);
+}

--- a/src/vcpkg/binarycaching.cpp
+++ b/src/vcpkg/binarycaching.cpp
@@ -36,6 +36,7 @@ namespace
 {
     // The length of an ABI in the binary cache
     static constexpr size_t ABI_LENGTH = 64;
+    static constexpr size_t OBJECT_STORAGE_DOWNLOAD_CONCURRENCY = 8;
 
     struct ConfigSegmentsParser : ParserBase
     {
@@ -1030,12 +1031,12 @@ namespace
                           View<const InstallPlanAction*> actions,
                           Span<Optional<ZipResource>> out_zip_paths) const override
         {
-            for (size_t idx = 0; idx < actions.size(); ++idx)
-            {
+            std::vector<FullyBufferedDiagnosticContext> diagnostic_contexts(actions.size());
+            execute_in_parallel(actions.size(), OBJECT_STORAGE_DOWNLOAD_CONCURRENCY, [&](size_t idx) {
                 auto&& action = *actions[idx];
                 const auto& abi = action.package_abi_or_exit(VCPKG_LINE_INFO);
                 auto tmp = make_temp_archive_path(m_buildtrees, action.spec, abi);
-                WarningDiagnosticContext wdc{context};
+                WarningDiagnosticContext wdc{diagnostic_contexts[idx]};
                 auto res = m_tool->download_file(wdc, make_object_path(m_prefix, abi), tmp);
                 if (auto cache_result = res.get())
                 {
@@ -1044,6 +1045,11 @@ namespace
                         out_zip_paths[idx].emplace(std::move(tmp), RemoveWhen::always);
                     }
                 }
+            });
+
+            for (auto&& diagnostic_context : diagnostic_contexts)
+            {
+                std::move(diagnostic_context).report_to(context);
             }
         }
 


### PR DESCRIPTION
This is https://github.com/microsoft/vcpkg-tool/pull/1485 / https://github.com/microsoft/vcpkg-tool/pull/1392 now that we have the DiagnosticContext infrastructure to make it not painful.

Run up to eight external object-storage downloads concurrently while respecting lower VCPKG_MAX_CONCURRENCY values. Each worker writes to its own result slot and FullyBufferedDiagnosticContext; after all workers finish, diagnostics are replayed on the calling thread in action order, avoiding concurrent console I/O.

Add a bounded execute_in_parallel overload without changing existing callers, plus regression coverage for its concurrency ceiling.