### PR TITLE
Use rename_or_delete when finalizing a downloaded .part file

### DIFF
--- a/src/vcpkg/base/downloads.cpp
+++ b/src/vcpkg/base/downloads.cpp
@@ -644,7 +644,11 @@ namespace vcpkg
             return DownloadPrognosis::OtherError;
         }
 
-        fs.rename(download_path_part_path, download_path, VCPKG_LINE_INFO);
+        if (!fs.rename_or_delete(context, download_path_part_path, download_path).has_value())
+        {
+            return DownloadPrognosis::OtherError;
+        }
+
         return DownloadPrognosis::Success;
     }
 
@@ -831,7 +835,11 @@ namespace vcpkg
                             *out_sha512 = std::move(hash_result.hash);
                         }
 
-                        fs.rename(download_path_part_path, download_path, VCPKG_LINE_INFO);
+                        if (!fs.rename_or_delete(context, download_path_part_path, download_path).has_value())
+                        {
+                            return DownloadPrognosis::OtherError;
+                        }
+
                         return DownloadPrognosis::Success;
                     }
 
@@ -865,7 +873,11 @@ namespace vcpkg
 
         if (fs.exists(download_path_part_path, VCPKG_LINE_INFO))
         {
-            fs.rename(download_path_part_path, download_path, VCPKG_LINE_INFO);
+            if (!fs.rename_or_delete(context, download_path_part_path, download_path).has_value())
+            {
+                return DownloadPrognosis::OtherError;
+            }
+
             return DownloadPrognosis::Success;
         }
 


### PR DESCRIPTION
Fixes #2096.

Concurrent vcpkg processes download an asset to `<dest>.<pid>.part` and then rename it onto the shared `<dest>`. The part files are distinct, but the rename is unserialized, and on Windows it fails with `ERROR_ACCESS_DENIED` while another process holds the freshly-renamed destination open — which is exactly what that process does next, hashing it or extracting it as a tool.

`rename_or_delete` is the compare-and-swap that already handles this pattern for the extracted tool directory, a few frames up in `download_tool`:

```cpp
auto maybe_partial_path = extract_archive_to_temp_subdirectory(context, fs, *this, download_path, tool_dir_path);
if (auto partial_path = maybe_partial_path.get())
{
    if (!fs.rename_or_delete(context, *partial_path, tool_dir_path))
```

It is the right primitive for the download too, and in fact more obviously so: the destination is content-addressed and `check_downloaded_file_hash` runs on the line immediately before, so a destination that already exists is bit-identical and discarding the loser's copy is a no-op. It also retries transient failures with backoff, which the bare `rename` did not.

The `DiagnosticContext` overload returns `Optional<bool>`, whose `operator bool` is `has_value`, so `!result` distinguishes a genuine failure from "lost the CAS, which is fine" — the same discrimination `download_tool` relies on.

Three call sites finalize a part file and all three are changed: the direct download, and the two asset-cache-script paths (with and without an expected hash). The third has no hash to verify, so which copy survives is arbitrary either way — it was `MOVEFILE_REPLACE_EXISTING` (last writer wins) and is now first writer wins. Happy to drop that one if you would rather keep the change to the hash-verified paths.

Verified against the reproducer in the issue: six concurrent `vcpkg install` invocations for different triplets against a cold `VCPKG_DOWNLOADS` go from 15/18 failures to passing, once the destination is no longer contended.
