### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 15684: Build ID 14800598

### DIFF
--- a/locales/messages.cs.json
+++ b/locales/messages.cs.json
@@ -1007,7 +1007,7 @@
   "SystemApiErrorMessage": "volání {system_api} selhalo s ukončovacím kódem {exit_code} ({error_msg}).",
   "ToRemovePackages": "Pokud chcete odebrat jenom zastaralé balíčky, spusťte\n{command_name} odeberte --outdated.",
   "ToUpdatePackages": "Pokud chcete aktualizovat tyto balíčky a všechny závislosti, spusťte\n{command_name} upgrade.",
-  "ToolDataEntryVersionMissing": "tool metadata must contain at least one of 'version' or 'min-version'",
+  "ToolDataEntryVersionMissing": "Metadata nástroje musí obsahovat alespoň jednu z hodnot version nebo min-version.",
   "ToolDataFileSchemaVersionNotSupported": "verze schématu dokumentu {version} není podporována touto verzí vcpkg.",
   "ToolFetchFailed": "Nepovedlo se načíst {tool_name}.",
   "ToolHashMismatch": "{tool_name} se zdá být již stažen, ale má nesprávnou hodnotu hash. Očekával se {expected}, ale byl {actual}",

--- a/locales/messages.de.json
+++ b/locales/messages.de.json
@@ -1007,7 +1007,7 @@
   "SystemApiErrorMessage": "Fehler beim Aufrufen von {system_api}. {exit_code} ({error_msg})",
   "ToRemovePackages": "Um nur veraltete Pakete zu entfernen, führen Sie\n{command_name} \"–veraltet entfernen\" aus.",
   "ToUpdatePackages": "Führen Sie \n{command_name}-Upgrade aus, um diese Pakete und alle Abhängigkeiten zu aktualisieren.",
-  "ToolDataEntryVersionMissing": "tool metadata must contain at least one of 'version' or 'min-version'",
+  "ToolDataEntryVersionMissing": "Die Toolmetadaten müssen mindestens eine der Optionen „version“ oder „min-version“ enthalten.",
   "ToolDataFileSchemaVersionNotSupported": "Die Dokumentschemaversion {version} wird von dieser Version von vcpkg nicht unterstützt.",
   "ToolFetchFailed": "{tool_name} konnte nicht abgerufen werden.",
   "ToolHashMismatch": "{tool_name} scheint bereits heruntergeladen zu sein, hat aber einen falschen Hash. {expected} erwartet, wurde jedoch {actual}.",

--- a/locales/messages.es.json
+++ b/locales/messages.es.json
@@ -1007,7 +1007,7 @@
   "SystemApiErrorMessage": "error al llamar a {system_api} con {exit_code} ({error_msg})",
   "ToRemovePackages": "Para quitar solo los paquetes obsoletos, ejecute\n{command_name} remove --outdated",
   "ToUpdatePackages": "Para actualizar estos paquetes y todas las dependencias, ejecute\n{command_name} upgrade”",
-  "ToolDataEntryVersionMissing": "tool metadata must contain at least one of 'version' or 'min-version'",
+  "ToolDataEntryVersionMissing": "Los metadatos de la herramienta de deben contener al menos una de las opciones \"version\" o \"min-version\"",
   "ToolDataFileSchemaVersionNotSupported": "la versión de esquema de documento {version} no es compatible con esta versión de vcpkg",
   "ToolFetchFailed": "No se pudo capturar {tool_name}.",
   "ToolHashMismatch": "{tool_name} parece que ya se ha descargado, pero tiene un hash incorrecto. Se esperaba {expected} pero se {actual}",

--- a/locales/messages.fr.json
+++ b/locales/messages.fr.json
@@ -1007,7 +1007,7 @@
   "SystemApiErrorMessage": "échec de l’appel {system_api} avec {exit_code} ({error_msg})",
   "ToRemovePackages": "Pour supprimer uniquement les packages obsolètes, exécutez\n{command_name} supprimer --outdated",
   "ToUpdatePackages": "Pour mettre à jour ces packages et toutes les dépendances, exécutez\n{command_name} la mise à niveau'",
-  "ToolDataEntryVersionMissing": "tool metadata must contain at least one of 'version' or 'min-version'",
+  "ToolDataEntryVersionMissing": "Les métadonnées de l’outil doivent contenir au moins l’une des valeurs « version » ou « min-version »",
   "ToolDataFileSchemaVersionNotSupported": "version de schéma de document {version} n’est pas prise en charge par cette version de vcpkg",
   "ToolFetchFailed": "Impossible de récupérer les {tool_name}.",
   "ToolHashMismatch": "{tool_name} semble être déjà téléchargé, mais son hachage est incorrect. {expected} attendu mais {actual}",

--- a/locales/messages.it.json
+++ b/locales/messages.it.json
@@ -1007,7 +1007,7 @@
   "SystemApiErrorMessage": "chiamata {system_api} non riuscita con {exit_code} ({error_msg})",
   "ToRemovePackages": "Per rimuovere solo i pacchetti obsoleti, eseguire\n{command_name} remove --outdated",
   "ToUpdatePackages": "Per aggiornare questi pacchetti e tutte le dipendenze, eseguire\n'aggiornamento di {command_name}'",
-  "ToolDataEntryVersionMissing": "tool metadata must contain at least one of 'version' or 'min-version'",
+  "ToolDataEntryVersionMissing": "i metadati dello strumento devono contenere almeno uno tra 'version' e 'min-version'",
   "ToolDataFileSchemaVersionNotSupported": "la versione dello schema del documento {version} non è supportata da questa versione di vcpkg",
   "ToolFetchFailed": "Impossibile recuperare {tool_name}.",
   "ToolHashMismatch": "{tool_name} è già stato scaricato, ma ha un hash non corretto. Previsto {expected} ma {actual}",

--- a/locales/messages.ja.json
+++ b/locales/messages.ja.json
@@ -1007,7 +1007,7 @@
   "SystemApiErrorMessage": "呼び出し {system_api} が {exit_code} ({error_msg}) で失敗しました",
   "ToRemovePackages": "古いパッケージのみを削除するには、\n{command_name} remove --outdated を実行します",
   "ToUpdatePackages": "これらのパッケージとすべての依存関係を更新するには、\n{command_name} upgrade' を実行します",
-  "ToolDataEntryVersionMissing": "tool metadata must contain at least one of 'version' or 'min-version'",
+  "ToolDataEntryVersionMissing": "ツール メタデータには、少なくとも 'version' または 'min-version' が含まれている必要があります",
   "ToolDataFileSchemaVersionNotSupported": "ドキュメント スキーマのバージョン {version} は、このバージョンの vcpkg ではサポートされていません",
   "ToolFetchFailed": "{tool_name} をフェッチできませんでした。",
   "ToolHashMismatch": "{tool_name} は既にダウンロードされているようですが、ハッシュが正しくありません。{expected} が必要ですが、{actual} されました",

--- a/locales/messages.ko.json
+++ b/locales/messages.ko.json
@@ -1007,7 +1007,7 @@
   "SystemApiErrorMessage": "{exit_code}({error_msg})(으)로 인해 {system_api} 호출에 실패했습니다.",
   "ToRemovePackages": "오래된 패키지만 제거하려면 \n{command_name}을(를) 실행하고 오래된 버전을 제거하세요.",
   "ToUpdatePackages": "이러한 패키지 및 모든 종속성을 업데이트하려면 \n{command_name} 업그레이드'를 실행합니다.",
-  "ToolDataEntryVersionMissing": "tool metadata must contain at least one of 'version' or 'min-version'",
+  "ToolDataEntryVersionMissing": "도구 메타데이터에는 'version' 또는 'min-version' 중 하나 이상이 포함되어야 합니다.",
   "ToolDataFileSchemaVersionNotSupported": "이 버전의 vcpkg에서는 문서 스키마 버전 {version} 지원되지 않습니다.",
   "ToolFetchFailed": "{tool_name}을(를) 가져올 수 없습니다.",
   "ToolHashMismatch": "{tool_name} 이미 다운로드되었지만 잘못된 해시가 있습니다. 필요한 {expected} {actual}",

--- a/locales/messages.pl.json
+++ b/locales/messages.pl.json
@@ -1007,7 +1007,7 @@
   "SystemApiErrorMessage": "wywołanie {system_api} nie powiodło się. Kod zakończenia:{exit_code} ({error_msg})",
   "ToRemovePackages": "Aby usunąć tylko nieaktualne pakiety, uruchom polecenie \n{command_name} remove --outdated",
   "ToUpdatePackages": "Aby zaktualizować te pakiety i wszystkie zależności, uruchom\n{command_name} uaktualnienie\"",
-  "ToolDataEntryVersionMissing": "tool metadata must contain at least one of 'version' or 'min-version'",
+  "ToolDataEntryVersionMissing": "metadane narzędzia muszą zawierać co najmniej jeden element „version” lub „min-version”",
   "ToolDataFileSchemaVersionNotSupported": "wersja schematu dokumentu {version} nie jest obsługiwana przez tę wersję programu vcpkg",
   "ToolFetchFailed": "Nie można pobrać elementu {tool_name}.",
   "ToolHashMismatch": "{tool_name} prawdopodobnie została już pobrana, ale ma niepoprawny skrót. Oczekiwano {expected}, ale {actual}",

--- a/locales/messages.pt-BR.json
+++ b/locales/messages.pt-BR.json
@@ -1007,7 +1007,7 @@
   "SystemApiErrorMessage": "Falha ao chamar {system_api} com {exit_code} ({error_msg})",
   "ToRemovePackages": "Para remover somente pacotes desatualizados, execute\n{command_name} remove --outdated",
   "ToUpdatePackages": "Para atualizar esses pacotes e todas as dependências, execute\n {command_name} upgrade'",
-  "ToolDataEntryVersionMissing": "tool metadata must contain at least one of 'version' or 'min-version'",
+  "ToolDataEntryVersionMissing": "metadados da ferramenta devem conter pelo menos um de 'version' ou 'min-version'",
   "ToolDataFileSchemaVersionNotSupported": "versão do esquema de {version} não tem suporte nesta versão do vcpkg",
   "ToolFetchFailed": "Não foi possível buscar {tool_name}.",
   "ToolHashMismatch": "{tool_name} parece já ter sido baixado, mas tem um hash incorreto. Esperado {expected} mas foi {actual}",

--- a/locales/messages.ru.json
+++ b/locales/messages.ru.json
@@ -1007,7 +1007,7 @@
   "SystemApiErrorMessage": "Сбой вызова API {system_api} с кодом завершения {exit_code} ({error_msg})",
   "ToRemovePackages": "Чтобы удалить только устаревшие пакеты, запустите команду\n{command_name} remove --outdated",
   "ToUpdatePackages": "Чтобы обновить эти пакеты и все зависимости, запустите команду обновления\n{command_name}",
-  "ToolDataEntryVersionMissing": "tool metadata must contain at least one of 'version' or 'min-version'",
+  "ToolDataEntryVersionMissing": "метаданные инструмента должны содержать как минимум одно из значений: version или min-version",
   "ToolDataFileSchemaVersionNotSupported": "версия схемы {version} не поддерживается данной версией vcpkg",
   "ToolFetchFailed": "Не удалось получить {tool_name}.",
   "ToolHashMismatch": "{tool_name} уже скачан, но имеет неправильный хэш. Ожидалось {expected}, но {actual}",

--- a/locales/messages.tr.json
+++ b/locales/messages.tr.json
@@ -1007,7 +1007,7 @@
   "SystemApiErrorMessage": "{system_api} çağrısı {exit_code} ile başarısız oldu ({error_msg})",
   "ToRemovePackages": "Yalnızca süresi geçmiş paketleri kaldırmak için\n{command_name} remove --outdated çalıştırın",
   "ToUpdatePackages": "Bu paketleri ve tüm bağımlılıkları güncelleştirmek için\n{command_name} upgrade' çalıştırın",
-  "ToolDataEntryVersionMissing": "tool metadata must contain at least one of 'version' or 'min-version'",
+  "ToolDataEntryVersionMissing": "araç meta verileri, 'version' veya 'min-version' değerlerinden en az birini içermelidir",
   "ToolDataFileSchemaVersionNotSupported": "belge şeması {version} bu vcpkg sürümü tarafından desteklenmiyor",
   "ToolFetchFailed": "{tool_name} getirilemedi.",
   "ToolHashMismatch": "{tool_name} zaten indirildi gibi görünüyor, ancak karma yanlış. Beklenen {expected} ancak {actual}",

--- a/locales/messages.zh-Hans.json
+++ b/locales/messages.zh-Hans.json
@@ -1007,7 +1007,7 @@
   "SystemApiErrorMessage": "调用 {system_api} 失败，{exit_code} ({error_msg})",
   "ToRemovePackages": "若要仅删除过时的包，请运行\n{command_name} remove --outdated",
   "ToUpdatePackages": "若要更新这些包和所有依赖项，请运行\n{command_name} upgrade'",
-  "ToolDataEntryVersionMissing": "tool metadata must contain at least one of 'version' or 'min-version'",
+  "ToolDataEntryVersionMissing": "工具元数据必须至少包含 'version' 或 'min-version' 其中之一",
   "ToolDataFileSchemaVersionNotSupported": "此版本的 vcpkg 不支持文档架构版本 {version}",
   "ToolFetchFailed": "无法提取 {tool_name}。",
   "ToolHashMismatch": "{tool_name} 似乎已下载，但哈希不正确。应为 {expected}，但已 {actual}",

--- a/locales/messages.zh-Hant.json
+++ b/locales/messages.zh-Hant.json
@@ -1007,7 +1007,7 @@
   "SystemApiErrorMessage": "呼叫 {system_api} 失敗，{exit_code} ({error_msg})",
   "ToRemovePackages": "若要僅移除過時的套件，請執行\n{command_name} remove --outdated",
   "ToUpdatePackages": "若要更新這些套件及所有相依性，請執行\n{command_name} upgrade'",
-  "ToolDataEntryVersionMissing": "tool metadata must contain at least one of 'version' or 'min-version'",
+  "ToolDataEntryVersionMissing": "工具中繼資料必須包含至少一個 'version' 或 'min-version'",
   "ToolDataFileSchemaVersionNotSupported": "此版本的 vcpkg 不支援文件架構版本 {version}",
   "ToolFetchFailed": "無法擷取 {tool_name}。",
   "ToolHashMismatch": "{tool_name} 似乎已下載，但哈希不正確。預期 {expected} 但 {actual}",


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.