### PR TITLE
[curl] propagate VCPKG_SSL_REVOKE_BEST_EFFORT to spawned processes

### DIFF
--- a/src/vcpkg/base/system.process.cpp
+++ b/src/vcpkg/base/system.process.cpp
@@ -651,6 +651,8 @@ namespace vcpkg
             "Z_VCPKG_UNDO",
             // Ensures that the escape hatch persists to recursive vcpkg invocations like x-download
             "VCPKG_KEEP_ENV_VARS",
+            // Enable REVOKE_BEST_EFFORT for libcurl downloads (same as curl --ssl-revoke-best-effort)
+            "VCPKG_SSL_REVOKE_BEST_EFFORT",
             // Enables Xbox SDKs
             "GameDKLatest",
             "GRDKLatest",


### PR DESCRIPTION
This change adds the missing propagation of the VCPKG_SSL_REVOKE_BEST_EFFORT environment variable to spawned processes (e.g., CMake builds). It complements the work done in #2043. For more context, see #2043.