### PR TITLE
Take the registries lock before `git init`

### DIFF
--- a/src/vcpkg/vcpkgpaths.cpp
+++ b/src/vcpkg/vcpkgpaths.cpp
@@ -1045,18 +1045,19 @@ namespace vcpkg
         }
 
         const auto base_cmd = git_cmd_builder(*git_tool_path, dot_git_dir, work_tree);
-        auto init_cmd = base_cmd;
-        init_cmd.string_arg("init");
-        auto maybe_init_output = cmd_execute_and_capture_output(bdc, init_cmd);
-        if (!check_zero_exit_code(bdc, init_cmd, maybe_init_output))
-        {
-            return LocalizedString::from_raw(bdc.to_string());
-        }
 
         auto lock_file = work_tree / ".vcpkg-lock";
 
         auto guard = fs.take_exclusive_file_lock(bdc, lock_file);
         if (!guard)
+        {
+            return LocalizedString::from_raw(bdc.to_string());
+        }
+
+        auto init_cmd = base_cmd;
+        init_cmd.string_arg("init");
+        auto maybe_init_output = cmd_execute_and_capture_output(bdc, init_cmd);
+        if (!check_zero_exit_code(bdc, init_cmd, maybe_init_output))
         {
             return LocalizedString::from_raw(bdc.to_string());
         }


### PR DESCRIPTION
Fixes #2066.

## The bug

`VcpkgPaths::git_fetch_from_remote_registry` runs `git init` on the **shared** registries work tree *before* taking `.vcpkg-lock`:

https://github.com/microsoft/vcpkg-tool/blob/60b5cfa92045b3abf92fc5ce81e0c8c8be3e73ac/src/vcpkg/vcpkgpaths.cpp#L1047-L1062

```cpp
const auto base_cmd = git_cmd_builder(*git_tool_path, dot_git_dir, work_tree);
auto init_cmd = base_cmd;
init_cmd.string_arg("init");
auto maybe_init_output = cmd_execute_and_capture_output(bdc, init_cmd);   // <-- unsynchronized
if (!check_zero_exit_code(bdc, init_cmd, maybe_init_output)) { ... }

auto lock_file = work_tree / ".vcpkg-lock";
auto guard = fs.take_exclusive_file_lock(bdc, lock_file);                 // <-- lock taken here
```

The sibling function `VcpkgPaths::git_fetch`, ~30 lines below, does it the other way around — lock first, then `git init` — so the two are already inconsistent, and `git_fetch` is the correct one.

Because the registries cache (`%LOCALAPPDATA%\vcpkg\registries` by default) is shared process-wide, any two concurrent vcpkg invocations run `git init` against the same `.git` at the same time and race on `.git/config.lock`.

Note this is *not* covered by the buildtrees/packages locks added in 2026-04-08: those guard `installed`/`buildtrees`/`packages`, which are already per-invocation when `--x-install-root` etc. are distinct. The registries cache is the remaining shared mutable state, and `git init` escapes its lock.

## Evidence

Captured from a real failing run with `GIT_TRACE2_EVENT`, vcpkg `2026-05-27-d5b6777d`, 8 concurrent `vcpkg install --dry-run` sharing one registries cache:

```json
{"event":"start","argv":["git.exe","--git-dir=C:\\race-cache\\git\\.git",
                         "--work-tree=C:\\race-cache\\git","-c","core.autocrlf=false","init"]}
{"event":"cmd_name","name":"init","hierarchy":"init"}
{"event":"error","msg":"could not lock config file C:/race-cache/git/.git/config: File exists"}
{"event":"error","msg":"could not set 'core.repositoryformatversion' to '0'"}
{"event":"exit","code":128}
```

The whole process lived 58 ms, i.e. it fails immediately, long before any network access.

#2066 reports the same race surfacing as a different `git init` failure mode:

```
fatal: cannot copy '.../templates/hooks/commit-msg.sample' to
       '.../registries/git/.git/hooks/commit-msg.sample': File exists
```

## Minimal reproducer

Concurrent `git init` on one already-initialized repo, started in the same millisecond (PowerShell, Windows, git 2.53.0):

```powershell
$dot = 'C:\t\git\.git'; $work = 'C:\t\git'
New-Item -ItemType Directory -Force $work | Out-Null
git --git-dir=$dot --work-tree=$work init | Out-Null

$body = {
    param($dot, $work, $startTicks)
    while ([DateTime]::UtcNow.Ticks -lt $startTicks) { }
    $o = & git "--git-dir=$dot" "--work-tree=$work" -c core.autocrlf=false init 2>&1
    [pscustomobject]@{ Code = $LASTEXITCODE; Out = ($o -join ' | ') }
}

$start = [DateTime]::UtcNow.AddSeconds(3).Ticks
$jobs = 1..6 | ForEach-Object { Start-Job -ScriptBlock $body -ArgumentList $dot, $work, $start }
$jobs | Wait-Job | Receive-Job | Where-Object Code -ne 0
```

Over 15 iterations x 6 processes this fails **41/90 (45.6%)**:

```
[35x] error: could not lock config file C:/t/git/.git/config: File exists
 [5x] fatal: unknown error occurred while reading the configuration files
 [1x] error: invalid config file C:/t/git/.git/config
```

The last two are worth calling out: a lost `git init` race can leave `.git/config` **unreadable**, which then poisons the cache for subsequent runs rather than just failing the current one.

## The fix

Move `git init` inside the `.vcpkg-lock` critical section, matching `git_fetch`. This is a pure statement reorder — no behaviour change for the single-process case.

## Impact

We hit this in CI, where a build fans out to 6 concurrent `vcpkg install` invocations (one per triplet). Before the workaround it failed ~100% of the time; the same race also accounts for intermittent failures in serial CI whenever two jobs share a machine.

Workaround for anyone blocked: give every concurrent invocation its own registries cache via `--x-registries-cache=<dir>` / `X_VCPKG_REGISTRIES_CACHE` (the directory must already exist and be absolute).
