### PR TITLE
Do not replace registry errors with "<port> does not exist"

### DIFF
--- a/src/vcpkg/portfileprovider.cpp
+++ b/src/vcpkg/portfileprovider.cpp
@@ -436,17 +436,7 @@ namespace vcpkg
                 {
                     if (auto reg = m_registry_set.registry_for_port(name))
                     {
-                        if (auto entry = reg->get_port_entry(name))
-                        {
-                            entry_it = m_entry_cache.emplace(name.to_string(), std::move(entry)).first;
-                        }
-                        else
-                        {
-                            entry_it = m_entry_cache
-                                           .emplace(name.to_string(),
-                                                    msg::format(msgPortDoesNotExist, msg::package_name = name))
-                                           .first;
-                        }
+                        entry_it = m_entry_cache.emplace(name.to_string(), reg->get_port_entry(name)).first;
                     }
                     else
                     {


### PR DESCRIPTION
Fixes #2094.

`VersionedPortfileProviderImpl::entry()` threw away the error returned by `get_port_entry` and substituted `{package_name} does not exist`, so any registry-level failure was reported as the port not existing.

`get_port_entry` returns `ExpectedL<std::unique_ptr<RegistryEntry>>` with three outcomes:

1. **error** — something went wrong talking to the registry
2. **value, null pointer** — the registry genuinely has no such port
3. **value, non-null** — found

Case 2 is already handled downstream in `load_control_file`:

```cpp
if (!ent->get())
{
    return msg::format_error(msgPortDoesNotExist, msg::package_name = version_spec.port_name);
}
```

so the `else` branch touched here is reached **only** for case 1. It also used `msg::format` rather than `msg::format_error`, so the line wasn't even prefixed with `error:`.

## Before / after

This hid #2066 from us entirely. A concurrent `git init` race in the registries cache made `get_port_entry` fail, and the entire user-visible output was:

```
Fetching registry information from https://github.com/microsoft/vcpkg (HEAD)...
apr does not exist
apr-util does not exist
capstone does not exist
crc32c does not exist
expat does not exist
...
```

No `error:` prefix, no git output — just every port from the default registry declared non-existent, which points suspicion at the manifest or the baseline instead of at the registry fetch that actually failed. Finding the real message required a `GIT_TRACE2_EVENT` capture of a live failure:

```
could not lock config file .../registries/git/.git/config: File exists
could not set 'core.repositoryformatversion' to '0'
```

With this change that message reaches the user directly.

Worth noting: #2066 hit the same underlying failure but reached it through `get_baseline_version`, which propagates errors correctly — so that reporter saw the actual git error. The difference was entirely this one `else` branch.

## The change

```cpp
entry_it = m_entry_cache.emplace(name.to_string(), std::move(entry).error()).first;
```

`ExpectedT::error() &&` already exists and the cache value type is constructible from `LocalizedString`, so this is a drop-in replacement for the discarded `msg::format(...)`. `msgPortDoesNotExist` remains in use for the genuine cases at both other call sites in this file.
